### PR TITLE
Add Codex Agenteam to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
 - [Claude Octopus](https://github.com/nyldn/claude-octopus) - Multi-LLM orchestration dispatching to 8 providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) with Double Diamond workflows, adversarial review, and safety gates.
+- [Codex Agenteam](https://github.com/yimwoo/codex-agenteam) - Specialist AI agents (researcher, PM, architect, developer, QA, reviewer) orchestrated as a configurable team pipeline.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin for Codex, Claude Code, and Cline with structured planning, review, and verification guardrails.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-03-30",
-  "total": 19,
+  "total": 20,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -38,6 +38,16 @@
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/nyldn/claude-octopus/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Codex Agenteam",
+      "url": "https://github.com/yimwoo/codex-agenteam",
+      "owner": "yimwoo",
+      "repo": "codex-agenteam",
+      "description": "Specialist AI agents (researcher, PM, architect, developer, QA, reviewer) orchestrated as a configurable team pipeline.",
+      "category": "Development & Workflow",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/yimwoo/codex-agenteam/main/.codex-plugin/plugin.json"
     },
     {
       "name": "Codex Multi Auth",


### PR DESCRIPTION
## Summary

- Adds [Codex Agenteam](https://github.com/yimwoo/codex-agenteam) to the **Development & Workflow** section
- Specialist AI agents (researcher, PM, architect, developer, QA, reviewer) orchestrated as a configurable team pipeline
- Regenerated `plugins.json` to stay in sync

## Checklist

- [x] Public GitHub repository
- [x] Includes `.codex-plugin/plugin.json` manifest
- [x] Functional plugin (not a placeholder)
- [x] Entry alphabetized within section
- [x] `plugins.json` regenerated via `python3 scripts/generate_plugins_json.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)