### PR TITLE
Add TokRepo Search plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.
+- [TokRepo Search](https://github.com/henu-wang/tokrepo-codex-plugin) - Search and install AI assets from TokRepo with a bundled skill and MCP server for Codex.
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
 
 


### PR DESCRIPTION
This adds TokRepo Search as a Codex plugin entry.

Why it fits:
- the linked repository includes a valid `.codex-plugin/plugin.json` manifest
- it bundles a Codex skill plus TokRepo MCP server wiring
- it gives Codex users a direct way to discover installable skills, prompts, MCP configs, and workflows

Happy to adjust the wording if you prefer a different description.