### PR TITLE
Add ru-text: Russian text quality plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [OpenProject](https://github.com/varaprasadreddy9676/team-codex-plugins) - Team collaboration via OpenProject integration.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
+- [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
 
 


### PR DESCRIPTION
## Summary

- Adds [ru-text](https://github.com/talkstream/ru-text) to the **Tools & Integrations** section
- ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence
- Full `.codex-plugin/plugin.json` manifest, MIT licensed
- Cross-platform: Codex CLI, Claude Code, Gemini CLI, Cursor

Submitted in response to [talkstream/ru-text#1](https://github.com/talkstream/ru-text/issues/1) — thanks @internet-dot for the invitation!