### PR TITLE
[codex] Add Remotion Plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
+- [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex with the official Remotion docs MCP, composition scaffolding, and a data-driven launch-video workflow.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.
 - [Task Scheduler](https://github.com/6Delta9/task-scheduler-codex-plugin) - OpenAI Codex plugin and local MCP server for turning task lists into realistic schedules with blocked dates, capacity overrides, overflow tracking, and markdown planning output.
 - [TokRepo Search](https://github.com/henu-wang/tokrepo-codex-plugin) - Search and install AI assets from TokRepo with a bundled skill and MCP server for Codex.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-04-03",
-  "total": 31,
+  "total": 32,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -278,6 +278,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/papersflow-ai/papersflow-codex-plugin/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Remotion Plugin",
+      "url": "https://github.com/tim-osterhus/codex-remotion-plugin",
+      "owner": "tim-osterhus",
+      "repo": "codex-remotion-plugin",
+      "description": "Build parameterized Remotion videos in Codex with the official Remotion docs MCP, composition scaffolding, and a data-driven launch-video workflow.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/tim-osterhus/codex-remotion-plugin/main/.codex-plugin/plugin.json"
     },
     {
       "name": "ru-text",


### PR DESCRIPTION
## Summary
- add the Remotion Plugin entry to the Community Plugins list under Tools & Integrations
- link to the public plugin repo at `tim-osterhus/codex-remotion-plugin`

## Why
- the plugin is public, functional, and documented
- the repository includes `.codex-plugin/plugin.json`

## Validation
- `codex-plugin-scanner lint . --format text` on `tim-osterhus/codex-remotion-plugin` reports `effective_score=100`
- verified the README entry is alphabetized in the target section
