### PR TITLE
Add Claude Octopus — multi-LLM orchestration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 ### Development & Workflow
 
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
+- [Claude Octopus](https://github.com/nyldn/claude-octopus) - Multi-LLM orchestration dispatching to 8 providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) with Double Diamond workflows, adversarial review, and safety gates.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin for Codex, Claude Code, and Cline with structured planning, review, and verification guardrails.


### PR DESCRIPTION
Adds [Claude Octopus](https://github.com/nyldn/claude-octopus) to the Development & Workflow section.

**What it does:** Multi-LLM orchestration plugin that dispatches to 8 providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) through structured Double Diamond workflows. 32 personas, 47 commands, 50 skills covering research, implementation, review, TDD, security audits, and more.

**Requirements checklist:**
- [x] Public GitHub repository
- [x] Valid `.codex-plugin/plugin.json` manifest
- [x] Functional and well-documented
- [x] Concise one-line description
- [x] Alphabetized within category

Ref: nyldn/claude-octopus#219