### PR TITLE
Add KiCad Happy to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Be Serious](https://github.com/lulucatdev/codex-be-serious) - Enforce formal, textbook-grade written register across all agent output.
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
+- [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.
 - [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-03-30",
-  "total": 21,
+  "total": 22,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -138,6 +138,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/Rothschildiuk/context-pack/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "KiCad Happy",
+      "url": "https://github.com/aklofas/kicad-happy",
+      "owner": "aklofas",
+      "repo": "kicad-happy",
+      "description": "KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/aklofas/kicad-happy/main/.codex-plugin/plugin.json"
     },
     {
       "name": "Langfuse Observability",


### PR DESCRIPTION
## Summary
- Adds [KiCad Happy](https://github.com/aklofas/kicad-happy) to the **Tools & Integrations** section
- KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation
- MIT licensed, includes `.codex-plugin/plugin.json` manifest, also works with Claude Code

## Checklist
- [x] Public GitHub repository
- [x] Includes `.codex-plugin/plugin.json` manifest
- [x] Functional plugin (not a placeholder)
- [x] Entry alphabetized within section
- [x] `plugins.json` regenerated via `python3 scripts/generate_plugins_json.py`