### PR TITLE
Add Agent Message Queue to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 
 ### Tools & Integrations
 
+- [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 <!-- pinned -->
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
-- [Claude Octopus](https://github.com/nyldn/claude-octopus) - Multi-LLM orchestration dispatching to 8 providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) with Double Diamond workflows, adversarial review, and safety gates.
 - [Claude Code Skills](https://github.com/alirezarezvani/claude-skills) - 223 production-ready skills, 23 agents, and 298 Python tools across 9 domains — engineering, marketing, product, compliance, and more.
+- [Claude Octopus](https://github.com/nyldn/claude-octopus) - Multi-LLM orchestration dispatching to 8 providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) with Double Diamond workflows, adversarial review, and safety gates.
 - [Codex Agenteam](https://github.com/yimwoo/codex-agenteam) - Specialist AI agents (researcher, PM, architect, developer, QA, reviewer) orchestrated as a configurable team pipeline.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-03-31",
-  "total": 26,
+  "total": 27,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-03-31",
-  "total": 25,
+  "total": 26,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -30,16 +30,6 @@
       "install_url": "https://raw.githubusercontent.com/boshu2/agentops/main/.codex-plugin/plugin.json"
     },
     {
-      "name": "Claude Octopus",
-      "url": "https://github.com/nyldn/claude-octopus",
-      "owner": "nyldn",
-      "repo": "claude-octopus",
-      "description": "Multi-LLM orchestration dispatching to 8 providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) with Double Diamond workflows, adversarial review, and safety gates.",
-      "category": "Development & Workflow",
-      "source": "awesome-codex-plugins",
-      "install_url": "https://raw.githubusercontent.com/nyldn/claude-octopus/main/.codex-plugin/plugin.json"
-    },
-    {
       "name": "Claude Code Skills",
       "url": "https://github.com/alirezarezvani/claude-skills",
       "owner": "alirezarezvani",
@@ -48,6 +38,16 @@
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Claude Octopus",
+      "url": "https://github.com/nyldn/claude-octopus",
+      "owner": "nyldn",
+      "repo": "claude-octopus",
+      "description": "Multi-LLM orchestration dispatching to 8 providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) with Double Diamond workflows, adversarial review, and safety gates.",
+      "category": "Development & Workflow",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/nyldn/claude-octopus/main/.codex-plugin/plugin.json"
     },
     {
       "name": "Codex Agenteam",
@@ -98,6 +98,16 @@
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/AlexMi64/codex-project-autopilot/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Agent Message Queue",
+      "url": "https://github.com/avivsinai/agent-message-queue",
+      "owner": "avivsinai",
+      "repo": "agent-message-queue",
+      "description": "File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/avivsinai/agent-message-queue/main/.codex-plugin/plugin.json"
     },
     {
       "name": "Apple Productivity",


### PR DESCRIPTION
## Summary
- add Agent Message Queue to the Community Plugins list under Tools & Integrations
- use the repository's plugin description as the one-line entry

## Why
This plugin already ships a public `.codex-plugin/plugin.json` manifest and fits the existing third-party tools section.
