### PR TITLE
Add Jenkins CLI community plugin entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Be Serious](https://github.com/lulucatdev/codex-be-serious) - Enforce formal, textbook-grade written register across all agent output.
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
+- [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.


### PR DESCRIPTION
## Summary\n- add Jenkins CLI to Community Plugins > Tools & Integrations\n- keep the entry alphabetical and one-line per the contribution guidelines\n\n## Entry\n- [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.\n\n## Validation\n- confirmed the repository is public and includes a valid .codex-plugin/plugin.json manifest\n- verified the README insertion remains alphabetical within the section\n