### PR TITLE
Add Flow Studio Power Automate to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
+- [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.

--- a/plugins.json
+++ b/plugins.json
@@ -44,7 +44,7 @@
       "url": "https://github.com/hyhmrright/brooks-lint",
       "owner": "hyhmrright",
       "repo": "brooks-lint",
-      "description": "AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).",
+      "description": "AI code reviews grounded in six classic engineering books \u2014 decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).",
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/hyhmrright/brooks-lint/main/.codex-plugin/plugin.json"
@@ -64,7 +64,7 @@
       "url": "https://github.com/alirezarezvani/claude-skills",
       "owner": "alirezarezvani",
       "repo": "claude-skills",
-      "description": "223 production-ready skills, 23 agents, and 298 Python tools across 9 domains — engineering, marketing, product, compliance, and more.",
+      "description": "223 production-ready skills, 23 agents, and 298 Python tools across 9 domains \u2014 engineering, marketing, product, compliance, and more.",
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/.codex-plugin/plugin.json"
@@ -210,6 +210,16 @@
       "install_url": "https://raw.githubusercontent.com/Rothschildiuk/context-pack/main/.codex-plugin/plugin.json"
     },
     {
+      "name": "Flow Studio Power Automate",
+      "url": "https://github.com/ninihen1/power-automate-mcp-skills",
+      "owner": "ninihen1",
+      "repo": "power-automate-mcp-skills",
+      "description": "Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/ninihen1/power-automate-mcp-skills/master/.codex-plugin/plugin.json"
+    },
+    {
       "name": "Jenkins CLI",
       "url": "https://github.com/avivsinai/jenkins-cli",
       "owner": "avivsinai",
@@ -304,7 +314,7 @@
       "url": "https://github.com/talkstream/ru-text",
       "owner": "talkstream",
       "repo": "ru-text",
-      "description": "Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.",
+      "description": "Russian text quality \u2014 ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.",
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/talkstream/ru-text/main/.codex-plugin/plugin.json"


### PR DESCRIPTION
## Plugin

**Flow Studio Power Automate** — Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.

- **GitHub:** https://github.com/ninihen1/power-automate-mcp-skills
- **Plugin manifest:** `.codex-plugin/plugin.json`
- **Skills:** 3 (power-automate-mcp, power-automate-debug, power-automate-build)

## What it does

Gives AI agents the same visibility you have in the Power Automate portal. The Graph API only returns top-level run status — Flow Studio MCP exposes action-level inputs, outputs, loop iterations, and nested child flow failures.

## Also available on

- [awesome-copilot](https://github.com/github/awesome-copilot) (merged)
- [skills.sh](https://skills.sh/?q=flowstudio) (3K+ installs)
- [Smithery](https://smithery.ai/skills/flowstudio/power-automate-mcp)
- [ClawHub](https://clawhub.ai/skills/power-automate-mcp) (v1.1.0, 221 downloads)

## Changes

- Added entry to README.md under Tools & Integrations (alphabetical)
- Added entry to plugins.json