### PR TITLE
Add Upwork Autopilot to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.
 - [Task Scheduler](https://github.com/6Delta9/task-scheduler-codex-plugin) - OpenAI Codex plugin and local MCP server for turning task lists into realistic schedules with blocked dates, capacity overrides, overflow tracking, and markdown planning output.
 - [TokRepo Search](https://github.com/henu-wang/tokrepo-codex-plugin) - Search and install AI assets from TokRepo with a bundled skill and MCP server for Codex.
+- [Upwork Autopilot](https://github.com/klajdikkolaj/upwork-autopilot) - Controlled Upwork job search, qualification, and proposal submission sessions through a dedicated Chrome profile.
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
 
 

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-04-03",
-  "total": 31,
+  "total": 32,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -308,6 +308,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/henu-wang/tokrepo-codex-plugin/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Upwork Autopilot",
+      "url": "https://github.com/klajdikkolaj/upwork-autopilot",
+      "owner": "klajdikkolaj",
+      "repo": "upwork-autopilot",
+      "description": "Controlled Upwork job search, qualification, and proposal submission sessions through a dedicated Chrome profile.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/klajdikkolaj/upwork-autopilot/main/.codex-plugin/plugin.json"
     },
     {
       "name": "Yandex Direct",


### PR DESCRIPTION
## Summary
- add Upwork Autopilot to the Community Plugins / Tools & Integrations section
- keep the list alphabetized within the category

## Notes
- plugin repo: https://github.com/klajdikkolaj/upwork-autopilot
- scanner workflow is already configured in the plugin repo's existing validate workflow