### PR TITLE
Add Auto Pilot to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 <!-- pinned -->
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
+- [Auto Pilot](https://github.com/minsu0707/auto-pilot) - Intake-first Codex plugin that turns a short project request into a structured, resumable execution workflow with one-question-at-a-time intake, project contract files, blocker triage, and resume support.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development pipeline that turns natural language into domain blueprints with testable acceptance criteria, generates parallel build plans, and implements them with automated validation and cross-model adversarial review.
 - [Brooks Lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).
 - [Claude Code Harness](https://github.com/dadwadw233/claude-code-harness) - Harness blueprint skill for turning vague agent ideas into concrete designs for request assembly, control loops, memory, permissions, recovery, and extension planes.


### PR DESCRIPTION
## Summary\n- add Auto Pilot to the Community Plugins > Development & Workflow section\n\n## Why this fits\n- Auto Pilot is a public Codex plugin repository\n- It includes a .codex-plugin/plugin.json manifest\n- It is documented and installable\n- It focuses on intake-first execution flow, blocker handling, and resume support