### PR TITLE
Add VibePortrait — developer personality portrait plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin for Codex, Claude Code, and Cline with structured planning, review, and verification guardrails.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
+- [VibePortrait](https://github.com/dadwadw233/VibePortrait) - Developer personality portrait generator — analyzes AI conversation history to produce MBTI type (16 color themes), capability radar, developer rating, 3-dimension famous match, and a persona skill that lets any AI "think like you".
 
 ### Tools & Integrations
 


### PR DESCRIPTION
Adds VibePortrait to the Development & Workflow section.

**VibePortrait** analyzes your Claude Code / Codex conversation history and generates:
- HTML portrait: MBTI type (16 color themes), capability radar, developer rating, 3-dimension famous match
- Persona skill: multi-file skill capturing thinking patterns, letting any AI "think like you"
- One-click PNG export, multi-machine sync via private GitHub repo

Companion to [claude-code-harness](https://github.com/dadwadw233/claude-code-harness) (already listed).

GitHub: https://github.com/dadwadw233/VibePortrait
License: MIT