### PR TITLE
Add Bitbucket CLI to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 ### Tools & Integrations
 
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
+- [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
 - [Codex Be Serious](https://github.com/lulucatdev/codex-be-serious) - Enforce formal, textbook-grade written register across all agent output.
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-03-30",
-  "total": 22,
+  "total": 23,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -98,6 +98,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/matk0shub/apple-productivity-mcp/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Bitbucket CLI",
+      "url": "https://github.com/avivsinai/bitbucket-cli",
+      "owner": "avivsinai",
+      "repo": "bitbucket-cli",
+      "description": "Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/avivsinai/bitbucket-cli/main/.codex-plugin/plugin.json"
     },
     {
       "name": "Chrome DevTools",


### PR DESCRIPTION
## Summary

- Adds [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) (`bkt`) to **Community Plugins > Tools & Integrations**
- Entry added to both `README.md` and `plugins.json`, alphabetized
- Plugin has a verified `.codex-plugin/plugin.json` manifest (v0.14.2, MIT license)

**Description:** Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.

Ref: avivsinai/bitbucket-cli#100