### PR TITLE
Add ru-text to plugins.json registry

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-03-30",
-  "total": 20,
+  "last_updated": "2026-03-31",
+  "total": 21,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -198,6 +198,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/papersflow-ai/papersflow-codex-plugin/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "ru-text",
+      "url": "https://github.com/talkstream/ru-text",
+      "owner": "talkstream",
+      "repo": "ru-text",
+      "description": "Russian text quality \u2014 ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/talkstream/ru-text/main/.codex-plugin/plugin.json"
     },
     {
       "name": "Yandex Direct",


### PR DESCRIPTION
## Summary

Follow-up to #11 — adds the machine-readable `plugins.json` registry entry for ru-text as recommended by @gemini-code-assist code review.

- Adds entry in alphabetical order
- Increments `total` to 21
- Updates `last_updated` to 2026-03-31