### PR TITLE
Add codex-multi-auth to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
+- [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin for Codex, Claude Code, and Cline with structured planning, review, and verification guardrails.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
 


### PR DESCRIPTION
## What Changed

Added `codex-multi-auth` to the Community `Development & Workflow` section in `README.md`.

## Why

This repo now includes a `.codex-plugin/plugin.json` manifest and a setup skill, so it fits the community plugin directory as a Codex CLI-focused companion plugin.
