### PR TITLE
Add Toprank to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Synta MCP](https://github.com/Synta-ai/n8n-mcp-codex-plugin-synta) - Build, edit, validate, and self-heal n8n workflows with Synta MCP tools and Codex-ready workflow guidance.
 - [Task Scheduler](https://github.com/6Delta9/task-scheduler-codex-plugin) - OpenAI Codex plugin and local MCP server for turning task lists into realistic schedules with blocked dates, capacity overrides, overflow tracking, and markdown planning output.
 - [TokRepo Search](https://github.com/henu-wang/tokrepo-codex-plugin) - Search and install AI assets from TokRepo with a bundled skill and MCP server for Codex.
+- [Toprank](https://github.com/nowork-studio/toprank) - Open-source MIT Claude Code plugin with 9 SEO and Google Ads skills that connects Google Search Console, PageSpeed Insights, and the Google Ads API, and can ship fixes such as meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes.
 - [Upwork Autopilot](https://github.com/klajdikkolaj/upwork-autopilot) - Controlled Upwork job search, qualification, and proposal submission sessions through a dedicated Chrome profile.
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
 


### PR DESCRIPTION
## Summary
- add Toprank to `README.md` under `Tools & Integrations`
- list it as an open-source MIT Claude Code plugin with SEO and Google Ads automation workflows
- keep the section alphabetical by inserting it after `TokRepo Search`

## Why it fits
Toprank is MIT-licensed, has 185 GitHub stars, and was actively maintained as of April 9, 2026. It is a Claude Code plugin focused on practical developer workflows around SEO and Google Ads, with skills that connect Google Search Console, PageSpeed Insights, and the Google Ads API to ship concrete fixes like meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes.

## Placement note
This repository does not currently have a `Developer Productivity Tools` category, so `Tools & Integrations` is the closest existing section for a workflow-oriented plugin with external API integrations.

## File updated
- `README.md` (`Tools & Integrations`)
