### PR TITLE
Add oc-chatgpt-multi-auth to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
+- [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.
 - [OpenProject](https://github.com/varaprasadreddy9676/team-codex-plugins) - Team collaboration via OpenProject integration.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.


### PR DESCRIPTION
Reference: ndycode/oc-chatgpt-multi-auth#101

## What Changed

Added `oc-chatgpt-multi-auth` to the Community `Tools & Integrations` section in `README.md`.

## Why

The repo now includes a `.codex-plugin/plugin.json` manifest and a setup skill, so it fits the community plugin list described in the issue.
