### PR TITLE
Add sitemd plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
 - [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex with the official Remotion docs MCP, composition scaffolding, and a data-driven launch-video workflow.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.
+- [sitemd](https://github.com/sitemd-cc/sitemd) - Build websites from Markdown via MCP — 22 tools for creating pages, generating content, validating, running SEO audits, configuring settings, and deploying static sites to Cloudflare Pages.
 - [Synta MCP](https://github.com/Synta-ai/n8n-mcp-codex-plugin-synta) - Build, edit, validate, and self-heal n8n workflows with Synta MCP tools and Codex-ready workflow guidance.
 - [Task Scheduler](https://github.com/6Delta9/task-scheduler-codex-plugin) - OpenAI Codex plugin and local MCP server for turning task lists into realistic schedules with blocked dates, capacity overrides, overflow tracking, and markdown planning output.
 - [TokRepo Search](https://github.com/henu-wang/tokrepo-codex-plugin) - Search and install AI assets from TokRepo with a bundled skill and MCP server for Codex.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-04-06",
-  "total": 39,
+  "total": 40,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -348,6 +348,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/talkstream/ru-text/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "sitemd",
+      "url": "https://github.com/sitemd-cc/sitemd",
+      "owner": "sitemd-cc",
+      "repo": "sitemd",
+      "description": "Build websites from Markdown via MCP — 22 tools for creating pages, generating content, validating, running SEO audits, configuring settings, and deploying static sites to Cloudflare Pages.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/sitemd-cc/sitemd/main/.codex-plugin/plugin.json"
     },
     {
       "name": "Synta MCP",


### PR DESCRIPTION
Adds [sitemd-cc/sitemd](https://github.com/sitemd-cc/sitemd) under **Community Plugins → Tools & Integrations**.

sitemd is a Codex plugin (and MCP server) that builds websites from Markdown. 22 MCP tools cover page creation, content generation, content validation, SEO audits, settings management, and one-command deployment to Cloudflare Pages. Ships a `.codex-plugin/plugin.json` manifest at the repo root.

- Repo: https://github.com/sitemd-cc/sitemd
- Site: https://sitemd.cc
- Insertion point: alphabetical, between `ru-text` and `Synta MCP`

Submitting at the maintainer's invitation.