### PR TITLE
Add Claude Code Skills to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
 - [Claude Octopus](https://github.com/nyldn/claude-octopus) - Multi-LLM orchestration dispatching to 8 providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) with Double Diamond workflows, adversarial review, and safety gates.
+- [Claude Code Skills](https://github.com/alirezarezvani/claude-skills) - 205 production-ready skills, 16 agents, and 268 Python tools across 9 domains — engineering, marketing, product, compliance, and more. Works with Codex, Claude Code, Gemini CLI, Cursor, and 7 other tools.
 - [Codex Agenteam](https://github.com/yimwoo/codex-agenteam) - Specialist AI agents (researcher, PM, architect, developer, QA, reviewer) orchestrated as a configurable team pipeline.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.


### PR DESCRIPTION
Adds [Claude Code Skills](https://github.com/alirezarezvani/claude-skills) to the Development & Workflow section.

- 205 production-ready skills across 9 domains (engineering, marketing, product, compliance, finance, etc.)
- 16 orchestration agents, 268 stdlib-only Python CLI tools
- Native Codex CLI support with `.codex/skills-index.json` and symlinks
- Also works with Claude Code, Gemini CLI, Cursor, Aider, Windsurf, and 5 more tools
- 7,100+ GitHub stars

Responding to the invitation in [alirezarezvani/claude-skills#443](https://github.com/alirezarezvani/claude-skills/issues/443).