### PR TITLE
Add Codex SEO plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
 - [Codex Be Serious](https://github.com/lulucatdev/codex-be-serious) - Enforce formal, textbook-grade written register across all agent output.
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.
+- [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-04-03",
-  "total": 31,
+  "total": 32,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -178,6 +178,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/2kDarki/codex-mem/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Codex SEO",
+      "url": "https://github.com/BestLemoon/codex-seo",
+      "owner": "BestLemoon",
+      "repo": "codex-seo",
+      "description": "Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/BestLemoon/codex-seo/main/.codex-plugin/plugin.json"
     },
     {
       "name": "Context Pack",


### PR DESCRIPTION
## What changed
- add `Codex SEO` to the `Tools & Integrations` section in `README.md`
- add the matching plugin entry to `plugins.json`
- keep ordering alphabetical within the category

## Why
`Codex SEO` is now a public Codex plugin repository with a valid `.codex-plugin/plugin.json`, installation docs, local assets, scanner CI, and a clean scanner preflight.

## Validation
- `python3 -m json.tool plugins.json`
- `node build.js`
- local `codex-plugin-scanner lint . --format text` on the plugin repo returns `effective_score=100` and `policy_pass=True`

## Plugin
- Repo: https://github.com/BestLemoon/codex-seo
- Manifest: https://raw.githubusercontent.com/BestLemoon/codex-seo/main/.codex-plugin/plugin.json
