### PR TITLE
feat: add rust reverse engineering listing

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -437,6 +437,18 @@
       "category": "Tools & Integrations"
     },
     {
+      "name": "rust-reverse-engineering",
+      "source": {
+        "source": "local",
+        "path": "./plugins/jingjing2222/rust-reverse-engineering-skill"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tools & Integrations"
+    },
+    {
       "name": "sitemd",
       "source": {
         "source": "local",

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
 - [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex with the official Remotion docs MCP, composition scaffolding, and a data-driven launch-video workflow.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.
+- [Rust Reverse Engineering](https://github.com/jingjing2222/rust-reverse-engineering-skill) - Reverse engineer Rust binaries and libraries: triage targets, demangle symbols, recover crate namespaces, and map panic, unwind, async, and FFI paths.
 - [sitemd](https://github.com/sitemd-cc/sitemd) - Build websites from Markdown via MCP — 22 tools for creating pages, generating content, validating, running SEO audits, configuring settings, and deploying static sites to Cloudflare Pages.
 - [Synta MCP](https://github.com/Synta-ai/n8n-mcp-codex-plugin-synta) - Build, edit, validate, and self-heal n8n workflows with Synta MCP tools and Codex-ready workflow guidance.
 - [Task Scheduler](https://github.com/6Delta9/task-scheduler-codex-plugin) - OpenAI Codex plugin and local MCP server for turning task lists into realistic schedules with blocked dates, capacity overrides, overflow tracking, and markdown planning output.
@@ -201,12 +202,12 @@ The score is best used as a quick trust signal and triage summary (not the only 
 
 - [agentskills.io](https://agentskills.io) - Open agent skills standard.
 - [antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills#readme) - Cross-agent skill library (Claude, Codex, Cursor, Gemini).
+- [awesome-ai-plugins](https://github.com/hashgraph-online/awesome-ai-plugins) - Umbrella list covering Codex, Claude Code, Gemini CLI, and MCP servers.
 - [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code#readme) - Claude Code resources.
 - [awesome-coding-agents](https://github.com/e2b-dev/awesome-ai-agents#readme) - Curated list of AI coding agents.
 - [awesome-mcp-servers](https://github.com/wong2/awesome-mcp-servers#readme) - MCP server directory.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) - Voice-enabled audio layer for coding agents with ambient soundscapes, event-driven SFX, and optional cloud TTS/ASR interaction.
 - [HOL Plugin Registry](https://hol.org/registry/plugins) - Browse plugins with scanner-backed security analysis and trust scores.
-- [awesome-ai-plugins](https://github.com/hashgraph-online/awesome-ai-plugins) - Umbrella list covering Codex, Claude Code, Gemini CLI, and MCP servers.
 
 ## Plugin Trust Scores
 

--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-04-17",
-  "total": 42,
+  "last_updated": "2026-04-19",
+  "total": 43,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -368,6 +368,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/talkstream/ru-text/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Rust Reverse Engineering",
+      "url": "https://github.com/jingjing2222/rust-reverse-engineering-skill",
+      "owner": "jingjing2222",
+      "repo": "rust-reverse-engineering-skill",
+      "description": "Reverse engineer Rust binaries and libraries: triage targets, demangle symbols, recover crate namespaces, and map panic, unwind, async, and FFI paths.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/jingjing2222/rust-reverse-engineering-skill/main/.codex-plugin/plugin.json"
     },
     {
       "name": "sitemd",

--- a/plugins/JuliusBrussee/blueprint/README.md
+++ b/plugins/JuliusBrussee/blueprint/README.md
@@ -16,106 +16,46 @@
 </p>
 
 <p align="center">
+  <a href="#the-loop">The loop</a> •
   <a href="#install">Install</a> •
-  <a href="#before--after">Before/After</a> •
-  <a href="#how-it-works">How It Works</a> •
-  <a href="#quick-start">Quick Start</a> •
-  <a href="#parallel-execution">Parallel Execution</a> •
-  <a href="#codex-adversarial-review">Codex Review</a> •
+  <a href="#your-first-run">Your first run</a> •
+  <a href="#adding-to-an-existing-repo">Existing repo</a> •
   <a href="#commands">Commands</a> •
+  <a href="#how-it-works">How it works</a> •
   <a href="example.md">Examples</a>
 </p>
 
 <p align="center">
-  Part of the <a href="https://github.com/JuliusBrussee/caveman">Caveman</a> ecosystem
+  <strong>🪨 Caveman Ecosystem</strong> &nbsp;·&nbsp;
+  <a href="https://github.com/JuliusBrussee/caveman">caveman</a> <em>talk less</em> &nbsp;·&nbsp;
+  <a href="https://github.com/JuliusBrussee/cavemem">cavemem</a> <em>remember more</em> &nbsp;·&nbsp;
+  <strong>cavekit</strong> <em>build better</em> <sub>(you are here)</sub>
 </p>
 
 ---
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin that turns natural language into **specs**, specs into **parallel build plans**, and build plans into **working software** — with automated iteration, validation, and dual-model adversarial review.
+A Cavekit bundle for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Codex](https://developers.openai.com/codex/skills) that turns natural language into **specs**, specs into **parallel build plans**, and build plans into **working software** — with an autonomous loop, validation gates, and optional cross-model review.
 
-You describe what you want. Cavekit writes the contract. Agents build from the contract. Every line of code traces to a requirement. Every requirement has acceptance criteria. Nothing gets lost, nothing gets guessed.
-
-## Before / After
-
-<table>
-<tr>
-<td width="50%">
-
-### Without Cavekit
-
-```
-> Build me a task management API
-
-  (agent writes 2000 lines)
-  (no tests)
-  (forgot the auth middleware)
-  (wrong database schema)
-  (you spend 3 hours fixing it)
-```
-
-One shot. No validation. No traceability.
-The agent guessed what you wanted.
-
-</td>
-<td width="50%">
-
-### With Cavekit
-
-```
-> /ck:sketch
-  4 kits, 22 requirements, 69 criteria
-
-> /ck:map
-  34 tasks across 5 dependency tiers
-
-> /ck:make
-  18 iterations — each validated against
-  the spec before committing
-
-  CAVEKIT COMPLETE
-```
-
-Every requirement traced. Every criterion checked.
-
-</td>
-</tr>
-</table>
-
-**Same feature. Zero guesswork. Full traceability.**
+You describe what you want. Cavekit writes the contract. Agents build from the contract. Every line of code traces to a requirement. Every requirement has acceptance criteria.
 
 ---
 
-## The Problem
-
-AI coding agents are powerful, but they fail the same way every time:
-
-| Failure | What Happens |
-|---------|-------------|
-| **Context loss** | Agent forgets what it said three steps ago |
-| **No validation** | Code written, never verified against intent |
-| **No parallelism** | One agent, one task, one branch — even when work is independent |
-| **No iteration** | Single pass produces a rough draft, not production code |
-
-Cavekit fixes all four.
-
----
-
-## The Idea
-
-Instead of "prompt and pray," Cavekit puts a **specification layer** between your intent and the code.
+## The Loop
 
 ```
-                        ┌─── Task 1 ─── Agent A ───┐
-                        │                           │
-You ── /ck:sketch ──► Kits ── /ck:map ──► Build Site ──┤─── Task 2 ─── Agent B ───┤──► done
-                        │                           │
-                        └─── Task 3 ─── Agent C ───┘
+/ck:sketch   →   /ck:map   →   /ck:make   →   /ck:check
+ what to         how to        build it       verify
+  build          build it                       it
 ```
 
-Kits are the source of truth. Agents read them, build from them, validate against them. When something breaks, the system traces the failure back to the kit — not the code.
+Four commands. In that order. That is the whole main cycle.
 
-Spec is the product. Code is the derivative.
+- **`/ck:sketch`** — decompose your project into domains, write kits with R-numbered requirements and testable acceptance criteria.
+- **`/ck:map`** — read kits, generate a tiered build site with a task dependency graph.
+- **`/ck:make`** — autonomous parallel build loop. Ready tasks grouped into packets, validated, merged wave by wave. Runs until all tasks are done or a budget trips.
+- **`/ck:check`** — gap analysis against kits + peer review of the code. Produces an APPROVE / REVISE / REJECT verdict and auto-amends kits when gaps appear.
+
+One shortcut: **`/ck:ship "<description>"`** runs all four end-to-end with no user gates. For tiny features and throwaways — the guided path is better for anything non-trivial, because the design conversation is where the value is.
 
 ---
 
@@ -126,11 +66,123 @@ git clone https://github.com/JuliusBrussee/cavekit.git ~/.cavekit
 cd ~/.cavekit && ./install.sh
 ```
 
-Registers the plugin with Claude Code, syncs into Codex marketplace, installs the `cavekit` CLI. Restart Claude Code after installing.
+Configures Cavekit for Claude Code, links the Codex bundle, and installs the `cavekit` CLI. Restart Claude Code and Codex after installing.
+
+### Agent Surfaces
+
+- **Claude Code**: Cavekit is consumed primarily as slash commands and subagents. Anthropic's public docs describe project and user commands under `.claude/commands/` and subagents under `.claude/agents/`.
+- **Codex**: Cavekit is consumed as Codex skills and plugin-bundled assets. OpenAI's docs describe skills as `SKILL.md`-based workflows, with plugins as the installable distribution unit.
+- Cavekit ships both surfaces so the same methodology can be used from Claude Code and Codex, but they are **not** the same extension mechanism under the hood.
 
 **Requires:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), git, macOS/Linux.
 
-**Optional:** [Codex](https://github.com/openai/codex) (`npm install -g @openai/codex`) — adds adversarial review. Cavekit works without it. Codex makes it significantly harder to ship flawed specs and broken code.
+**Optional:** [Codex](https://github.com/openai/codex) (`npm install -g @openai/codex`) — adds adversarial review. Cavekit works without it.
+
+---
+
+## Your First Run
+
+Greenfield. New repo. You want a task-management API.
+
+```
+> /ck:init
+  Context hierarchy created. Capabilities detected.
+  Next: /ck:sketch
+
+> /ck:sketch
+  What are you building?
+
+> A REST API for task management. Users, projects, tasks with
+  priorities and due dates. PostgreSQL.
+
+  (design conversation — research if warranted, domain decomposition,
+   acceptance criteria refinement)
+
+  4 kits, 22 requirements, 69 acceptance criteria.
+  Next: /ck:map
+
+> /ck:map
+  34 tasks across 5 tiers. Coverage: 69/69 criteria mapped.
+  Next: /ck:make
+
+> /ck:make
+  Loop active — 34 tasks, 20 max iterations.
+  Wave 1 (3 tasks), Wave 2 (4 tasks), …
+  ALL TASKS DONE. Build passes. Tests pass.
+  Next: /ck:check
+
+> /ck:check
+  Coverage: 100%. Verdict: APPROVE.
+  CAVEKIT COMPLETE
+```
+
+That is the experience.
+
+## Adding to an Existing Repo
+
+Same loop, different first command.
+
+```
+> /ck:sketch --from-code
+  Scanning repo… Next.js 14, Prisma, NextAuth.
+  6 kits reverse-engineered. 4 requirements flagged as gaps (not yet implemented).
+  Next: /ck:map --filter collaboration   (or whichever domain you're adding to)
+
+> /ck:map --filter collaboration
+  8 tasks, 3 tiers.
+  Next: /ck:make
+
+> /ck:make
+  …
+
+> /ck:check
+  Verdict: APPROVE. Design-system compliance: 100%.
+```
+
+See [example.md](example.md) for fully annotated sessions.
+
+---
+
+## Commands
+
+The main cycle is four commands. Everything else is optional.
+
+### Core
+
+| Command | Phase | What it does |
+|---------|-------|--------------|
+| `/ck:sketch` | Draft | Decompose into domains; write kits with R-numbered requirements and testable acceptance criteria |
+| `/ck:map` | Architect | Generate a tiered build site (task dependency graph) from kits |
+| `/ck:make` | Build | Autonomous parallel build loop; validates each task against its criteria |
+| `/ck:check` | Inspect | Gap analysis + peer review; verdict APPROVE / REVISE / REJECT |
+| `/ck:ship` | End-to-end | One-shot sketch → map → make → check, no user gates. Tiny features only. |
+
+### Auxiliary
+
+| Command | What it does |
+|---------|--------------|
+| `/ck:init` | Bootstrap `context/` and `.cavekit/` runtime state. `--tools-only` re-detects capabilities. |
+| `/ck:design` | Create / import / update / audit `DESIGN.md` (9-section visual system) |
+| `/ck:research` | Parallel multi-agent research → brief in `context/refs/` |
+| `/ck:revise` | Trace manual fixes back into kits. `--trace` runs the single-failure backpropagation protocol (auto-invoked on test failure). |
+| `/ck:review` | Branch review: kit compliance + code quality. `--mode gap`, `--codex`, `--tier`, `--strict` narrow scope. |
+| `/ck:status` | Task frontier and runtime state. `--watch` tails the live dashboard. |
+| `/ck:config` | Execution presets and runtime keys. `--global` writes to `~/.cavekit/config`. |
+| `/ck:resume` | Recover an interrupted loop. |
+| `/ck:team` | Multi-person / multi-device coordination (opt-in). See [Teams](#teams). |
+| `/ck:help` | Command reference. |
+
+Run `/ck:help` for flag-level detail on any command.
+
+### CLI
+
+| Command | What it does |
+|---------|--------------|
+| `cavekit monitor` | Interactive launcher — pick build sites, launch in tmux |
+| `cavekit status` | Build site progress |
+| `cavekit kill` | Stop all sessions, clean up worktrees |
+| `cavekit version` | Print version |
+| `cavekit reset` | Clear persisted state |
 
 ---
 
@@ -138,285 +190,79 @@ Registers the plugin with Claude Code, syncs into Codex marketplace, installs th
 
 Four phases. Each one a slash command.
 
-```
-  RESEARCH         DRAFT            ARCHITECT           BUILD              INSPECT
-  ────────         ─────            ─────────           ─────              ───────
-  (optional)       "What are we     Break into tasks,   Auto-parallel:     Gap analysis:
-  Multi-agent       building?"      map dependencies,    /ck:make          built vs.
-  codebase +                        organize into        groups work        intended.
-  web research     Produces:        tiered build site    into adaptive      Peer review.
-                   kits with        + dependency graph   subagent packets   Trace to specs.
-  Produces:        R-numbered                            tier by tier
-  research brief   requirements     Produces:                               Produces:
-                                    task graph           Codex reviews      findings report
-                   Codex challenges                      every tier gate
-                   the design
-```
+### 1. Sketch — define the what
 
-### 0. Research — ground the design (optional)
+Describe what you're building in natural language. Cavekit decomposes it into **domain kits** — structured documents with numbered requirements (R1, R2, …) and testable acceptance criteria. Stack-independent. Human-readable.
 
-```
-/ck:research "build a C+ compiler"
-```
+If Codex is installed, kits go through a [design challenge](#codex-review-modes) — adversarial review that catches decomposition flaws before any code is written.
 
-Dispatches 2–8 parallel subagents to explore the codebase and search the web for best practices, library landscape, reference implementations, and common pitfalls. A synthesizer agent cross-validates findings and produces a research brief in `context/refs/`.
+Brownfield: `/ck:sketch --from-code` reverse-engineers kits from your code and flags gaps.
 
-### /ck:design — establish the design system
+### 2. Map — plan the order
 
-```
-/ck:design
-```
+Reads every kit. Breaks requirements into tasks. Maps dependencies. Organizes into a **tiered build site** — a dependency graph where Tier 0 has no deps, Tier 1 depends only on Tier 0, and so on. Includes a Coverage Matrix mapping every acceptance criterion to its task(s). Nothing specified gets lost in translation.
 
-Creates or imports a **DESIGN.md** design system — a cross-cutting constraint layer enforced across the entire pipeline. Every kit references its design tokens, every task carries a Design Ref, every build result is audited for violations.
-
-| Sub-command | What it does |
-|------------|-------------|
-| `/ck:design create` | Generate new DESIGN.md via guided Q&A |
-| `/ck:design import` | Extract DESIGN.md from existing codebase |
-| `/ck:design audit` | Check implementation against DESIGN.md |
-| `/ck:design update` | Revise DESIGN.md, log to changelog |
-
-### 1. Draft — define the what
-
-```
-/ck:sketch
-```
-
-Describe what you're building in natural language. Cavekit decomposes it into **domain kits** — structured documents with numbered requirements (R1, R2, ...) and testable acceptance criteria. Stack-independent. Human-readable.
-
-After internal review, kits go to Codex for a [design challenge](#design-challenge--catch-spec-flaws-before-building) — adversarial review that catches decomposition flaws, missing requirements, and ambiguous criteria before any code is written.
-
-For existing codebases: `/ck:sketch --from-code` reverse-engineers kits from your code and identifies gaps.
-
-### 2. Architect — plan the order
-
-```
-/ck:map
-```
-
-Reads all kits. Breaks requirements into tasks. Maps dependencies. Organizes into a **tiered build site** — a dependency graph where Tier 0 has no deps, Tier 1 depends only on Tier 0, and so on. Includes a **Coverage Matrix** mapping every acceptance criterion to its task(s). Nothing specified gets lost in translation.
-
-### 3. Build — run the loop
-
-```
-/ck:make
-```
+### 3. Make — run the loop
 
 Pre-flight coverage check validates all acceptance criteria are covered. Then the loop runs:
 
 ```
-  ┌──────────────────────────────────────────────────────┐
-  │                                                      │
-  │  Read build site → Find next unblocked task          │
-  │       │                                              │
-  │       ▼                                              │
-  │  Load relevant kit + acceptance criteria             │
-  │       │                                              │
-  │       ▼                                              │
-  │  Implement the task                                  │
-  │       │                                              │
-  │       ▼                                              │
-  │  Validate (build + tests + acceptance criteria)      │
-  │       │                                              │
-  │       ├── PASS → commit → mark done → next ──┐      │
-  │       │                                       │      │
-  │       └── FAIL → diagnose → fix → revalidate  │      │
-  │                                               │      │
-  │  ◄────────────────────────────────────────────┘      │
-  │                                                      │
-  │  Loop until: all tasks done OR limit reached         │
-  └──────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│  Read build site → Find next unblocked task          │
+│       ▼                                              │
+│  Load kit + acceptance criteria                      │
+│       ▼                                              │
+│  Implement task                                      │
+│       ▼                                              │
+│  Validate (build + tests + acceptance criteria)      │
+│       ▼                                              │
+│  PASS → commit → mark done → next ──┐                │
+│  FAIL → diagnose → fix → revalidate │                │
+│  ◄──────────────────────────────────┘                │
+│                                                      │
+│  Loop until: all tasks done OR budget exhausted      │
+└──────────────────────────────────────────────────────┘
 ```
 
-At every tier boundary, [Codex adversarial review](#codex-adversarial-review) gates advancement. P0/P1 findings must be fixed before the next tier starts. With speculative review (default), this adds near-zero latency.
-
-Post-flight verification cross-references what was built against original kits. Gaps get remediation tasks.
-
-### 4. Inspect — verify the result
-
-```
-/ck:check
-```
-
-Gap analysis: built vs. specified. Peer review: bugs, security, missed requirements. Everything traced back to kit requirements.
-
----
-
-## Quick Start
-
-**Greenfield:**
-
-```
-> /ck:sketch
-What are you building?
-
-> A REST API for task management. Users, projects, tasks
-  with priorities and due dates. PostgreSQL.
-
-Created 4 kits (22 requirements, 69 acceptance criteria)
-Next: /ck:map
-
-> /ck:map
-Generated build site: 34 tasks, 5 tiers
-Next: /ck:make
-
-> /ck:make
-Loop activated — 34 tasks, 20 max iterations.
-...
-All tasks done. Build passes. Tests pass.
-CAVEKIT COMPLETE — 34 tasks in 18 iterations.
-```
-
-**Existing codebase:**
-
-```
-> /ck:sketch --from-code
-Exploring codebase... Next.js 14, Prisma, NextAuth.
-Created 6 kits — 4 requirements are gaps (not yet implemented).
-
-> /ck:map --filter collaboration
-Generated build site: 8 tasks, 3 tiers
-
-> /ck:make
-CAVEKIT COMPLETE — 8 tasks in 8 iterations.
-```
-
-See [example.md](example.md) for full annotated sessions.
-
----
-
-## Parallel Execution
-
-`/ck:make` parallelizes automatically. Multiple ready tasks get grouped into coherent work packets and dispatched concurrently.
+`/ck:make` parallelizes automatically. Multiple ready tasks get grouped into coherent work packets and dispatched concurrently:
 
 ```
 ═══ Wave 1 ═══
 3 task(s) ready:
-  T-001: Database schema       (tier 0, deps: none)
-  T-002: Auth middleware        (tier 0, deps: none)
-  T-003: Config loader          (tier 0, deps: none)
+  T-001: Database schema   (tier 0)
+  T-002: Auth middleware   (tier 0)
+  T-003: Config loader     (tier 0)
 
-Dispatching 2 grouped subagents...
-All 3 tasks complete. Merging...
+Dispatching 2 grouped subagents…
+All 3 tasks complete. Merging…
 
 ═══ Wave 2 ═══
 2 task(s) ready:
-  T-004: User endpoints         (tier 1, deps: T-001, T-002)
-  T-005: Health check           (tier 1, deps: T-003)
-
-Dispatching 2 grouped subagents...
-All done.
-
-═══ BUILD COMPLETE ═══
-Waves: 2 | Tasks: 5/5
+  T-004: User endpoints    (tier 1, deps: T-001, T-002)
+  T-005: Health check      (tier 1, deps: T-003)
+…
 ```
 
-| Step | What happens |
-|------|-------------|
-| **Compute frontier** | Find all tasks whose dependencies are complete |
-| **Group** | Bundle frontier into work packets by shared files, subsystem, task size |
-| **Dispatch** | Run packets as parallel subagents |
-| **Merge** | Collect results, compute next frontier |
-| **Repeat** | Wave-by-wave until all tasks done — no manual intervention |
+Circuit breakers prevent infinite loops: 3 test failures → task BLOCKED; all blocked → stop and report.
 
-Circuit breakers prevent infinite loops: 3 test failures → task BLOCKED, all blocked → stop and report.
+At every tier boundary, optional [Codex review](#codex-review-modes) gates advancement. P0/P1 findings must be fixed before the next tier starts. Speculative review (default) adds near-zero latency.
+
+### 4. Check — verify the result
+
+Gap analysis: built vs. specified. Peer review: bugs, security, missed requirements. Everything traced back to kit requirements. Verdict: APPROVE / REVISE / REJECT. Gaps feed back as remediation tasks.
 
 ---
 
-## Codex Adversarial Review
+## Design System (optional)
 
-Cavekit uses [Codex](https://github.com/openai/codex) as an adversarial reviewer — a second model with different training and different blind spots. Catches things Claude cannot see in its own output. Operates at three levels:
-
-### Design Challenge — catch spec flaws before building
-
-After kits are drafted and internally reviewed, the full set goes to Codex:
+If the project has UI, run `/ck:design` first. It creates or imports `DESIGN.md` — a 9-section Google-Stitch-format design system. Every kit then references its design tokens; every UI task carries a Design Ref; every build result is audited for design violations during `/ck:check`.
 
 ```
-Claude drafts            Kit set             Codex challenges         User reviews
-kits ──────► reviewer approves ──────► the design ──────► kits + findings
+/ck:design                       # interactive
+/ck:design --import vercel       # start from a known system
+/ck:design --from-site <url>     # extract tokens from a live site
+/ck:design --audit               # gap-check an existing DESIGN.md
 ```
-
-| Finding type | Behavior |
-|-------------|----------|
-| **Critical** | Must fix before building. Auto-fix loop, up to 2 cycles |
-| **Advisory** | Presented alongside kits at user review gate |
-
-No implementation feedback allowed. No framework suggestions. Only design-level concerns that would cause real problems during build.
-
-### Tier Gate — catch code defects between tiers
-
-Every completed tier triggers a Codex code review before advancing:
-
-```
-═══ Tier 0 Complete ═══
-Codex reviews diff (T-001, T-002, T-003) ...
-Review: 2 findings (1 P0, 1 P3)
-Gate: BLOCKED → fix cycle 1/2
-
-Fixing P0: nil pointer in auth middleware ...
-Re-review ...
-Gate: PROCEED
-
-═══ Tier 1 starting ═══
-```
-
-| Severity | Behavior |
-|----------|----------|
-| **P0** (critical) | Blocks advancement. Auto-generates fix task |
-| **P1** (high) | Blocks advancement. Auto-generates fix task |
-| **P2** (medium) | Logged, does not block |
-| **P3** (low) | Logged, does not block |
-
-Gate modes: `severity` (default — P0/P1 block), `strict` (all block), `permissive` (nothing blocks), `off`.
-
-Fix cycle runs up to 2 iterations per tier. After that, advances with warning. Never deadlocks.
-
-### Speculative Review — eliminate gate latency
-
-Codex reviews the *previous* tier in the background while Claude builds the *current* tier:
-
-```
-Tier 0 complete ───────────────────────────► Tier 1 complete
-     │                                            │
-     └── Codex reviews Tier 0 (background) ──────►│
-                                                   │
-                         Results ready ◄───────────┘
-                         before gate runs
-```
-
-Results are already available when the gate checks. Near-zero latency. Falls back to synchronous if needed.
-
-### Command Safety Gate
-
-PreToolUse hook intercepts every Bash command before execution:
-
-```
-Agent runs command
-     │
-     ▼
-Fast-path check ──► allowlist (50+ safe commands) → approve
-     │           └► blocklist (rm -rf, force push, DROP TABLE) → block
-     │
-     ▼ (ambiguous)
-Codex classifies ──► safe / warn / block
-     │
-     ▼ (cached)
-Verdict cache ──► normalized pattern → reuse verdict
-```
-
-Integrates with Claude Code's permission system. Cached per session. Falls back to static rules when Codex is unavailable — never blocks solely because classifier is unreachable.
-
-### Graceful Degradation
-
-All Codex features are **additive**. Without Codex installed:
-
-| Feature | Fallback |
-|---------|----------|
-| Design challenge | Skipped — internal reviewer still runs |
-| Tier gate | Skipped — build proceeds without review pauses |
-| Command gate | Static allowlist/blocklist only |
-
-Cavekit works the same. Codex makes it harder to ship bad specs and bad code.
 
 ---
 
@@ -429,93 +275,275 @@ Settings live in two places:
 | `~/.cavekit/config` | User default |
 | `.cavekit/config` | Project override (takes precedence) |
 
-| Setting | Values | Default | Purpose |
-|---------|--------|---------|---------|
-| `bp_model_preset` | `expensive` `quality` `balanced` `fast` | `quality` | Model selection for Cavekit commands |
-| `codex_review` | `auto` `off` | `auto` | Enable/disable Codex reviews |
-| `codex_model` | model string | (Codex default) | Model for Codex calls |
-| `tier_gate_mode` | `severity` `strict` `permissive` `off` | `severity` | How findings gate tier advancement |
-| `command_gate` | `all` `interactive` `off` | `all` | Which sessions get command gating |
-| `command_gate_timeout` | milliseconds | `3000` | Codex safety classification timeout |
-| `speculative_review` | `on` `off` | `on` | Background review of previous tier |
-| `speculative_review_timeout` | seconds | `300` | Max wait for speculative results |
-| `caveman_mode` | `on` `off` | `on` | Token-compressed output (~75% savings) |
-| `caveman_phases` | comma-separated | `build,inspect` | Which phases use caveman-speak |
-
-**Model presets:**
+### Model Presets
 
 | Preset | Reasoning | Execution | Exploration |
 |--------|-----------|-----------|-------------|
-| `expensive` | `opus` | `opus` | `opus` |
-| `quality` | `opus` | `opus` | `sonnet` |
-| `balanced` | `opus` | `sonnet` | `haiku` |
-| `fast` | `sonnet` | `sonnet` | `haiku` |
+| `expensive` | opus | opus | opus |
+| `quality` | opus | opus | sonnet |
+| `balanced` | opus | sonnet | haiku |
+| `fast` | sonnet | sonnet | haiku |
 
 ```
-/ck:config                      # show current
-/ck:config preset balanced      # change preset
-/ck:config preset fast --global # change default
+/ck:config                       # show current
+/ck:config preset balanced       # change preset for this repo
+/ck:config preset fast --global  # change default for all repos
 ```
+
+<details>
+<summary><strong>All configuration keys</strong></summary>
+
+| Setting | Values | Default | Purpose |
+|---------|--------|---------|---------|
+| `bp_model_preset` | `expensive` `quality` `balanced` `fast` | `quality` | Model selection |
+| `codex_review` | `auto` `off` | `auto` | Enable/disable Codex reviews |
+| `codex_model` | model string | (Codex default) | Model for Codex calls |
+| `tier_gate_mode` | `severity` `strict` `permissive` `off` | `severity` | How findings gate tier advancement |
+| `command_gate` | `all` `interactive` `off` | `all` | Command-gating scope |
+| `command_gate_timeout` | ms | `3000` | Codex classification timeout |
+| `speculative_review` | `on` `off` | `on` | Background review of previous tier |
+| `speculative_review_timeout` | s | `300` | Max wait for speculative results |
+| `caveman_mode` | `on` `off` | `on` | Token-compressed output (~75% savings) |
+| `caveman_phases` | comma-separated | `build,inspect` | Which phases use caveman-speak |
+| `session_budget` | tokens | `500000` | Loop token cap before auto-halt |
+| `max_iterations` | integer | `60` | Stop-hook iteration cap |
+| `task_budget_quick` | tokens | `8000` | Per-task budget for `depth: quick` |
+| `task_budget_standard` | tokens | `20000` | Per-task budget for `depth: standard` |
+| `task_budget_thorough` | tokens | `45000` | Per-task budget for `depth: thorough` |
+| `auto_backprop` | `on` `off` | `on` | Trigger backpropagation on test failure |
+| `tool_cache` | `on` `off` | `on` | Cache read-only tool results |
+| `tool_cache_ttl_ms` | ms | `120000` | TTL for cached tool results |
+| `test_filter` | `on` `off` | `on` | Condense test output around failures |
+| `progress_tracker` | `on` `off` | `on` | Write `.cavekit/.progress.json` |
+| `parallelism_max_agents` | integer | `3` | Max concurrent subagents per wave |
+| `parallelism_max_per_repo` | integer | `2` | Max concurrent subagents writing the same repo |
+| `model_routing` | `on` `off` | `on` | Score-based tier routing |
+| `graphify_enabled` | `on` `off` | `off` | Use knowledge-graph queries |
+
+</details>
 
 ---
 
-## Commands
+## Teams
 
-### Claude Code
+Cavekit has an **opt-in team mode** that lets multiple people — or the same person on multiple devices — safely share one build site without stepping on each other.
 
-| Command | Phase | What it does |
-|---------|-------|-------------|
-| `/ck:research` | Research | Multi-agent codebase + web research, produces brief |
-| `/ck:design` | Design | Create, import, audit, or update DESIGN.md |
-| `/ck:sketch` | Draft | Decompose requirements into domain kits |
-| `/ck:map` | Architect | Generate tiered build site from kits |
-| `/ck:make` | Build | Auto-parallel build with validation loop |
-| `/ck:check` | Inspect | Gap analysis + peer review against kits |
-| `/ck:config` | — | Show or update execution preset |
-| `/ck:judge` | — | Standalone Codex adversarial review on diff |
-| `/ck:progress` | — | Check build site progress |
-| `/ck:scan` | — | Compare built vs. intended |
-| `/ck:revise` | — | Trace manual fixes back into kits |
-| `/ck:help` | — | Usage guide |
+It is *not* a server. It's a CAS-backed ledger on its own git ref plus a pre-commit guard, so the coordination state travels with the repo and nothing else needs to be hosted.
 
-### CLI
+### Setup
 
-| Command | What it does |
-|---------|-------------|
-| `cavekit monitor` | Interactive launcher — pick build sites, launch in tmux |
-| `cavekit status` | Show build site progress |
-| `cavekit kill` | Stop all sessions, clean up worktrees |
-| `cavekit version` | Print version |
-| `cavekit debug` | Show state file path and version |
-| `cavekit reset` | Clear persisted state |
+```bash
+cavekit team init   # once, per repo — creates the ledger ref on origin and installs a pre-commit hook
+cavekit team join   # in every other checkout / clone / machine
+```
+
+### What it gives you
+
+- **Claims on tasks** — `cavekit team claim T-013` reserves a task for your identity. Teammates see it and `team next` skips it.
+- **Path-scoped claims** — two people can share one task if their file footprints are disjoint: `claim T-013 --paths "src/auth/**,tests/auth/**"`.
+- **Automatic path scoping from kits** — if the build site declares a `Files` column, claims default to those globs. No one has to guess.
+- **Pre-commit guard** — a local hook refuses to commit files another teammate has actively claimed. Emergency override: `CAVEKIT_TEAM_OVERRIDE=1 git commit …` (recorded in the ledger).
+- **Offline-safe** — claims and releases queue locally if you can't reach origin, and drain on the next successful op.
+- **No feature-branch pollution** — the ledger lives on `refs/heads/cavekit/team`, not on your working branch.
+
+### Declaring file footprints in kits (`Files` column)
+
+Add an optional trailing `Files` column to any build-site table. When present, the scheduler uses it for real path-overlap detection and `claim` auto-defaults to these globs:
+
+```markdown
+## Tier 0 — No Dependencies
+
+| Task  | Title       | Spec     | Requirement | Effort | Files                         |
+|-------|-------------|----------|-------------|--------|-------------------------------|
+| T-001 | Auth module | spec.md  | R1          | S      | src/auth/**, tests/auth/**    |
+
+## Tier 1 — Depends on Tier 0
+
+| Task  | Title   | Spec    | Requirement | blockedBy | Effort | Files                           |
+|-------|---------|---------|-------------|-----------|--------|---------------------------------|
+| T-003 | DB layer| spec.md | R2          | T-001     | M      | internal/db/**; migrations/**   |
+```
+
+Separate globs with commas (or semicolons if a pattern itself contains a comma). Kits without a `Files` column keep working — the scheduler falls back to coarser heuristics for those tasks.
+
+### Day-to-day
+
+```bash
+cavekit team status              # active claims, recent activity, idle members
+cavekit team status --conflicts  # add race/override/outbox diagnostics
+cavekit team next --json         # best unclaimed path-safe task for you
+cavekit team claim T-013         # paths default to the kit's Files column
+cavekit team release T-013 --complete
+cavekit team sync --timeout 5    # fetch ledger + drain offline outbox
+```
+
+`/ck:make` integrates automatically — when team mode is active, it claims packets before dispatch, runs a background heartbeat, and releases on merge or failure.
+
+Configuration lives in `.cavekit/team/config.json` (`lease_ttl_seconds`, `heartbeat_interval_seconds`, `allow_offline`, …). Exit codes and troubleshooting are in `/ck:team --help` and [`commands/team.md`](commands/team.md).
 
 ---
 
-## File Structure
+<details>
+<summary><strong>Codex review modes</strong></summary>
+
+Cavekit uses [Codex](https://github.com/openai/codex) as an adversarial reviewer — a second model with different training and different blind spots. Three levels:
+
+### Design Challenge — catch spec flaws before building
+
+After kits are drafted and internally reviewed, the full set goes to Codex.
+
+| Finding type | Behavior |
+|--------------|----------|
+| **Critical** | Must fix before building. Auto-fix loop, up to 2 cycles. |
+| **Advisory** | Presented alongside kits at user review gate. |
+
+Only design-level concerns. No implementation feedback.
+
+### Tier Gate — catch code defects between tiers
+
+Every completed tier triggers a Codex code review before advancing.
+
+| Severity | Behavior |
+|----------|----------|
+| **P0** (critical) | Blocks advancement. Auto-generates fix task. |
+| **P1** (high) | Blocks advancement. Auto-generates fix task. |
+| **P2** (medium) | Logged, does not block. |
+| **P3** (low) | Logged, does not block. |
+
+Gate modes: `severity` (default — P0/P1 block), `strict` (all block), `permissive` (nothing blocks), `off`.
+
+Fix cycle runs up to 2 iterations per tier. After that, advances with warning. Never deadlocks.
+
+### Speculative Review — eliminate gate latency
+
+Codex reviews the previous tier in the background while Claude builds the current tier. Results are ready when the gate checks. Near-zero latency. Falls back to synchronous if needed.
+
+### Command Safety Gate
+
+PreToolUse hook intercepts every Bash command. Fast-path allowlist (50+ safe commands) / blocklist (rm -rf, force push, DROP TABLE). Ambiguous commands → Codex classifies → safe / warn / block. Verdict cached per session. Falls back to static rules when Codex is unavailable — never blocks solely because classifier is unreachable.
+
+### Graceful Degradation
+
+Without Codex installed: design challenge skipped, tier gate skipped, command gate falls back to static allowlist. Cavekit works the same; Codex makes it harder to ship bad specs and bad code.
+
+</details>
+
+<details>
+<summary><strong>Autonomous runtime internals</strong></summary>
+
+`/ck:make` is an autonomous loop. A Claude Code **Stop hook** drives the session iteration by iteration until every task is complete or a budget trips a circuit breaker.
+
+- **`hooks/stop-hook.sh`** — state-machine driver. Fires on every Stop event, routes the next prompt, returns `{"decision":"block"}` so the session continues.
+- **`hooks/token-monitor.sh`** — PostToolUse budget guard. Warns at 80% of per-task budget, halts at 100%.
+- **`hooks/tool-cache.js` / `tool-cache-store.js`** — 120s TTL cache for read-only commands (`git status`, `ls`, `Read`, `Grep`, `Glob`).
+- **`hooks/test-output-filter.js`** — condenses test output around failures.
+- **`hooks/auto-backprop.js`** — on test failure, writes a flag file; next iteration prepends a trace directive.
+- **`hooks/progress-tracker.js`** — zero-stdout snapshot writer for `/ck:status --watch`.
+- **`scripts/cavekit-tools.cjs`** — orchestration engine: state machine, heartbeat lock, token ledger, task registry, routing, capability discovery, checkpoints, artifact summaries.
+- **`scripts/cavekit-router.cjs`** — model-tier router. Scores tasks across five axes, maps to haiku/sonnet/opus within each role's band, demotes under budget pressure.
+
+Runtime state under `<project>/.cavekit/`:
 
 ```
-context/
-├── kits/                     # Domain kits (persist across cycles)
-│   ├── kit-overview.md
-│   └── kit-{domain}.md
-├── designs/                  # Design system artifacts
+.cavekit/
+├── config.json
+├── state.md
+├── .loop.json
+├── .loop.lock
+├── token-ledger.json
+├── task-status.json
+├── capabilities.json
+├── .progress.json
+├── .auto-backprop-pending.json
+├── history/backprop-log.md
+└── tool-cache/
+```
+
+Agents end the loop cleanly by emitting `<promise>CAVEKIT COMPLETE</promise>` on its own line. Debug with `CAVEKIT_DEBUG=1`. Recover with `/ck:resume`.
+
+### Per-phase runtime calls
+
+| Phase | Runtime call |
+|-------|--------------|
+| `/ck:init` | `cavekit-tools init` + `discover`; seeds `.cavekit/` and `.gitignore` |
+| `/ck:sketch` | dispatches `ck:complexity` per kit to auto-fill `complexity:` |
+| `/ck:map` | writes `.cavekit/tasks.json` + `init-registry` + `cavekit-router` |
+| `/ck:make` | `setup-build.sh` calls `setup-loop`; stop-hook drives waves |
+| `/ck:check` | dispatches `ck:verifier` for goal-backward check |
+| `/ck:review` | two-pass review; fix-cycle emits fix tasks back into the loop |
+| `/ck:revise` | routes each manual fix through the single-failure trace |
+| `/ck:status` | prints live runtime status; `--watch` tails snapshots |
+| `/ck:resume` | steals stale locks, validates state, re-enters the loop |
+| `/ck:config` | surfaces runtime keys alongside preset controls |
+
+Opt in per repo with `/ck:init`. Commands fall back to the pre-3.0 path when `.cavekit/` is absent.
+
+</details>
+
+<details>
+<summary><strong>File structure</strong></summary>
+
+```
+context/                       # Project artifacts (persist across cycles)
+├── kits/
+│   ├── cavekit-overview.md
+│   └── cavekit-{domain}.md
+├── designs/
 │   ├── DESIGN.md
 │   └── design-changelog.md
-├── sites/                    # Build sites (one per plan)
-│   └── build-site-*.md
-├── impl/                     # Implementation tracking
+├── plans/
+│   └── build-site.md
+├── impl/
 │   ├── impl-{domain}.md
 │   ├── impl-review-findings.md
-│   ├── impl-speculative-log.md
 │   └── loop-log.md
-└── refs/                     # Research briefs + raw findings
+└── refs/
+
+.cavekit/                      # Runtime state (machine-managed)
+├── config.json
+├── state.md
+├── .loop.json
+├── .loop.lock
+├── token-ledger.json
+├── task-status.json
+├── capabilities.json
+├── .progress.json
+├── .auto-backprop-pending.json
+├── history/backprop-log.md
+└── tool-cache/
 ```
 
----
+</details>
 
-## Methodology
+<details>
+<summary><strong>Skills</strong></summary>
 
-Cavekit applies the **scientific method** to AI-generated code. LLMs are non-deterministic. Software engineering doesn't have to be.
+| Skill | What it covers |
+|-------|----------------|
+| [Methodology](skills/methodology) | Core Hunt lifecycle |
+| [Design System](skills/design-system) | Create and maintain DESIGN.md |
+| [UI Craft](skills/ui-craft) | Component patterns, animation, accessibility, review checklist |
+| [Cavekit Writing](skills/cavekit-writing) | Write kits agents can consume |
+| [Peer Review](skills/peer-review) | Six review modes + Codex Loop Mode |
+| [Validation-First Design](skills/validation-first) | Every requirement must be verifiable |
+| [Context Architecture](skills/context-architecture) | Progressive disclosure for agent context |
+| [Revision](skills/revision) | Trace bugs upstream to kits (includes automated backprop) |
+| [Convergence Monitoring](skills/convergence-monitoring) | Detect when iterations plateau |
+| [Impl Tracking](skills/impl-tracking) | Living records of build progress |
+| [Brownfield Adoption](skills/brownfield-adoption) | Add Cavekit to existing codebases |
+| [Speculative Pipeline](skills/speculative-pipeline) | Overlap phases for faster builds |
+| [Prompt Pipeline](skills/prompt-pipeline) | Design the prompts driving each phase |
+| [Documentation Inversion](skills/documentation-inversion) | Docs for agents, not just humans |
+| [Karpathy Guardrails](skills/karpathy-guardrails) | Think-before-code, simplicity, surgical changes |
+| [Autonomous Loop](skills/autonomous-loop) | State machine, sentinels, lock protocol |
+| [Caveman](skills/caveman) | Token-compressed output (~75% savings) |
+
+</details>
+
+<details>
+<summary><strong>Methodology</strong></summary>
+
+Cavekit applies the **scientific method** to AI-generated code. LLMs are non-deterministic. Software engineering does not have to be.
 
 | Concept | Role |
 |---------|------|
@@ -525,43 +553,15 @@ Cavekit applies the **scientific method** to AI-generated code. LLMs are non-det
 | **Implementation tracking** | Lab notebook — what was tried, what worked, what failed |
 | **Revision** | Update the hypothesis — trace bugs back to kits |
 
-Ships with 9 specialized agents (including **design-reviewer** for UI validation against DESIGN.md), a multi-agent research system, and 15 skills covering the full methodology. With Codex, operates as a **dual-model architecture** — Claude builds, Codex reviews — catching errors single-model self-review cannot.
-
-<details>
-<summary><strong>All 16 skills</strong></summary>
-
-| Skill | What it covers |
-|-------|---------------|
-| [Design System](skills/design-system) | Create and maintain DESIGN.md |
-| [UI Craft](skills/ui-craft) | Component patterns, animation, accessibility, review checklist |
-| [Cavekit Writing](skills/cavekit-writing) | Write kits agents can consume |
-| [Convergence Monitoring](skills/convergence-monitoring) | Detect when iterations plateau |
-| [Peer Review](skills/peer-review) | Six modes for cross-model review |
-| [Validation-First Design](skills/validation-first) | Every requirement must be verifiable |
-| [Context Architecture](skills/context-architecture) | Progressive disclosure for agent context |
-| [Revision](skills/revision) | Trace bugs upstream to kits |
-| [Brownfield Adoption](skills/brownfield-adoption) | Add Cavekit to existing codebases |
-| [Speculative Pipeline](skills/speculative-pipeline) | Overlap phases for faster builds |
-| [Prompt Pipeline](skills/prompt-pipeline) | Design the prompts driving each phase |
-| [Implementation Tracking](skills/impl-tracking) | Living records of build progress |
-| [Documentation Inversion](skills/documentation-inversion) | Docs for agents, not just humans |
-| [Peer Review Loop](skills/peer-review-loop) | Combine build loop with cross-model review |
-| [Core Methodology](skills/methodology) | The full Hunt lifecycle |
-| [Caveman](skills/caveman) | Token-compressed output (~75% savings), built-in for build/inspect phases |
-
-</details>
-
----
-
-## Why "Cavekit"
-
-Most AI coding tools treat the agent as a black box. Prompt, generate, hope. Cavekit inverts this.
+Ships with specialized agents (including **design-reviewer** for UI validation against DESIGN.md), a multi-agent research system, and 21 skills. With Codex, operates as a **dual-model architecture** — Claude builds, Codex reviews — catching errors single-model self-review cannot.
 
 **The spec is the product. The code is a derivative.**
 
-When the spec is clear, the code follows. When the code is wrong, the spec tells you why. Without a specification, there's nothing to validate against. Cavekit gives every agent — current and future — a contract to build from and a standard to meet.
+When the spec is clear, the code follows. When the code is wrong, the spec tells you why.
 
 Two models disagreeing is a signal. Two models agreeing is confidence.
+
+</details>
 
 ---
 
@@ -573,10 +573,21 @@ If cavekit save you mass debug time — leave star.
 
 ---
 
+## 🪨 The Caveman Ecosystem
+
+Three tools. One philosophy: **agent do more with less**.
+
+| Repo | What | One-liner |
+|------|------|-----------|
+| [**caveman**](https://github.com/JuliusBrussee/caveman) | Output compression skill | *why use many token when few do trick* — ~75% fewer output tokens across Claude Code, Cursor, Gemini, Codex |
+| [**cavemem**](https://github.com/JuliusBrussee/cavemem) | Cross-agent persistent memory | *why agent forget when agent can remember* — compressed SQLite + MCP, local by default |
+| [**cavekit**](https://github.com/JuliusBrussee/cavekit) *(you are here)* | Spec-driven autonomous build loop | *why agent guess when agent can know* — natural language → kits → parallel build → verified |
+
+They compose: **cavekit** orchestrates the build, **caveman** compresses what the agent *says* (bundled, on by default for build/inspect phases), **cavemem** compresses what the agent *remembers* across sessions. Install one, some, or all — each stands alone.
+
 ## Also by Julius Brussee
 
-- **[Caveman](https://github.com/JuliusBrussee/caveman)** — Claude Code skill that cuts ~75% of output tokens. Same accuracy, way less fluff. Bundled in Cavekit and enabled by default for build/inspect phases. Standalone install: `npx skills add JuliusBrussee/caveman`
-- **[Revu](https://github.com/JuliusBrussee/revu-swift)** — local-first macOS study app with FSRS spaced repetition, decks, exams, and study guides. [revu.cards](https://revu.cards)
+- **[Revu](https://github.com/JuliusBrussee/revu-swift)** — local-first macOS study app with FSRS spaced repetition. [revu.cards](https://revu.cards)
 
 ## License
 

--- a/plugins/JuliusBrussee/blueprint/skills/autonomous-loop/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/autonomous-loop/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: autonomous-loop
+description: |
+  How Cavekit's autonomous execution loop works — state machine, stop hook,
+  completion sentinel, lock, budgets, iteration cap. Read this skill any time
+  you are about to run /ck:make, debug a stuck session, or write a new command
+  that needs the loop. Trigger phrases: "how does the loop work", "stop hook",
+  "autonomous", "completion sentinel", "why is the session looping".
+---
+
+# Autonomous Loop
+
+The loop lets a single `/ck:make` invocation run dozens of agent iterations
+without user intervention, while still respecting per-task budgets, session
+budgets, and explicit user-approval gates.
+
+## Architecture
+
+```
+┌─────────────────┐  Stop event   ┌────────────────────┐
+│  Claude Code    │──────────────▶│   stop-hook.sh     │
+│   session       │               │  (.cavekit/loop    │
+└─────────────────┘               │   active?)         │
+        ▲                         └─────────┬──────────┘
+        │                                   │ route()
+        │ next prompt injected              ▼
+        │                         ┌────────────────────┐
+        │                         │ cavekit-tools.cjs  │
+        │                         │  routeDecision()   │
+        │                         │  + status-block    │
+        │                         │  + backprop-       │
+        │                         │    directive       │
+        │                         └─────────┬──────────┘
+        │                                   │
+        └───────── {decision:"block",       │
+                    reason:<next prompt>} ◀─┘
+```
+
+## Files the loop touches
+
+All under `<project>/.cavekit/`:
+
+| File                            | Writer                | Purpose                                      |
+|---------------------------------|-----------------------|----------------------------------------------|
+| `.loop.json`                    | setup-loop            | Sentinel; stop-hook no-ops without it.       |
+| `.loop.lock`                    | stop-hook (heartbeat) | Single-writer lock. PID + hostname + ts.     |
+| `state.md`                      | cavekit-tools         | `phase`, `current_task`, `iteration`.        |
+| `token-ledger.json`             | token-monitor hook    | Session + per-task token tallies.            |
+| `task-status.json`              | commands              | Authoritative task registry.                 |
+| `.progress.json`                | progress-tracker      | Zero-context UI snapshot.                    |
+| `.auto-backprop-pending.json`   | auto-backprop hook    | Flag file from failed tests.                 |
+| `history/backprop-log.md`       | backprop skill        | Append-only trace log.                       |
+| `capabilities.json`             | discover command      | MCP + CLI tool detection.                    |
+
+## Lifecycle
+
+1. **Setup** — `/ck:make` calls:
+   ```
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/cavekit-tools.cjs" setup-loop
+   ```
+   This writes `.loop.json` (activating the stop hook) and resets `state.md`.
+
+2. **Work** — the agent does one wave of task execution per iteration.
+
+3. **Stop fires** — Claude Code's Stop event triggers `stop-hook.sh`. The hook:
+   - reads stdin for `session_id` and `transcript_path`
+   - acquires / refreshes the lock
+   - scans the last 20 transcript lines for `<promise>CAVEKIT COMPLETE</promise>`
+   - if sentinel found → teardown + exit silently
+   - else → asks `routeDecision()` for the next prompt
+   - prepends the backprop directive if the flag file exists
+   - returns `{"decision":"block","reason":<next prompt>}`
+
+4. **Repeat** — Claude Code treats `decision:block` + `reason:...` as a new
+   user message, so the session continues.
+
+5. **Teardown** — one of:
+   - completion sentinel detected
+   - max-iterations reached (`CAVEKIT_MAX_ITERATIONS`)
+   - session budget exhausted (`CAVEKIT_BUDGET_EXHAUSTED`)
+   - lock stolen by another session (`CAVEKIT_LOCK_CONFLICT`)
+   - user interrupt (hook returns no output; session stops normally)
+
+## Completion sentinel
+
+To end the loop cleanly, emit exactly:
+
+```
+<promise>CAVEKIT COMPLETE</promise>
+```
+
+The hook searches for this literal in the last 20 transcript lines. Put it on
+its own line at the very end of the final message. Do not wrap it in code
+fences or paraphrase it — the search is a literal substring match.
+
+## Terminal sentinels
+
+When `routeDecision()` cannot safely continue, it returns one of these
+strings instead of a prompt:
+
+| Sentinel                     | Meaning                               |
+|------------------------------|---------------------------------------|
+| `CAVEKIT_LOOP_DONE`          | All tasks complete. Hook exits silent.|
+| `CAVEKIT_MAX_ITERATIONS`     | Iteration cap hit. Loop halted.       |
+| `CAVEKIT_BUDGET_EXHAUSTED`   | Session budget exhausted.             |
+| `CAVEKIT_LOCK_CONFLICT`      | Another session owns the lock.        |
+
+The hook translates each into a short user-facing message before returning.
+
+## Lock protocol
+
+The lock is a JSON file (`.loop.lock`) with `{owner, pid, host, heartbeat_at}`.
+
+- **Owner tag**: `session:<session_id>`.
+- **Heartbeat**: every Stop invocation refreshes `heartbeat_at`.
+- **Stale**: > 5 minutes since last heartbeat. A new session may steal a stale
+  lock.
+- **Conflict**: non-owner with fresh lock → returns `CAVEKIT_LOCK_CONFLICT`.
+
+Never delete `.loop.lock` while a session might be active. Use
+`cavekit-tools release-lock --owner <tag>` instead.
+
+## Debugging a stuck loop
+
+```bash
+# Inspect current state
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cavekit-tools.cjs" status
+
+# Who holds the lock?
+cat .cavekit/.loop.lock
+
+# What would the router do right now?
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cavekit-tools.cjs" route
+
+# Drop the loop entirely (safe after a crash)
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cavekit-tools.cjs" teardown-loop
+```
+
+Turn on debug logging by exporting `CAVEKIT_DEBUG=1`. The hook will write to
+`.cavekit/.debug.log`.
+
+## What not to do
+
+- Do **not** hand-edit `state.md`'s `phase` field while a loop is active. The
+  hook assumes single-writer semantics and will overwrite you.
+- Do **not** set your own stop hook that also blocks. Multiple blocking hooks
+  race, and Claude Code picks one arbitrarily.
+- Do **not** emit the completion sentinel unless every task in the registry is
+  truly `complete`. The hook trusts the sentinel and tears down immediately.

--- a/plugins/JuliusBrussee/blueprint/skills/capability-discovery/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/capability-discovery/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: capability-discovery
+description: |
+  Detect which MCP servers, Claude Code plugins, and CLI tools are available
+  in the current environment, so kits and build sites can bind to real
+  capabilities instead of imagined ones. Runs via /ck:init --tools-only or
+  `cavekit-tools.cjs discover`. Writes .cavekit/capabilities.json. Trigger
+  phrases: "what do we have available", "what's installed", "detect tools",
+  "can we use X", "setup tools".
+---
+
+# Capability Discovery
+
+The pipeline should never invent tools. Before drafting a kit that references
+GitHub Actions, Supabase, Codex, or any other external dependency, check what
+actually exists.
+
+## What we detect
+
+- **CLI tools on $PATH**: `gh`, `git`, `node`, `go`, `rustc`, `cargo`,
+  `python3`, `pip`, `docker`, `vercel`, `supabase`, `firebase`, `wrangler`,
+  `ffmpeg`, `playwright`, `codex`, `graphify`.
+- **MCP servers**: parsed from `.mcp.json` in the project root and
+  `~/.claude.json` (user level).
+- **Claude Code plugins**: parsed from `~/.claude/plugins/installed_plugins.json`.
+- **Codex**: presence of the `codex` CLI (enables peer-review commands).
+- **Knowledge graph**: presence of `graphify-out/graph.json` (enables the
+  `graphify-integration` skill).
+
+## Running discovery
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cavekit-tools.cjs" discover
+```
+
+Writes `.cavekit/capabilities.json`:
+
+```json
+{
+  "discovered_at": "2026-04-17T14:22Z",
+  "cli_tools": {
+    "gh": true, "git": true, "node": true, "codex": false
+  },
+  "mcp_servers": ["codex-reviewer", "graphify"],
+  "plugins": [],
+  "codex": { "available": false }
+}
+```
+
+## How other commands use it
+
+- **`/ck:sketch`** — reads capabilities before proposing integrations. If a
+  kit would need a missing tool, it either adds a "Setup" task to the build
+  site or asks the user whether to proceed without it.
+- **`/ck:map`** — flags tasks that depend on missing capabilities as
+  `blocked: setup-required`.
+- **`/ck:make`** — refuses to dispatch subagents that require a missing MCP
+  server.
+- **`/ck:check`** — includes a "Capability Coverage" section in the inspect
+  report.
+
+## When to re-run
+
+- After installing a new CLI tool.
+- After adding or removing an MCP server.
+- At the start of every new project (via `/ck:init`).
+- Whenever a task fails with "command not found".
+
+The file is cheap to regenerate — always discover, never guess.
+
+## What we deliberately do not detect
+
+- Network-accessible APIs behind credentials. Availability is not reachability;
+  kits should record credentials as a separate concern (never committed).
+- IDE extensions. They are not scriptable from the loop and would create false
+  assurances.
+- Language versions. Version-pinning is the project's responsibility
+  (package.json / go.mod / pyproject.toml); discovery only confirms
+  executables exist.

--- a/plugins/JuliusBrussee/blueprint/skills/caveman-internal/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/caveman-internal/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: caveman-internal
+description: |
+  Internal token-compression protocol for Cavekit agent artifacts — handoff
+  notes, artifact summaries, context bundles, review notes, status lines.
+  NOT the user-facing /caveman skill; that one compresses assistant replies to
+  the user. This skill compresses machine-to-machine prose so the next agent in
+  the loop reads fewer tokens. Three intensities (lite / full / ultra) with
+  automatic selection based on budget pressure. Used by task-builder, builder,
+  inspector, verifier, convergence-monitor, and the stop-hook status block.
+---
+
+# Caveman Internal Protocol
+
+## Scope
+
+### IN-scope (compress)
+- Artifact summaries written to `.cavekit/artifacts/`
+- Context bundles between tasks (`.cavekit/context-bundles/`)
+- Review notes and gap lists (non-user-facing)
+- `state.md` `notes:` field and `loop-log.md` entries
+- Status-block body (dashboard injected by the stop hook)
+- Inter-agent handoff memos
+
+### OUT-of-scope (never compress)
+- Source code (any language, any file)
+- Git commit messages and PR descriptions
+- Kits (specs), build sites, DESIGN.md
+- Error messages that a human will act on
+- Security warnings and deprecation notices
+- Structured findings tables (P0/P1/P2/P3, coverage matrices)
+- Regression test names and assertion messages
+
+Compressing out-of-scope content is a bug. If a reader cannot act on a
+compressed artifact, regenerate it verbose and log a caveman fallback — see
+"Fallback protocol" below.
+
+## Intensity levels
+
+### Lite — trim the fat (~20% savings)
+
+Professional tone. Grammar intact. Drop filler, pleasantries, hedging. Keep
+articles and full sentences.
+
+> Rate-limit middleware passes unit tests. Integration failed on 429 header
+> case sensitivity. Fix in progress.
+
+### Full — default (~40% savings)
+
+Classic caveman. Drop articles, filler, pleasantries. Fragments fine.
+Technical terms stay exact. Pattern: `[thing] [action] [reason]. [next].`
+
+> Rate-limit mw pass unit. Integration fail on 429 header case. Fixing.
+
+### Ultra — maximum grunt (~65% savings)
+
+Telegraphic. Abbreviate common terms (DB, auth, config, req, res, fn, impl,
+mw, mcp). Arrow notation for causality. One-word answers when enough.
+
+> mw ok, int fail header case → fix
+
+## Automatic intensity selection
+
+Consult the session budget ledger before writing an internal artifact:
+
+| Budget remaining | Intensity |
+|------------------|-----------|
+| > 50 %           | lite      |
+| 20 – 50 %        | full      |
+| < 20 %           | ultra     |
+
+Override rules:
+- `depth = thorough` tasks clamp to **lite** regardless of pressure (accuracy
+  matters more than tokens when the stakes are high).
+- `phase = inspecting` clamps to **lite** for the gap-analysis output.
+- Security-sensitive artifacts clamp to **lite**.
+- If the caller sets `caveman_intensity` explicitly in the artifact envelope,
+  use that and skip auto-selection.
+
+See `references/budget-thresholds.md` for the detailed decision table.
+
+## Fallback protocol
+
+If a downstream reader cannot reconstruct intent from a compressed artifact:
+
+1. Regenerate the artifact in **full prose** (no compression).
+2. Append a one-line entry to `state.md`'s "Caveman fallbacks" section:
+   ```
+   - 2026-04-17T12:34Z T-017 verifier fallback: artifact summary re-expanded
+   ```
+3. If the same artifact category fails 3+ times in one session, clamp that
+   category to `lite` for the rest of the session and log to `state.md`.
+
+## Envelope
+
+Every compressed artifact carries a tiny header:
+
+```
+<!-- caveman: intensity=full version=1 -->
+```
+
+Readers that see this header know the body is compressed and apply the
+reverse-expansion grammar (re-add articles, re-expand abbreviations) when
+rendering for a human.
+
+## Examples
+
+| Verbose                                                                 | Full                                        | Ultra                |
+|-------------------------------------------------------------------------|---------------------------------------------|----------------------|
+| "The build completed successfully after three waves."                   | "Build complete. 3 waves."                  | "Build ok 3w"        |
+| "All tests pass, but one test was skipped due to a missing fixture."    | "Tests pass. One skipped, missing fixture." | "Tests ok 1 skip fx" |
+| "The reviewer flagged two critical issues in the auth middleware."     | "Reviewer: 2 P0 in auth mw."                | "Rev 2 P0 auth mw"   |
+
+## Integration with the existing `caveman` skill
+
+The user-facing `caveman` skill governs how the assistant **speaks to the user**
+during a session (answers, explanations, replies). This `caveman-internal`
+skill governs how agents **write artifacts** for each other. Both must be on
+or both off for a coherent experience, so `caveman_mode = off` in config also
+disables this skill.

--- a/plugins/JuliusBrussee/blueprint/skills/caveman-internal/references/budget-thresholds.md
+++ b/plugins/JuliusBrussee/blueprint/skills/caveman-internal/references/budget-thresholds.md
@@ -1,0 +1,43 @@
+# Caveman-internal Budget Thresholds
+
+Session budget is the cumulative token count across all iterations of a
+Cavekit loop. Read it from `.cavekit/token-ledger.json` (`session_used` /
+`session_budget`). Per-task budget lives in the same ledger under
+`tasks.<id>.used` / `tasks.<id>.budget`.
+
+## Decision table
+
+| Session pressure | Task pressure | Task depth | Chosen intensity |
+|------------------|---------------|------------|------------------|
+| < 50 %           | < 50 %        | any        | lite             |
+| < 50 %           | ≥ 50 %        | any        | full             |
+| 50 – 80 %        | < 80 %        | quick      | full             |
+| 50 – 80 %        | < 80 %        | standard   | full             |
+| 50 – 80 %        | < 80 %        | thorough   | lite             |
+| 50 – 80 %        | ≥ 80 %        | any        | ultra            |
+| ≥ 80 %           | any           | thorough   | lite (clamped)   |
+| ≥ 80 %           | any           | other      | ultra            |
+
+## Clamping rules
+
+- `depth = thorough` and `phase = inspecting` clamp to **lite** regardless of
+  pressure. Accuracy dominates cost.
+- Security-sensitive artifacts (auth, secrets, permissions, crypto) clamp to
+  **lite**.
+- If three consecutive fallbacks hit, clamp the affected category to **lite**
+  for the rest of the session.
+
+## Artifact-category overrides
+
+| Category                 | Baseline |
+|--------------------------|----------|
+| handoff-memo             | full     |
+| context-bundle           | full     |
+| artifact-summary         | full     |
+| review-notes (non-user)  | lite     |
+| status-block (dashboard) | lite     |
+| loop-log entry           | ultra    |
+| state.md notes           | full     |
+
+Baselines apply when pressure is low. When pressure rises, escalate in
+ultra direction by one step.

--- a/plugins/JuliusBrussee/blueprint/skills/complexity-detection/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/complexity-detection/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: complexity-detection
+description: |
+  Classify a task or feature as quick, standard, or thorough so the rest of
+  the pipeline (budget sizing, model routing, review depth) can right-size
+  itself. Used by /ck:sketch to default the kit's complexity, by /ck:map to
+  assign task depth, and by /ck:make for per-task budgets. Also invoked by
+  the ck:complexity agent with the haiku model. Trigger phrases:
+  "how complex", "what depth", "pick a depth", "classify this task".
+---
+
+# Complexity Detection
+
+A deterministic scoring rubric. Five axes, 0–4 each, summed to 0–20.
+
+## Axes
+
+| Axis                  | 0                | 1                 | 2                 | 3                    | 4                   |
+|-----------------------|------------------|-------------------|-------------------|----------------------|---------------------|
+| **Files touched**     | 0–2              | 3–5               | 6–10              | 11–20                | 20+                 |
+| **Type**              | chore / format   | refactor          | feature           | cross-cutting        | architectural       |
+| **Judgment required** | mechanical       | low-ambiguity     | medium            | high                 | critical (sec/prod) |
+| **Cross-component**   | single module    | two modules       | three modules     | many within one repo | multi-repo          |
+| **Novelty**           | known pattern    | rare pattern      | novel             | research needed      | unknown unknowns    |
+
+Total score maps to:
+
+| Score  | Depth      |
+|--------|------------|
+| 0 – 6  | quick      |
+| 7 – 13 | standard   |
+| 14+    | thorough   |
+
+## Override signals
+
+Upgrade one step regardless of score when any of these are true:
+
+- Security-sensitive: authentication, authorization, crypto, secrets, PII.
+- Data migration that is not reversible.
+- Public API shape change (breaking).
+- Performance-critical hot path with an existing SLA.
+
+Downgrade one step only when **all** of these are true:
+
+- Zero new dependencies.
+- Existing tests cover the change.
+- No user-visible behaviour change.
+- Single file, single function.
+
+## Per-depth defaults
+
+| Depth    | Token budget | Model tier | Review    | Tests                       |
+|----------|--------------|------------|-----------|-----------------------------|
+| quick    | 8 000        | haiku      | optional  | smoke                       |
+| standard | 20 000       | sonnet     | required  | unit + integration          |
+| thorough | 45 000       | sonnet/opus| mandatory | unit + integration + E2E    |
+
+These defaults are recorded in `.cavekit/config.json` under `task_budgets`
+and consumed by the `cavekit-router.cjs` model router.
+
+## How agents score
+
+The `ck:complexity` subagent (haiku) receives a task description and returns
+a JSON blob:
+
+```json
+{
+  "score": 11,
+  "depth": "standard",
+  "axes": {
+    "files": 2, "type": 2, "judgment": 2, "cross_component": 2, "novelty": 3
+  },
+  "overrides_applied": []
+}
+```
+
+`/ck:map` calls this agent per task to set `depth` in the task registry. If
+the agent produces a score in the "thorough" band with a novelty of 4 and a
+security override, it may return `needs_research: true`, which `/ck:map` must
+translate into an upstream `ck:researcher` task dependency before the work
+itself.
+
+## Integration points
+
+- `/ck:sketch` — runs complexity scoring on the whole domain to set the kit's
+  `complexity:` frontmatter.
+- `/ck:map` — runs it per task to assign `depth`.
+- `/ck:make` — reads `depth` to size the task budget and pick the review
+  intensity.
+- `ck:complexity` agent — pure-haiku worker; does nothing else.
+
+## Anti-patterns
+
+- Using one depth for every task in a kit "for consistency." Cost up, signal
+  down.
+- Padding depth to "be safe" — if the budget is oversized, the model wastes
+  tokens exploring. Right-size, then raise only when verification fails.
+- Ignoring overrides — scoring a login flow as "quick" because it touches one
+  file. Security overrides exist for exactly this reason.

--- a/plugins/JuliusBrussee/blueprint/skills/convergence-monitoring/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/convergence-monitoring/SKILL.md
@@ -140,7 +140,7 @@ Iteration 4:  ██████████████████████
 |-----------|---------|-----|
 | **Fuzzy specs** | Agent interprets requirements differently each iteration | Make specs more precise; add concrete acceptance criteria |
 | **Weak validation** | Agent cannot verify correctness, so it keeps changing things | Add build/test/lint gates; strengthen acceptance criteria |
-| **Fighting sub-agents** | Multiple agents change the same code in conflicting ways | Add file ownership tables; dispatch subagents with `isolation: "worktree"` via the Agent tool |
+| **Fighting sub-agents** | Multiple agents change the same code in conflicting ways | Add file ownership tables; dispatch subagents via the Agent tool |
 | **Contradictory requirements** | Spec A says X, spec B says not-X | Resolve contradictions in specs; add explicit priority/precedence |
 | **Missing exit criteria** | Agent does not know when it is done | Add explicit exit criteria checklists and completion signals |
 | **Over-broad scope** | Too much work for one prompt/iteration | Split into smaller, focused prompts with clear boundaries |
@@ -369,7 +369,7 @@ Do not keep running. More iterations will not help.
 |-----------|-----|
 | Fuzzy specs | Rewrite ambiguous requirements with concrete acceptance criteria |
 | Weak validation | Add build/test/lint gates to the prompt |
-| File conflicts | Add file ownership tables; dispatch subagents with `isolation: "worktree"` via the Agent tool |
+| File conflicts | Add file ownership tables; dispatch subagents via the Agent tool |
 | Over-broad scope | Split into smaller prompts; reduce concurrent agents |
 | External dependency | Mock the dependency; or resolve it before resuming |
 

--- a/plugins/JuliusBrussee/blueprint/skills/graphify-integration/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/graphify-integration/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: graphify-integration
+description: |
+  Optional knowledge-graph integration. When `graphify-out/graph.json` is
+  present, architect/researcher/reviewer/task-builder agents can query
+  symbol-level dependencies (IMPORTS, CALLS, EXTENDS, IMPLEMENTS, DEPENDS_ON)
+  instead of grepping. Degrades gracefully when the graph is missing. Trigger
+  phrases: "knowledge graph", "graphify", "blast radius", "dependency graph".
+---
+
+# Graphify Integration
+
+A knowledge graph turns "what will break if I change this file" from a guess
+into a query. Cavekit uses it only when it is available — nothing in the
+pipeline depends on it.
+
+## Installation (optional)
+
+```bash
+pip install graphifyy
+graphify build .          # writes graphify-out/graph.json
+```
+
+If the file is missing, this skill returns no-ops and every caller falls back
+to grep + ripgrep search.
+
+## Graph shape
+
+NetworkX node-link JSON. Nodes are symbols (functions, classes, modules).
+Edges carry:
+
+- `type`: `DEPENDS_ON` | `IMPORTS` | `CALLS` | `EXTENDS` | `IMPLEMENTS`
+- `confidence`: `EXTRACTED` (high) | `INFERRED` (medium) | `AMBIGUOUS` (low)
+- `community`: cluster ID (for partitioning big graphs into readable slices)
+
+## CLI surface (via cavekit-tools)
+
+```bash
+cavekit-tools.cjs graph-status                 # is the graph present?
+cavekit-tools.cjs graph-query --term auth      # search by name substring
+cavekit-tools.cjs graph-dependents --file X    # who imports/calls this?
+cavekit-tools.cjs graph-summary                # top-level community list
+```
+
+(These subcommands are optional extensions; the base `cavekit-tools.cjs`
+ships without them, and they activate only if `graphify-out/graph.json` is
+present.)
+
+## Per-phase use
+
+- **Draft (`/ck:sketch`)** — query existing symbols for a proposed kit name
+  to avoid collision with existing code.
+- **Map (`/ck:map`)** — use `community` IDs to partition tasks into coherent
+  tiers. Two tasks whose affected symbols share no edges can run in parallel.
+- **Research (`ck:researcher`)** — query existing before fetching external.
+  If the graph already answers the question, skip the web.
+- **Build (`/ck:make`)** — load the subgraph of the current task's files only.
+  Smaller context → faster, cheaper agent.
+- **Review / Inspect** — compute blast radius of the diff. Files touched ∪
+  transitive dependents = review scope.
+
+## Confidence tiers
+
+Do not treat low-confidence edges (`AMBIGUOUS`) as true without verification.
+When blast radius includes an `AMBIGUOUS` edge, fall back to grep and confirm.
+
+## Stub mode
+
+When the graph is missing, every graph-* query returns:
+
+```json
+{ "available": false, "fallback": "grep" }
+```
+
+Callers check `available` and fall back to `Grep` + `Read`. No error is
+raised — this is a degradation, not a failure.

--- a/plugins/JuliusBrussee/blueprint/skills/karpathy-guardrails/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/karpathy-guardrails/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: karpathy-guardrails
+description: |
+  Behavioral guardrails for Cavekit agents. Four principles — think before coding,
+  simplicity first, surgical changes, goal-driven execution — that prevent
+  over-engineering, silent assumptions, scope creep, and unfocused work. Every
+  task-builder, reviewer, planner, and inspector must internalize these before
+  writing a single line. Trigger phrases: "guardrails", "karpathy", "scope creep",
+  "over-engineering", "stop adding features", "surgical fix".
+---
+
+# Karpathy Guardrails
+
+Four rules. Load them into context at the start of every task. The reviewer
+enforces them as a Pass-1 filter before it looks at code quality.
+
+## 1. Think Before Coding
+
+Before the first edit, write down:
+
+- **What am I actually building?** One sentence. If you cannot state it, stop.
+- **What am I assuming?** List every assumption. If any is load-bearing and
+  unverified, flag `NEEDS_CONTEXT` and ask — do not guess.
+- **What does success look like?** Map each acceptance criterion to a concrete
+  test, check, or observable behaviour. If a criterion is not verifiable,
+  propose a sharpening via the `revision` skill (automated-trace subsection), not a vague attempt.
+
+Refusing to produce code is allowed. A task with unknown scope is a spec bug,
+not a coding task.
+
+## 2. Simplicity First
+
+The correct amount of code is the minimum that meets the acceptance criteria.
+
+- No speculative features. No abstraction layer "in case we need it."
+- No new dependencies unless the task requires one and no existing dep fits.
+- No "while I'm in here" refactors. Surface them as separate kits.
+- Duplication is not always wrong. Three similar lines usually beat a premature
+  abstraction with two configuration knobs.
+
+If the diff is larger than the acceptance criteria seem to demand, explain why
+in the commit body. If you cannot, trim the diff.
+
+## 3. Surgical Changes
+
+Every line in the diff must trace back to an acceptance criterion. Touching
+code outside the task's owned files is justified only when a requirement forces
+it. Examples of violations:
+
+- Fixing a formatter warning in an unrelated file.
+- Renaming a helper "to match new convention."
+- Reordering imports, docstrings, whitespace.
+- Tightening a type signature the task did not ask about.
+
+If you see a real bug in adjacent code, log it to `.cavekit/history/backprop-log.md`
+as a candidate kit item and keep it out of this task's diff.
+
+## 4. Goal-Driven Execution
+
+Transform vague tasks into verifiable success criteria before execution.
+
+- A task that cannot be verified is not a task — escalate it.
+- The verification plan must be concrete: exact commands, exact assertions,
+  exact files to inspect. "Make sure it works" is not a plan.
+- After implementation, run the verification plan. Report the output.
+
+## Role-specific enforcement
+
+- **task-builder** — must produce, alongside code, a Verification Report listing
+  each AC, the verification step, and the observed result.
+- **reviewer** — must refuse to advance to Pass 2 (code quality) if Pass 1 finds
+  any of: undeclared assumptions, diff lines unjustified by an AC, out-of-scope
+  edits, or unreachable verification steps.
+- **planner** — must reject kits that contain un-testable ACs. They are spec
+  bugs and block planning.
+- **inspector** — must flag completed tasks whose verification logs are missing
+  or hand-waved.
+
+## When you are tempted to break a rule
+
+You are probably over-confident about a shortcut that will cost more than the
+delay of asking. Stop and note the tension in the commit body or in the build
+log so the reviewer can judge.

--- a/plugins/JuliusBrussee/blueprint/skills/peer-review/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/peer-review/SKILL.md
@@ -4,10 +4,12 @@ description: >
   Patterns for using a second AI agent or model to challenge the primary builder agent's work.
   Covers six review modes (Diff Critique, Design Challenge, Threaded Debate, Delegated Scrutiny,
   Deciding Vote, Coverage Audit), how to set up peer review with any model via MCP server,
-  peer review iteration loops that alternate builder and reviewer prompts, and prompt templates for
+  peer review iteration loops that alternate builder and reviewer prompts, the Codex Loop Mode
+  (Cavekit + Ralph Loop + Codex as reviewer via CLI or MCP fallback), and prompt templates for
   each strategy. The peer reviewer's job is to find what the builder missed, not to agree.
   Triggers: "peer review", "peer review agent", "use another model to review",
-  "second opinion on code", "cross-model review".
+  "second opinion on code", "cross-model review", "peer review loop", "ralph loop with codex",
+  "cavekit ralph", "cross-model loop", "codex peer reviewer".
 ---
 
 # Peer Review
@@ -431,3 +433,166 @@ that neither automated tests nor single-agent convergence loops find.
 - **prompt-pipeline** -- How to structure builder and reviewer prompts in the Hunt pipeline
 - **revision** -- When the peer reviewer finds a cavekit gap, revise the fix into kits
 - **impl-tracking** -- Record peer review findings in implementation tracking documents
+
+---
+
+## Codex Loop Mode — Cavekit + Ralph Loop + Codex Peer Reviewer
+
+The most rigorous automated quality process available: run a Cavekit cavekit through a Ralph Loop where Claude builds and Codex adversarially reviews every few iterations. A completely different model (different training data, different biases, different blind spots) challenges your implementation.
+
+### Why This Works
+
+| Factor | Single-Model Loop | Codex Loop Mode |
+|--------|-------------------|-----------------|
+| Blind spots | Same model, same blind spots every iteration | Two models catch different classes of issues |
+| Cavekit drift | Builder may silently deviate from cavekit | Peer reviewer checks cavekit compliance explicitly |
+| Quality floor | Converges to "good enough for one model" | Converges to "survives cross-examination" |
+| Dead ends | May retry failed approaches | Peer reviewer flags repeated patterns |
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Ralph Loop                         │
+│  (Stop hook feeds same prompt each iteration)        │
+│                                                      │
+│  ┌──────────┐    ┌──────────────┐    ┌────────────┐ │
+│  │  Claude   │───▶│ Build from   │───▶│  Commit    │ │
+│  │  (Build)  │    │ cavekit      │    │  changes   │ │
+│  └──────────┘    └──────────────┘    └──────┬─────┘ │
+│       ▲                                      │       │
+│       │                                      ▼       │
+│  ┌──────────┐    ┌──────────────┐    ┌────────────┐ │
+│  │  Fix      │◀──│ Parse        │◀──│  Codex CLI │ │
+│  │  findings │    │ findings     │    │  (Review)  │ │
+│  └──────────┘    └──────────────┘    └────────────┘ │
+│                                                      │
+│  Completion: all cavekit requirements met +         │
+│              no CRITICAL/HIGH findings               │
+└─────────────────────────────────────────────────────┘
+```
+
+### Review Invocation: Codex CLI (primary) vs MCP (legacy)
+
+1. **Codex CLI delegation (primary)** — `scripts/codex-review.sh` calls `codex` directly in `--approval-mode full-auto` with a structured review prompt. Faster, no MCP server overhead. Findings parsed and appended to `context/impl/impl-review-findings.md`.
+2. **MCP server (legacy fallback)** — Codex configured as an MCP server in `.mcp.json`. Claude calls the MCP tool on review iterations. Used only when Codex CLI delegation is unavailable.
+
+`setup-build.sh` auto-detects: if `codex-review.sh` is present and `codex` CLI is available, CLI delegation is used. Otherwise, falls back to MCP configuration.
+
+### Activation
+
+```bash
+/ck:make --peer-review                       # activates Codex Loop Mode (default interval: every 2nd iteration)
+/ck:make --peer-review --review-interval 1   # review every iteration (maximum rigor)
+/ck:make --peer-review --codex-model gpt-5.4-mini   # faster, cheaper reviewer
+```
+
+### What `--peer-review` Does
+
+1. **Validates** Codex CLI is installed (or MCP fallback is configured).
+2. **Configures** Codex as an MCP server in `.mcp.json` if CLI delegation is unavailable.
+3. **Builds** a Ralph Loop prompt that embeds:
+   - The cavekit path and related plan/impl files.
+   - Instructions to alternate between build and review iterations.
+   - The peer review prompt template for Codex.
+   - Completion criteria tied to cavekit acceptance criteria.
+4. **Starts** the Ralph Loop via the stop hook mechanism.
+
+### Codex CLI Invocation (what runs on review iterations)
+
+```bash
+source scripts/codex-review.sh
+bp_codex_review --base main
+```
+
+The CLI path produces structured findings with severity levels (P0–P3) and handles fallback gracefully if Codex is unavailable.
+
+### MCP Fallback Configuration
+
+```json
+{
+  "mcpServers": {
+    "codex-reviewer": {
+      "command": "codex",
+      "args": ["mcp-server", "-c", "model=\"gpt-5.4\""]
+    }
+  }
+}
+```
+
+### Iteration Pattern
+
+```
+Iteration 1: BUILD  — Read cavekit, implement first requirement
+Iteration 2: REVIEW — Call Codex CLI (or MCP fallback), get findings, fix CRITICAL/HIGH
+Iteration 3: BUILD  — Continue implementing, address remaining findings
+Iteration 4: REVIEW — Call Codex CLI again, new findings on new code
+...
+Iteration N: BUILD  — All requirements met, all findings fixed
+             → outputs <promise>CAVEKIT COMPLETE</promise>
+```
+
+Default review interval: every 2nd iteration. `--review-interval 1` = review every iteration.
+
+### Peer Review Findings File
+
+Review findings tracked in `context/impl/impl-review-findings.md`:
+
+```markdown
+# Peer Review Findings
+
+## Latest Review: Iteration 4 — 2026-03-14T10:30:00Z
+### Reviewer: Codex (gpt-5.4)
+
+| # | Severity | File | Issue | Status |
+|---|----------|------|-------|--------|
+| 1 | CRITICAL | src/auth.ts:L42 | Missing input validation on token | FIXED |
+| 2 | HIGH | src/auth.ts:L67 | Race condition in session refresh | FIXED |
+| 3 | MEDIUM | src/auth.ts:L15 | Unused import | NEW |
+| 4 | LOW | src/auth.ts:L3 | Comment typo | WONTFIX |
+
+## History
+### Iteration 2
+| # | Severity | File | Issue | Status |
+|---|----------|------|-------|--------|
+| 1 | CRITICAL | src/auth.ts:L20 | SQL injection in login query | FIXED |
+```
+
+### Completion Criteria (Codex Loop Mode)
+
+The loop exits when the completion promise is output. The prompt instructs Claude to ONLY output it when ALL of these are true:
+
+- All cavekit requirements (R-numbers) have been implemented.
+- All acceptance criteria pass.
+- No CRITICAL or HIGH peer review findings remain unfixed.
+- Build passes.
+- Tests pass.
+- At least one review iteration completed with no new CRITICAL/HIGH findings.
+
+### Review-Only Mode
+
+For reviewing existing code against a cavekit without building:
+
+```bash
+/ck:review --codex     # single Codex-only review (see /ck:review command)
+```
+
+Each iteration calls Codex to review existing code against the cavekit, then fixes issues found.
+
+### Prerequisites (Codex Loop Mode)
+
+1. **Codex CLI installed:** `npm install -g @openai/codex`
+2. **OpenAI API key configured:** Codex needs authentication (via `codex login` or env var).
+3. **Cavekit context directory:** Cavekit file must exist at the given path.
+
+### Convergence Signals (Codex Loop Mode)
+
+The peer review loop has converged when:
+- Codex's findings drop to zero or only LOW/MEDIUM severity.
+- Code diffs between iterations are minimal.
+- All cavekit requirements confirmed as met by both Claude and Codex.
+
+If the loop hits max iterations without converging:
+- Check `context/impl/impl-review-findings.md` for persistent issues.
+- Consider whether the cavekit needs clarification.
+- Run `/ck:revise --trace` to trace issues back to kits.

--- a/plugins/JuliusBrussee/blueprint/skills/prompt-pipeline/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/prompt-pipeline/SKILL.md
@@ -169,16 +169,16 @@ Agent Team Structure:
   Lead (delegate mode -- never writes code directly)
   +-- Teammate A: domain-auth
   |   Owns: src/auth/*, context/impl/impl-auth.md
-  |   Dispatch: Agent tool with isolation: "worktree"
+  |   Dispatch: Agent tool
   +-- Teammate B: domain-data
   |   Owns: src/data/*, context/impl/impl-data.md
-  |   Dispatch: Agent tool with isolation: "worktree"
+  |   Dispatch: Agent tool
   +-- Teammate C: domain-ui
       Owns: src/ui/*, context/impl/impl-ui.md
-      Dispatch: Agent tool with isolation: "worktree"
+      Dispatch: Agent tool
 ```
 
-**Why:** Agents need to understand their role and what they own. Dispatch subagents with `isolation: "worktree"` via the Agent tool for filesystem isolation. After merging a subagent's branch, the caller must clean up: `git worktree remove <path>` then `git branch -D <branch>`. Claude Code only auto-cleans worktrees when agents make no changes.
+**Why:** Agents need to understand their role and what they own. Dispatch subagents via the Agent tool. After merging a subagent's branch, the caller must clean up: `git branch -D <branch>`.
 
 ### 4.3 Batching Rules
 
@@ -241,7 +241,7 @@ You are implementing {DOMAIN} for the {PROJECT_NAME} project.
 
 ### Your Role
 - You own: {FILE_PATTERNS}
-- Isolation: dispatched via Agent tool with `isolation: "worktree"`
+- Dispatched via the Agent tool
 - Your impl tracking: context/impl/impl-{DOMAIN}.md
 
 ### Context to Read First

--- a/plugins/JuliusBrussee/blueprint/skills/revision/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/revision/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: revision
 description: >
-  The technique of tracing bugs and manual fixes back to kits and prompts, then fixing at the source
-  so the iteration loop can reproduce the fix autonomously. Covers the 6-step revision process,
-  commit classification, cavekit-level root cause analysis, and regression test generation.
-  Trigger phrases: "revise", "revision", "trace bug to cavekit", "fix the cavekit not the code",
-  "why did this bug happen", "update kits from bug"
+  Trace bugs and manual fixes back to kits and prompts, then fix at the source so the iteration loop
+  can reproduce the fix autonomously. Covers the 6-step revision process for commit sweeps AND the
+  single-failure backpropagation protocol (six steps: TRACE, ANALYZE, PROPOSE, GENERATE, VERIFY, LOG)
+  that runs automatically via the auto-backprop hook on test failure and manually via
+  /ck:revise --trace. Trigger phrases: "revise", "revision", "trace bug to cavekit",
+  "fix the cavekit not the code", "why did this bug happen", "update kits from bug",
+  "trace this bug", "backprop", "why wasn't this caught", "fix the kit", "regression test".
 ---
 
 # Revision: Tracing Bugs Back to Kits
@@ -330,7 +332,7 @@ Every revision cycle tightens the kits, so the iteration loop settles into a sta
 - **Convergence monitoring:** Use `ck:convergence-monitoring` to detect when manual fixes are decreasing (good) or increasing (revision debt).
 - **Prompt pipeline:** Revision may trigger changes to prompts (Step 6), which affects the `ck:prompt-pipeline` design.
 - **Validation-first design:** Stronger validation gates catch issues earlier, reducing the need for revision.
-- **Gap analysis:** Systematic gap analysis (`/ck:scan`) identifies revision targets proactively, rather than waiting for bugs.
+- **Gap analysis:** Systematic gap analysis (`/ck:review --mode gap`) identifies revision targets proactively, rather than waiting for bugs.
 
 ---
 
@@ -340,3 +342,107 @@ Every revision cycle tightens the kits, so the iteration loop settles into a sta
 - **Prompt pipeline:** See `ck:prompt-pipeline` skill for how prompt 006 (rewrite pattern) implements automated revision.
 - **Impl tracking:** See `ck:impl-tracking` skill for the revision log format in implementation tracking documents.
 - **Validation gates:** See `ck:validation-first` skill for validation layers that catch issues before they require revision.
+
+---
+
+## 8. Automated Backpropagation (Single-Failure Trace)
+
+The revision skill also handles the **single-failure backpropagation protocol** — invoked automatically when a test command fails during `/ck:make`, or manually via `/ck:revise --trace`. Where Sections 1–7 describe the multi-commit revision sweep, this section describes the single-failure trace with a tighter six-step procedure and an explicit audit log.
+
+**Principle:** Bugs are spec bugs until proven otherwise. Before patching code, verify the kit actually covered the failing behavior. If it did not, the fix is a kit amendment plus a regression test — not just a patch.
+
+### Six-Step Procedure
+
+#### 1. TRACE — match failure to a requirement
+
+Read the failure output. Find the single acceptance criterion (or gap of one) that, if asserted, would have caught this. Identify the kit and R-ID:
+
+```
+Kit: cavekit-auth.md
+Requirement: R004 (rate-limit middleware)
+Closest AC: AC2 ("returns 429 when limit exceeded")
+Missing coverage: 429 header case sensitivity not asserted
+```
+
+If no requirement fits, the bug is in a dimension the kit never addressed — this is a **missing requirement** (case D below).
+
+#### 2. ANALYZE — classify the gap
+
+One of:
+
+- **A. missing_criterion** — the requirement exists but the acceptance criteria do not cover this case. Add an AC.
+- **B. incomplete_criterion** — an AC partially covers it but is too vague to catch the failure. Tighten the AC.
+- **C. wrong_criterion** — an AC asserts the wrong thing. Correct it.
+- **D. missing_requirement** — no requirement addresses this dimension at all. Add a new R.
+
+#### 3. PROPOSE — draft the spec change
+
+Write the exact amendment. Required fields:
+
+```
+Classification: missing_criterion
+Kit: cavekit-auth.md
+Change: R004 append AC5
+Proposed AC: "AC5 — Rate-limit headers (X-RateLimit-*, Retry-After) are
+  returned with canonical lowercase casing per RFC 7230 §3.2."
+Trace: auth.test.ts → 429 path → header casing mismatch
+```
+
+Show the proposed change to the user. **Wait for explicit approval** before writing to the kit. Do not silently amend specs.
+
+#### 4. GENERATE — regression test
+
+Before fixing the bug, write a test that asserts the new AC and currently **fails**. This locks in the requirement in executable form.
+
+Commit the failing test separately from the fix:
+
+```
+git commit -m "test: add regression for rate-limit header casing (cavekit-auth.md R004 AC5)"
+```
+
+#### 5. VERIFY — fix until the test passes
+
+Patch the code. Run the full test suite. Confirm the new regression test passes and nothing else regresses. Commit the fix referencing the AC.
+
+#### 6. LOG — write a trace entry
+
+Append to `.cavekit/history/backprop-log.md`:
+
+```markdown
+## Entry {n}
+
+- id: 12
+- date: 2026-04-17T14:22Z
+- classification: missing_criterion
+- kit: cavekit-auth.md
+- requirement: R004
+- ac_added: AC5
+- failing_test_before_fix: auth.test.ts::rate-limit headers casing
+- fix_commit: abc1234
+- pattern_category: input_validation
+```
+
+### Pattern Detection
+
+The log is a corpus. If the same `pattern_category` appears 3+ times in one project, the issue is systemic and belongs one layer up — at the brainstorming / kit-writing layer, not per-requirement. Categories:
+
+- `input_validation` — unvalidated / mis-cased / range-unchecked input.
+- `concurrency` — races, missed locks, stale reads.
+- `error_handling` — swallowed exceptions, missing retries, partial rollbacks.
+- `integration` — contract drift between services, missing end-to-end tests.
+- `observability` — silent failures, missing logs/metrics.
+
+When a threshold hits, propose a cross-kit amendment (e.g., a validation rule added to every input-accepting kit). Announce this to the user.
+
+### Auto-Backprop Hook Integration
+
+The `auto-backprop.js` hook writes `.cavekit/.auto-backprop-pending.json` when a test command fails during `/ck:make`. The stop hook reads this flag and prepends a trace directive to the next iteration's prompt, which tells the agent to run the six steps above before resuming normal task execution. Once the directive fires, the flag is atomically deleted.
+
+Disable via `auto_backprop = false` in `.cavekit/config.json` if you need to run `/ck:make` without this safety net (e.g., during exploratory spikes).
+
+### Anti-Patterns
+
+- **Patch first, spec later** — fixes that never make it back to the kit. Every rerun of the loop may re-introduce the bug.
+- **Silent amendment** — updating a kit without user approval. The spec is the contract; amendments are a negotiation, not a refactor.
+- **Per-bug regression test with no spec change** — the test passes, but the next reader of the kit still will not know why. The AC must be written down.
+- **Bulk backprop** — rolling up N failures into one spec change. Each failure gets its own entry. Patterns emerge only if each is logged separately.

--- a/plugins/JuliusBrussee/blueprint/skills/speculative-pipeline/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/speculative-pipeline/SKILL.md
@@ -230,7 +230,7 @@ In multi-agent setups, speculative-pipeline applies at the pipeline level, not t
 Pipeline Level (speculative-pipeline timing):
   Stage 1 (Specs)     → Single agent or agent team
   Stage 2 (Plans)     → Single agent or agent team (starts after delay)
-  Stage 3 (Implement) → Agent team dispatched with `isolation: "worktree"` via Agent tool (starts after delay)
+  Stage 3 (Implement) → Agent team dispatched via Agent tool (starts after delay)
 ```
 
 Each stage can internally use agent teams (multiple teammates working in parallel on different

--- a/plugins/JuliusBrussee/blueprint/skills/validation-first/SKILL.md
+++ b/plugins/JuliusBrussee/blueprint/skills/validation-first/SKILL.md
@@ -281,7 +281,7 @@ Before reporting completion:
 
 ## Merge Protocol
 
-When working with agent teams (multiple agents dispatched with `isolation: "worktree"` via the Agent tool), the merge protocol ensures that integrating work from different agents does not break validation gates.
+When working with agent teams (multiple agents dispatched via the Agent tool), the merge protocol ensures that integrating work from different agents does not break validation gates.
 
 ### The Protocol
 
@@ -313,7 +313,7 @@ Merging all agent branches simultaneously and then running tests makes it imposs
 1. **Merge one agent branch at a time** — never batch-merge
 2. **Run Gates 1-3 after each merge** — build, unit tests, integration tests
 3. **Run Gate 5 after all merges** — launch verification on the fully integrated codebase
-4. **Clean up after each merge**: remove the worktree (`git worktree remove <path>`), then delete the branch (`git branch -D <branch>`). Claude Code only auto-cleans worktrees when agents make no changes; when changes are committed, the caller must remove the worktree before deleting the branch.
+4. **Clean up after each merge**: delete the merged branch (`git branch -D <branch>`).
 5. **If a merge fails validation,** fix it before proceeding to the next merge
 
 ---

--- a/plugins/Kanevry/session-orchestrator/.codex-plugin/plugin.json
+++ b/plugins/Kanevry/session-orchestrator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session-orchestrator",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0",
   "description": "Session-level orchestration for structured planning, wave execution, quality gates, and clean session close-out",
   "author": {
     "name": "Bernhard Goetzendorfer",

--- a/plugins/Kanevry/session-orchestrator/README.md
+++ b/plugins/Kanevry/session-orchestrator/README.md
@@ -1,20 +1,20 @@
 # Session Orchestrator
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.0--beta.5-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.0.0-green.svg)](CHANGELOG.md)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet.svg)](https://docs.anthropic.com/en/docs/claude-code)
 [![Codex](https://img.shields.io/badge/Codex-Compatible-green.svg)](https://developers.openai.com/codex/)
 [![Cursor IDE](https://img.shields.io/badge/Cursor_IDE-Compatible-blue.svg)](https://cursor.com)
 
-Session orchestration plugin for Claude Code, Codex, and Cursor IDE — project planning, wave execution, VCS integration, quality gates.
+Session orchestration plugin for Claude Code, Codex, and Cursor IDE. Covers project planning, wave execution, VCS integration, and quality gates.
 
-> [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://developers.openai.com/codex/), and [Cursor IDE](https://cursor.com) are agentic coding tools. This plugin adds structured session management on top — turning ad-hoc agent interactions into repeatable, quality-gated engineering workflows. No runtime code. Pure Markdown.
+> [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://developers.openai.com/codex/), and [Cursor IDE](https://cursor.com) are agentic coding tools. This plugin adds structured session management on top, turning ad-hoc agent interactions into repeatable, quality-gated engineering workflows. No runtime code. Pure Markdown.
 
 ## Install
 
 ### Claude Code
 
-Run these two slash commands **inside** Claude Code (they are not shell commands — there is no `claude plugin` CLI):
+Run these two slash commands **inside** Claude Code (they are not shell commands; there is no `claude plugin` CLI):
 
 ```text
 /plugin marketplace add Kanevry/session-orchestrator
@@ -76,18 +76,18 @@ Add Session Config to `AGENTS.md`, restart Codex, then run:
 /close
 ```
 
-See [Usage](#usage) for all 6 commands and [User Guide](docs/USER-GUIDE.md) for the full walkthrough.
+See [Usage](#usage) for all 7 commands and [User Guide](docs/USER-GUIDE.md) for the full walkthrough.
 
 ## Prerequisites
 
-- **Claude Code**, **Codex**, or **Cursor IDE** — [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [Codex](https://developers.openai.com/codex/) | [Cursor IDE](https://cursor.com)
-- **jq** (recommended) — required for scope and command enforcement hooks
+- **Claude Code**, **Codex**, or **Cursor IDE**: [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [Codex](https://developers.openai.com/codex/) | [Cursor IDE](https://cursor.com)
+- **jq** (recommended): required for scope and command enforcement hooks
 
 ### Platform Support
 
 | Feature | Claude Code | Codex | Cursor IDE |
 |---------|------------|-----------|------------|
-| All 6 commands | Native slash commands | Native plugin commands | Rules-based (.mdc) |
+| All 7 commands | Native slash commands | Native plugin commands | Rules-based (.mdc) |
 | Parallel agents | Agent tool | Multi-agent roles | Sequential only |
 | Session persistence | .claude/STATE.md | .codex/STATE.md | .cursor/STATE.md |
 | Shared knowledge | .orchestrator/metrics/ | .orchestrator/metrics/ | .orchestrator/metrics/ |
@@ -100,11 +100,11 @@ All platforms share the same skills, commands, hooks, and scripts. Platform-spec
 
 ## Why Session Orchestrator
 
-Session Orchestrator provides a complete development session lifecycle — from project state analysis through structured wave execution to verified close-out. While other tools optimize for speed or cost, Session Orchestrator optimizes for session quality and engineering discipline.
+Session Orchestrator covers the full development session lifecycle: project state analysis, structured wave execution, and verified close-out. Each step is gated on quality, not just speed.
 
 ### Soul Personality System
 
-A `soul.md` file defines the orchestrator's identity — communication principles, a decision-making hierarchy (safety > productivity > quality > ecosystem health > speed), and values (pragmatism, evidence, ownership). This shapes every interaction, not just tone.
+A `soul.md` file defines the orchestrator's identity: communication principles, a decision-making hierarchy (safety > productivity > quality > ecosystem health > speed), and values (pragmatism, evidence, ownership). This shapes every interaction, not just tone.
 
 ### 5-Wave Execution Pattern
 
@@ -116,7 +116,7 @@ A session-reviewer agent runs 8 review sections between waves (implementation co
 
 ### Design-Code Alignment
 
-When configured with a Pencil design file, the wave executor screenshots design frames after Impl-Core and Impl-Polish waves and compares them with the actual implementation — checking layout structure, component hierarchy, and visual elements. Results are classified as ALIGNED / MINOR DRIFT / MAJOR MISMATCH with automatic plan adaptation.
+When a Pencil design file is configured, the wave executor screenshots design frames after Impl-Core and Impl-Polish waves and compares them with the actual implementation, checking layout structure, component hierarchy, and visual elements. Results are classified as ALIGNED / MINOR DRIFT / MAJOR MISMATCH with automatic plan adaptation.
 
 ### VCS Dual Support
 
@@ -157,7 +157,7 @@ A complexity scoring formula (files x modules x issues) determines agent counts 
 | Design-code alignment | Pencil integration | None | None |
 | Session close with carryover | Verified, with issue creation | Manual | Partial |
 
-Session Orchestrator optimizes for engineering quality -- every wave verified, every issue tracked, every session closed cleanly.
+The design goal is engineering quality: every wave exits verified, every unfinished issue gets a carryover ticket, and every session closes with a clean commit.
 
 ## Usage
 
@@ -169,6 +169,7 @@ Session Orchestrator optimizes for engineering quality -- every wave verified, e
 | `/discovery [scope]` | Systematic quality discovery and issue detection |
 | `/plan [mode]` | Plan a project, feature, or retrospective |
 | `/evolve [mode]` | Extract, review, or list cross-session learnings |
+| `/bootstrap` | Scaffold required repo structure for session-orchestrator |
 
 ## Workflow
 
@@ -183,11 +184,11 @@ Session Orchestrator has two complementary workflows: **planning** (what to buil
 
 Run `/plan` **before** starting a session to define requirements and create issues:
 
-- **`/plan new`** — Full project kickoff: 3-wave requirement gathering, 8-section PRD, repo scaffolding, Epic + prioritized issues. Use when starting from scratch.
-- **`/plan feature`** — Compact feature PRD: 1-2 wave discovery, acceptance criteria, feature issues. Use when adding a feature to an existing project.
-- **`/plan retro`** — Data-driven retrospective: analyzes session metrics, surfaces trends, creates improvement issues. Use after completing significant work.
+- **`/plan new`**: Full project kickoff. 3-wave requirement gathering, 8-section PRD, repo scaffolding, Epic + prioritized issues. Use when starting from scratch.
+- **`/plan feature`**: Compact feature PRD. 1-2 wave discovery, acceptance criteria, feature issues. Use when adding a feature to an existing project.
+- **`/plan retro`**: Data-driven retrospective. Analyzes session metrics, surfaces trends, creates improvement issues. Use after completing significant work.
 
-`/plan` is optional — you can create issues manually and jump straight to `/session`.
+`/plan` is optional. You can create issues manually and jump straight to `/session`.
 
 ### Execution (`/session` → `/go` → `/close`)
 
@@ -210,19 +211,19 @@ Run `/session` to **implement** existing issues across structured waves:
 
 ### Learning (`/evolve`)
 
-`/evolve` is a standalone command for deliberate reflection — it is **not** called automatically during sessions.
+`/evolve` is a standalone command for deliberate reflection. It is **not** called automatically during sessions.
 
 **Why it exists:** `/close` extracts learnings from the *current* session only. `/evolve` analyzes *all* session history to find cross-session patterns that only emerge over time.
 
-- **`/evolve analyze`** (default) — Reads `sessions.jsonl`, extracts patterns across all sessions (fragile files, effective sizing, recurring issues, scope guidance, deviation patterns). Presents findings for confirmation before writing.
-- **`/evolve review`** — Interactive management: boost or reduce confidence, delete stale learnings, extend expiry.
-- **`/evolve list`** — Read-only display of active learnings grouped by type.
+- **`/evolve analyze`** (default): Reads `sessions.jsonl`, extracts patterns across all sessions (fragile files, effective sizing, recurring issues, scope guidance, deviation patterns). Presents findings for confirmation before writing.
+- **`/evolve review`**: Interactive management. Boost or reduce confidence, delete stale learnings, extend expiry.
+- **`/evolve list`**: Read-only display of active learnings grouped by type.
 
 **When to use:**
-- After 5+ sessions — enough data for meaningful patterns
+- After 5+ sessions, so there is enough data for meaningful patterns
 - When Project Intelligence is empty despite running sessions
-- Before a big feature — check if the system has useful sizing/scope recommendations
-- Periodically for housekeeping — prune outdated or incorrect learnings
+- Before a big feature, to check if the system has useful sizing/scope recommendations
+- Periodically for housekeeping, to prune outdated or incorrect learnings
 
 **How it fits in the flow:**
 ```
@@ -234,9 +235,9 @@ Run `/session` to **implement** existing issues across structured waves:
 
 ## Session Types
 
-- **housekeeping** — Git cleanup, SSOT refresh, CI checks, branch merges (1-2 agents, serial)
-- **feature** — Frontend/backend feature work (4-6 agents per wave x 5 waves)
-- **deep** — Complex backend, security, DB, refactoring (up to 10-18 agents per wave x 5 waves)
+- **housekeeping**: Git cleanup, SSOT refresh, CI checks, branch merges (1-2 agents, serial)
+- **feature**: Frontend/backend feature work (4-6 agents per wave x 5 waves)
+- **deep**: Complex backend, security, DB, refactoring (up to 10-18 agents per wave x 5 waves)
 
 ## Repo Session Config
 
@@ -269,13 +270,13 @@ Add to each repo's `CLAUDE.md`:
 
 When dispatching agents, Session Orchestrator uses a three-tier resolution:
 
-1. **Project agents** (`.claude/agents/`) — highest priority, domain-specific
-2. **Plugin agents** (`session-orchestrator:*`) — generic base agents, work in any project
-3. **`general-purpose`** — fallback when no specialized agent matches
+1. **Project agents** (`.claude/agents/`): highest priority, domain-specific
+2. **Plugin agents** (`session-orchestrator:*`): generic base agents, work in any project
+3. **`general-purpose`**: fallback when no specialized agent matches
 
 The `agent-mapping` config lets you explicitly bind roles to agents. Without it, session-plan auto-matches tasks to agents based on their descriptions.
 
-For the complete field reference with types, defaults, and descriptions, see the [User Guide — Session Config Reference](docs/USER-GUIDE.md#4-session-config-reference).
+For the full field reference with types, defaults, and descriptions, see the [User Guide: Session Config Reference](docs/USER-GUIDE.md#4-session-config-reference).
 
 ## VCS Auto-Detection
 
@@ -302,21 +303,21 @@ Superpowers handles the **task layer** (TDD, debugging, brainstorming per featur
 
 ## Components
 
-- **11 Skills** (10 implemented + 1 design brief): session-start, session-plan, wave-executor, session-end, ecosystem-health, gitlab-ops, quality-gates, discovery, plan, evolve, vault-sync
-- **6 Commands**: /session, /go, /close, /discovery, /plan, /evolve
+- **13 Skills**: session-start, session-plan, wave-executor, session-end, ecosystem-health, gitlab-ops, quality-gates, discovery, plan, evolve, vault-sync, bootstrap, daily
+- **7 Commands**: /session, /go, /close, /discovery, /plan, /evolve, /bootstrap
 - **6 Agents**: code-implementer, test-writer, ui-developer, db-specialist, security-reviewer (generic base agents) + session-reviewer (inter-wave quality gate)
 - **Hooks**: SessionStart notification + Clank Event Bus integration + PreToolUse enforcement (scope + commands)
 - **Output Styles**: 3 styles (session-report, wave-summary, finding-report) for consistent reporting
-- `.codex-plugin/` — Codex plugin manifest (`plugin.json`) + compatibility config + 3 agent role definitions
-- `scripts/codex-install.sh` — installs into the active Codex desktop plugin catalog or falls back to a local marketplace
-- `scripts/` — 5 deterministic scripts (parse-config, run-quality-gate, validate-wave-scope, validate-plugin, token-audit) + shared lib + 328 tests
+- `.codex-plugin/`: Codex plugin manifest (`plugin.json`) + compatibility config + 3 agent role definitions
+- `scripts/codex-install.sh`: installs into the active Codex desktop plugin catalog or falls back to a local marketplace
+- `scripts/`: 5 deterministic scripts (parse-config, run-quality-gate, validate-wave-scope, validate-plugin, token-audit) + shared lib + 328 tests
 
 ## Documentation
 
-- [User Guide](docs/USER-GUIDE.md) — installation, config reference, workflow walkthrough, FAQ
-- [CONTRIBUTING.md](CONTRIBUTING.md) — plugin architecture, skill anatomy, development setup
-- [CHANGELOG.md](CHANGELOG.md) — version history
-- [Example Configs](docs/examples/) — Session Config examples for Next.js, Express, Swift
+- [User Guide](docs/USER-GUIDE.md): installation, config reference, workflow walkthrough, FAQ
+- [CONTRIBUTING.md](CONTRIBUTING.md): plugin architecture, skill anatomy, development setup
+- [CHANGELOG.md](CHANGELOG.md): version history
+- [Example Configs](docs/examples/): Session Config examples for Next.js, Express, Swift
 
 ## Links
 

--- a/plugins/Kanevry/session-orchestrator/skills/_shared/config-reading.md
+++ b/plugins/Kanevry/session-orchestrator/skills/_shared/config-reading.md
@@ -72,7 +72,7 @@ If the script is not available (missing file, `$PLUGIN_ROOT` unresolvable), fall
 
 ## Learning Expiry Semantics
 
-Learnings live exclusively in `.orchestrator/metrics/learnings.jsonl`. The pre-`2.0.0-beta.4` location `<state-dir>/metrics/learnings.jsonl` is no longer read; consumers with leftover entries should run `scripts/migrate-legacy-learnings.sh` once.
+Learnings live exclusively in `.orchestrator/metrics/learnings.jsonl`. The pre-`2.0.0` location `<state-dir>/metrics/learnings.jsonl` is no longer read; consumers with leftover entries should run `scripts/migrate-legacy-learnings.sh` once.
 
 The learning lifecycle states are:
 

--- a/plugins/aklofas/kicad-happy/README.md
+++ b/plugins/aklofas/kicad-happy/README.md
@@ -1,13 +1,13 @@
 # ⚡ kicad-happy
 
 [![CI](https://github.com/aklofas/kicad-happy/actions/workflows/ci.yml/badge.svg)](https://github.com/aklofas/kicad-happy/actions/workflows/ci.yml)
-[![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Mentioned in Awesome KiCad](https://awesome.re/mentioned-badge.svg)](https://github.com/joanbono/awesome-kicad)
 
 AI-powered design review for KiCad. Analyzes schematics, PCB layouts, and Gerbers. Catches real bugs before you order boards.
 
-Works with **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** and **[OpenAI Codex](https://github.com/openai/codex)**, as a **GitHub Action** for automated PR reviews, or as standalone Python scripts you can run anywhere.
+Works with **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, **[OpenAI Codex](https://github.com/openai/codex)**, **[GitHub Copilot CLI](https://docs.github.com/en/copilot)**, and **[Gemini CLI](https://github.com/google-gemini/gemini-cli)**, as a **GitHub Action** for automated PR reviews, or as standalone Python scripts you can run anywhere.
 
 These skills turn your AI coding agent into a full-fledged electronics design assistant that understands your KiCad projects at a deep level: parses schematics and PCB layouts into structured data, cross-references component values against datasheets, detects common design errors, and walks you through the full prototype-to-production workflow.
 
@@ -90,6 +90,9 @@ For the end-to-end walkthrough from S-expression parsing through signal detectio
 
 ## 🚀 Install
 
+> [!TIP]
+> For detailed installation, upgrade, and troubleshooting guidance across all platforms, have your AI agent read [`install-guidance.md`](install-guidance.md). It covers platform-specific quirks, known bugs, workarounds, and OS-specific issues.
+
 **Claude Code:**
 
 ```
@@ -108,17 +111,19 @@ For the end-to-end walkthrough from S-expression parsing through signal detectio
 
 **OpenAI Codex:**
 
-Clone and open the repo in Codex — skills are auto-discovered from `.agents/skills/`:
+Use Codex's built-in skill installer first:
+
+> "Use $skill-installer to install the kicad-happy skills from https://github.com/aklofas/kicad-happy"
+
+If you prefer a manual install, install the skills into `~/.codex/skills/`.
+
+Clone the repo:
 
 ```bash
 git clone https://github.com/aklofas/kicad-happy.git
 ```
 
-Run `/plugins` to browse the repo-local plugin marketplace, or just start using the skills directly — Codex scans `.agents/skills/` automatically.
-
-To use the skills in your own hardware projects instead, ask your agent:
-
-> "Clone https://github.com/aklofas/kicad-happy and install all the skills"
+After installing new skills, restart Codex if they do not appear immediately.
 
 <details>
 <summary><strong>Manual install & other platforms</strong></summary>
@@ -129,7 +134,7 @@ To use the skills in your own hardware projects instead, ask your agent:
 git clone https://github.com/aklofas/kicad-happy.git
 cd kicad-happy
 mkdir -p ~/.claude/skills
-for skill in kicad spice emc bom digikey mouser lcsc element14 jlcpcb pcbway kidoc; do
+for skill in kicad spice emc datasheets bom digikey mouser lcsc element14 jlcpcb pcbway kidoc; do
   ln -sf "$(pwd)/skills/$skill" ~/.claude/skills/$skill
 done
 ```
@@ -139,9 +144,9 @@ done
 ```bash
 git clone https://github.com/aklofas/kicad-happy.git
 cd kicad-happy
-mkdir -p ~/.agents/skills
-for skill in kicad spice emc bom digikey mouser lcsc element14 jlcpcb pcbway kidoc; do
-  ln -sf "$(pwd)/skills/$skill" ~/.agents/skills/$skill
+mkdir -p ~/.codex/skills
+for skill in kicad spice emc datasheets bom digikey mouser lcsc element14 jlcpcb pcbway kidoc; do
+  ln -sf "$(pwd)/skills/$skill" ~/.codex/skills/$skill
 done
 ```
 
@@ -150,9 +155,9 @@ done
 ```powershell
 git clone https://github.com/aklofas/kicad-happy.git
 cd kicad-happy
-New-Item -ItemType Directory -Force "$HOME\.agents\skills" | Out-Null
-"kicad","spice","emc","bom","digikey","mouser","lcsc","element14","jlcpcb","pcbway","kidoc" | ForEach-Object {
-  New-Item -ItemType SymbolicLink -Path "$HOME\.agents\skills\$_" -Target "$(Get-Location)\skills\$_" -Force | Out-Null
+New-Item -ItemType Directory -Force "$HOME\.codex\skills" | Out-Null
+"kicad","spice","emc","datasheets","bom","digikey","mouser","lcsc","element14","jlcpcb","pcbway","kidoc" | ForEach-Object {
+  New-Item -ItemType SymbolicLink -Path "$HOME\.codex\skills\$_" -Target "$(Get-Location)\skills\$_" -Force | Out-Null
 }
 ```
 
@@ -160,7 +165,7 @@ Note: Windows symlinks may require Developer Mode or elevated privileges.
 
 </details>
 
-The analysis scripts are **pure Python 3.8+** with zero required dependencies. No pip install, no Docker, no KiCad installation needed.
+The analysis scripts are **pure Python 3.10+** with zero required dependencies. No pip install, no Docker, no KiCad installation needed.
 
 ## ⚙️ GitHub Action
 
@@ -471,7 +476,7 @@ v1.1 shipped the analysis engine. v1.2 makes it something you'd actually hand to
 
 | Category | Capabilities |
 | --- | --- |
-| **Codex support** | First-class OpenAI Codex — 11 skills auto-discovered from `.agents/skills/`, repo-local marketplace, agent-neutral docs. |
+| **Codex support** | First-class OpenAI Codex support with agent-neutral docs, skill-installer compatibility, and global installs via `~/.codex/skills/`. |
 | **KiDoc (beta)** | 8 document types, 12 figure generators, PDF/DOCX/ODT/HTML output. Scaffolds with auto-updating data + narrative placeholders. |
 | **Datasheet verification** | Pin voltage enforcement, required external component checks, per-IC decoupling validation against manufacturer specs. |
 | **What-if tools** | Sweep tables, tolerance analysis, fix suggestions with E-series snapping, EMC impact preview, PCB parasitic awareness. |

--- a/plugins/aklofas/kicad-happy/skills/emc/scripts/analyze_emc.py
+++ b/plugins/aklofas/kicad-happy/skills/emc/scripts/analyze_emc.py
@@ -556,16 +556,11 @@ def main():
         from analysis_cache import (hash_source_file, should_create_new_run,
                                     create_run, overwrite_current,
                                     CANONICAL_OUTPUTS, MANIFEST_FILENAME,
-                                    save_manifest, _empty_manifest, GITIGNORE_CONTENT)
+                                    save_manifest, _empty_manifest, GITIGNORE_CONTENT,
+                                    resolve_analysis_dir)
 
-        # Resolve --analysis-dir relative to CWD, not to the schematic JSON's
-        # directory. The schematic argument is typically *already* inside the
-        # analysis tree (analysis/<run>/schematic.json); anchoring on its
-        # parent would recursively create analysis/<run>/analysis/<run>/…
-        if not os.path.isabs(args.analysis_dir):
-            analysis_dir = os.path.abspath(args.analysis_dir)
-        else:
-            analysis_dir = args.analysis_dir
+        # Keep analysis-dir semantics aligned with the core KiCad analyzers.
+        analysis_dir = resolve_analysis_dir(args.analysis_dir)
 
         os.makedirs(analysis_dir, exist_ok=True)
         manifest_path = os.path.join(analysis_dir, MANIFEST_FILENAME)

--- a/plugins/aklofas/kicad-happy/skills/kicad/SKILL.md
+++ b/plugins/aklofas/kicad-happy/skills/kicad/SKILL.md
@@ -38,6 +38,49 @@ description: >-
 
 **If you see a `DS-001` finding in the analyzer output** (severity `high`, detector `audit_datasheet_coverage`), the review cannot make any verified claim. Stop and either (a) run the datasheet sync via `digikey` / `mouser` / `lcsc` / `element14` (whichever has credentials/stock), (b) populate MPNs on the BOM parts, or (c) state explicitly in the report that every pin-level, electrical, and regulator finding is *consistency only* — do not use the words "verified", "confirmed", or "per datasheet" anywhere. `DS-002` (datasheets missing but MPNs set) and `DS-003` (partial MPN coverage) are softer variants with the same implication for the parts they cite.
 
+## Design Review Contract
+
+When the user asks for a **design review**, **complete report**, **ready-to-fab assessment**, or anything equivalent, do not stop at running one or two analyzers and summarizing their findings. A design review in this skill has a stricter contract:
+
+1. Read the full workflow in this `SKILL.md`, not just the analyzer command sections.
+2. Read `references/report-generation.md` before writing the report.
+3. Run every applicable analyzer for the files present in the project, then say explicitly which ones were and were not run.
+4. Perform raw-file and datasheet cross-verification before claiming anything is "verified".
+5. Triage likely analyzer false positives before elevating them into blockers.
+6. If a required step could not be done, state it as a review gap, not as silent omission.
+
+Treat this as the minimum bar. Analyzer JSON alone is not the final review.
+
+### Minimum Review Checklist
+
+For a full design review, explicitly account for each item below in the report:
+
+- `datasheets/` present, synced, or verification gap stated
+- `analyze_schematic.py`
+- `analyze_pcb.py --full`
+- `cross_analysis.py`
+- `analyze_emc.py`
+- SPICE simulation when any simulator is installed
+- `analyze_thermal.py` when both schematic and PCB JSON exist
+- `analyze_gerbers.py` when fabrication outputs exist
+- lifecycle audit when network access and MPN coverage allow it
+- prior review / prior run delta check
+- raw schematic/PCB spot-verification elevated to full verification for critical parts
+- explicit report sections for blockers, verification basis, false positives, and skipped analyses
+
+If an item is not applicable, say why. If it was skipped, say why. If it failed, say how that limits confidence.
+
+### Common Review Failure Modes
+
+These are the failure modes this contract is meant to prevent:
+
+- Stopping after schematic + PCB + EMC output and calling it a complete review
+- Reporting analyzer findings without checking whether they are expected layout artifacts
+- Claiming "verified" without direct datasheet evidence or structured extraction evidence
+- Omitting thermal, lifecycle, prior-review delta, or gerber checks without disclosure
+- Writing a report that lacks a verdict, blockers table, verification basis, or skipped-analysis notes
+- Reading only the first part of this skill and missing the design-review workflow later in the file
+
 ## PDF Schematic Analysis
 
 This skill also handles **PDF schematics** — reference designs, dev board schematics, eval board docs, application notes, and datasheet typical-application circuits. Common use cases:
@@ -358,6 +401,8 @@ drill_classification, pad_summary, board_dimensions, gerbers, drills
 
 **Workflow:** When analyzing a KiCad project, scan the project directory for all available file types and run **every applicable analyzer** — not just the one the user mentioned. A complete analysis uses all the data available. Use `--analysis-dir analysis/` on all analyzers to share a single run folder tracked by the manifest. For one-off runs without cache tracking, use `--output file.json` instead.
 
+**Before starting the workflow below for a design review:** read `references/report-generation.md`. The report structure, verification basis rules, skipped-analysis disclosure, and false-positive triage expectations there are part of the review workflow, not optional polish added at the end.
+
 1. **Scan the project directory** for `.kicad_sch`, `.kicad_pcb`, `.kicad_pro`, gerber directories, and `.net`/`.xml` netlist files.
 2. **Sync datasheets** (see Datasheet Acquisition below) — this is a prerequisite for verification, not optional. Without datasheets, all subsequent verification is reduced to internal consistency checks — confirming the design agrees with itself, not that it's correct. Run the sync before reading any analyzer output. If sync fails or no API keys are available, use fallback methods (Datasheet property URLs, individual downloads via `digikey` skill, ask the user). If critical IC datasheets can't be obtained, note this prominently in the report as a verification gap.
 3. **Run the core analyzers.** If the schematic exists, run `analyze_schematic.py`. If the PCB exists, run `analyze_pcb.py --full`. If gerbers exist, run `analyze_gerbers.py`. Run them in parallel when possible.
@@ -370,6 +415,7 @@ drill_classification, pad_summary, board_dimensions, gerbers, drills
 10. **Check for prior design reviews** — scan the project directory for existing review files (`*review*.md`, `*design-review*.md`). If found, read the most recent one. If `auto_diff` is enabled and prior runs exist, run `diff_analysis.py` on current vs previous run and include the delta in the "Previous Review Delta" section.
 11. **Verify each output** against the raw files and datasheets before using the data in your report.
 12. **Produce a unified report** covering schematic analysis, PCB layout analysis, cross-domain findings, EMC risk assessment, simulation verification, thermal hotspots, and cross-reference findings. See `references/report-generation.md` for the report template.
+13. **Disclose all review gaps explicitly** — if thermal, lifecycle, gerber, datasheet extraction, or prior-review delta were not performed, add a short "Not performed / limits" section to the report instead of omitting them silently.
 
 The more data sources you combine, the more confident the analysis. A schematic-only review misses layout issues; a PCB-only review misses design intent. Always use everything available.
 

--- a/plugins/aklofas/kicad-happy/skills/kicad/references/report-generation.md
+++ b/plugins/aklofas/kicad-happy/skills/kicad/references/report-generation.md
@@ -2,6 +2,76 @@
 
 Guide for producing comprehensive design review reports from analyzer output + raw file cross-referencing. These reports help EE designers validate their designs before committing to fabrication.
 
+## Minimum Review Contract
+
+This reference is not optional reading for full design reviews. If the user asks for a complete review, ready-to-fab assessment, or comprehensive report, the resulting report must satisfy this minimum contract:
+
+1. Name the analyzers that were actually run.
+2. Name the applicable analyzers that were not run, and why.
+3. Separate verified findings from inference-only findings.
+4. Put blockers and warnings near the top.
+5. Triage obvious false positives instead of repeating analyzer output unfiltered.
+6. State verification gaps explicitly when datasheets, thermal, lifecycle, gerbers, or prior-review delta were not available.
+
+If the review does not meet this contract, it is an incomplete review, not a full one.
+
+## Required Sections for Full Reviews
+
+These sections are expected in a complete design review unless genuinely not applicable:
+
+- Overview
+- Previous Review Delta, when a prior review or prior runs exist
+- Critical Findings
+- Component Summary
+- Power Tree
+- Analyzer Verification
+- Signal Analysis Review
+- Power Analysis
+- PCB Layout Analysis, when a PCB exists
+- Thermal Analysis or an explicit note that thermal analysis was not performed
+- EMC / Cross-Domain Analysis when schematic and PCB both exist
+- Component Lifecycle or an explicit note that lifecycle audit was not performed
+- Manufacturing / DFM / testability
+- False Positives / reviewer overrides
+- Not Performed / Review Limits
+- Final verdict / readiness statement
+
+## Evidence Basis Rules
+
+Every substantive finding should make its evidence basis clear. Use these categories consistently:
+
+- **Datasheet-verified** — checked against the manufacturer PDF, with page / figure / table / equation citation
+- **Extraction-verified** — checked against structured datasheet extraction in `datasheets/extracted/`
+- **Raw-file verified** — checked against the raw `.kicad_sch`, `.kicad_pcb`, or fabrication files
+- **Analyzer-derived** — came from analyzer output and was accepted after review
+- **Inference-only** — plausible engineering reasoning, but not directly verified against datasheet or raw file
+
+Do not use the word "verified" for analyzer-only or inference-only claims.
+
+## Skipped Analysis Disclosure
+
+If any applicable analysis was not run, include a short section in the report that says so explicitly. Do not bury omissions in prose or leave them unstated.
+
+Recommended format:
+
+```markdown
+## Not Performed / Review Limits
+
+- Thermal analysis not performed — reason.
+- Lifecycle audit not performed — reason.
+- Gerber analysis not performed — no fabrication outputs present.
+- Datasheet extraction not available — pin-level checks are datasheet-manual or inference-only.
+```
+
+## False-Positive Triage
+
+A good design review is not a transcript of analyzer output. For findings likely to be layout artifacts, intentional keepouts, expected RF-module courtyard behavior, or known heuristic overreach:
+
+- either dismiss them explicitly with reasoning
+- or downgrade them and explain the residual risk
+
+If a finding was reviewed and judged benign, keep it in a "False Positives / Reviewer Overrides" section so the reader can see that it was considered rather than missed.
+
 ## Contents
 
 | Section | Line | Purpose |

--- a/plugins/aklofas/kicad-happy/skills/kicad/references/schematic-analysis.md
+++ b/plugins/aklofas/kicad-happy/skills/kicad/references/schematic-analysis.md
@@ -23,6 +23,8 @@ Methodology for validating KiCad schematics against datasheets, common design pa
 
 **Fallback methodology**: If `analyze_schematic.py` fails, see [`manual-schematic-parsing.md`](manual-schematic-parsing.md) for direct file parsing instructions.
 
+**For full design reviews:** read `report-generation.md` before writing conclusions. The report format, evidence-basis labeling, skipped-analysis disclosure, and false-positive triage expectations are part of the review method, not post-processing.
+
 ---
 
 ## Analysis Workflow
@@ -68,6 +70,15 @@ Perform thorough verification of the analyzer output against the raw schematic. 
 5. **Connector pinout verification**: For every connector, verify pin-to-net mapping against the relevant standard or mating connector. Connector pinout errors are among the most common mistakes (see Connector Pinout Verification section below).
 
 This thorough verification catches the cases where the analyzer silently drops components, misidentifies subcircuits, or — most dangerously — reports wrong pin-to-net mappings.
+
+**Evidence classification during Step 2:** as you verify items, keep track of which bucket each conclusion belongs to:
+- datasheet-verified
+- extraction-verified
+- raw-file verified
+- analyzer-derived
+- inference-only
+
+Do not collapse these into a generic "verified" label in the final report.
 
 ### Step 3: Review and augment subcircuit identification
 
@@ -121,6 +132,8 @@ Compare the actual schematic against the datasheet's reference design. Check:
 - Are optional features (enable, power-good, soft-start) handled appropriately?
 - Are absolute maximum ratings respected with margin?
 
+When a datasheet recommendation is absent or ambiguous, say so. Do not overstate confidence just because the topology looks conventional.
+
 ### Step 6: Verify computed values
 
 For every value that derives from a formula (resistor dividers, RC filters, current limits, etc.), compute the expected result and compare to the design intent. Flag discrepancies.
@@ -152,6 +165,23 @@ After subcircuit validation, check system-level issues:
 
 If your coordinate-based analysis finds "critical" issues (floating pins, wrong connections) but the user says the schematic is correct, **assume your coordinate math is wrong** and re-derive from scratch with the Y-axis formula from `net-tracing.md`.
 
+### Step 8b: Triage analyzer false positives before ranking severity
+
+Before turning analyzer output into blockers, explicitly classify each notable finding as one of:
+- real issue
+- likely false positive
+- expected-by-design tradeoff
+- unresolved / needs more evidence
+
+Common sources of false positives:
+- RF module courtyard / antenna keepout overlaps
+- intentional copper under bypass caps or local power islands
+- general USB resistor heuristics that do not apply to the specific PHY
+- board-edge warnings triggered by intentional antenna placement
+- inferred lifecycle or sourcing warnings based on partial distributor coverage
+
+A strong review explains why a finding was accepted, downgraded, or dismissed.
+
 ### Step 9: Produce the report
 
 Organize findings by severity (Critical / Warning / Suggestion / Info) and by subcircuit. For each finding, show the reasoning — not just the conclusion:
@@ -160,6 +190,8 @@ Organize findings by severity (Critical / Warning / Suggestion / Info) and by su
 - **Show formulas**: When validating computed values (feedback dividers, RC filters, current limits), write out the equation with the actual component values substituted in (e.g., "VOUT = VREF × (1 + R_top/R_bottom) = 0.595V × (1 + 732k/100k) = 4.95V").
 - **Compare against spec**: Show the design's value alongside the datasheet's recommended range so the reader can see the margin (e.g., "L = 1µH, datasheet recommends 0.37-2.9µH ✓").
 - **Explain the chain of reasoning** for non-obvious issues: if something looks wrong, explain how you traced the net, what you expected to find, and what you found instead.
+- **Disclose review limits**: If thermal, lifecycle, gerber, prior-review delta, or datasheet extraction work was not performed, state that explicitly in the report.
+- **Separate evidence from judgment**: A finding can be well-supported and still not be a blocker. Distinguish the factual observation from the severity judgment.
 
 ---
 

--- a/plugins/aklofas/kicad-happy/skills/kicad/scripts/analysis_cache.py
+++ b/plugins/aklofas/kicad-happy/skills/kicad/scripts/analysis_cache.py
@@ -19,6 +19,7 @@ import json
 import os
 import shutil
 import sys
+import tempfile
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -109,6 +110,23 @@ def ensure_analysis_dir(project_dir: str,
     return analysis_dir
 
 
+def resolve_analysis_dir(path: str) -> str:
+    """Return a canonical analysis-dir path.
+
+    Command-line ``--analysis-dir`` paths should be interpreted the same way
+    across all analyzers:
+    - absolute paths stay absolute
+    - relative paths are resolved from the current working directory
+
+    Do not anchor ``path`` to the input schematic/PCB file's directory. When
+    callers already pass a project-relative path like ``hardware/foo/analysis``
+    alongside a project-relative input file like ``hardware/foo/design.kicad_*``,
+    joining them would incorrectly duplicate the prefix as
+    ``hardware/foo/hardware/foo/analysis``.
+    """
+    return os.path.abspath(path)
+
+
 # ---------------------------------------------------------------------------
 # Manifest I/O
 # ---------------------------------------------------------------------------
@@ -138,11 +156,19 @@ def load_manifest(analysis_dir: str) -> Dict[str, Any]:
 
 def save_manifest(analysis_dir: str, manifest: Dict[str, Any]) -> None:
     """Write manifest.json atomically (write-to-temp then rename)."""
+    os.makedirs(analysis_dir, exist_ok=True)
     manifest_path = os.path.join(analysis_dir, MANIFEST_FILENAME)
-    tmp_path = manifest_path + '.tmp'
-    with open(tmp_path, 'w', encoding='utf-8') as f:
+    with tempfile.NamedTemporaryFile(
+        mode='w',
+        encoding='utf-8',
+        dir=analysis_dir,
+        prefix=MANIFEST_FILENAME + '.',
+        suffix='.tmp',
+        delete=False,
+    ) as f:
         json.dump(manifest, f, indent=2)
         f.write('\n')
+        tmp_path = f.name
     os.replace(tmp_path, manifest_path)
 
 

--- a/plugins/aklofas/kicad-happy/skills/kicad/scripts/analyze_pcb.py
+++ b/plugins/aklofas/kicad-happy/skills/kicad/scripts/analyze_pcb.py
@@ -117,15 +117,18 @@ class ZoneFills:
 
     def __init__(self) -> None:
         self._fills: list[
-            tuple[int, str, list[tuple[float, float]],
+            tuple[int, int, str, list[tuple[float, float]],
                   tuple[float, float, float, float]]
         ] = []
+        self._next_fill_id = 0
 
     def add(self, zone_idx: int, layer: str,
             coords: list[tuple[float, float]]) -> None:
         """Register a filled polygon region for spatial queries."""
         bbox = _polygon_bbox(coords)
-        self._fills.append((zone_idx, layer, coords, bbox))
+        fill_id = self._next_fill_id
+        self._next_fill_id += 1
+        self._fills.append((fill_id, zone_idx, layer, coords, bbox))
 
     @property
     def has_data(self) -> bool:
@@ -137,7 +140,7 @@ class ZoneFills:
         """Return zone dicts that have filled copper at (x, y) on layer."""
         results = []
         seen: set[int] = set()
-        for zone_idx, fill_layer, coords, bbox in self._fills:
+        for _fill_id, zone_idx, fill_layer, coords, bbox in self._fills:
             if fill_layer != layer or zone_idx in seen:
                 continue
             # Fast bounding box rejection
@@ -148,9 +151,27 @@ class ZoneFills:
                 seen.add(zone_idx)
         return results
 
+    def fill_regions_at_point(self, x: float, y: float, layer: str,
+                              zones: list[dict],
+                              *,
+                              net_name: str | None = None) -> list[tuple[int, int]]:
+        """Return ``(fill_id, zone_idx)`` regions containing the point."""
+        results: list[tuple[int, int]] = []
+        for fill_id, zone_idx, fill_layer, coords, bbox in self._fills:
+            if fill_layer != layer:
+                continue
+            if x < bbox[0] or x > bbox[2] or y < bbox[1] or y > bbox[3]:
+                continue
+            if not _point_in_polygon(x, y, coords):
+                continue
+            if net_name is not None and zones[zone_idx].get("net_name", "") != net_name:
+                continue
+            results.append((fill_id, zone_idx))
+        return results
+
     def has_copper_at(self, x: float, y: float, layer: str) -> bool:
         """Check if any zone has filled copper at (x, y) on layer."""
-        for _zone_idx, fill_layer, coords, bbox in self._fills:
+        for _fill_id, _zone_idx, fill_layer, coords, bbox in self._fills:
             if fill_layer != layer:
                 continue
             if x < bbox[0] or x > bbox[2] or y < bbox[1] or y > bbox[3]:
@@ -661,9 +682,11 @@ def extract_footprints(root: list) -> list[dict]:
                 # Pad position is relative to footprint; compute absolute
                 px, py = pad_at[0], pad_at[1]
                 pad_angle = pad_at[2]
-                # Rotate pad position by footprint angle
+                # KiCad PCB footprint rotations are clockwise in board coords.
+                # Use the negative angle to map local pad offsets into absolute
+                # board space; using +angle mirrors rotated footprints.
                 if angle != 0:
-                    rad = math.radians(angle)
+                    rad = math.radians(-angle)
                     rpx = px * math.cos(rad) - py * math.sin(rad)
                     rpy = px * math.sin(rad) + py * math.cos(rad)
                     px, py = rpx, rpy
@@ -756,7 +779,7 @@ def extract_footprints(root: list) -> list[dict]:
                             if len(xy) >= 3:
                                 lx, ly = float(xy[1]), float(xy[2])
                                 if angle != 0:
-                                    rad = math.radians(angle)
+                                    rad = math.radians(-angle)
                                     rx = lx * math.cos(rad) - ly * math.sin(rad)
                                     ry = lx * math.sin(rad) + ly * math.cos(rad)
                                     lx, ly = rx, ry
@@ -768,7 +791,7 @@ def extract_footprints(root: list) -> list[dict]:
                         lx, ly = float(node[1]), float(node[2])
                         # Transform to absolute coordinates
                         if angle != 0:
-                            rad = math.radians(angle)
+                            rad = math.radians(-angle)
                             rx = lx * math.cos(rad) - ly * math.sin(rad)
                             ry = lx * math.sin(rad) + ly * math.cos(rad)
                             lx, ly = rx, ry
@@ -6587,13 +6610,11 @@ def main():
         import tempfile
         from analysis_cache import (ensure_analysis_dir, hash_source_file,
                                      should_create_new_run, create_run,
-                                     overwrite_current, CANONICAL_OUTPUTS)
+                                     overwrite_current, CANONICAL_OUTPUTS,
+                                     resolve_analysis_dir)
 
         project_dir = str(Path(args.pcb).parent)
-        if not os.path.isabs(args.analysis_dir):
-            analysis_dir = os.path.join(project_dir, args.analysis_dir)
-        else:
-            analysis_dir = args.analysis_dir
+        analysis_dir = resolve_analysis_dir(args.analysis_dir)
 
         # Find .kicad_pro for manifest
         pro_file = ""

--- a/plugins/aklofas/kicad-happy/skills/kicad/scripts/analyze_schematic.py
+++ b/plugins/aklofas/kicad-happy/skills/kicad/scripts/analyze_schematic.py
@@ -9264,13 +9264,11 @@ def main():
         import tempfile
         from analysis_cache import (ensure_analysis_dir, hash_source_file,
                                      should_create_new_run, create_run,
-                                     overwrite_current, CANONICAL_OUTPUTS)
+                                     overwrite_current, CANONICAL_OUTPUTS,
+                                     resolve_analysis_dir)
 
         project_dir = str(Path(args.schematic).parent)
-        if not os.path.isabs(args.analysis_dir):
-            analysis_dir = os.path.join(project_dir, args.analysis_dir)
-        else:
-            analysis_dir = args.analysis_dir
+        analysis_dir = resolve_analysis_dir(args.analysis_dir)
 
         # Find .kicad_pro for manifest
         pro_file = ""

--- a/plugins/aklofas/kicad-happy/skills/kicad/scripts/cross_analysis.py
+++ b/plugins/aklofas/kicad-happy/skills/kicad/scripts/cross_analysis.py
@@ -64,6 +64,26 @@ def _parse_voltage_from_name(name: str) -> float | None:
     return None
 
 
+def _flagged_return_path_entries(pcb: dict, threshold_pct: float = 95.0) -> dict[str, dict]:
+    """Return nets with measured return-plane coverage below threshold."""
+    flagged: dict[str, dict] = {}
+    for entry in pcb.get('return_path_continuity', []) or []:
+        net_name = entry.get('net', '')
+        coverage = entry.get('reference_plane_coverage_pct', 100)
+        if net_name and isinstance(coverage, (int, float)) and coverage < threshold_pct:
+            flagged[net_name] = entry
+    return flagged
+
+
+def _island_size_map(graph: dict) -> dict[int, int]:
+    """Return {island_id: member_count} for a connectivity graph."""
+    sizes: dict[int, int] = {}
+    for island_id in (graph.get('components', {}) or {}).values():
+        if isinstance(island_id, int):
+            sizes[island_id] = sizes.get(island_id, 0) + 1
+    return sizes
+
+
 # ---------------------------------------------------------------------------
 # CC-001: Connector current capacity
 # ---------------------------------------------------------------------------
@@ -473,6 +493,8 @@ def check_return_path_enhanced(schematic, pcb):
         return findings
     conn_graph = pcb.get('connectivity_graph', {})
     net_id_map = _build_net_id_map(pcb)
+    rpc_flagged = _flagged_return_path_entries(pcb, threshold_pct=95.0)
+    has_rpc_data = len(pcb.get('return_path_continuity', []) or []) > 0
     plane_gaps = []
     for net_name, graph in conn_graph.items():
         if not (_is_ground_net(net_name) or _is_power_net(net_name)):
@@ -505,6 +527,8 @@ def check_return_path_enhanced(schematic, pcb):
         if not net_name or _is_power_net(net_name) or _is_ground_net(net_name):
             continue
         if net_name in flagged:
+            continue
+        if has_rpc_data and net_name not in rpc_flagged:
             continue
         classification = _get_net_classification(net_name, schematic)
         if not classification:
@@ -602,11 +626,14 @@ def check_plane_splits(schematic, pcb):
         return findings
     segments = pcb.get('tracks', {}).get('segments', [])
     net_id_map = _build_net_id_map(pcb)
+    rpc_flagged = _flagged_return_path_entries(pcb, threshold_pct=95.0)
     for plane_net, graph in conn_graph.items():
         if not (_is_ground_net(plane_net) or _is_power_net(plane_net)):
             continue
         if graph.get('islands', 1) <= 1:
             continue
+        island_sizes = _island_size_map(graph)
+        significant_islands = [size for size in island_sizes.values() if size >= 2]
         is_intentional = any(plane_net.upper().startswith(p) for p in ('AGND', 'DGND', 'PGND', 'GNDA', 'GNDD'))
         gaps = graph.get('gaps', [])
         if not gaps:
@@ -626,23 +653,26 @@ def check_plane_splits(schematic, pcb):
                     if seg_net not in crossing_signals:
                         crossing_signals.append(seg_net)
                     break
+        crossing_signals_rpc = [s for s in crossing_signals if s in rpc_flagged]
+        if len(significant_islands) <= 1 and not crossing_signals_rpc:
+            continue
         if is_intentional:
             severity = 'info'
-        elif crossing_signals:
+        elif crossing_signals_rpc:
             has_hs = any(_get_net_classification(s, schematic) and
                          _get_net_classification(s, schematic).get('type') in _HIGH_SPEED_TYPES
-                         for s in crossing_signals)
+                         for s in crossing_signals_rpc)
             severity = 'error' if has_hs else 'warning'
         else:
             severity = 'info'
-        desc_signals = f' Signals crossing: {", ".join(crossing_signals[:5])}.' if crossing_signals else ''
+        desc_signals = f' Signals crossing: {", ".join(crossing_signals_rpc[:5])}.' if crossing_signals_rpc else ''
         findings.append(make_finding(
             detector='check_plane_splits', rule_id='PS-002',
             category='plane_integrity',
-            summary=f'{plane_net} plane split: {graph["islands"]} islands{", " + str(len(crossing_signals)) + " signals crossing" if crossing_signals else ""}',
+            summary=f'{plane_net} plane split: {graph["islands"]} islands{", " + str(len(crossing_signals_rpc)) + " signals crossing" if crossing_signals_rpc else ""}',
             description=f'{plane_net} plane has {graph["islands"]} disconnected islands.{desc_signals}',
             severity=severity, confidence='deterministic', evidence_source='topology',
-            nets=[plane_net] + crossing_signals[:5],
+            nets=[plane_net] + crossing_signals_rpc[:5],
             recommendation='Bridge the plane gap with copper pour or stitching vias.',
             impact='Return path discontinuity increases EMI',
         ))

--- a/plugins/aklofas/kicad-happy/skills/kicad/scripts/pcb_connectivity.py
+++ b/plugins/aklofas/kicad-happy/skills/kicad/scripts/pcb_connectivity.py
@@ -13,6 +13,75 @@ from __future__ import annotations
 import math
 
 
+def _node_probe_points(x: float,
+                       y: float,
+                       copper_radius: float) -> list[tuple[float, float]]:
+    """Probe center plus perimeter points around a copper feature.
+
+    Uses 8 perimeter points (not 16) at one radius to keep zone lookups
+    bounded.  Total: 9 probes per node (center + 8 perimeter).
+    """
+    points = [(x, y)]
+    radius = max(0.05, copper_radius * 0.85) if copper_radius > 0 else 0.10
+    for i in range(8):
+        ang = i * math.pi / 4.0
+        points.append((x + radius * math.cos(ang), y + radius * math.sin(ang)))
+    return points
+
+
+def _node_fill_regions(node: dict,
+                       zone_fills,
+                       zones: list[dict],
+                       net_name: str) -> set[int]:
+    """Return same-net fill-region ids touching a pad or via."""
+    if zone_fills is None or not zone_fills.has_data:
+        return set()
+    x = node.get('x')
+    y = node.get('y')
+    layer = node.get('layer', '')
+    if x is None or y is None or not layer:
+        return set()
+    regions: set[int] = set()
+    for px, py in _node_probe_points(x, y, node.get('copper_radius', 0.0)):
+        for fill_id, _zone_idx in zone_fills.fill_regions_at_point(
+                px, py, layer, zones, net_name=net_name):
+            regions.add(fill_id)
+    return regions
+
+
+def _bucket_coord(value: float, tolerance: float) -> int:
+    """Bucket a coordinate for endpoint clustering."""
+    if tolerance <= 0:
+        tolerance = 0.05
+    return int(round(value / tolerance))
+
+
+def _dist_point_to_segment(px: float, py: float,
+                           x1: float, y1: float,
+                           x2: float, y2: float) -> float:
+    """Euclidean distance from a point to a segment."""
+    dx, dy = x2 - x1, y2 - y1
+    if dx == 0 and dy == 0:
+        return math.sqrt((px - x1) ** 2 + (py - y1) ** 2)
+    t = max(0.0, min(1.0, ((px - x1) * dx + (py - y1) * dy) / (dx * dx + dy * dy)))
+    proj_x = x1 + t * dx
+    proj_y = y1 + t * dy
+    return math.sqrt((px - proj_x) ** 2 + (py - proj_y) ** 2)
+
+
+def _expand_copper_layers(layers: list[str],
+                          copper_layers: list[str]) -> list[str]:
+    """Expand wildcard copper layer specs like ``*.Cu``."""
+    expanded: list[str] = []
+    for layer in layers or []:
+        if layer == '*.Cu':
+            expanded.extend(copper_layers)
+        elif '.Cu' in layer:
+            expanded.append(layer)
+    # Preserve order while de-duplicating
+    return list(dict.fromkeys(expanded))
+
+
 class UnionFind:
     """Weighted union-find with path compression."""
 
@@ -99,12 +168,28 @@ def build_connectivity_graph(
     """
     segments = tracks.get('segments', [])
     via_list = vias.get('vias', [])
+    copper_layer_set: set[str] = set()
+    for seg in segments:
+        layer = seg.get('layer', '')
+        if '.Cu' in layer:
+            copper_layer_set.add(layer)
+    for via in via_list:
+        for layer in via.get('layers', []) or []:
+            if '.Cu' in layer:
+                copper_layer_set.add(layer)
+    for zone in zones:
+        for layer in zone.get('layers', []) or []:
+            if '.Cu' in layer:
+                copper_layer_set.add(layer)
+    copper_layers = sorted(copper_layer_set) or ['F.Cu', 'B.Cu']
 
     # Collect all nodes per net
-    net_nodes: dict[str, list[tuple[str, float, float, str]]] = {}
+    net_nodes: dict[str, list[dict]] = {}
+    net_track_segments: dict[str, list[dict]] = {}
 
     for fp in footprints:
         ref = fp.get('reference', '')
+        pad_instance_counts: dict[str, int] = {}
         for pad in fp.get('pads', []):
             net_name = pad.get('net_name', '')
             if not net_name:
@@ -113,11 +198,24 @@ def build_connectivity_graph(
             y = pad.get('abs_y')
             if x is None or y is None:
                 continue
-            pad_key = f"{ref}:{pad.get('number', '?')}"
-            layers = pad.get('layers', [])
+            report_key = f"{ref}:{pad.get('number', '?')}"
+            instance_idx = pad_instance_counts.get(report_key, 0)
+            pad_instance_counts[report_key] = instance_idx + 1
+            pad_key = report_key if instance_idx == 0 else f"{report_key}#{instance_idx}"
+            layers = _expand_copper_layers(pad.get('layers', []), copper_layers)
+            width = pad.get('width', 0) or 0
+            height = pad.get('height', 0) or 0
+            copper_radius = max(width, height) / 2.0 if (width or height) else 0.0
             for layer in layers:
-                if '.Cu' in layer:
-                    net_nodes.setdefault(net_name, []).append((pad_key, x, y, layer))
+                net_nodes.setdefault(net_name, []).append({
+                    'key': pad_key,
+                    'report_key': report_key,
+                    'x': x,
+                    'y': y,
+                    'layer': layer,
+                    'copper_radius': copper_radius,
+                    'kind': 'pad',
+                })
 
     for i, via in enumerate(via_list):
         net_id = via.get('net', 0)
@@ -129,19 +227,75 @@ def build_connectivity_graph(
         if x is None or y is None:
             continue
         via_key = f"via_{i}"
-        layers = via.get('layers', [])
+        layers = _expand_copper_layers(via.get('layers', []), copper_layers)
+        size = via.get('size', 0) or 0
+        copper_radius = size / 2.0 if size else 0.0
         for layer in layers:
-            if '.Cu' in layer:
-                net_nodes.setdefault(net_name, []).append((via_key, x, y, layer))
+            net_nodes.setdefault(net_name, []).append({
+                'key': via_key,
+                'report_key': via_key,
+                'x': x,
+                'y': y,
+                'layer': layer,
+                'copper_radius': copper_radius,
+                'kind': 'via',
+            })
+
+    for seg_idx, seg in enumerate(segments):
+        seg_net_id = seg.get('net', 0)
+        net_name = net_id_map.get(seg_net_id, '') if isinstance(seg_net_id, int) else str(seg_net_id)
+        if not net_name:
+            continue
+        layer = seg.get('layer', '')
+        if not layer or '.Cu' not in layer:
+            continue
+        x1 = seg.get('x1')
+        y1 = seg.get('y1')
+        x2 = seg.get('x2')
+        y2 = seg.get('y2')
+        if None in (x1, y1, x2, y2):
+            continue
+        a_key = f"seg_{seg_idx}:a"
+        b_key = f"seg_{seg_idx}:b"
+        width = seg.get('width', 0) or 0
+        copper_radius = width / 2.0 if width else 0.0
+        node_a = {
+            'key': a_key,
+            'x': x1,
+            'y': y1,
+            'layer': layer,
+            'copper_radius': copper_radius,
+            'kind': 'track',
+        }
+        node_b = {
+            'key': b_key,
+            'x': x2,
+            'y': y2,
+            'layer': layer,
+            'copper_radius': copper_radius,
+            'kind': 'track',
+        }
+        net_nodes.setdefault(net_name, []).extend([node_a, node_b])
+        net_track_segments.setdefault(net_name, []).append({
+            'a': a_key,
+            'b': b_key,
+            'layer': layer,
+            'x1': x1,
+            'y1': y1,
+            'x2': x2,
+            'y2': y2,
+            'width': width,
+        })
 
     result: dict[str, dict] = {}
 
     for net_name, nodes in net_nodes.items():
         if len(nodes) < 2:
             if nodes:
+                first_key = nodes[0]['key']
                 result[net_name] = {
                     'islands': 1,
-                    'components': {nodes[0][0]: 0},
+                    'components': {first_key: 0},
                     'gaps': [],
                     'disconnected_pads': [],
                 }
@@ -149,56 +303,102 @@ def build_connectivity_graph(
 
         uf = UnionFind()
         all_keys: set[str] = set()
-        for key, x, y, layer in nodes:
+        report_keys: set[str] = set()
+        logical_groups: dict[str, list[str]] = {}
+        for node in nodes:
+            key = node['key']
             uf.make_set(key)
             all_keys.add(key)
+            if node.get('kind') in ('pad', 'via'):
+                report_key = node.get('report_key', key)
+                report_keys.add(report_key)
+                logical_groups.setdefault(report_key, []).append(key)
+
+        # Compound pads can be represented by multiple copper primitives with
+        # the same reference/pad number. They are a single electrical node.
+        for members in logical_groups.values():
+            for i in range(1, len(members)):
+                uf.union(members[0], members[i])
 
         # Spatial index per layer
         layer_grids: dict[str, _SpatialGrid] = {}
+        track_layer_grids: dict[str, _SpatialGrid] = {}
         key_positions: dict[str, tuple[float, float]] = {}
-        for key, x, y, layer in nodes:
+        for node in nodes:
+            key = node['key']
+            x = node['x']
+            y = node['y']
+            layer = node['layer']
             grid = layer_grids.setdefault(layer, _SpatialGrid(0.5))
             grid.add(key, x, y)
+            if node.get('kind') == 'track':
+                track_grid = track_layer_grids.setdefault(layer, _SpatialGrid(0.5))
+                track_grid.add(key, x, y)
             key_positions[key] = (x, y)
 
-        # Phase 1: Track segments
-        for seg in segments:
-            seg_net_id = seg.get('net', 0)
-            seg_net = net_id_map.get(seg_net_id, '') if isinstance(seg_net_id, int) else str(seg_net_id)
-            if seg_net != net_name:
+        # Phase 1: Route graph from explicit segment endpoints
+        endpoint_buckets: dict[tuple[str, int, int], list[str]] = {}
+        for node in nodes:
+            if node.get('kind') != 'track':
                 continue
-            layer = seg.get('layer', '')
-            grid = layer_grids.get(layer)
+            bucket = (
+                node['layer'],
+                _bucket_coord(node['x'], 0.05),
+                _bucket_coord(node['y'], 0.05),
+            )
+            endpoint_buckets.setdefault(bucket, []).append(node['key'])
+        for members in endpoint_buckets.values():
+            for i in range(1, len(members)):
+                uf.union(members[0], members[i])
+        for seg in net_track_segments.get(net_name, []):
+            uf.union(seg['a'], seg['b'])
+
+        # Phase 2: Attach pads and vias to routed copper nearby.
+        # Use the spatial grid to find candidate track endpoints instead of
+        # iterating all segments — keeps this O(pads × nearby) not O(pads × all).
+        # Build a reverse index from track endpoint key → segment dict so we
+        # can do distance-to-segment verification on grid hits.
+        seg_by_endpoint: dict[str, dict] = {}
+        for seg in net_track_segments.get(net_name, []):
+            seg_by_endpoint.setdefault(seg['a'], seg)
+            seg_by_endpoint.setdefault(seg['b'], seg)
+
+        for node in nodes:
+            if node.get('kind') not in ('pad', 'via'):
+                continue
+            grid = track_layer_grids.get(node['layer'])
             if not grid:
                 continue
-            x1, y1 = seg.get('x1', 0), seg.get('y1', 0)
-            x2, y2 = seg.get('x2', 0), seg.get('y2', 0)
-            k1 = grid.nearest(x1, y1, 0.15)
-            k2 = grid.nearest(x2, y2, 0.15)
-            if k1 and k2 and k1 != k2:
-                uf.union(k1, k2)
-            elif k1 and not k2:
-                k2 = grid.nearest(x2, y2, 0.5)
-                if k2 and k1 != k2:
-                    uf.union(k1, k2)
-            elif k2 and not k1:
-                k1 = grid.nearest(x1, y1, 0.5)
-                if k1 and k1 != k2:
-                    uf.union(k1, k2)
+            tolerance = max(0.5, node.get('copper_radius', 0.0) + 0.25)
+            nearby = grid.nearest(node['x'], node['y'], tolerance)
+            if nearby and nearby != node['key']:
+                # Verify via distance-to-segment if we have the segment data
+                seg = seg_by_endpoint.get(nearby)
+                if seg and seg['layer'] == node['layer']:
+                    clearance = (node.get('copper_radius', 0.0)
+                                 + (seg.get('width', 0.0) / 2.0) + 0.12)
+                    if _dist_point_to_segment(
+                            node['x'], node['y'],
+                            seg['x1'], seg['y1'],
+                            seg['x2'], seg['y2']) <= clearance:
+                        uf.union(node['key'], nearby)
+                else:
+                    uf.union(node['key'], nearby)
 
-        # Phase 2: Zone fills
+        # Phase 3: Zone fills — only probe pads and vias (track endpoints
+        # are already connected via Phase 1).
         if zone_fills is not None and zone_fills.has_data:
             for layer, grid in layer_grids.items():
-                layer_keys = [(key, x, y) for key, x, y, l in nodes if l == layer]
-                if len(layer_keys) < 2:
+                layer_pv = [node for node in nodes
+                            if node['layer'] == layer
+                            and node.get('kind') in ('pad', 'via')]
+                if len(layer_pv) < 2:
                     continue
-                zone_groups: dict[int, list[str]] = {}
-                for key, x, y in layer_keys:
-                    matching_zones = zone_fills.zones_at_point(x, y, layer, zones)
-                    for z in matching_zones:
-                        if z.get('net_name', '') == net_name:
-                            zone_groups.setdefault(id(z), []).append(key)
-                for z_idx, members in zone_groups.items():
+                fill_groups: dict[int, list[str]] = {}
+                for node in layer_pv:
+                    for fill_id in _node_fill_regions(node, zone_fills, zones, net_name):
+                        fill_groups.setdefault(fill_id, []).append(node['key'])
+                for _fill_id, members in fill_groups.items():
                     for i in range(1, len(members)):
                         uf.union(members[0], members[i])
 
@@ -238,9 +438,10 @@ def build_connectivity_graph(
                     if gy1 > gy2:
                         gy1, gy2 = gy2, gy1
                     layer_guess = ''
-                    for key, x, y, l in nodes:
+                    for node in nodes:
+                        key = node['key']
                         if key in island_keys.get(id_a, []) or key in island_keys.get(id_b, []):
-                            layer_guess = l
+                            layer_guess = node['layer']
                             break
                     gaps.append({
                         'layer': layer_guess,
@@ -250,11 +451,17 @@ def build_connectivity_graph(
 
         # Find disconnected pad pairs
         disconnected = []
-        pad_keys = [k for k in all_keys if not k.startswith('via_')]
+        pad_keys = [k for k in report_keys if not k.startswith('via_')]
         if num_islands > 1 and len(pad_keys) > 1:
             island_rep_pads: dict[int, str] = {}
             for pk in pad_keys:
-                isl = island_id_map.get(pk)
+                members = logical_groups.get(pk, [pk])
+                island_candidates = [
+                    island_id_map[m] for m in members if m in island_id_map
+                ]
+                if not island_candidates:
+                    continue
+                isl = max(set(island_candidates), key=island_candidates.count)
                 if isl is not None and isl not in island_rep_pads:
                     island_rep_pads[isl] = pk
             rep_list = list(island_rep_pads.values())
@@ -262,9 +469,17 @@ def build_connectivity_graph(
                 for j in range(i + 1, len(rep_list)):
                     disconnected.append([rep_list[i], rep_list[j]])
 
+        report_components = {}
+        for report_key in sorted(report_keys):
+            members = logical_groups.get(report_key, [report_key])
+            island_candidates = [island_id_map[m] for m in members if m in island_id_map]
+            if island_candidates:
+                report_components[report_key] = max(
+                    set(island_candidates), key=island_candidates.count)
+
         result[net_name] = {
             'islands': num_islands,
-            'components': {k: island_id_map[k] for k in sorted(all_keys)},
+            'components': report_components,
             'gaps': gaps,
             'disconnected_pads': disconnected,
         }

--- a/plugins/avivsinai/bitbucket-cli/.codex-plugin/plugin.json
+++ b/plugins/avivsinai/bitbucket-cli/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/SKILL.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.25.0
+version: 0.26.0
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/admin.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/admin.md
@@ -79,7 +79,8 @@ bkt admin logging get [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -123,7 +124,8 @@ bkt admin logging set [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -183,7 +185,8 @@ bkt admin secrets rotate [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -197,3 +200,4 @@ bkt admin secrets rotate [flags]
   # Rotate keys on a named DC context
   bkt admin secrets rotate --context prod-dc
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/auth.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/auth.md
@@ -70,7 +70,8 @@ bkt auth login [host] [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -123,7 +124,8 @@ bkt auth logout [host] [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -164,7 +166,8 @@ bkt auth status [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/branch.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/branch.md
@@ -67,7 +67,8 @@ bkt branch create <branch> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -115,7 +116,8 @@ bkt branch delete <branch> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -164,7 +166,8 @@ bkt branch list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -255,7 +258,8 @@ bkt branch protect add <branch> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -303,7 +307,8 @@ bkt branch protect list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -343,7 +348,8 @@ bkt branch protect remove <restriction-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -387,7 +393,8 @@ bkt branch rebase <branch> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -425,7 +432,8 @@ bkt branch set-default <branch> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -439,3 +447,4 @@ bkt branch set-default <branch> [flags]
   # Switch the default branch to develop
   bkt branch set-default develop
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/commit.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/commit.md
@@ -58,7 +58,8 @@ bkt commit diff <from> <to> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -78,3 +79,4 @@ bkt commit diff <from> <to> [flags]
   # Diff on a Cloud workspace
   bkt commit diff develop main --workspace myteam --repo backend
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/context.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/context.md
@@ -61,7 +61,8 @@ bkt context create <name> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -98,7 +99,8 @@ bkt context delete <name> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -132,7 +134,8 @@ bkt context list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -167,7 +170,8 @@ bkt context use <name> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -181,3 +185,4 @@ bkt context use <name> [flags]
   # Switch to a personal Cloud context
   bkt context use personal
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/extension.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/extension.md
@@ -54,7 +54,8 @@ bkt extension exec <name> [args...] [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -93,7 +94,8 @@ bkt extension install <repository> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -131,7 +133,8 @@ bkt extension list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -168,7 +171,8 @@ bkt extension remove <name> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -182,3 +186,4 @@ bkt extension remove <name> [flags]
   # Remove using the short alias
   bkt extension rm deploy
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/issue.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/issue.md
@@ -71,7 +71,8 @@ bkt issue attachment delete <issue-id> <filename> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -116,7 +117,8 @@ bkt issue attachment download <issue-id> [<filename>] [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -163,7 +165,8 @@ bkt issue attachment list <issue-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -203,7 +206,8 @@ bkt issue attachment upload <issue-id> <files>... [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -241,7 +245,8 @@ bkt issue close <issue-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -280,7 +285,8 @@ bkt issue comment <issue-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -329,7 +335,8 @@ bkt issue create [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -373,7 +380,8 @@ bkt issue delete <issue-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -423,7 +431,8 @@ bkt issue edit <issue-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -475,7 +484,8 @@ bkt issue list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -517,7 +527,8 @@ bkt issue reopen <issue-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -553,7 +564,8 @@ bkt issue status [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -591,7 +603,8 @@ bkt issue view <issue-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -608,3 +621,4 @@ bkt issue view <issue-id> [flags]
   # Output as JSON
   bkt issue view 42 --json
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/other.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/other.md
@@ -32,7 +32,9 @@ bkt api <path> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/perms.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/perms.md
@@ -94,7 +94,8 @@ bkt perms project grant [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -138,7 +139,8 @@ bkt perms project list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -182,7 +184,8 @@ bkt perms project revoke [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -258,7 +261,8 @@ bkt perms repo grant [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -303,7 +307,8 @@ bkt perms repo list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -348,7 +353,8 @@ bkt perms repo revoke [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -362,3 +368,4 @@ bkt perms repo revoke [flags]
   # Revoke using a different context
   bkt perms repo revoke --project MYPROJ --repo my-service --user jdoe --context my-dc
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/pipeline.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/pipeline.md
@@ -46,7 +46,8 @@ bkt pipeline list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -92,7 +93,8 @@ bkt pipeline logs <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -141,7 +143,8 @@ bkt pipeline run [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -188,7 +191,8 @@ bkt pipeline view <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -205,3 +209,4 @@ bkt pipeline view <id> [flags]
   # View a pipeline in a specific repository
   bkt pipeline view 10 --workspace myteam --repo backend-api
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/pr.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/pr.md
@@ -37,7 +37,7 @@ bkt pr <command> [flags]
 | [checks](#bkt-pr-checks) | Show build/CI status for a pull request | `--fail-fast`, `--interval`, `--max-interval`, `--project` |
 | [comment](#bkt-pr-comment) | Comment on a pull request | `--file`, `--from-line`, `--parent`, `--pending` |
 | [comments](#bkt-pr-comments) | List comments on a pull request | `--details`, `--project`, `--repo`, `--state` |
-| [create](#bkt-pr-create) | Create a new pull request | `--body`, `--close-source`, `--description`, `--draft` |
+| [create](#bkt-pr-create) | Create a new pull request | `--body`, `--close-source`, `--description`, `--destination` |
 | [decline](#bkt-pr-decline) | Decline a pull request | `--body`, `--comment`, `--delete-source`, `--project` |
 | [diff](#bkt-pr-diff) | Show the diff for a pull request | `--project`, `--repo`, `--stat`, `--workspace` |
 | [edit](#bkt-pr-edit) | Edit a pull request | `--body`, `--description`, `--project`, `--remove-reviewer` |
@@ -78,7 +78,8 @@ bkt pr approve <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -146,7 +147,8 @@ bkt pr auto-merge disable <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -186,7 +188,8 @@ bkt pr auto-merge enable <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -226,7 +229,8 @@ bkt pr auto-merge status <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -269,7 +273,8 @@ bkt pr checkout <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -328,7 +333,8 @@ bkt pr checks <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -383,7 +389,8 @@ bkt pr comment <id> --text <message> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -433,7 +440,8 @@ bkt pr comments <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -477,6 +485,7 @@ bkt pr create [flags]
 | `--body` | `-b` | Pull request description (alias for --description) |
 | `--close-source` |  | Close source branch on merge |
 | `--description` |  | Pull request description |
+| `--destination` |  | Target branch (alias for --target) |
 | `--draft` | `-d` | Create pull request as a draft (DC 8.18+, Cloud always supported) |
 | `--project` |  | Bitbucket project key override |
 | `--repo` |  | Repository slug override |
@@ -492,7 +501,8 @@ bkt pr create [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -521,6 +531,8 @@ is not supported on Cloud.
 
 Works on both Data Center and Cloud.
 
+**Alias:** `close`
+
 ### Usage
 
 ```
@@ -544,7 +556,8 @@ bkt pr decline <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -557,6 +570,9 @@ bkt pr decline <id> [flags]
 
   # Decline with a comment explaining the reason
   bkt pr decline 42 --comment "Needs more work before we can merge"
+
+  # Same using the close alias
+  bkt pr close 42
 
   # Decline and delete the source branch (Data Center only)
   bkt pr decline 42 --delete-source
@@ -591,7 +607,8 @@ bkt pr diff <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -637,7 +654,8 @@ bkt pr edit <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -701,7 +719,8 @@ bkt pr list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -753,7 +772,8 @@ bkt pr merge <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -802,7 +822,8 @@ bkt pr publish <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -869,7 +890,8 @@ bkt pr reaction add <id> <comment-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -903,7 +925,8 @@ bkt pr reaction list <id> <comment-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -938,7 +961,8 @@ bkt pr reaction remove <id> <comment-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -976,7 +1000,8 @@ bkt pr reopen <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -1039,7 +1064,8 @@ bkt pr reviewer-group add <group> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -1073,7 +1099,8 @@ bkt pr reviewer-group list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -1107,7 +1134,8 @@ bkt pr reviewer-group remove <group> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -1146,7 +1174,8 @@ bkt pr suggestion <id> <comment-id> <suggestion-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -1217,7 +1246,8 @@ bkt pr task complete <id> <task-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -1252,7 +1282,8 @@ bkt pr task create <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -1286,7 +1317,8 @@ bkt pr task list <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -1320,7 +1352,8 @@ bkt pr task reopen <id> <task-id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -1360,7 +1393,8 @@ bkt pr view <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -1377,3 +1411,4 @@ bkt pr view <id> [flags]
   # View a pull request in a different repository
   bkt pr view 10 --repo my-other-repo
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/project.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/project.md
@@ -58,7 +58,8 @@ bkt project list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -78,3 +79,4 @@ bkt project list [flags]
   # List projects in JSON format
   bkt project list --json
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/repo.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/repo.md
@@ -50,7 +50,8 @@ bkt repo browse [<repository>] [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -99,7 +100,8 @@ bkt repo clone <repository> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -154,7 +156,8 @@ bkt repo create <repository> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -222,7 +225,8 @@ bkt repo default-reviewers list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -269,7 +273,8 @@ bkt repo list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -319,7 +324,8 @@ bkt repo view [repository] [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -339,3 +345,4 @@ bkt repo view [repository] [flags]
   # View a Cloud repository in a specific workspace
   bkt repo view --workspace my-team --repo frontend-app
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/status.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/status.md
@@ -55,7 +55,8 @@ bkt status commit <sha> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -102,7 +103,8 @@ bkt status pipeline <uuid> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -148,7 +150,8 @@ bkt status pr <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -186,7 +189,8 @@ bkt status rate-limit [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -203,3 +207,4 @@ bkt status rate-limit [flags]
   # Check rate limits for a specific context
   bkt status rate-limit --context my-cloud-ctx
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/variable.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/variable.md
@@ -57,7 +57,8 @@ bkt variable delete <variable-name> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -107,7 +108,8 @@ bkt variable get <variable-name> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -161,7 +163,8 @@ bkt variable list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -224,7 +227,8 @@ bkt variable set [<variable-name>] [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -250,3 +254,4 @@ bkt variable set [<variable-name>] [flags]
   # Import variables from an env file
   bkt variable set --env-file .env
 ```
+

--- a/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/webhook.md
+++ b/plugins/avivsinai/bitbucket-cli/skills/bkt/rules/webhook.md
@@ -71,7 +71,8 @@ bkt webhook create [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -118,7 +119,8 @@ bkt webhook delete <id|uuid> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -167,7 +169,8 @@ bkt webhook list [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -211,7 +214,8 @@ bkt webhook test <id> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--context` | `-c` | Active Bitbucket context name |
-| `--jq` |  | Apply a jq expression to JSON output (requires --json) |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
@@ -225,3 +229,4 @@ bkt webhook test <id> [flags]
   # Test a webhook in a specific repository
   bkt webhook test 7 --project MYPROJ --repo my-repo
 ```
+

--- a/plugins/hyhmrright/brooks-lint/README.md
+++ b/plugins/hyhmrright/brooks-lint/README.md
@@ -375,7 +375,9 @@ brooks-lint/
 │   │   ├── common.md            # Iron Law, Project Config, Report Template, Health Score
 │   │   ├── source-coverage.md   # 12-book coverage matrix, tradeoffs, false-positive guards
 │   │   ├── decay-risks.md       # Six decay risks with symptoms and book citations
-│   │   └── test-decay-risks.md  # Six test-space decay risks with book citations
+│   │   ├── test-decay-risks.md  # Six test-space decay risks with book citations
+│   │   ├── remedy-guide.md      # --fix mode: actionable Remedy enhancement rules
+│   │   └── custom-risks-guide.md  # Template for project-specific risk codes
 │   ├── brooks-review/           # Mode 1: PR Review
 │   │   ├── SKILL.md
 │   │   └── pr-review-guide.md

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/.codex-plugin/plugin.json
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "rust-reverse-engineering",
+  "version": "0.1.0",
+  "description": "Reverse engineer Rust binaries and libraries: triage targets, demangle symbols, recover crate boundaries, and map FFI, panic, unwind, and async paths.",
+  "author": {
+    "name": "jingjing2222",
+    "email": "hj.jingjing2222@gmail.com",
+    "url": "https://github.com/jingjing2222"
+  },
+  "homepage": "https://github.com/jingjing2222/rust-reverse-engineering-skill",
+  "repository": "https://github.com/jingjing2222/rust-reverse-engineering-skill",
+  "license": "Apache-2.0",
+  "keywords": [
+    "rust",
+    "reverse-engineering",
+    "binary-analysis",
+    "ffi",
+    "demangling",
+    "security"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Rust Reverse Engineering",
+    "shortDescription": "Triage and analyze Rust binaries without source code",
+    "longDescription": "Use this plugin to triage Rust executables and libraries, recover likely crate namespaces, demangle symbols, and map panic, unwind, async, and FFI paths across ELF, Mach-O, and PE targets.",
+    "developerName": "jingjing2222",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Reverse engineer this Rust binary and summarize the main namespaces.",
+      "Demangle symbols in this Rust library and find likely FFI boundaries.",
+      "Triage this ELF or PE and tell me if it looks Rust-built."
+    ],
+    "brandColor": "#C96442",
+    "screenshots": []
+  }
+}

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/LICENSE
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/LICENSE
@@ -1,0 +1,184 @@
+Apache License
+Version 2.0, January 2004
+https://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and
+configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the purposes
+of this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to the Licensor or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated in
+writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Work, where such license applies only to those
+patent claims licensable by such Contributor that are necessarily infringed by
+their Contribution(s) alone or by combination of their Contribution(s) with the
+Work to which such Contribution(s) was submitted. If You institute patent
+litigation against any entity (including a cross-claim or counterclaim in a
+lawsuit) alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent
+licenses granted to You under this License for that Work shall terminate as of
+the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any
+part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a
+whole, provided Your use, reproduction, and distribution of the Work otherwise
+complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability to
+use the Work (including but not limited to damages for loss of goodwill, work
+stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the
+possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification
+within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/README.md
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/README.md
@@ -1,0 +1,173 @@
+# Rust Reverse Engineering Skill
+
+Shared Rust reverse-engineering skill for Claude Code and Codex.
+
+This project is for defensive security work. Reverse-engineering tooling is not inherently harmful; used responsibly, it helps developers understand what their own compiled artifacts expose, audit attack surface, and protect the binaries they ship.
+
+Use it for binaries you own or are explicitly authorized to assess.
+
+## What It Helps With
+
+- Fingerprinting Rust binaries and libraries
+- Recovering likely crate boundaries and entry points
+- Surfacing panic, unwind, async, and FFI edges
+- Producing reviewable artifacts such as demangled symbols, disassembly, and Ghidra pseudocode bundles
+- Driving a repeatable static and dynamic analysis workflow
+
+## Who This Is For
+
+- Developers auditing their own release binaries
+- Security engineers reviewing compiled Rust deliverables
+- Authorized interoperability, compatibility, malware-triage, or CTF work
+
+## Requirements
+
+Required:
+
+- `file`
+- `strings`
+- `nm` or `llvm-nm`
+- `objdump` or `llvm-objdump`, or `otool` on macOS
+- `readelf` or `llvm-readelf` for ELF, or `otool` for Mach-O
+
+Recommended:
+
+- `rustfilt`
+- `gdb` or `lldb`
+- Ghidra, IDA Pro, or Binary Ninja
+
+## Install
+
+### Claude Code
+
+For a public GitHub repository, the recommended install path is the marketplace flow:
+
+```bash
+claude plugin marketplace add jingjing2222/rust-reverse-engineering-skill
+claude plugin install rust-reverse-engineering@jingjing2222-plugins
+```
+
+This flow was validated against the public repo.
+
+For local development, you can still load the repository directly:
+
+```bash
+claude --plugin-dir /absolute/path/to/rust-reverse-engineering-skill
+```
+
+### Codex
+
+Codex can install this plugin from local or repo-scoped marketplaces, but public self-serve publishing to the official Codex Plugin Directory is not open yet. For now, use one of the local marketplace flows below.
+
+Option A: install from this repo directly when you have the repo open in Codex.
+
+1. Open this repository in Codex.
+2. Restart Codex if needed.
+3. Run `/plugins`.
+4. Open the `Rust Reverse Engineering Local` marketplace exposed by `.agents/plugins/marketplace.json`.
+5. Install `Rust Reverse Engineering`.
+
+Option B: install as a reusable local plugin.
+
+```bash
+mkdir -p ~/.codex/plugins
+git clone https://github.com/jingjing2222/rust-reverse-engineering-skill.git ~/.codex/plugins/rust-reverse-engineering
+```
+
+Add an entry to `~/.agents/plugins/marketplace.json` that points at the cloned path:
+
+```json
+{
+  "name": "personal-local-plugins",
+  "interface": {
+    "displayName": "Personal Local Plugins"
+  },
+  "plugins": [
+    {
+      "name": "rust-reverse-engineering",
+      "source": {
+        "source": "local",
+        "path": "./.codex/plugins/rust-reverse-engineering"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}
+```
+
+Then restart Codex, run `/plugins`, open your marketplace, and install `Rust Reverse Engineering`.
+
+You can also copy or symlink this repo into another local directory and point the marketplace entry there instead of cloning.
+
+## Typical Output
+
+The skill is built around artifact generation, not just chat answers. A normal run can produce:
+
+- Binary triage summaries
+- Demangled symbol inventories
+- Import and export snapshots
+- Pattern hits for runtime, panic, async, FFI, and network-adjacent code
+- Ghidra pseudocode exports when headless Ghidra is available
+
+Important: Ghidra output is pseudocode, not recovered original Rust source.
+
+## Key Behavior
+
+- Universal Mach-O inputs are thinned automatically to one analysis slice
+- Long-running Ghidra exports keep live progress markers on disk
+- `runner-status.txt` is the fast liveness signal for "still running" vs "actually stopped"
+
+## Repository Layout
+
+- `skills/rust-reverse-engineering/SKILL.md`: full skill instructions and analysis workflow
+- `commands/re-rust.md`: Claude slash-command entry point
+- `skills/rust-reverse-engineering/scripts/`: helper scripts for triage, symbol recovery, artifact collection, and Ghidra export
+- `.claude-plugin/`: Claude plugin and marketplace manifests
+- `.codex-plugin/` and `.agents/plugins/`: Codex plugin and marketplace manifests
+
+## Repository Structure
+
+```text
+rust-reverse-engineering-skill/
+├── .agents/
+│   └── plugins/marketplace.json
+├── .claude-plugin/
+│   ├── marketplace.json
+│   └── plugin.json
+├── .codex/
+│   └── INSTALL.md
+├── .codex-plugin/
+│   └── plugin.json
+├── commands/
+│   └── re-rust.md
+└── skills/
+    └── rust-reverse-engineering/
+        ├── agents/openai.yaml
+        ├── references/
+        ├── scripts/
+        │   ├── check-deps.sh
+        │   ├── collect-artifacts.sh
+        │   ├── demangle-symbols.sh
+        │   ├── export-ghidra-pseudocode.sh
+        │   ├── find-rust-patterns.sh
+        │   ├── ghidra-job.sh
+        │   ├── install-dep.sh
+        │   ├── macho-slice.sh
+        │   └── triage.sh
+        └── SKILL.md
+```
+
+## Where To Start
+
+- Want to install in Claude Code: use the marketplace commands above
+- Want to install in Codex: follow the install steps above
+- Want the full analysis workflow: read [skills/rust-reverse-engineering/SKILL.md](skills/rust-reverse-engineering/SKILL.md)
+- Want the Claude command entry point: read [commands/re-rust.md](commands/re-rust.md)
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/SKILL.md
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/SKILL.md
@@ -1,0 +1,404 @@
+---
+name: rust-reverse-engineering
+description: Use when analyzing a Rust binary without source code, reverse engineering Rust executables or libraries, demangling Rust symbols, recovering likely crate namespaces, tracing panic or unwind paths, identifying FFI boundaries, or mapping behavior from ELF, Mach-O, PE, `.so`, `.dylib`, `.dll`, `.a`, `.rlib`, or object files.
+---
+
+# Rust Reverse Engineering
+
+Reverse engineer Rust-compiled binaries methodically. Start with fast triage, confirm that the target is actually Rust, recover namespaces and runtime clues, then move into static or dynamic analysis with a clear hypothesis.
+
+Do **not** jump straight into decompiler output and treat it as source truth. Rust binaries often contain compiler-generated glue, monomorphized generic code, panic paths, and async state machines that will drown the signal if you skip the triage stage.
+
+## When to Use
+
+Use this skill when the user wants to:
+
+- analyze a Rust executable, shared library, static archive, `.rlib`, or object file
+- confirm whether a binary was built from Rust
+- demangle Rust symbols and recover likely crate namespaces
+- trace entry points, panic/unwind paths, FFI exports/imports, or async executors
+- understand high-level architecture without source code
+- prepare a Rust binary for deeper work in Ghidra, IDA, Binary Ninja, `gdb`, or `lldb`
+
+## When NOT to Use
+
+Do **not** use this skill when:
+
+- the user already has the Rust source code and wants normal code review or debugging
+- the target is primarily an Android APK/DEX/JAR/AAR package — use an Android-focused workflow instead
+- the task is generic PE/ELF malware triage with no Rust-specific angle
+- the request is to bypass licensing, DRM, or authorization controls on software the user is not authorized to analyze
+
+## Prerequisites
+
+Required command-line tools:
+
+- `file`
+- `strings`
+- `readelf` or `llvm-readelf` for ELF, or `otool` for Mach-O
+- `nm` or `llvm-nm`
+- `objdump` or `llvm-objdump`, or `otool` on macOS
+
+Recommended:
+
+- `rustfilt`
+- `gdb` or `lldb`
+- Ghidra, IDA Pro, or Binary Ninja
+
+Verify availability first:
+
+```bash
+bash <path-to-skill>/scripts/check-deps.sh
+```
+
+If tooling is missing, install one dependency at a time:
+
+```bash
+bash <path-to-skill>/scripts/install-dep.sh rustfilt
+bash <path-to-skill>/scripts/install-dep.sh ghidra
+```
+
+If automatic installation is not possible on the current machine, read `references/setup-guide.md`.
+
+## Workflow
+
+### Phase 1: Check and install dependencies
+
+Run the dependency checker first:
+
+```bash
+bash <path-to-skill>/scripts/check-deps.sh
+```
+
+Parse the output looking for:
+
+- `INSTALL_REQUIRED:`
+- `INSTALL_OPTIONAL:`
+
+If required tooling is missing, install it one dependency at a time:
+
+```bash
+bash <path-to-skill>/scripts/install-dep.sh <dependency>
+```
+
+The installer:
+
+- uses Homebrew when available on macOS
+- uses `apt`, `dnf`, or `pacman` on Linux when available
+- uses `cargo install rustfilt` for `rustfilt` when `cargo` exists
+- prints exact manual instructions and exits when a dependency cannot be installed automatically
+
+For optional tooling, recommend at least:
+
+- `rustfilt`
+- one debugger: `gdb` or `lldb`
+- `ghidra`
+
+Re-run `check-deps.sh` after installation attempts. Do not proceed until all required dependencies show `OK`.
+
+### Phase 2: Materialize reverse-engineering artifacts first
+
+Do not keep the analysis ephemeral. Create an artifact bundle on disk before doing interpretation.
+
+```bash
+bash <path-to-skill>/scripts/collect-artifacts.sh /path/to/binary
+```
+
+The script writes a reusable output directory:
+
+```text
+<target>-reverse-output/
+├── input/
+├── triage/
+├── symbols/
+├── headers/
+├── disassembly/
+├── decompiled/
+│   └── ghidra/
+└── reports/
+```
+
+Treat this directory as the source of truth for the rest of the workflow. It should contain:
+
+- `triage/summary.txt` — file type, architecture, strip/debug-info status, Rust confidence
+- `triage/strings.txt` and `triage/interesting-strings.txt` — raw and filtered strings
+- `symbols/raw.txt`, `symbols/demangled.txt`, `symbols/namespaces.txt`, `symbols/imports.txt`, `symbols/exports.txt`
+- `headers/*` — readelf, otool, or PE header dumps
+- `disassembly/disassembly.txt` — best-effort disassembly when available
+- `decompiled/ghidra/status.txt`, `summary.txt`, `functions.tsv`, `decompile-errors.tsv`, and `functions/*.c` — headless Ghidra pseudocode artifacts when available
+- `reports/summary.md` and `reports/pattern-hits.txt`
+
+### Phase 3: Fast triage before any deep analysis
+
+If you need a quick rerun or a narrower pass, the underlying triage script is still available.
+
+```bash
+bash <path-to-skill>/scripts/triage.sh /path/to/binary
+```
+
+Capture these facts before doing anything else:
+
+1. **Container and file type**
+   - ELF, Mach-O, PE/COFF, static archive, object file, or `.rlib`
+   - target architecture and bitness
+   - executable vs shared library vs archive
+
+2. **Symbol quality**
+   - stripped vs not stripped
+   - exported vs imported symbols
+   - whether a usable symbol table still exists
+
+3. **Debug-info availability**
+   - DWARF sections
+   - macOS DWARF segments / dSYM hints
+   - Windows PDB hints in strings
+   - split-debug or external-debug indicators when visible
+
+4. **Rust confidence**
+   - v0 or legacy Rust mangling patterns
+   - demangled `core::`, `alloc::`, `std::`, or crate-like namespaces
+   - panic/unwind strings and runtime artifacts
+   - Rust-specific crate names in symbols or strings
+
+Do not describe the binary as “definitely Rust” from a single clue. Use multiple, independent signals.
+
+### Phase 4: Recover symbols and namespaces
+
+Dump symbols and demangle them as early as possible.
+
+```bash
+bash <path-to-skill>/scripts/demangle-symbols.sh /path/to/binary
+```
+
+Focus on these buckets:
+
+- **standard runtime buckets**: `core::`, `alloc::`, `std::`, `panic`, unwinding, formatting
+- **user-space buckets**: crate-like top-level namespaces that are not runtime crates
+- **interop buckets**: `main`, `_start`, exported C ABI functions, imported libc / Win32 / networking APIs
+- **framework buckets**: likely third-party crates such as serialization, async runtimes, HTTP stacks, crypto, CLI parsing, and logging
+
+Build a short namespace inventory:
+
+```text
+- runtime crates:
+- likely app crates:
+- likely third-party crates:
+- exported ABI functions:
+- imported platform APIs:
+```
+
+Use `references/triage-and-fingerprinting.md` for the triage rubric and `references/rust-patterns.md` for common Rust-specific fingerprints.
+
+For targeted bucket searches across the generated artifacts, run:
+
+```bash
+bash <path-to-skill>/scripts/find-rust-patterns.sh <target>-reverse-output
+```
+
+### Phase 5: Recover high-level structure without assuming a stable Rust ABI
+
+Recover structure conservatively.
+
+Look for:
+
+1. **Entry and boundary functions**
+   - `_start`, `main`, CRT glue, loader entry points
+   - exported `extern "C"` / `no_mangle` style boundaries
+   - plugin or callback registration functions
+   - thread starts, task executors, and worker loops
+
+2. **Subsystem anchors**
+   - config parsing
+   - logging initialization
+   - network / filesystem / crypto imports
+   - panic setup and error paths
+   - serialization and IPC edges
+
+3. **Call-shape clues**
+   - large dispatcher-style functions that may be async state machines
+   - indirect calls through vtable-like structures
+   - formatter-heavy branches around error handling or panic paths
+   - repeated monomorphized helpers with type-specific variants
+
+Critical rule: **do not assume undocumented Rust layouts are stable**.
+
+- Treat `Option`, `Result`, `Vec`, `String`, trait objects, and closure layouts as hypotheses until confirmed by debug info, repeated call-site evidence, or explicit `repr(C)` / `repr(transparent)` style interop boundaries.
+- Do not label every two-word structure as a trait object.
+- Do not infer source-level module boundaries from one demangled symbol alone; confirm using clusters of neighboring symbols, xrefs, and strings.
+
+### Phase 6: Static analysis in a decompiler / disassembler
+
+Once triage is complete, load the target into Ghidra, IDA, or Binary Ninja.
+
+If `analyzeHeadless` is installed, `collect-artifacts.sh` should already materialize a decompiler bundle under `decompiled/ghidra/`. Treat those `.c` files as working pseudocode and review aids, not as original Rust source.
+
+If the target is a universal Mach-O, thin it to the slice you actually want to analyze before trusting any disassembly or decompiler output. The automation now does this for you, defaulting to the host architecture when `--macho-arch` is omitted and recording the chosen slice in `input/analysis-target.txt` and `decompiled/ghidra/analysis-target.txt`. If the host slice is not the slice you want, pass `--macho-arch` explicitly.
+
+Do not treat the export as complete until `decompiled/ghidra/status.txt` says `STATE: completed` or `decompiled/ghidra/complete.marker` exists. The export now writes progress and partial summary state during the run, so interrupted batches are clearly marked as partial or failed instead of looking empty.
+
+Inside Codex, long-running Ghidra exports must stay attached to a live session and be allowed to run until `STATE: completed`. Do not interrupt them just because they are slow. Do not stop because “enough signal was gathered”, because the expected remaining value seems low, or because the auto-analysis phase looks quiet for a while. If the process is alive and `decompiled/ghidra/runner-status.txt` is still getting fresh heartbeats, the job is still in progress.
+
+Use `decompiled/ghidra/runner-status.txt` to distinguish “slow but alive” from “actually stopped”, and use `decompiled/ghidra/warning-summary.txt` to see whether a small set of hotspot functions is dominating the `Unable to resolve constructor` / `pcode error` noise in `headless.log`. A fresh runner heartbeat together with `PROCESS_ALIVE: yes` means the export is still live. For detached jobs, `ghidra-job.sh status` now derives `RUNNER_HEARTBEAT_AGE_SECONDS`, `RUNNER_HEARTBEAT_STALE`, and `LIVENESS_HINT` so you can separate a slow analysis phase from a dead wrapper.
+
+Recommended order:
+
+1. Run auto-analysis
+2. Apply or verify Rust demangling
+3. Rename obvious runtime buckets away from the app-specific namespace inventory
+4. Start from one of:
+   - exported C ABI functions
+   - `main` / startup glue
+   - strong strings with xrefs
+   - networking / filesystem imports
+   - panic and formatting anchors
+5. Label crate clusters and subsystem boundaries
+6. Trace only one feature path at a time
+
+Prefer **strings, imports, exports, and clear subsystem anchors** over huge decompiler functions. In stripped Rust binaries, anchor-based analysis is more reliable than trying to understand every generic helper.
+
+Use `references/static-analysis-workflow.md` for the detailed workflow.
+
+### Phase 7: Dynamic analysis when static evidence is weak
+
+When stripped code or compiler-generated glue makes static analysis ambiguous, move to a debugger.
+
+Use `gdb` or `lldb` to:
+
+- break at exported ABI functions or `main`
+- watch network, file I/O, process creation, and crypto-adjacent imports
+- break on panic / abort paths
+- confirm which indirect call sites are real dispatch points
+- trace buffer lifetimes and ownership hand-offs across FFI boundaries
+
+Dynamic analysis is especially valuable for:
+
+- heavily stripped binaries
+- async runtimes
+- plugin or callback architectures
+- binaries with large amounts of monomorphized generic code
+- distinguishing app logic from runtime support
+
+Use `references/dynamic-analysis-notes.md` for breakpoint ideas and debugger notes.
+
+### Phase 8: Produce a structured report
+
+At the end, deliver both the artifact bundle and a structured report.
+
+The artifact bundle should exist on disk and include at least:
+
+1. **Captured input and triage**
+   - original target under `input/`
+   - triage summary
+   - raw and filtered strings
+
+2. **Recovered symbol artifacts**
+   - raw symbols
+   - demangled symbols
+   - namespace histogram
+   - imports and exports
+
+3. **Low-level evidence**
+   - header dumps
+   - disassembly when available
+   - grouped pattern hits
+   - Ghidra pseudocode files when headless export is available
+
+4. **Human-readable report**
+   - `reports/summary.md`
+
+Then, in the chat response, deliver:
+
+1. **Binary fingerprint**
+   - format, architecture, strip/debug-info status, Rust confidence
+
+2. **Namespace inventory**
+   - runtime crates
+   - likely application crates
+   - likely third-party crates
+
+3. **Entry points and boundaries**
+   - startup path
+   - exported functions
+   - imported APIs
+   - likely FFI edges
+
+4. **Recovered subsystems**
+   - networking
+   - storage
+   - crypto
+   - config
+   - async/task execution
+   - panic/error handling
+
+5. **Key call flows**
+   - one or two high-value paths only
+   - note confidence and evidence for each path
+
+6. **Open questions**
+   - what remains ambiguous
+   - what extra evidence is needed next (debug info, runtime breakpoints, comparison build, related library)
+
+## Rationalizations to Reject
+
+Reject these shortcuts:
+
+- “The decompiler said it, so it must be true.”
+- “This looks like a trait object because it has two pointers.”
+- “Demangled symbols prove the original source layout.”
+- “A crate name in strings means the feature is definitely used.”
+- “This large dispatcher is obviously business logic.”  
+  It may just be compiler-generated async or panic/runtime machinery.
+
+## Output standard
+
+Always mention the output directory first, then summarize the findings.
+
+Use this format when reporting to the user:
+
+```markdown
+## Reverse output
+
+- **Output dir**: `path/to/target-reverse-output`
+- **Summary report**: `path/to/target-reverse-output/reports/summary.md`
+
+## Rust binary summary
+
+- **Target**: `path/to/binary`
+- **Format / arch**: `ELF x86-64`
+- **Symbols**: `partially stripped`
+- **Debug info**: `DWARF absent`
+- **Rust confidence**: `high`
+
+## Namespaces
+
+- **Runtime crates**: `core`, `alloc`, `std`
+- **Likely app crates**: `my_app`, `engine`
+- **Likely third-party crates**: `tokio`, `serde_json`, `reqwest`
+
+## Entry points and boundaries
+
+- **Startup**: `_start -> ... -> main`
+- **Exports**: `plugin_init`, `process_request`
+- **Imports**: `connect`, `send`, `recv`, `pthread_create`
+- **FFI edges**: `plugin_init`, `process_request`
+
+## Key findings
+
+1. `process_request` appears to drive the request parsing path.
+2. Networking likely flows through a `reqwest`/`hyper`-adjacent stack.
+3. A large dispatcher near `...::poll` is a strong async-state-machine candidate.
+
+## Next best move
+
+- break on `process_request`
+- trace the async poll path
+- inspect nearby strings/xrefs for request routing or serialization formats
+```
+
+## References
+
+- `references/setup-guide.md`
+- `references/triage-and-fingerprinting.md`
+- `references/rust-patterns.md`
+- `references/static-analysis-workflow.md`
+- `references/dynamic-analysis-notes.md`

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/agents/openai.yaml
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Reverse Engineering"
+  short_description: "Reverse engineer Rust binaries and libraries"
+  default_prompt: "Use $rust-reverse-engineering to triage this Rust binary and map likely crate boundaries."

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/references/dynamic-analysis-notes.md
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/references/dynamic-analysis-notes.md
@@ -1,0 +1,32 @@
+# Dynamic analysis notes
+
+## When to switch to a debugger
+
+Move to dynamic analysis when:
+
+- the binary is stripped enough that decompiler output is ambiguous
+- you need to confirm a suspected FFI boundary
+- async/runtime glue dominates the static view
+- you need to see which imports are actually exercised
+
+## High-value breakpoint ideas
+
+Break on:
+
+- exported ABI functions
+- `main` or first reachable user-space function
+- panic/abort paths
+- networking imports
+- file-I/O imports
+- thread/task creation imports
+
+## Debugger goals
+
+Use the debugger to answer a narrow question:
+
+- Which function actually handles the request?
+- Is this indirect call a real dispatch boundary?
+- Which strings or buffers reach the network layer?
+- Which panic path is reachable in normal execution?
+
+Do not single-step every runtime helper. Stay focused on the feature path you are trying to confirm.

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/references/rust-patterns.md
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/references/rust-patterns.md
@@ -1,0 +1,62 @@
+# Rust-specific reverse-engineering patterns
+
+## Symbol patterns
+
+### v0 mangling
+
+Modern Rust commonly emits symbols that begin with `_R`.
+
+### Legacy mangling
+
+Older or alternate builds often contain `_ZN...17h...E`-style symbols.
+
+Use `rustfilt` whenever possible. Raw names are useful, but demangled names are better for namespace recovery.
+
+## Panic and unwind anchors
+
+Common anchors include panic-related strings or symbols, formatting-heavy error paths, and abort/unwind support.
+
+These are useful for:
+
+- confirming Rust runtime presence
+- finding error-handling hot paths
+- separating runtime support from application logic
+
+## FFI boundaries
+
+Good anchors:
+
+- exported C ABI functions
+- imported C / OS APIs
+- plugin initialization functions
+- callback registration sites
+
+These boundaries often preserve names better than internal Rust functions.
+
+## Trait-object caution
+
+Indirect calls and paired pointer-like values may indicate trait-object dispatch, but do not treat that as proven from one local pattern.
+
+Confirm with:
+
+- repeated indirect-call shape
+- nearby vtable-like tables
+- multiple related call sites
+- debugger validation when possible
+
+## Async-state-machine caution
+
+Large dispatcher-like functions with repeated state checks may be async-generated `poll` machinery, not hand-written business logic.
+
+Treat these as candidates until confirmed by neighboring symbols, xrefs, and runtime behavior.
+
+## Layout caution
+
+Rust does not promise a stable general ABI for ordinary Rust types.
+
+Only make concrete layout claims when you have evidence such as:
+
+- explicit interop boundaries
+- debug info
+- repeated memory-access patterns across call sites
+- serialization formats or tests that expose exact layout

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/references/setup-guide.md
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/references/setup-guide.md
@@ -1,0 +1,95 @@
+# Setup guide
+
+## Automatic installer
+
+The skill ships with an installer helper:
+
+```bash
+bash <path-to-skill>/scripts/install-dep.sh <dependency>
+```
+
+Examples:
+
+```bash
+bash <path-to-skill>/scripts/install-dep.sh rustfilt
+bash <path-to-skill>/scripts/install-dep.sh ghidra
+```
+
+The helper uses Homebrew on macOS when possible, Linux package managers when available, and `cargo install rustfilt` for `rustfilt`. When it cannot install something directly, it prints the exact manual next step.
+
+## Required tools
+
+Install at least these:
+
+- `file`
+- `strings`
+- `readelf` or `llvm-readelf`
+- `nm` or `llvm-nm`
+- `objdump` or `llvm-objdump`
+
+On Linux, these usually come from `file`, `binutils`, or LLVM packages.
+On macOS, install Xcode command-line tools first, then add GNU binutils or LLVM if you want `readelf`-style output.
+On Windows, use an environment that provides LLVM/binutils-style tools, or perform triage from WSL.
+
+Quick mapping:
+
+- `file` -> `install-dep.sh file`
+- `strings` -> `install-dep.sh strings`
+- `headers` -> `install-dep.sh headers`
+- `nm` -> `install-dep.sh nm`
+- `disassembler` -> `install-dep.sh disassembler`
+
+## Recommended tools
+
+### rustfilt
+
+Best-effort demangler for Rust symbol names:
+
+```bash
+cargo install rustfilt
+```
+
+Or use:
+
+```bash
+bash <path-to-skill>/scripts/install-dep.sh rustfilt
+```
+
+If `cargo` is unavailable, the skill still works, but symbol recovery is worse.
+
+### Debuggers
+
+Install at least one of:
+
+- `gdb`
+- `lldb`
+
+### GUI reverse-engineering tools
+
+At least one of:
+
+- Ghidra
+- IDA Pro
+- Binary Ninja
+
+For Ghidra:
+
+```bash
+bash <path-to-skill>/scripts/install-dep.sh ghidra
+```
+
+## Sanity check
+
+Run:
+
+```bash
+bash <path-to-skill>/scripts/check-deps.sh
+```
+
+Required tools must show `OK`. Optional tools are not blockers.
+
+## Notes
+
+- `rustfilt` is the single highest-value optional dependency in this skill.
+- Prefer LLVM variants (`llvm-readelf`, `llvm-nm`, `llvm-objdump`) when GNU tools are missing.
+- On macOS, `readelf` is often absent by default. That is expected.

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/references/static-analysis-workflow.md
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/references/static-analysis-workflow.md
@@ -1,0 +1,48 @@
+# Static analysis workflow
+
+## Recommended order
+
+1. Load the binary and run auto-analysis
+2. Apply Rust demangling if the tool did not do it well enough
+3. Identify runtime crates and mentally de-prioritize them
+4. Build a namespace inventory
+5. Start from one feature path only
+
+## Best anchors
+
+Prefer:
+
+- exports
+- imports
+- strong strings and xrefs
+- config/env parsing
+- network and filesystem APIs
+- panic/error boundaries
+
+Avoid starting from:
+
+- giant dispatcher functions with no good anchors
+- massive formatting helpers
+- allocator internals
+- generic runtime glue
+
+## Rename strategy
+
+Use consistent prefixes such as:
+
+- `rt_` for runtime helpers
+- `ffi_` for ABI boundaries
+- `app_` for likely application entry points
+- `sub_` for unresolved but grouped subsystems
+
+Do not over-rename early. Keep uncertainty visible.
+
+## What to recover first
+
+Recover in this order:
+
+1. startup path
+2. exports/imports
+3. one subsystem
+4. one end-to-end call flow
+5. supporting helpers only as needed

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/references/triage-and-fingerprinting.md
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/references/triage-and-fingerprinting.md
@@ -1,0 +1,59 @@
+# Triage and fingerprinting
+
+## Goal
+
+Answer these questions quickly:
+
+1. What format and architecture is this target?
+2. Is it stripped?
+3. Is there any usable debug info?
+4. How strong is the evidence that this is a Rust build?
+5. What namespaces, crates, or subsystem hints are visible immediately?
+
+## Evidence rubric for Rust confidence
+
+### High confidence
+
+Use **high** when multiple independent signals agree, for example:
+
+- Rust mangling patterns in symbols
+- demangled `core::`, `alloc::`, or `std::` namespaces
+- panic/unwind artifacts
+- multiple crate-like namespaces that fit Rust symbol structure
+
+### Medium confidence
+
+Use **medium** when only some of the above are present, or when the target is heavily stripped but still has strong Rust-adjacent strings.
+
+### Low confidence
+
+Use **low** when the target lacks symbols and strings do not clearly indicate Rust.
+
+## Fast anchors
+
+Start with:
+
+```bash
+file <target>
+strings -a <target> | grep -E 'rust|panic|core::|alloc::|std::'
+nm -an <target> | head
+```
+
+Then look for:
+
+- raw `_R...`-style v0 symbols
+- legacy `_ZN...17h...E`-style symbols
+- demangled namespaces after `rustfilt`
+- crate names that are not runtime crates
+- imported libc / Win32 / networking APIs that indicate subsystem boundaries
+
+## Namespace handling
+
+Separate findings into:
+
+- runtime crates: `core`, `alloc`, `std`, panic/unwind internals
+- likely app crates
+- likely third-party crates
+- uncertain buckets
+
+Do not claim a crate is “application code” from one symbol alone. Confirm with neighboring symbols, xrefs, or strings.

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/check-deps.sh
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/check-deps.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+has() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+check_any() {
+  local label="$1"
+  shift
+  local found=""
+  for tool in "$@"; do
+    if has "$tool"; then
+      found="$tool"
+      break
+    fi
+  done
+
+  if [[ -n "$found" ]]; then
+    echo "OK:${label}:${found}"
+  else
+    echo "INSTALL_REQUIRED:${label}:$*"
+  fi
+}
+
+check_optional_any() {
+  local label="$1"
+  shift
+  local found=""
+  for tool in "$@"; do
+    if has "$tool"; then
+      found="$tool"
+      break
+    fi
+  done
+
+  if [[ -n "$found" ]]; then
+    echo "OK_OPTIONAL:${label}:${found}"
+  else
+    echo "INSTALL_OPTIONAL:${label}:$*"
+  fi
+}
+
+check_any file file
+check_any strings strings llvm-strings gstrings
+check_any headers readelf llvm-readelf greadelf otool
+check_any nm nm llvm-nm gnm
+check_any disassembler objdump llvm-objdump gobjdump otool
+
+check_optional_any rustfilt rustfilt
+check_optional_any debugger gdb lldb
+check_optional_any ghidra ghidraRun analyzeHeadless ghidra
+check_optional_any ida idat64 ida64 ida
+check_optional_any binaryninja binaryninja
+
+missing_required=0
+while IFS= read -r line; do
+  [[ "$line" == INSTALL_REQUIRED:* ]] && missing_required=1
+done < <(
+  check_any file file
+  check_any strings strings llvm-strings gstrings
+  check_any headers readelf llvm-readelf greadelf otool
+  check_any nm nm llvm-nm gnm
+  check_any disassembler objdump llvm-objdump gobjdump otool
+)
+
+if [[ "$missing_required" -eq 1 ]]; then
+  exit 1
+fi

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/collect-artifacts.sh
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/collect-artifacts.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: collect-artifacts.sh [OPTIONS] <binary-or-archive>
+
+Create a Rust reverse-engineering artifact bundle for a native target.
+
+Arguments:
+  <binary-or-archive>      Path to ELF, Mach-O, PE/COFF, .so, .dylib, .dll, .a,
+                           .rlib, or object file
+
+Options:
+  -o, --output DIR         Output directory (default: <basename>-reverse-output)
+  --no-disasm              Skip disassembly output
+  --no-ghidra              Skip Ghidra headless pseudocode export
+  --macho-arch ARCH        Select a specific universal Mach-O slice before analysis
+  --ghidra-max-functions N Limit Ghidra decompilation to N functions (default: all)
+  --ghidra-timeout SEC     Ghidra per-function decompile timeout in seconds (default: 60)
+  -h, --help               Show this help message
+
+Output layout:
+  <output>/
+  ├── input/
+  ├── triage/
+  ├── symbols/
+  ├── headers/
+  ├── disassembly/
+  ├── decompiled/
+  └── reports/
+EOF
+  exit 0
+}
+
+pick_tool() {
+  for tool in "$@"; do
+    if command -v "$tool" >/dev/null 2>&1; then
+      echo "$tool"
+      return 0
+    fi
+  done
+  return 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_DIR=""
+NO_DISASM=false
+NO_GHIDRA=false
+MACHO_ARCH=""
+GHIDRA_MAX_FUNCTIONS=0
+GHIDRA_TIMEOUT=60
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --no-disasm)
+      NO_DISASM=true
+      shift
+      ;;
+    --no-ghidra)
+      NO_GHIDRA=true
+      shift
+      ;;
+    --macho-arch)
+      MACHO_ARCH="$2"
+      shift 2
+      ;;
+    --ghidra-max-functions)
+      GHIDRA_MAX_FUNCTIONS="$2"
+      shift 2
+      ;;
+    --ghidra-timeout)
+      GHIDRA_TIMEOUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    -*)
+      echo "Error: Unknown option $1" >&2
+      usage
+      ;;
+    *)
+      TARGET="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$TARGET" ]]; then
+  echo "Error: No target specified." >&2
+  usage
+fi
+
+if [[ ! -e "$TARGET" ]]; then
+  echo "Error: target does not exist: $TARGET" >&2
+  exit 2
+fi
+
+TARGET_NAME="$(basename "$TARGET")"
+TARGET_STEM="${TARGET_NAME%.*}"
+if [[ "$TARGET_STEM" == "$TARGET_NAME" ]]; then
+  TARGET_STEM="${TARGET_NAME}"
+fi
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+  OUTPUT_DIR="${TARGET_STEM}-reverse-output"
+fi
+
+mkdir -p \
+  "$OUTPUT_DIR/input" \
+  "$OUTPUT_DIR/triage" \
+  "$OUTPUT_DIR/symbols" \
+  "$OUTPUT_DIR/headers" \
+  "$OUTPUT_DIR/disassembly" \
+  "$OUTPUT_DIR/decompiled/ghidra" \
+  "$OUTPUT_DIR/reports"
+
+cp -p "$TARGET" "$OUTPUT_DIR/input/$TARGET_NAME"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/macho-slice.sh"
+macho_resolve_target "$TARGET" "$MACHO_ARCH" "$OUTPUT_DIR/input"
+ANALYSIS_TARGET="$MACHO_ANALYSIS_TARGET"
+macho_write_metadata "$OUTPUT_DIR/input/analysis-target.txt"
+
+if [[ "$ANALYSIS_TARGET" != "$TARGET" ]]; then
+  echo "INFO: selected Mach-O slice $MACHO_SELECTED_ARCH_TOKEN -> $ANALYSIS_TARGET"
+fi
+
+echo "=== Collecting triage output ==="
+bash "$SCRIPT_DIR/triage.sh" "$ANALYSIS_TARGET" > "$OUTPUT_DIR/triage/summary.txt"
+
+STRINGS_TOOL="$(pick_tool strings llvm-strings gstrings || true)"
+NM_TOOL="$(pick_tool nm llvm-nm gnm || true)"
+READELF_TOOL="$(pick_tool readelf llvm-readelf greadelf || true)"
+OBJDUMP_TOOL="$(pick_tool llvm-objdump objdump gobjdump || true)"
+OTOOL_TOOL="$(pick_tool otool || true)"
+
+if [[ -n "$STRINGS_TOOL" ]]; then
+  "$STRINGS_TOOL" -a "$ANALYSIS_TARGET" > "$OUTPUT_DIR/triage/strings.txt" 2>/dev/null || true
+  grep -Eim 200 'rust_begin_unwind|panic|core::|alloc::|std::|tokio|serde|reqwest|hyper|mio|tracing|clap|prost|tonic|openssl|ring|jni|ffi|objc' \
+    "$OUTPUT_DIR/triage/strings.txt" > "$OUTPUT_DIR/triage/interesting-strings.txt" || true
+fi
+
+if [[ -n "$NM_TOOL" ]]; then
+  "$NM_TOOL" -an "$ANALYSIS_TARGET" > "$OUTPUT_DIR/symbols/raw.txt" 2>/dev/null || true
+  "$NM_TOOL" -g "$ANALYSIS_TARGET" > "$OUTPUT_DIR/symbols/exports.txt" 2>/dev/null || true
+fi
+
+bash "$SCRIPT_DIR/demangle-symbols.sh" "$ANALYSIS_TARGET" > "$OUTPUT_DIR/symbols/demangled.txt" 2>/dev/null || true
+
+grep -Eo '([A-Za-z_][A-Za-z0-9_]*::){1,}' "$OUTPUT_DIR/symbols/demangled.txt" 2>/dev/null \
+  | sed 's/::$//' \
+  | cut -d: -f1 \
+  | sort | uniq -c | sort -nr > "$OUTPUT_DIR/symbols/namespaces.txt" || true
+
+FORMAT="$(sed -n 's/^FORMAT: //p' "$OUTPUT_DIR/triage/summary.txt" | head -1)"
+
+case "$FORMAT" in
+  ELF)
+    if [[ -n "$READELF_TOOL" ]]; then
+      "$READELF_TOOL" -h "$ANALYSIS_TARGET" > "$OUTPUT_DIR/headers/readelf-header.txt" 2>/dev/null || true
+      "$READELF_TOOL" -S "$ANALYSIS_TARGET" > "$OUTPUT_DIR/headers/readelf-sections.txt" 2>/dev/null || true
+      "$READELF_TOOL" -Ws "$ANALYSIS_TARGET" > "$OUTPUT_DIR/headers/readelf-symbols.txt" 2>/dev/null || true
+      grep ' UND ' "$OUTPUT_DIR/headers/readelf-symbols.txt" > "$OUTPUT_DIR/symbols/imports.txt" || true
+    fi
+    ;;
+  Mach-O)
+    if [[ -n "$OTOOL_TOOL" ]]; then
+      "$OTOOL_TOOL" -hv "$ANALYSIS_TARGET" > "$OUTPUT_DIR/headers/otool-header.txt" 2>/dev/null || true
+      "$OTOOL_TOOL" -l "$ANALYSIS_TARGET" > "$OUTPUT_DIR/headers/otool-load-commands.txt" 2>/dev/null || true
+      "$OTOOL_TOOL" -L "$ANALYSIS_TARGET" > "$OUTPUT_DIR/symbols/imports.txt" 2>/dev/null || true
+    fi
+    ;;
+  PE/COFF)
+    if [[ -n "$OBJDUMP_TOOL" ]]; then
+      "$OBJDUMP_TOOL" -p "$ANALYSIS_TARGET" > "$OUTPUT_DIR/headers/objdump-pe.txt" 2>/dev/null || true
+      grep 'DLL Name:' "$OUTPUT_DIR/headers/objdump-pe.txt" > "$OUTPUT_DIR/symbols/imports.txt" || true
+    fi
+    ;;
+esac
+
+if [[ "$NO_DISASM" == false ]]; then
+  echo "=== Collecting disassembly ==="
+  case "$FORMAT" in
+    Mach-O)
+      if [[ -n "$OTOOL_TOOL" ]]; then
+        "$OTOOL_TOOL" -tvV "$ANALYSIS_TARGET" > "$OUTPUT_DIR/disassembly/disassembly.txt" 2>/dev/null || true
+      fi
+      ;;
+    *)
+      if [[ -n "$OBJDUMP_TOOL" ]]; then
+        if [[ "$OBJDUMP_TOOL" == "llvm-objdump" ]]; then
+          "$OBJDUMP_TOOL" --demangle -d "$ANALYSIS_TARGET" > "$OUTPUT_DIR/disassembly/disassembly.txt" 2>/dev/null || true
+        else
+          "$OBJDUMP_TOOL" -d "$ANALYSIS_TARGET" > "$OUTPUT_DIR/disassembly/disassembly.txt" 2>/dev/null || true
+        fi
+      fi
+      ;;
+  esac
+fi
+
+GHIDRA_STATUS="not-run"
+if [[ "$NO_GHIDRA" == false ]]; then
+  if command -v analyzeHeadless >/dev/null 2>&1; then
+    echo "=== Exporting Ghidra pseudocode ==="
+    if bash "$SCRIPT_DIR/export-ghidra-pseudocode.sh" \
+      --max-functions "$GHIDRA_MAX_FUNCTIONS" \
+      --timeout "$GHIDRA_TIMEOUT" \
+      --macho-arch "$MACHO_ARCH" \
+      "$TARGET" \
+      "$OUTPUT_DIR/decompiled/ghidra"; then
+      GHIDRA_STATUS="ok"
+    else
+      GHIDRA_STATE="$(sed -n 's/^STATE: //p' "$OUTPUT_DIR/decompiled/ghidra/status.txt" 2>/dev/null | head -1)"
+      case "$GHIDRA_STATE" in
+        interrupted)
+          GHIDRA_STATUS="interrupted"
+          ;;
+        running|launching)
+          GHIDRA_STATUS="partial"
+          ;;
+        failed)
+          GHIDRA_STATUS="failed"
+          ;;
+        *)
+          if [[ -s "$OUTPUT_DIR/decompiled/ghidra/functions.tsv" ]]; then
+            GHIDRA_STATUS="partial"
+          else
+            GHIDRA_STATUS="failed"
+          fi
+          ;;
+      esac
+    fi
+  else
+    GHIDRA_STATUS="missing"
+  fi
+else
+  GHIDRA_STATUS="skipped"
+fi
+
+bash "$SCRIPT_DIR/find-rust-patterns.sh" "$OUTPUT_DIR" > "$OUTPUT_DIR/reports/pattern-hits.txt" 2>/dev/null || true
+
+TARGET_LINE="$(sed -n 's/^TARGET: //p' "$OUTPUT_DIR/triage/summary.txt" | head -1)"
+ORIGINAL_TARGET_LINE="$(sed -n 's/^ORIGINAL_TARGET: //p' "$OUTPUT_DIR/input/analysis-target.txt" | head -1)"
+ANALYSIS_TARGET_LINE="$(sed -n 's/^ANALYSIS_TARGET: //p' "$OUTPUT_DIR/input/analysis-target.txt" | head -1)"
+MACHO_UNIVERSAL_LINE="$(sed -n 's/^MACHO_UNIVERSAL: //p' "$OUTPUT_DIR/input/analysis-target.txt" | head -1)"
+MACHO_ARCHES_LINE="$(sed -n 's/^MACHO_ARCHES: //p' "$OUTPUT_DIR/input/analysis-target.txt" | head -1)"
+MACHO_SELECTED_ARCH_LINE="$(sed -n 's/^MACHO_SELECTED_ARCH: //p' "$OUTPUT_DIR/input/analysis-target.txt" | head -1)"
+ARCH_LINE="$(sed -n 's/^ARCH: //p' "$OUTPUT_DIR/triage/summary.txt" | head -1)"
+STRIPPED_LINE="$(sed -n 's/^STRIPPED: //p' "$OUTPUT_DIR/triage/summary.txt" | head -1)"
+DEBUG_LINE="$(sed -n 's/^DEBUG_INFO: //p' "$OUTPUT_DIR/triage/summary.txt" | head -1)"
+RUST_LINE="$(sed -n 's/^RUST_CONFIDENCE: //p' "$OUTPUT_DIR/triage/summary.txt" | head -1)"
+EVIDENCE_LINE="$(sed -n 's/^RUST_EVIDENCE: //p' "$OUTPUT_DIR/triage/summary.txt" | head -1)"
+EXPORTS_LINE="$(sed -n 's/^EXPORTED_SYMBOLS: //p' "$OUTPUT_DIR/triage/summary.txt" | head -1)"
+IMPORTS_LINE="$(sed -n 's/^IMPORTED_SYMBOL_HINTS: //p' "$OUTPUT_DIR/triage/summary.txt" | head -1)"
+GHIDRA_STATE_LINE="$(sed -n 's/^STATE: //p' "$OUTPUT_DIR/decompiled/ghidra/status.txt" 2>/dev/null | head -1)"
+GHIDRA_RUNNER_HEARTBEAT_LINE="$(sed -n 's/^RUNNER_HEARTBEAT_AT: //p' "$OUTPUT_DIR/decompiled/ghidra/runner-status.txt" 2>/dev/null | head -1)"
+GHIDRA_RUNNER_PHASE_LINE="$(sed -n 's/^RUNNER_PHASE: //p' "$OUTPUT_DIR/decompiled/ghidra/runner-status.txt" 2>/dev/null | head -1)"
+GHIDRA_WRITTEN_LINE="$(sed -n 's/^PSEUDOCODE_FILES_WRITTEN: //p' "$OUTPUT_DIR/decompiled/ghidra/summary.txt" 2>/dev/null | head -1)"
+GHIDRA_PROCESSED_LINE="$(sed -n 's/^FUNCTIONS_PROCESSED: //p' "$OUTPUT_DIR/decompiled/ghidra/summary.txt" 2>/dev/null | head -1)"
+GHIDRA_LAST_ERROR_LINE="$(sed -n 's/^LAST_ERROR: //p' "$OUTPUT_DIR/decompiled/ghidra/summary.txt" 2>/dev/null | head -1)"
+GHIDRA_CONSTRUCTOR_WARNINGS_LINE="$(sed -n 's/^CONSTRUCTOR_RESOLVE_WARNINGS: //p' "$OUTPUT_DIR/decompiled/ghidra/warning-summary.txt" 2>/dev/null | head -1)"
+GHIDRA_TOP_WARNING_FUNCTION_LINE="$(sed -n 's/^TOP_CONSTRUCTOR_WARNING_FUNCTION: //p' "$OUTPUT_DIR/decompiled/ghidra/warning-summary.txt" 2>/dev/null | head -1)"
+GHIDRA_TOP_WARNING_FUNCTION_COUNT_LINE="$(sed -n 's/^TOP_CONSTRUCTOR_WARNING_FUNCTION_COUNT: //p' "$OUTPUT_DIR/decompiled/ghidra/warning-summary.txt" 2>/dev/null | head -1)"
+
+{
+  echo "## Rust reverse output"
+  echo
+  echo "- **Target**: \`${ORIGINAL_TARGET_LINE:-$TARGET_LINE}\`"
+  if [[ -n "$ANALYSIS_TARGET_LINE" && "$ANALYSIS_TARGET_LINE" != "${ORIGINAL_TARGET_LINE:-$TARGET_LINE}" ]]; then
+    echo "- **Analysis target**: \`${ANALYSIS_TARGET_LINE}\`"
+  fi
+  if [[ "$MACHO_UNIVERSAL_LINE" == "yes" ]]; then
+    echo "- **Mach-O slices**: \`${MACHO_ARCHES_LINE:-unknown}\`"
+    echo "- **Selected slice**: \`${MACHO_SELECTED_ARCH_LINE:-unknown}\`"
+  fi
+  echo "- **Format / arch**: \`${FORMAT:-unknown} ${ARCH_LINE:-unknown}\`"
+  echo "- **Stripped**: \`${STRIPPED_LINE:-unknown}\`"
+  echo "- **Debug info**: \`${DEBUG_LINE:-unknown}\`"
+  echo "- **Rust confidence**: \`${RUST_LINE:-unknown}\`"
+  echo "- **Rust evidence**: \`${EVIDENCE_LINE:-none}\`"
+  echo "- **Export count**: \`${EXPORTS_LINE:-0}\`"
+  echo "- **Import hint count**: \`${IMPORTS_LINE:-0}\`"
+  echo "- **Ghidra pseudocode export**: \`${GHIDRA_STATUS}\`"
+  if [[ -n "$GHIDRA_STATE_LINE" ]]; then
+    echo "- **Ghidra export state**: \`${GHIDRA_STATE_LINE}\`"
+  fi
+  if [[ -n "$GHIDRA_RUNNER_PHASE_LINE" ]]; then
+    echo "- **Ghidra runner phase**: \`${GHIDRA_RUNNER_PHASE_LINE}\`"
+  fi
+  if [[ -n "$GHIDRA_RUNNER_HEARTBEAT_LINE" ]]; then
+    echo "- **Ghidra runner heartbeat**: \`${GHIDRA_RUNNER_HEARTBEAT_LINE}\`"
+  fi
+  if [[ -n "$GHIDRA_PROCESSED_LINE" ]]; then
+    echo "- **Ghidra functions processed**: \`${GHIDRA_PROCESSED_LINE}\`"
+  fi
+  if [[ -n "$GHIDRA_WRITTEN_LINE" ]]; then
+    echo "- **Ghidra pseudocode files**: \`${GHIDRA_WRITTEN_LINE}\`"
+  fi
+  if [[ -n "$GHIDRA_LAST_ERROR_LINE" ]]; then
+    echo "- **Ghidra last error**: \`${GHIDRA_LAST_ERROR_LINE}\`"
+  fi
+  if [[ -n "$GHIDRA_CONSTRUCTOR_WARNINGS_LINE" ]]; then
+    echo "- **Ghidra constructor warnings**: \`${GHIDRA_CONSTRUCTOR_WARNINGS_LINE}\`"
+  fi
+  if [[ -n "$GHIDRA_TOP_WARNING_FUNCTION_LINE" ]]; then
+    echo "- **Top constructor-warning function**: \`${GHIDRA_TOP_WARNING_FUNCTION_LINE}\` (\`${GHIDRA_TOP_WARNING_FUNCTION_COUNT_LINE:-0}\`)"
+  fi
+  echo
+  echo "## Generated artifacts"
+  echo
+  echo "- \`input/analysis-target.txt\`"
+  echo "- \`triage/summary.txt\`"
+  echo "- \`triage/strings.txt\`"
+  echo "- \`triage/interesting-strings.txt\`"
+  echo "- \`symbols/raw.txt\`"
+  echo "- \`symbols/demangled.txt\`"
+  echo "- \`symbols/namespaces.txt\`"
+  echo "- \`symbols/imports.txt\`"
+  echo "- \`symbols/exports.txt\`"
+  echo "- \`reports/pattern-hits.txt\`"
+  if [[ "$NO_DISASM" == false ]]; then
+    echo "- \`disassembly/disassembly.txt\`"
+  fi
+  if [[ "$GHIDRA_STATUS" == "ok" ]]; then
+    echo "- \`decompiled/ghidra/analysis-target.txt\`"
+    echo "- \`decompiled/ghidra/runner-status.txt\`"
+    echo "- \`decompiled/ghidra/status.txt\`"
+    echo "- \`decompiled/ghidra/summary.txt\`"
+    echo "- \`decompiled/ghidra/complete.marker\`"
+    echo "- \`decompiled/ghidra/warning-summary.txt\`"
+    echo "- \`decompiled/ghidra/functions.tsv\`"
+    echo "- \`decompiled/ghidra/decompile-errors.tsv\`"
+    echo "- \`decompiled/ghidra/functions/*.c\`"
+  elif [[ "$GHIDRA_STATUS" == "partial" || "$GHIDRA_STATUS" == "interrupted" ]]; then
+    echo "- Ghidra export produced partial output; inspect \`decompiled/ghidra/runner-status.txt\`, \`decompiled/ghidra/status.txt\`, \`decompiled/ghidra/functions.tsv\`, and \`decompiled/ghidra/decompile-errors.tsv\`"
+  elif [[ "$GHIDRA_STATUS" == "missing" ]]; then
+    echo "- Ghidra headless not available; \`decompiled/ghidra/\` was left empty"
+  elif [[ "$GHIDRA_STATUS" == "failed" ]]; then
+    echo "- Ghidra headless export failed; inspect \`decompiled/ghidra/runner-status.txt\`, \`decompiled/ghidra/status.txt\`, \`decompiled/ghidra/headless.log\`, and \`decompiled/ghidra/script.log\`"
+  fi
+  echo
+  echo "## Candidate namespaces"
+  echo
+  if [[ -s "$OUTPUT_DIR/symbols/namespaces.txt" ]]; then
+    head -10 "$OUTPUT_DIR/symbols/namespaces.txt" | sed 's/^/- /'
+  else
+    echo "- none recovered"
+  fi
+  echo
+  echo "## Next artifact-driven moves"
+  echo
+  echo "- Review \`reports/pattern-hits.txt\` to separate runtime, panic, async, FFI, and network-adjacent clusters."
+  if [[ "$GHIDRA_STATUS" == "ok" ]]; then
+    echo "- Start from \`decompiled/ghidra/functions.tsv\` and the \`decompiled/ghidra/functions/*.c\` pseudocode files, then validate only the high-signal flows in Ghidra."
+  elif [[ "$GHIDRA_STATUS" == "partial" || "$GHIDRA_STATUS" == "interrupted" ]]; then
+    echo "- Resume or rerun the Ghidra export and do not treat the decompiler bundle as final until \`decompiled/ghidra/status.txt\` says \`STATE: completed\`."
+  else
+    echo "- Pivot from \`symbols/demangled.txt\` into Ghidra, IDA, or Binary Ninja and rename only the high-signal buckets first."
+  fi
+  echo "- Use \`symbols/imports.txt\` and \`triage/interesting-strings.txt\` to choose the first subsystem path for static or dynamic analysis."
+} > "$OUTPUT_DIR/reports/summary.md"
+
+echo
+echo "OUTPUT_DIR: $OUTPUT_DIR"
+echo "REPORT: $OUTPUT_DIR/reports/summary.md"

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/demangle-symbols.sh
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/demangle-symbols.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <binary-or-archive> [grep-regex]"
+  exit 2
+fi
+
+TARGET="$1"
+FILTER="${2:-}"
+
+pick_tool() {
+  for tool in "$@"; do
+    if command -v "$tool" >/dev/null 2>&1; then
+      echo "$tool"
+      return 0
+    fi
+  done
+  return 1
+}
+
+NM_TOOL="$(pick_tool nm llvm-nm gnm || true)"
+RUSTFILT_TOOL="$(pick_tool rustfilt || true)"
+
+if [[ -z "$NM_TOOL" ]]; then
+  echo "ERROR: nm, llvm-nm, or gnm is required"
+  exit 1
+fi
+
+if [[ ! -e "$TARGET" ]]; then
+  echo "ERROR: target does not exist: $TARGET"
+  exit 2
+fi
+
+if [[ -n "$RUSTFILT_TOOL" ]]; then
+  if [[ -n "$FILTER" ]]; then
+    "$NM_TOOL" -an "$TARGET" 2>/dev/null | "$RUSTFILT_TOOL" | grep -Ei "$FILTER" || true
+  else
+    "$NM_TOOL" -an "$TARGET" 2>/dev/null | "$RUSTFILT_TOOL"
+  fi
+else
+  echo "WARN: rustfilt not found; emitting raw symbols" >&2
+  if [[ -n "$FILTER" ]]; then
+    "$NM_TOOL" -an "$TARGET" 2>/dev/null | grep -Ei "$FILTER" || true
+  else
+    "$NM_TOOL" -an "$TARGET" 2>/dev/null
+  fi
+fi

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/export-ghidra-pseudocode.sh
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/export-ghidra-pseudocode.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: export-ghidra-pseudocode.sh [OPTIONS] <binary> <output-dir>
+
+Run Ghidra headless analysis and export decompiler pseudocode artifacts.
+
+Arguments:
+  <binary>                Native target to import into Ghidra
+  <output-dir>            Destination directory, typically .../decompiled/ghidra
+
+Options:
+  --max-functions N       Limit exported functions (default: all)
+  --timeout SECONDS       Per-function decompile timeout (default: 60)
+  --macho-arch ARCH       Select a specific universal Mach-O slice before import
+  --progress-interval N   Print progress heartbeat every N seconds (default: 30)
+  -h, --help              Show this help message
+EOF
+  exit 0
+}
+
+pick_tool() {
+  for tool in "$@"; do
+    if command -v "$tool" >/dev/null 2>&1; then
+      echo "$tool"
+      return 0
+    fi
+  done
+  return 1
+}
+
+MAX_FUNCTIONS=0
+TIMEOUT_SECONDS=60
+MACHO_ARCH=""
+PROGRESS_INTERVAL_SECONDS=30
+TARGET=""
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --max-functions)
+      MAX_FUNCTIONS="$2"
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT_SECONDS="$2"
+      shift 2
+      ;;
+    --macho-arch)
+      MACHO_ARCH="$2"
+      shift 2
+      ;;
+    --progress-interval)
+      PROGRESS_INTERVAL_SECONDS="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    -*)
+      echo "Error: unknown option $1" >&2
+      usage
+      ;;
+    *)
+      if [[ -z "$TARGET" ]]; then
+        TARGET="$1"
+      elif [[ -z "$OUTPUT_DIR" ]]; then
+        OUTPUT_DIR="$1"
+      else
+        echo "Error: unexpected argument $1" >&2
+        usage
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$TARGET" || -z "$OUTPUT_DIR" ]]; then
+  echo "Error: target and output directory are required." >&2
+  usage
+fi
+
+if [[ ! -e "$TARGET" ]]; then
+  echo "Error: target does not exist: $TARGET" >&2
+  exit 2
+fi
+
+ANALYZE_HEADLESS="$(pick_tool analyzeHeadless || true)"
+if [[ -z "$ANALYZE_HEADLESS" ]]; then
+  echo "Error: analyzeHeadless not found in PATH." >&2
+  exit 127
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GHIDRA_SCRIPT_DIR="$SCRIPT_DIR/ghidra"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/macho-slice.sh"
+
+mkdir -p "$OUTPUT_DIR"
+
+macho_resolve_target "$TARGET" "$MACHO_ARCH" "$OUTPUT_DIR/input"
+ANALYSIS_TARGET="$MACHO_ANALYSIS_TARGET"
+macho_write_metadata "$OUTPUT_DIR/analysis-target.txt"
+
+if [[ "$ANALYSIS_TARGET" != "$TARGET" ]]; then
+  echo "INFO: selected Mach-O slice $MACHO_SELECTED_ARCH_TOKEN -> $ANALYSIS_TARGET"
+fi
+
+PROJECT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/ghidra-rust-reverse.XXXXXX")"
+PROJECT_NAME="rust_reverse_headless"
+SCRIPT_LOG="$OUTPUT_DIR/script.log"
+HEADLESS_LOG="$OUTPUT_DIR/headless.log"
+STATUS_FILE="$OUTPUT_DIR/status.txt"
+RUNNER_STATUS_FILE="$OUTPUT_DIR/runner-status.txt"
+SUMMARY_FILE="$OUTPUT_DIR/summary.txt"
+COMPLETE_MARKER="$OUTPUT_DIR/complete.marker"
+FAILED_MARKER="$OUTPUT_DIR/failed.marker"
+INTERRUPTED_MARKER="$OUTPUT_DIR/interrupted.marker"
+ANALYZE_PID=""
+RUNNER_PHASE="launching"
+
+rm -f "$COMPLETE_MARKER" "$FAILED_MARKER" "$INTERRUPTED_MARKER"
+cat > "$STATUS_FILE" <<EOF
+STATE: launching
+STARTED_AT: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+LAST_UPDATE_AT: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+COMPLETED_AT:
+FUNCTIONS_PROCESSED: 0
+PSEUDOCODE_FILES_WRITTEN: 0
+DECOMPILATION_FAILURES: 0
+DECOMPILATION_TIMEOUTS: 0
+DECOMPILATION_CANCELLED: 0
+LAST_FUNCTION_ENTRY:
+LAST_FUNCTION_NAME:
+LAST_ERROR:
+EOF
+
+file_mtime_epoch() {
+  local path="$1"
+  if [[ ! -e "$path" ]]; then
+    echo "0"
+    return 0
+  fi
+  if stat -f %m "$path" >/dev/null 2>&1; then
+    stat -f %m "$path" 2>/dev/null || echo "0"
+  else
+    stat -c %Y "$path" 2>/dev/null || echo "0"
+  fi
+}
+
+write_runner_status() {
+  local status_state processed written failed timeouts cancelled last_name last_error
+  local heartbeat_at heartbeat_epoch process_alive log_bytes log_mtime phase
+
+  status_state="$(sed -n 's/^STATE: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  processed="$(sed -n 's/^FUNCTIONS_PROCESSED: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  written="$(sed -n 's/^PSEUDOCODE_FILES_WRITTEN: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  failed="$(sed -n 's/^DECOMPILATION_FAILURES: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  timeouts="$(sed -n 's/^DECOMPILATION_TIMEOUTS: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  cancelled="$(sed -n 's/^DECOMPILATION_CANCELLED: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  last_name="$(sed -n 's/^LAST_FUNCTION_NAME: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  last_error="$(sed -n 's/^LAST_ERROR: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+
+  if [[ -n "$ANALYZE_PID" ]] && kill -0 "$ANALYZE_PID" >/dev/null 2>&1; then
+    process_alive="yes"
+  else
+    process_alive="no"
+  fi
+
+  phase="$RUNNER_PHASE"
+  if [[ "$status_state" == "completed" ]]; then
+    phase="completed"
+  elif [[ "$status_state" == "failed" ]]; then
+    phase="failed"
+  elif [[ "$status_state" == "interrupted" ]]; then
+    phase="interrupted"
+  elif [[ "$status_state" == "running" || "${processed:-0}" != "0" || "${written:-0}" != "0" ]]; then
+    phase="decompiling"
+  fi
+
+  heartbeat_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  heartbeat_epoch="$(date +%s)"
+  if [[ -f "$HEADLESS_LOG" ]]; then
+    log_bytes="$(wc -c < "$HEADLESS_LOG" 2>/dev/null | tr -d ' ' || echo 0)"
+  else
+    log_bytes="0"
+  fi
+  log_mtime="$(file_mtime_epoch "$HEADLESS_LOG")"
+
+  cat > "$RUNNER_STATUS_FILE" <<EOF
+RUNNER_HEARTBEAT_AT: $heartbeat_at
+RUNNER_HEARTBEAT_EPOCH: $heartbeat_epoch
+RUNNER_PID: $$
+ANALYZE_PID: ${ANALYZE_PID:-}
+PROCESS_ALIVE: $process_alive
+RUNNER_PHASE: $phase
+HEARTBEAT_TIMEOUT_SECONDS: $((PROGRESS_INTERVAL_SECONDS * 3))
+HEADLESS_LOG_BYTES: ${log_bytes:-0}
+HEADLESS_LOG_MTIME_EPOCH: ${log_mtime:-0}
+STATUS_STATE: ${status_state:-}
+FUNCTIONS_PROCESSED: ${processed:-0}
+PSEUDOCODE_FILES_WRITTEN: ${written:-0}
+DECOMPILATION_FAILURES: ${failed:-0}
+DECOMPILATION_TIMEOUTS: ${timeouts:-0}
+DECOMPILATION_CANCELLED: ${cancelled:-0}
+LAST_FUNCTION_NAME: ${last_name:-}
+LAST_ERROR: ${last_error:-}
+EOF
+}
+
+write_runner_status
+
+mark_interrupted() {
+  if [[ -n "$ANALYZE_PID" ]]; then
+    kill -TERM "$ANALYZE_PID" >/dev/null 2>&1 || true
+  fi
+  RUNNER_PHASE="interrupted"
+  cat > "$STATUS_FILE" <<EOF
+STATE: interrupted
+STARTED_AT: $(sed -n 's/^STARTED_AT: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+LAST_UPDATE_AT: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+COMPLETED_AT:
+FUNCTIONS_PROCESSED: $(sed -n 's/^FUNCTIONS_PROCESSED: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+PSEUDOCODE_FILES_WRITTEN: $(sed -n 's/^PSEUDOCODE_FILES_WRITTEN: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+DECOMPILATION_FAILURES: $(sed -n 's/^DECOMPILATION_FAILURES: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+DECOMPILATION_TIMEOUTS: $(sed -n 's/^DECOMPILATION_TIMEOUTS: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+DECOMPILATION_CANCELLED: $(sed -n 's/^DECOMPILATION_CANCELLED: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+LAST_FUNCTION_ENTRY: $(sed -n 's/^LAST_FUNCTION_ENTRY: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+LAST_FUNCTION_NAME: $(sed -n 's/^LAST_FUNCTION_NAME: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+LAST_ERROR: interrupted by shell signal
+EOF
+  : > "$INTERRUPTED_MARKER"
+  write_runner_status
+}
+
+cleanup() {
+  rm -rf "$PROJECT_ROOT"
+}
+trap cleanup EXIT
+trap 'mark_interrupted; exit 130' INT TERM
+
+summarize_headless_warnings() {
+  local warnings_file="$OUTPUT_DIR/warning-summary.txt"
+  local raw_matches="$OUTPUT_DIR/.constructor-warnings.tsv"
+  local total_pcode_errors
+  local constructor_warnings
+  local top_function
+  local top_function_count
+  local top_address
+  local top_address_count
+
+  if [[ ! -f "$HEADLESS_LOG" ]]; then
+    return 0
+  fi
+
+  total_pcode_errors="$(grep -c 'pcode error' "$HEADLESS_LOG" 2>/dev/null || true)"
+  constructor_warnings="$(grep -c 'Unable to resolve constructor' "$HEADLESS_LOG" 2>/dev/null || true)"
+
+  grep 'Unable to resolve constructor' "$HEADLESS_LOG" 2>/dev/null \
+    | sed -E 's/.*Decompiling ([^,]+), pcode error at ([^:]+):.*/\1\t\2/' > "$raw_matches" || true
+
+  top_function=""
+  top_function_count="0"
+  top_address=""
+  top_address_count="0"
+
+  if [[ -s "$raw_matches" ]]; then
+    top_function="$(awk -F'\t' '{count[$1]++} END {for (k in count) print count[k] "\t" k}' "$raw_matches" | sort -nr | head -1 | awk '{print $2}')"
+    top_function_count="$(awk -F'\t' -v func="$top_function" '$1 == func {count++} END {print count+0}' "$raw_matches")"
+    top_address="$(awk -F'\t' -v func="$top_function" '$1 == func {count[$2]++} END {for (k in count) print count[k] "\t" k}' "$raw_matches" | sort -nr | head -1 | awk '{print $2}')"
+    top_address_count="$(awk -F'\t' -v func="$top_function" -v addr="$top_address" '$1 == func && $2 == addr {count++} END {print count+0}' "$raw_matches")"
+  fi
+
+  {
+    echo "TOTAL_PCODE_ERRORS: ${total_pcode_errors:-0}"
+    echo "CONSTRUCTOR_RESOLVE_WARNINGS: ${constructor_warnings:-0}"
+    echo "TOP_CONSTRUCTOR_WARNING_FUNCTION: ${top_function:-}"
+    echo "TOP_CONSTRUCTOR_WARNING_FUNCTION_COUNT: ${top_function_count:-0}"
+    echo "TOP_CONSTRUCTOR_WARNING_ADDRESS: ${top_address:-}"
+    echo "TOP_CONSTRUCTOR_WARNING_ADDRESS_COUNT: ${top_address_count:-0}"
+    echo
+    echo "TOP_CONSTRUCTOR_WARNING_FUNCTIONS:"
+    if [[ -s "$raw_matches" ]]; then
+      awk -F'\t' '{count[$1]++} END {for (k in count) print count[k] "\t" k}' "$raw_matches" \
+        | sort -nr \
+        | head -20 \
+        | awk '{printf "FUNCTION: %s\tCOUNT: %s\n", $2, $1}'
+      if [[ -n "$top_function" ]]; then
+        echo
+        echo "TOP_CONSTRUCTOR_WARNING_ADDRESSES_FOR_${top_function}:"
+        awk -F'\t' -v func="$top_function" '$1 == func {count[$2]++} END {for (k in count) print count[k] "\t" k}' "$raw_matches" \
+          | sort -nr \
+          | head -20 \
+          | awk '{printf "ADDRESS: %s\tCOUNT: %s\n", $2, $1}'
+      fi
+    else
+      echo "(none)"
+    fi
+  } > "$warnings_file"
+
+  rm -f "$raw_matches"
+}
+
+print_progress() {
+  local state processed written failed timeouts cancelled last_name last_error
+  state="$(sed -n 's/^STATE: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  processed="$(sed -n 's/^FUNCTIONS_PROCESSED: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  written="$(sed -n 's/^PSEUDOCODE_FILES_WRITTEN: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  failed="$(sed -n 's/^DECOMPILATION_FAILURES: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  timeouts="$(sed -n 's/^DECOMPILATION_TIMEOUTS: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  cancelled="$(sed -n 's/^DECOMPILATION_CANCELLED: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  last_name="$(sed -n 's/^LAST_FUNCTION_NAME: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+  last_error="$(sed -n 's/^LAST_ERROR: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+
+  echo "PROGRESS: state=${state:-unknown} processed=${processed:-0} written=${written:-0} failures=${failed:-0} timeouts=${timeouts:-0} cancelled=${cancelled:-0} last_function=${last_name:-} last_error=${last_error:-}"
+}
+
+echo "INFO: launching Ghidra headless export"
+
+set +e
+"$ANALYZE_HEADLESS" \
+  "$PROJECT_ROOT" \
+  "$PROJECT_NAME" \
+  -import "$ANALYSIS_TARGET" \
+  -overwrite \
+  -scriptPath "$GHIDRA_SCRIPT_DIR" \
+  -postScript ExportRustPseudocode.java "$OUTPUT_DIR" "$MAX_FUNCTIONS" "$TIMEOUT_SECONDS" \
+  -scriptlog "$SCRIPT_LOG" \
+  -log "$HEADLESS_LOG" \
+  -analysisTimeoutPerFile 1800 \
+  -deleteProject &
+ANALYZE_PID=$!
+RUNNER_PHASE="analyzing"
+write_runner_status
+
+while kill -0 "$ANALYZE_PID" >/dev/null 2>&1; do
+  sleep "$PROGRESS_INTERVAL_SECONDS"
+  if kill -0 "$ANALYZE_PID" >/dev/null 2>&1; then
+    write_runner_status
+    print_progress
+  fi
+done
+
+wait "$ANALYZE_PID"
+rc=$?
+set -e
+
+summarize_headless_warnings
+
+if [[ "$rc" -ne 0 ]]; then
+  RUNNER_PHASE="failed"
+  if [[ ! -f "$FAILED_MARKER" && ! -f "$INTERRUPTED_MARKER" ]]; then
+    cat > "$STATUS_FILE" <<EOF
+STATE: failed
+STARTED_AT: $(sed -n 's/^STARTED_AT: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+LAST_UPDATE_AT: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+COMPLETED_AT:
+FUNCTIONS_PROCESSED: $(sed -n 's/^FUNCTIONS_PROCESSED: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+PSEUDOCODE_FILES_WRITTEN: $(sed -n 's/^PSEUDOCODE_FILES_WRITTEN: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+DECOMPILATION_FAILURES: $(sed -n 's/^DECOMPILATION_FAILURES: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+DECOMPILATION_TIMEOUTS: $(sed -n 's/^DECOMPILATION_TIMEOUTS: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+DECOMPILATION_CANCELLED: $(sed -n 's/^DECOMPILATION_CANCELLED: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+LAST_FUNCTION_ENTRY: $(sed -n 's/^LAST_FUNCTION_ENTRY: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+LAST_FUNCTION_NAME: $(sed -n 's/^LAST_FUNCTION_NAME: //p' "$STATUS_FILE" 2>/dev/null | head -1)
+LAST_ERROR: analyzeHeadless exited with status $rc
+EOF
+    : > "$FAILED_MARKER"
+  fi
+  write_runner_status
+  exit "$rc"
+fi
+
+if [[ -f "$COMPLETE_MARKER" && -f "$SUMMARY_FILE" ]]; then
+  RUNNER_PHASE="completed"
+  write_runner_status
+  print_progress
+  echo "INFO: Ghidra export completed successfully"
+  exit 0
+fi
+
+state="$(sed -n 's/^STATE: //p' "$STATUS_FILE" 2>/dev/null | head -1)"
+if [[ -z "$state" ]]; then
+  state="failed"
+fi
+
+RUNNER_PHASE="$state"
+write_runner_status
+print_progress
+echo "Error: Ghidra export exited without a completion marker (state: $state)." >&2
+if [[ -f "$STATUS_FILE" ]]; then
+  echo "Inspect: $STATUS_FILE" >&2
+fi
+if [[ -f "$SUMMARY_FILE" ]]; then
+  echo "Partial summary: $SUMMARY_FILE" >&2
+fi
+exit 1

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/find-rust-patterns.sh
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/find-rust-patterns.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: find-rust-patterns.sh <artifact-dir-or-demangled-file> [OPTIONS]
+
+Search Rust reverse-engineering artifacts for high-signal buckets.
+
+Arguments:
+  <artifact-dir-or-demangled-file>   Reverse output directory from collect-artifacts.sh
+                                     or a demangled symbols file
+
+Options:
+  --runtime      Search runtime namespaces only
+  --ffi          Search FFI and interop patterns only
+  --async        Search async/runtime-dispatch patterns only
+  --network      Search network-adjacent crates and imports only
+  --panic        Search panic and unwind patterns only
+  --all          Search all buckets (default)
+  -h, --help     Show this help message
+EOF
+  exit 0
+}
+
+INPUT=""
+SEARCH_RUNTIME=false
+SEARCH_FFI=false
+SEARCH_ASYNC=false
+SEARCH_NETWORK=false
+SEARCH_PANIC=false
+SEARCH_ALL=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runtime) SEARCH_RUNTIME=true; SEARCH_ALL=false; shift ;;
+    --ffi) SEARCH_FFI=true; SEARCH_ALL=false; shift ;;
+    --async) SEARCH_ASYNC=true; SEARCH_ALL=false; shift ;;
+    --network) SEARCH_NETWORK=true; SEARCH_ALL=false; shift ;;
+    --panic) SEARCH_PANIC=true; SEARCH_ALL=false; shift ;;
+    --all) SEARCH_ALL=true; shift ;;
+    -h|--help) usage ;;
+    -*) echo "Error: Unknown option $1" >&2; usage ;;
+    *) INPUT="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$INPUT" ]]; then
+  echo "Error: No artifact directory or symbols file specified." >&2
+  usage
+fi
+
+DEMANGLED_FILE=""
+STRINGS_FILE=""
+IMPORTS_FILE=""
+
+if [[ -d "$INPUT" ]]; then
+  DEMANGLED_FILE="$INPUT/symbols/demangled.txt"
+  STRINGS_FILE="$INPUT/triage/strings.txt"
+  IMPORTS_FILE="$INPUT/symbols/imports.txt"
+else
+  DEMANGLED_FILE="$INPUT"
+fi
+
+if [[ ! -f "$DEMANGLED_FILE" ]]; then
+  echo "Error: demangled symbols file not found: $DEMANGLED_FILE" >&2
+  exit 1
+fi
+
+section() {
+  echo
+  echo "==== $1 ===="
+  echo
+}
+
+run_file_grep() {
+  local file="$1"
+  local pattern="$2"
+  if [[ -f "$file" ]]; then
+    grep -Eni "$pattern" "$file" || true
+  fi
+}
+
+if [[ "$SEARCH_ALL" == true || "$SEARCH_RUNTIME" == true ]]; then
+  section "Runtime namespaces"
+  run_file_grep "$DEMANGLED_FILE" '(^|[^A-Za-z0-9_])(core|alloc|std|hashbrown|panic_unwind|compiler_builtins)::'
+fi
+
+if [[ "$SEARCH_ALL" == true || "$SEARCH_FFI" == true ]]; then
+  section "FFI and interop patterns"
+  run_file_grep "$DEMANGLED_FILE" '(ffi|cxx|bindgen|JNI_OnLoad|Java_[A-Za-z0-9_]+|objc|swift_|com::apple|windows::Win32)'
+  run_file_grep "$STRINGS_FILE" '(JNI_OnLoad|Java_[A-Za-z0-9_]+|objc_msgSend|dlopen|dlsym|CFBundle|LoadLibrary|GetProcAddress)'
+  run_file_grep "$IMPORTS_FILE" '(objc|dlopen|dlsym|LoadLibrary|GetProcAddress|JNI)'
+fi
+
+if [[ "$SEARCH_ALL" == true || "$SEARCH_ASYNC" == true ]]; then
+  section "Async and dispatcher patterns"
+  run_file_grep "$DEMANGLED_FILE" '(tokio|futures|poll|core::task|wake_by_ref|RawWaker|async)'
+  run_file_grep "$STRINGS_FILE" '(tokio|futures|poll|waker|async)'
+fi
+
+if [[ "$SEARCH_ALL" == true || "$SEARCH_NETWORK" == true ]]; then
+  section "Network and IPC patterns"
+  run_file_grep "$DEMANGLED_FILE" '(reqwest|hyper|tonic|prost|mio|socket2|rustls|openssl|native_tls|ureq|grpc|serde_json)'
+  run_file_grep "$STRINGS_FILE" '(https?://|reqwest|hyper|grpc|protobuf|socket|tls|openssl)'
+  run_file_grep "$IMPORTS_FILE" '(connect|send|recv|socket|SSL_|tls|CFNetwork|WinHTTP|libcurl)'
+fi
+
+if [[ "$SEARCH_ALL" == true || "$SEARCH_PANIC" == true ]]; then
+  section "Panic and unwind patterns"
+  run_file_grep "$DEMANGLED_FILE" '(panic|begin_unwind|core::panicking|backtrace|abort)'
+  run_file_grep "$STRINGS_FILE" '(rust_begin_unwind|panic|backtrace|abort)'
+fi
+
+echo
+echo "=== Search complete ==="

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/ghidra-job.sh
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/ghidra-job.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ghidra-job.sh start [OPTIONS] <binary> <output-dir>
+  ghidra-job.sh status <output-dir>
+  ghidra-job.sh wait [--poll SECONDS] <output-dir>
+  ghidra-job.sh stop <output-dir>
+
+Manage detached Ghidra headless pseudocode export jobs.
+
+Commands:
+  start                 Launch export-ghidra-pseudocode.sh under nohup
+  status                Print current job and export state
+  wait                  Poll until the export reaches a terminal state
+  stop                  Stop a detached export job
+
+Start options:
+  --max-functions N     Limit exported functions (default: all)
+  --timeout SECONDS     Per-function decompile timeout (default: 60)
+
+Wait options:
+  --poll SECONDS        Poll interval in seconds (default: 15)
+EOF
+  exit 0
+}
+
+pick_tool() {
+  for tool in "$@"; do
+    if command -v "$tool" >/dev/null 2>&1; then
+      echo "$tool"
+      return 0
+    fi
+  done
+  return 1
+}
+
+status_value() {
+  local file="$1"
+  local key="$2"
+  if [[ -f "$file" ]]; then
+    sed -n "s/^${key}: //p" "$file" | head -1
+  fi
+}
+
+current_epoch() {
+  date +%s
+}
+
+is_pid_alive() {
+  local pid="$1"
+  [[ -n "$pid" ]] && kill -0 "$pid" >/dev/null 2>&1
+}
+
+print_status() {
+  local output_dir="$1"
+  local pid_file="$output_dir/job.pid"
+  local pgid_file="$output_dir/job.pgid"
+  local status_file="$output_dir/status.txt"
+  local runner_status_file="$output_dir/runner-status.txt"
+  local pid=""
+  local pgid=""
+  local process_alive="no"
+  local state="unknown"
+  local runner_heartbeat_epoch=""
+  local runner_heartbeat_timeout=""
+  local runner_heartbeat_age=""
+  local runner_heartbeat_stale="unknown"
+  local liveness_hint="unknown"
+  local now_epoch=""
+
+  if [[ -f "$pid_file" ]]; then
+    pid="$(tr -d '[:space:]' < "$pid_file")"
+    if is_pid_alive "$pid"; then
+      process_alive="yes"
+    fi
+  fi
+
+  if [[ -f "$pgid_file" ]]; then
+    pgid="$(tr -d '[:space:]' < "$pgid_file")"
+  fi
+
+  if [[ -f "$output_dir/complete.marker" ]]; then
+    state="completed"
+  elif [[ -f "$output_dir/failed.marker" ]]; then
+    state="failed"
+  elif [[ -f "$output_dir/interrupted.marker" ]]; then
+    state="interrupted"
+  elif [[ -f "$status_file" ]]; then
+    state="$(status_value "$status_file" "STATE")"
+  fi
+
+  runner_heartbeat_epoch="$(status_value "$runner_status_file" "RUNNER_HEARTBEAT_EPOCH")"
+  runner_heartbeat_timeout="$(status_value "$runner_status_file" "HEARTBEAT_TIMEOUT_SECONDS")"
+  if [[ -n "$runner_heartbeat_epoch" && -n "$runner_heartbeat_timeout" ]]; then
+    now_epoch="$(current_epoch)"
+    runner_heartbeat_age="$((now_epoch - runner_heartbeat_epoch))"
+    if (( runner_heartbeat_age > runner_heartbeat_timeout )); then
+      runner_heartbeat_stale="yes"
+    else
+      runner_heartbeat_stale="no"
+    fi
+  fi
+
+  if [[ "$state" == "completed" || "$state" == "failed" || "$state" == "interrupted" ]]; then
+    liveness_hint="terminal"
+  elif [[ "$process_alive" == "yes" && "$runner_heartbeat_stale" == "no" ]]; then
+    liveness_hint="running"
+  elif [[ "$process_alive" == "no" && "$runner_heartbeat_stale" == "yes" ]]; then
+    liveness_hint="stopped"
+  elif [[ "$process_alive" == "yes" && "$runner_heartbeat_stale" == "yes" ]]; then
+    liveness_hint="stale-heartbeat-check-runner"
+  fi
+
+  cat <<EOF
+OUTPUT_DIR: $output_dir
+PID: ${pid:-}
+PGID: ${pgid:-}
+PROCESS_ALIVE: $process_alive
+STATE: ${state:-unknown}
+STARTED_AT: $(status_value "$status_file" "STARTED_AT")
+LAST_UPDATE_AT: $(status_value "$status_file" "LAST_UPDATE_AT")
+COMPLETED_AT: $(status_value "$status_file" "COMPLETED_AT")
+FUNCTIONS_PROCESSED: $(status_value "$status_file" "FUNCTIONS_PROCESSED")
+PSEUDOCODE_FILES_WRITTEN: $(status_value "$status_file" "PSEUDOCODE_FILES_WRITTEN")
+DECOMPILATION_FAILURES: $(status_value "$status_file" "DECOMPILATION_FAILURES")
+DECOMPILATION_TIMEOUTS: $(status_value "$status_file" "DECOMPILATION_TIMEOUTS")
+DECOMPILATION_CANCELLED: $(status_value "$status_file" "DECOMPILATION_CANCELLED")
+LAST_FUNCTION_ENTRY: $(status_value "$status_file" "LAST_FUNCTION_ENTRY")
+LAST_FUNCTION_NAME: $(status_value "$status_file" "LAST_FUNCTION_NAME")
+LAST_ERROR: $(status_value "$status_file" "LAST_ERROR")
+STATUS_FILE: $status_file
+RUNNER_STATUS_FILE: $runner_status_file
+RUNNER_HEARTBEAT_AT: $(status_value "$runner_status_file" "RUNNER_HEARTBEAT_AT")
+RUNNER_HEARTBEAT_EPOCH: ${runner_heartbeat_epoch:-}
+RUNNER_HEARTBEAT_AGE_SECONDS: ${runner_heartbeat_age:-}
+RUNNER_HEARTBEAT_STALE: ${runner_heartbeat_stale:-unknown}
+RUNNER_PHASE: $(status_value "$runner_status_file" "RUNNER_PHASE")
+RUNNER_PROCESS_ALIVE: $(status_value "$runner_status_file" "PROCESS_ALIVE")
+HEARTBEAT_TIMEOUT_SECONDS: $(status_value "$runner_status_file" "HEARTBEAT_TIMEOUT_SECONDS")
+LIVENESS_HINT: ${liveness_hint}
+HEADLESS_LOG_BYTES: $(status_value "$runner_status_file" "HEADLESS_LOG_BYTES")
+HEADLESS_LOG_MTIME_EPOCH: $(status_value "$runner_status_file" "HEADLESS_LOG_MTIME_EPOCH")
+LAUNCHER_LOG: $output_dir/launcher.log
+HEADLESS_LOG: $output_dir/headless.log
+SCRIPT_LOG: $output_dir/script.log
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPORT_SCRIPT="$SCRIPT_DIR/export-ghidra-pseudocode.sh"
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+COMMAND="$1"
+shift
+
+case "$COMMAND" in
+  start)
+    MAX_FUNCTIONS=0
+    TIMEOUT_SECONDS=60
+    TARGET=""
+    OUTPUT_DIR=""
+
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --max-functions)
+          MAX_FUNCTIONS="$2"
+          shift 2
+          ;;
+        --timeout)
+          TIMEOUT_SECONDS="$2"
+          shift 2
+          ;;
+        -h|--help)
+          usage
+          ;;
+        -*)
+          echo "Error: unknown option $1" >&2
+          usage
+          ;;
+        *)
+          if [[ -z "$TARGET" ]]; then
+            TARGET="$1"
+          elif [[ -z "$OUTPUT_DIR" ]]; then
+            OUTPUT_DIR="$1"
+          else
+            echo "Error: unexpected argument $1" >&2
+            usage
+          fi
+          shift
+          ;;
+      esac
+    done
+
+    if [[ -z "$TARGET" || -z "$OUTPUT_DIR" ]]; then
+      echo "Error: target and output directory are required." >&2
+      usage
+    fi
+
+    mkdir -p "$OUTPUT_DIR"
+
+    if [[ -f "$OUTPUT_DIR/job.pid" ]]; then
+      existing_pid="$(tr -d '[:space:]' < "$OUTPUT_DIR/job.pid")"
+      if is_pid_alive "$existing_pid"; then
+        echo "Error: export job is already running for $OUTPUT_DIR (pid: $existing_pid)." >&2
+        exit 1
+      fi
+    fi
+
+    LAUNCHER_LOG="$OUTPUT_DIR/launcher.log"
+    COMMAND_FILE="$OUTPUT_DIR/job-command.txt"
+    STARTED_FILE="$OUTPUT_DIR/job-started-at.txt"
+    : > "$LAUNCHER_LOG"
+
+    {
+      printf 'bash %q --max-functions %q --timeout %q %q %q\n' \
+        "$EXPORT_SCRIPT" "$MAX_FUNCTIONS" "$TIMEOUT_SECONDS" "$TARGET" "$OUTPUT_DIR"
+    } > "$COMMAND_FILE"
+    date -u +"%Y-%m-%dT%H:%M:%SZ" > "$STARTED_FILE"
+
+    nohup bash "$EXPORT_SCRIPT" \
+      --max-functions "$MAX_FUNCTIONS" \
+      --timeout "$TIMEOUT_SECONDS" \
+      "$TARGET" \
+      "$OUTPUT_DIR" >> "$LAUNCHER_LOG" 2>&1 < /dev/null &
+
+    pid="$!"
+    pgid="$(ps -o pgid= -p "$pid" | tr -d '[:space:]' || true)"
+    printf '%s\n' "$pid" > "$OUTPUT_DIR/job.pid"
+    printf '%s\n' "$pgid" > "$OUTPUT_DIR/job.pgid"
+
+    cat <<EOF
+STARTED: yes
+OUTPUT_DIR: $OUTPUT_DIR
+PID: $pid
+PGID: $pgid
+STATUS_FILE: $OUTPUT_DIR/status.txt
+LAUNCHER_LOG: $LAUNCHER_LOG
+EOF
+    ;;
+
+  status)
+    if [[ $# -ne 1 ]]; then
+      echo "Error: status requires <output-dir>." >&2
+      usage
+    fi
+    print_status "$1"
+    ;;
+
+  wait)
+    POLL_SECONDS=15
+    OUTPUT_DIR=""
+
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --poll)
+          POLL_SECONDS="$2"
+          shift 2
+          ;;
+        -h|--help)
+          usage
+          ;;
+        -*)
+          echo "Error: unknown option $1" >&2
+          usage
+          ;;
+        *)
+          if [[ -z "$OUTPUT_DIR" ]]; then
+            OUTPUT_DIR="$1"
+          else
+            echo "Error: unexpected argument $1" >&2
+            usage
+          fi
+          shift
+          ;;
+      esac
+    done
+
+    if [[ -z "$OUTPUT_DIR" ]]; then
+      echo "Error: wait requires <output-dir>." >&2
+      usage
+    fi
+
+    while true; do
+      current_state="$(status_value "$OUTPUT_DIR/status.txt" "STATE")"
+      if [[ -f "$OUTPUT_DIR/complete.marker" || "$current_state" == "completed" ]]; then
+        print_status "$OUTPUT_DIR"
+        exit 0
+      fi
+      if [[ -f "$OUTPUT_DIR/failed.marker" || "$current_state" == "failed" ]]; then
+        print_status "$OUTPUT_DIR"
+        exit 1
+      fi
+      if [[ -f "$OUTPUT_DIR/interrupted.marker" || "$current_state" == "interrupted" ]]; then
+        print_status "$OUTPUT_DIR"
+        exit 1
+      fi
+
+      current_pid=""
+      if [[ -f "$OUTPUT_DIR/job.pid" ]]; then
+        current_pid="$(tr -d '[:space:]' < "$OUTPUT_DIR/job.pid")"
+      fi
+
+      if [[ -n "$current_pid" ]] && ! is_pid_alive "$current_pid"; then
+        echo "Error: detached export process is no longer running, but no terminal marker was written." >&2
+        print_status "$OUTPUT_DIR"
+        exit 1
+      fi
+
+      sleep "$POLL_SECONDS"
+    done
+    ;;
+
+  stop)
+    if [[ $# -ne 1 ]]; then
+      echo "Error: stop requires <output-dir>." >&2
+      usage
+    fi
+
+    OUTPUT_DIR="$1"
+    if [[ ! -f "$OUTPUT_DIR/job.pid" ]]; then
+      echo "Error: no job.pid found under $OUTPUT_DIR." >&2
+      exit 1
+    fi
+
+    pid="$(tr -d '[:space:]' < "$OUTPUT_DIR/job.pid")"
+    pgid=""
+    if [[ -f "$OUTPUT_DIR/job.pgid" ]]; then
+      pgid="$(tr -d '[:space:]' < "$OUTPUT_DIR/job.pgid")"
+    fi
+
+    pkill -TERM -P "$pid" >/dev/null 2>&1 || true
+    kill -TERM "$pid" >/dev/null 2>&1 || true
+
+    echo "STOP_SIGNAL_SENT: yes"
+    echo "OUTPUT_DIR: $OUTPUT_DIR"
+    echo "PID: $pid"
+    echo "PGID: $pgid"
+    ;;
+
+  *)
+    echo "Error: unknown command $COMMAND" >&2
+    usage
+    ;;
+esac

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/ghidra/ExportRustPseudocode.java
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/ghidra/ExportRustPseudocode.java
@@ -1,0 +1,380 @@
+/* ###
+ * IP: personal-local-plugins
+ */
+// Export Ghidra decompiler pseudocode to disk for artifact-driven Rust RE workflows.
+//@category ReverseEngineering
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileOptions;
+import ghidra.app.decompiler.DecompileResults;
+import ghidra.app.decompiler.DecompiledFunction;
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.FunctionIterator;
+import ghidra.program.model.symbol.Namespace;
+
+public class ExportRustPseudocode extends GhidraScript {
+
+	private static final int DEFAULT_MAX_FUNCTIONS = 0;
+	private static final int DEFAULT_TIMEOUT_SECONDS = 60;
+	private static final int MAX_FILE_NAME_CHARS = 120;
+
+	@Override
+	protected void run() throws Exception {
+		String[] args = getScriptArgs();
+		if (args.length < 1) {
+			throw new IllegalArgumentException(
+				"Expected output directory, optional max-function count, and optional timeout seconds");
+		}
+
+		File outputDir = new File(args[0]);
+		int maxFunctions = parsePositiveInt(args, 1, DEFAULT_MAX_FUNCTIONS);
+		int timeoutSeconds = parsePositiveInt(args, 2, DEFAULT_TIMEOUT_SECONDS);
+
+		File functionsDir = new File(outputDir, "functions");
+		if (!functionsDir.exists() && !functionsDir.mkdirs()) {
+			throw new IOException("Failed to create output directory: " + functionsDir.getAbsolutePath());
+		}
+
+		Path indexPath = new File(outputDir, "functions.tsv").toPath();
+		Path errorPath = new File(outputDir, "decompile-errors.tsv").toPath();
+		Path statusPath = new File(outputDir, "status.txt").toPath();
+		Path summaryPath = new File(outputDir, "summary.txt").toPath();
+		Path completeMarkerPath = new File(outputDir, "complete.marker").toPath();
+		Path failedMarkerPath = new File(outputDir, "failed.marker").toPath();
+		Path interruptedMarkerPath = new File(outputDir, "interrupted.marker").toPath();
+
+		writeString(indexPath,
+			"index\tentry\tname\tnamespace\tbody_addresses\tstatus\tpseudocode_path\tsignature\n");
+		writeString(errorPath, "index\tentry\tname\terror\n");
+		deleteIfExists(completeMarkerPath);
+		deleteIfExists(failedMarkerPath);
+		deleteIfExists(interruptedMarkerPath);
+
+		int processed = 0;
+		int emitted = 0;
+		int failed = 0;
+		int timedOut = 0;
+		int cancelled = 0;
+		long totalChars = 0L;
+		String state = "running";
+		String startedAt = nowIso();
+		String lastUpdateAt = startedAt;
+		String completedAt = "";
+		String lastFunctionEntry = "";
+		String lastFunctionName = "";
+		String lastError = "";
+
+		writeProgress(statusPath, summaryPath, state, startedAt, lastUpdateAt, completedAt,
+			processed, emitted, failed, timedOut, cancelled,
+			timeoutSeconds, maxFunctions, totalChars,
+			lastFunctionEntry, lastFunctionName, lastError);
+
+		DecompInterface decompiler = new DecompInterface();
+		DecompileOptions options = new DecompileOptions();
+		decompiler.setOptions(options);
+		decompiler.toggleCCode(true);
+		decompiler.toggleSyntaxTree(false);
+		decompiler.setSimplificationStyle("decompile");
+
+		try {
+			if (!decompiler.openProgram(currentProgram)) {
+				state = "failed";
+				lastError = sanitizeField(decompiler.getLastMessage());
+				throw new IOException("Failed to open program in decompiler: " + decompiler.getLastMessage());
+			}
+
+			FunctionIterator iterator = currentProgram.getFunctionManager().getFunctionsNoStubs(true);
+			while (iterator.hasNext() && !monitor.isCancelled()) {
+				Function function = iterator.next();
+				if (function == null || function.isExternal()) {
+					continue;
+				}
+				if (maxFunctions > 0 && processed >= maxFunctions) {
+					break;
+				}
+
+				processed++;
+				monitor.setMessage("Decompiling " + function.getName());
+				lastFunctionEntry = function.getEntryPoint().toString();
+				lastFunctionName = function.getName();
+				lastError = "";
+
+				String entry = function.getEntryPoint().toString();
+				String name = function.getName();
+				String namespace = getNamespaceName(function);
+				long bodyAddresses = function.getBody().getNumAddresses();
+				String signature = sanitizeField(function.getPrototypeString(true, true));
+				String pseudocodePath = "";
+				String status = "error";
+				String error = "";
+
+				DecompileResults results =
+					decompiler.decompileFunction(function, timeoutSeconds, monitor);
+
+				if (results == null) {
+					failed++;
+					error = "null decompile result";
+				}
+				else if (results.isCancelled()) {
+					cancelled++;
+					status = "cancelled";
+					error = sanitizeField(results.getErrorMessage());
+				}
+				else if (results.isTimedOut()) {
+					timedOut++;
+					status = "timeout";
+					error = sanitizeField(results.getErrorMessage());
+				}
+				else if (!results.decompileCompleted() || !results.isValid()) {
+					failed++;
+					error = sanitizeField(results.getErrorMessage());
+				}
+				else {
+					DecompiledFunction decompiledFunction = results.getDecompiledFunction();
+					if (decompiledFunction == null) {
+						failed++;
+						error = "missing decompiled function";
+					}
+					else {
+						String cText = decompiledFunction.getC();
+						if (cText == null || cText.isEmpty()) {
+							failed++;
+							error = "empty pseudocode output";
+						}
+						else {
+							status = "ok";
+							signature = sanitizeField(decompiledFunction.getSignature());
+							String fileName = buildFileName(processed, entry, name);
+							pseudocodePath = "functions/" + fileName;
+							writeString(
+								new File(outputDir, pseudocodePath).toPath(),
+								buildPseudocodeHeader(function, namespace, signature) + cText + "\n");
+							emitted++;
+							totalChars += cText.length();
+						}
+					}
+				}
+
+				appendString(indexPath,
+					processed + "\t" +
+						sanitizeField(entry) + "\t" +
+						sanitizeField(name) + "\t" +
+						sanitizeField(namespace) + "\t" +
+						bodyAddresses + "\t" +
+						status + "\t" +
+						sanitizeField(pseudocodePath) + "\t" +
+						signature + "\n");
+
+				if (!error.isEmpty()) {
+					lastError = error;
+					appendString(errorPath,
+						processed + "\t" +
+							sanitizeField(entry) + "\t" +
+							sanitizeField(name) + "\t" +
+							error + "\n");
+				}
+
+				lastUpdateAt = nowIso();
+				writeProgress(statusPath, summaryPath, state, startedAt, lastUpdateAt, completedAt,
+					processed, emitted, failed, timedOut, cancelled,
+					timeoutSeconds, maxFunctions, totalChars,
+					lastFunctionEntry, lastFunctionName, lastError);
+			}
+
+			state = monitor.isCancelled() ? "interrupted" : "completed";
+		}
+		catch (Exception e) {
+			if (!"interrupted".equals(state)) {
+				state = "failed";
+			}
+			if (lastError == null || lastError.isEmpty()) {
+				lastError = sanitizeField(e.toString());
+			}
+			throw e;
+		}
+		finally {
+			decompiler.dispose();
+			lastUpdateAt = nowIso();
+			if ("completed".equals(state)) {
+				completedAt = lastUpdateAt;
+				touch(completeMarkerPath);
+			}
+			else if ("interrupted".equals(state)) {
+				touch(interruptedMarkerPath);
+			}
+			else if ("failed".equals(state)) {
+				touch(failedMarkerPath);
+			}
+			writeProgress(statusPath, summaryPath, state, startedAt, lastUpdateAt, completedAt,
+				processed, emitted, failed, timedOut, cancelled,
+				timeoutSeconds, maxFunctions, totalChars,
+				lastFunctionEntry, lastFunctionName, lastError);
+		}
+	}
+
+	private int parsePositiveInt(String[] args, int index, int defaultValue) {
+		if (index >= args.length || args[index] == null || args[index].isEmpty()) {
+			return defaultValue;
+		}
+		int parsed = Integer.parseInt(args[index]);
+		if (parsed < 0) {
+			throw new IllegalArgumentException("Expected non-negative integer at argument " + index);
+		}
+		return parsed;
+	}
+
+	private String getNamespaceName(Function function) {
+		Namespace namespace = function.getParentNamespace();
+		if (namespace == null) {
+			return "";
+		}
+		return namespace.getName(true);
+	}
+
+	private String buildFileName(int index, String entry, String name) {
+		String stem = String.format("%05d_%s_%s.c",
+			index,
+			sanitizeFilePart(entry),
+			sanitizeFilePart(name));
+		if (stem.length() <= MAX_FILE_NAME_CHARS) {
+			return stem;
+		}
+		int suffixLength = ".c".length();
+		return stem.substring(0, MAX_FILE_NAME_CHARS - suffixLength) + ".c";
+	}
+
+	private String sanitizeFilePart(String value) {
+		String sanitized = value.replaceAll("[^A-Za-z0-9._-]+", "_");
+		sanitized = sanitized.replaceAll("_+", "_");
+		sanitized = sanitized.replaceAll("^_+", "");
+		sanitized = sanitized.replaceAll("_+$", "");
+		if (sanitized.isEmpty()) {
+			return "unnamed";
+		}
+		return sanitized;
+	}
+
+	private String sanitizeField(String value) {
+		if (value == null) {
+			return "";
+		}
+		return value.replace('\t', ' ')
+			.replace('\r', ' ')
+			.replace('\n', ' ')
+			.trim();
+	}
+
+	private String buildPseudocodeHeader(Function function, String namespace, String signature) {
+		StringBuilder builder = new StringBuilder();
+		builder.append("/*\n");
+		builder.append(" * Ghidra headless pseudocode export\n");
+		builder.append(" * Program: ").append(currentProgram.getName()).append("\n");
+		builder.append(" * Executable path: ").append(currentProgram.getExecutablePath()).append("\n");
+		builder.append(" * Function: ").append(function.getName()).append("\n");
+		builder.append(" * Namespace: ").append(namespace).append("\n");
+		builder.append(" * Entry: ").append(function.getEntryPoint()).append("\n");
+		builder.append(" * Signature: ").append(signature).append("\n");
+		builder.append(" * Note: Decompiled pseudocode, not original Rust source.\n");
+		builder.append(" */\n\n");
+		return builder.toString();
+	}
+
+	private void writeProgress(Path statusPath, Path summaryPath, String state,
+			String startedAt, String lastUpdateAt, String completedAt,
+			int processed, int emitted, int failed, int timedOut, int cancelled,
+			int timeoutSeconds, int maxFunctions, long totalChars,
+			String lastFunctionEntry, String lastFunctionName, String lastError) throws IOException {
+		writeString(statusPath, buildStatus(state, startedAt, lastUpdateAt, completedAt,
+			processed, emitted, failed, timedOut, cancelled,
+			lastFunctionEntry, lastFunctionName, lastError));
+		writeString(summaryPath, buildSummary(state, startedAt, lastUpdateAt, completedAt,
+			processed, emitted, failed, timedOut, cancelled,
+			timeoutSeconds, maxFunctions, totalChars,
+			lastFunctionEntry, lastFunctionName, lastError));
+	}
+
+	private String buildStatus(String state, String startedAt, String lastUpdateAt, String completedAt,
+			int processed, int emitted, int failed, int timedOut, int cancelled,
+			String lastFunctionEntry, String lastFunctionName, String lastError) {
+		StringBuilder builder = new StringBuilder();
+		builder.append("STATE: ").append(state).append("\n");
+		builder.append("STARTED_AT: ").append(startedAt).append("\n");
+		builder.append("LAST_UPDATE_AT: ").append(lastUpdateAt).append("\n");
+		builder.append("COMPLETED_AT: ").append(completedAt).append("\n");
+		builder.append("FUNCTIONS_PROCESSED: ").append(processed).append("\n");
+		builder.append("PSEUDOCODE_FILES_WRITTEN: ").append(emitted).append("\n");
+		builder.append("DECOMPILATION_FAILURES: ").append(failed).append("\n");
+		builder.append("DECOMPILATION_TIMEOUTS: ").append(timedOut).append("\n");
+		builder.append("DECOMPILATION_CANCELLED: ").append(cancelled).append("\n");
+		builder.append("LAST_FUNCTION_ENTRY: ").append(sanitizeField(lastFunctionEntry)).append("\n");
+		builder.append("LAST_FUNCTION_NAME: ").append(sanitizeField(lastFunctionName)).append("\n");
+		builder.append("LAST_ERROR: ").append(sanitizeField(lastError)).append("\n");
+		return builder.toString();
+	}
+
+	private String buildSummary(String state, String startedAt, String lastUpdateAt, String completedAt,
+			int processed, int emitted, int failed, int timedOut, int cancelled,
+			int timeoutSeconds, int maxFunctions, long totalChars,
+			String lastFunctionEntry, String lastFunctionName, String lastError) {
+		StringBuilder builder = new StringBuilder();
+		builder.append("STATE: ").append(state).append("\n");
+		builder.append("STARTED_AT: ").append(startedAt).append("\n");
+		builder.append("LAST_UPDATE_AT: ").append(lastUpdateAt).append("\n");
+		builder.append("COMPLETED_AT: ").append(completedAt).append("\n");
+		builder.append("PROGRAM: ").append(currentProgram.getName()).append("\n");
+		builder.append("EXECUTABLE_PATH: ").append(currentProgram.getExecutablePath()).append("\n");
+		builder.append("EXECUTABLE_FORMAT: ").append(currentProgram.getExecutableFormat()).append("\n");
+		builder.append("LANGUAGE: ").append(currentProgram.getLanguageID()).append("\n");
+		builder.append("COMPILER: ").append(currentProgram.getCompiler()).append("\n");
+		builder.append("FUNCTIONS_PROCESSED: ").append(processed).append("\n");
+		builder.append("PSEUDOCODE_FILES_WRITTEN: ").append(emitted).append("\n");
+		builder.append("DECOMPILATION_FAILURES: ").append(failed).append("\n");
+		builder.append("DECOMPILATION_TIMEOUTS: ").append(timedOut).append("\n");
+		builder.append("DECOMPILATION_CANCELLED: ").append(cancelled).append("\n");
+		builder.append("PER_FUNCTION_TIMEOUT_SECONDS: ").append(timeoutSeconds).append("\n");
+		builder.append("MAX_FUNCTIONS: ").append(maxFunctions == 0 ? "all" : Integer.toString(maxFunctions))
+			.append("\n");
+		builder.append("TOTAL_PSEUDOCODE_CHARACTERS: ").append(totalChars).append("\n");
+		builder.append("LAST_FUNCTION_ENTRY: ").append(sanitizeField(lastFunctionEntry)).append("\n");
+		builder.append("LAST_FUNCTION_NAME: ").append(sanitizeField(lastFunctionName)).append("\n");
+		builder.append("LAST_ERROR: ").append(sanitizeField(lastError)).append("\n");
+		builder.append("FILES_INDEX: functions.tsv\n");
+		builder.append("FILES_ERRORS: decompile-errors.tsv\n");
+		builder.append("FILES_DIR: functions/\n");
+		builder.append("STATUS_FILE: status.txt\n");
+		builder.append("COMPLETE_MARKER: complete.marker\n");
+		return builder.toString();
+	}
+
+	private String nowIso() {
+		return Instant.now().toString();
+	}
+
+	private void deleteIfExists(Path path) throws IOException {
+		Files.deleteIfExists(path);
+	}
+
+	private void touch(Path path) throws IOException {
+		Files.writeString(path, "", StandardCharsets.UTF_8,
+			StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+	}
+
+	private void writeString(Path path, String content) throws IOException {
+		Files.writeString(path, content, StandardCharsets.UTF_8,
+			StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+	}
+
+	private void appendString(Path path, String content) throws IOException {
+		Files.writeString(path, content, StandardCharsets.UTF_8,
+			StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+	}
+}

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/install-dep.sh
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/install-dep.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: install-dep.sh <dependency>
+
+Install or help install a dependency used by the Rust reverse-engineering skill.
+
+Available dependencies:
+  file           file type detection utility
+  strings        strings extraction utility
+  headers        readelf / llvm-readelf / otool style header tooling
+  nm             nm / llvm-nm style symbol tooling
+  disassembler   objdump / llvm-objdump / otool style disassembly tooling
+  rustfilt       Rust symbol demangler
+  debugger       gdb or lldb
+  ghidra         Ghidra / analyzeHeadless
+  ida            IDA Pro (manual)
+  binaryninja    Binary Ninja (manual)
+
+The script auto-detects your OS and package manager, installs directly when it can,
+and prints exact manual instructions when it cannot.
+EOF
+  exit 0
+}
+
+if [[ $# -lt 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+fi
+
+DEP="$1"
+
+OS="unknown"
+PKG_MANAGER="none"
+HAS_SUDO=false
+
+case "$(uname -s)" in
+  Darwin) OS="macos" ;;
+  Linux) OS="linux" ;;
+esac
+
+if command -v brew >/dev/null 2>&1; then
+  PKG_MANAGER="brew"
+elif command -v apt-get >/dev/null 2>&1; then
+  PKG_MANAGER="apt"
+elif command -v dnf >/dev/null 2>&1; then
+  PKG_MANAGER="dnf"
+elif command -v pacman >/dev/null 2>&1; then
+  PKG_MANAGER="pacman"
+fi
+
+if command -v sudo >/dev/null 2>&1; then
+  HAS_SUDO=true
+fi
+
+info() {
+  echo "[INFO] $*"
+}
+
+ok() {
+  echo "[OK] $*"
+}
+
+fail() {
+  echo "[FAIL] $*" >&2
+}
+
+manual() {
+  echo "[MANUAL] $*" >&2
+  exit 2
+}
+
+has_any() {
+  for tool in "$@"; do
+    if command -v "$tool" >/dev/null 2>&1; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+add_to_profile() {
+  local line="$1"
+  local profile=""
+  if [[ -f "$HOME/.zshrc" ]]; then
+    profile="$HOME/.zshrc"
+  elif [[ -f "$HOME/.bashrc" ]]; then
+    profile="$HOME/.bashrc"
+  elif [[ -f "$HOME/.profile" ]]; then
+    profile="$HOME/.profile"
+  fi
+
+  if [[ -z "$profile" ]]; then
+    info "Add this to your shell profile: $line"
+    return 0
+  fi
+
+  if ! grep -qF "$line" "$profile" 2>/dev/null; then
+    echo "$line" >> "$profile"
+    info "Added to $profile: $line"
+    info "Start a new shell or source $profile to apply it."
+  fi
+}
+
+ensure_brew_formula_on_path() {
+  local formula="$1"
+  local prefix=""
+  prefix="$(brew --prefix "$formula" 2>/dev/null || true)"
+  if [[ -n "$prefix" && -d "$prefix/bin" ]]; then
+    export PATH="$prefix/bin:$PATH"
+    add_to_profile "export PATH=\"$prefix/bin:\$PATH\""
+  fi
+}
+
+pkg_install() {
+  local brew_pkg="$1"
+  local apt_pkg="$2"
+  local dnf_pkg="$3"
+  local pacman_pkg="$4"
+
+  case "$PKG_MANAGER" in
+    brew)
+      if [[ -z "$brew_pkg" ]]; then
+        manual "No Homebrew formula configured for this dependency."
+      fi
+      info "Installing $brew_pkg via Homebrew..."
+      brew install "$brew_pkg"
+      ensure_brew_formula_on_path "$brew_pkg"
+      ;;
+    apt)
+      if [[ -z "$apt_pkg" ]]; then
+        manual "Run the manual installation for this dependency on apt-based systems."
+      fi
+      if [[ "$HAS_SUDO" != true ]]; then
+        manual "Run: sudo apt-get update && sudo apt-get install -y $apt_pkg"
+      fi
+      info "Installing $apt_pkg via apt..."
+      sudo apt-get update -qq
+      sudo apt-get install -y -qq "$apt_pkg"
+      ;;
+    dnf)
+      if [[ -z "$dnf_pkg" ]]; then
+        manual "Run the manual installation for this dependency on dnf-based systems."
+      fi
+      if [[ "$HAS_SUDO" != true ]]; then
+        manual "Run: sudo dnf install -y $dnf_pkg"
+      fi
+      info "Installing $dnf_pkg via dnf..."
+      sudo dnf install -y "$dnf_pkg"
+      ;;
+    pacman)
+      if [[ -z "$pacman_pkg" ]]; then
+        manual "Run the manual installation for this dependency on pacman-based systems."
+      fi
+      if [[ "$HAS_SUDO" != true ]]; then
+        manual "Run: sudo pacman -S --noconfirm $pacman_pkg"
+      fi
+      info "Installing $pacman_pkg via pacman..."
+      sudo pacman -S --noconfirm "$pacman_pkg"
+      ;;
+    *)
+      manual "No supported package manager found."
+      ;;
+  esac
+}
+
+install_xcode_cli_tools() {
+  if [[ "$OS" != "macos" ]]; then
+    manual "This helper is only available on macOS."
+  fi
+
+  if xcode-select -p >/dev/null 2>&1; then
+    ok "Xcode Command Line Tools already installed"
+    return 0
+  fi
+
+  if ! command -v xcode-select >/dev/null 2>&1; then
+    manual "Install Xcode Command Line Tools manually from Apple Developer tools."
+  fi
+
+  info "Triggering Xcode Command Line Tools installer..."
+  if xcode-select --install >/dev/null 2>&1; then
+    manual "Finish the Xcode Command Line Tools installation, then rerun this script."
+  fi
+
+  manual "Run: xcode-select --install"
+}
+
+verify_any() {
+  local dep_name="$1"
+  shift
+  if has_any "$@"; then
+    ok "$dep_name is ready"
+  else
+    fail "$dep_name installation did not expose any expected command in PATH"
+    exit 1
+  fi
+}
+
+install_file_dep() {
+  if has_any file; then
+    ok "file already available"
+    return 0
+  fi
+
+  case "$OS" in
+    macos)
+      pkg_install "file-formula" "" "" ""
+      ;;
+    linux)
+      pkg_install "" "file" "file" "file"
+      ;;
+    *)
+      manual "Install the 'file' utility manually."
+      ;;
+  esac
+
+  verify_any "file" file
+}
+
+install_strings_dep() {
+  if has_any strings llvm-strings gstrings; then
+    ok "strings-compatible tool already available"
+    return 0
+  fi
+
+  case "$OS" in
+    macos)
+      pkg_install "llvm" "" "" ""
+      ;;
+    linux)
+      pkg_install "" "binutils" "binutils" "binutils"
+      ;;
+    *)
+      manual "Install strings, llvm-strings, or gstrings manually."
+      ;;
+  esac
+
+  verify_any "strings" strings llvm-strings gstrings
+}
+
+install_headers_dep() {
+  if has_any readelf llvm-readelf greadelf otool; then
+    ok "header-analysis tool already available"
+    return 0
+  fi
+
+  case "$OS" in
+    macos)
+      if command -v otool >/dev/null 2>&1; then
+        ok "otool already available"
+        return 0
+      fi
+      if [[ "$PKG_MANAGER" == "brew" ]]; then
+        pkg_install "llvm" "" "" ""
+      else
+        install_xcode_cli_tools
+      fi
+      ;;
+    linux)
+      pkg_install "" "binutils" "binutils" "binutils"
+      ;;
+    *)
+      manual "Install readelf, llvm-readelf, greadelf, or otool manually."
+      ;;
+  esac
+
+  verify_any "headers" readelf llvm-readelf greadelf otool
+}
+
+install_nm_dep() {
+  if has_any nm llvm-nm gnm; then
+    ok "symbol table tool already available"
+    return 0
+  fi
+
+  case "$OS" in
+    macos)
+      if command -v nm >/dev/null 2>&1; then
+        ok "nm already available"
+        return 0
+      fi
+      if [[ "$PKG_MANAGER" == "brew" ]]; then
+        pkg_install "llvm" "" "" ""
+      else
+        install_xcode_cli_tools
+      fi
+      ;;
+    linux)
+      pkg_install "" "binutils" "binutils" "binutils"
+      ;;
+    *)
+      manual "Install nm, llvm-nm, or gnm manually."
+      ;;
+  esac
+
+  verify_any "nm" nm llvm-nm gnm
+}
+
+install_disassembler_dep() {
+  if has_any objdump llvm-objdump gobjdump otool; then
+    ok "disassembler already available"
+    return 0
+  fi
+
+  case "$OS" in
+    macos)
+      if command -v otool >/dev/null 2>&1; then
+        ok "otool already available"
+        return 0
+      fi
+      if [[ "$PKG_MANAGER" == "brew" ]]; then
+        pkg_install "llvm" "" "" ""
+      else
+        install_xcode_cli_tools
+      fi
+      ;;
+    linux)
+      pkg_install "" "binutils" "binutils" "binutils"
+      ;;
+    *)
+      manual "Install objdump, llvm-objdump, gobjdump, or otool manually."
+      ;;
+  esac
+
+  verify_any "disassembler" objdump llvm-objdump gobjdump otool
+}
+
+install_rustfilt_dep() {
+  if has_any rustfilt; then
+    ok "rustfilt already available"
+    return 0
+  fi
+
+  if command -v cargo >/dev/null 2>&1; then
+    info "Installing rustfilt via cargo..."
+    cargo install rustfilt
+    export PATH="$HOME/.cargo/bin:$PATH"
+    add_to_profile 'export PATH="$HOME/.cargo/bin:$PATH"'
+    verify_any "rustfilt" rustfilt
+    return 0
+  fi
+
+  manual "Install cargo first, then run: cargo install rustfilt"
+}
+
+install_debugger_dep() {
+  if has_any gdb lldb; then
+    ok "debugger already available"
+    return 0
+  fi
+
+  case "$OS" in
+    macos)
+      install_xcode_cli_tools
+      ;;
+    linux)
+      pkg_install "" "lldb" "lldb" "lldb"
+      ;;
+    *)
+      manual "Install lldb or gdb manually."
+      ;;
+  esac
+
+  verify_any "debugger" gdb lldb
+}
+
+install_ghidra_dep() {
+  if has_any analyzeHeadless ghidraRun ghidra; then
+    ok "Ghidra already available"
+    return 0
+  fi
+
+  case "$PKG_MANAGER" in
+    brew)
+      pkg_install "ghidra" "" "" ""
+      ;;
+    dnf)
+      pkg_install "" "" "ghidra" ""
+      ;;
+    *)
+      manual "Install Ghidra manually from https://ghidra-sre.org/ or use Homebrew: brew install ghidra"
+      ;;
+  esac
+
+  verify_any "ghidra" analyzeHeadless ghidraRun ghidra
+}
+
+install_ida_dep() {
+  manual "Install IDA Pro manually from Hex-Rays, then ensure idat64 or ida64 is in PATH."
+}
+
+install_binaryninja_dep() {
+  manual "Install Binary Ninja manually, then ensure the binaryninja launcher is in PATH."
+}
+
+case "$DEP" in
+  file)
+    install_file_dep
+    ;;
+  strings)
+    install_strings_dep
+    ;;
+  headers)
+    install_headers_dep
+    ;;
+  nm)
+    install_nm_dep
+    ;;
+  disassembler)
+    install_disassembler_dep
+    ;;
+  rustfilt)
+    install_rustfilt_dep
+    ;;
+  debugger)
+    install_debugger_dep
+    ;;
+  ghidra)
+    install_ghidra_dep
+    ;;
+  ida)
+    install_ida_dep
+    ;;
+  binaryninja)
+    install_binaryninja_dep
+    ;;
+  *)
+    fail "Unknown dependency: $DEP"
+    usage
+    ;;
+esac

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/macho-slice.sh
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/macho-slice.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+
+# Common helpers for choosing a single-slice analysis target from a universal Mach-O.
+
+macho_normalize_arch() {
+  case "$1" in
+    arm64|arm64e|aarch64)
+      echo "arm64"
+      ;;
+    x86_64|x86_64h|x86-64|amd64|i386)
+      echo "x86_64"
+      ;;
+    *)
+      echo "$1"
+      ;;
+  esac
+}
+
+macho_host_arch() {
+  macho_normalize_arch "$(uname -m 2>/dev/null || echo unknown)"
+}
+
+macho_is_universal_target() {
+  local target="$1"
+  local file_out
+
+  file_out="$(file "$target" 2>/dev/null || true)"
+  [[ "$file_out" == *"Mach-O universal binary"* ]]
+}
+
+macho_list_arch_tokens() {
+  local target="$1"
+
+  if ! command -v lipo >/dev/null 2>&1; then
+    return 1
+  fi
+
+  lipo -archs "$target" 2>/dev/null
+}
+
+macho_pick_arch_token() {
+  local requested_arch="$1"
+  shift
+
+  local token
+  local requested_norm
+  local host_norm
+
+  if [[ "$#" -eq 0 ]]; then
+    return 1
+  fi
+
+  requested_norm="$(macho_normalize_arch "$requested_arch")"
+  if [[ -n "$requested_norm" ]]; then
+    for token in "$@"; do
+      if [[ "$(macho_normalize_arch "$token")" == "$requested_norm" ]]; then
+        echo "$token"
+        return 0
+      fi
+    done
+    return 1
+  fi
+
+  host_norm="$(macho_host_arch)"
+  for token in "$@"; do
+    if [[ "$(macho_normalize_arch "$token")" == "$host_norm" ]]; then
+      echo "$token"
+      return 0
+    fi
+  done
+
+  for requested_norm in arm64 x86_64; do
+    for token in "$@"; do
+      if [[ "$(macho_normalize_arch "$token")" == "$requested_norm" ]]; then
+        echo "$token"
+        return 0
+      fi
+    done
+  done
+
+  echo "$1"
+}
+
+macho_resolve_target() {
+  local target="$1"
+  local requested_arch="${2:-}"
+  local output_dir="${3:-}"
+  local arch_words
+  local arch_token
+  local thin_target
+  local token
+  local -a arch_tokens
+
+  MACHO_ORIGINAL_TARGET="$target"
+  MACHO_ANALYSIS_TARGET="$target"
+  MACHO_IS_UNIVERSAL="no"
+  MACHO_ARCH_LIST=""
+  MACHO_SELECTED_ARCH=""
+  MACHO_SELECTED_ARCH_TOKEN=""
+
+  if ! macho_is_universal_target "$target"; then
+    return 0
+  fi
+
+  if ! command -v lipo >/dev/null 2>&1; then
+    echo "Error: lipo is required to thin a universal Mach-O target before analysis." >&2
+    return 1
+  fi
+
+  arch_words="$(macho_list_arch_tokens "$target" || true)"
+  if [[ -z "$arch_words" ]]; then
+    echo "Error: failed to enumerate Mach-O slices for $target" >&2
+    return 1
+  fi
+
+  MACHO_IS_UNIVERSAL="yes"
+  MACHO_ARCH_LIST="$(printf '%s\n' "$arch_words" | awk '{$1=$1; gsub(/ /,","); print}')"
+
+  arch_tokens=()
+  for token in $arch_words; do
+    arch_tokens+=("$token")
+  done
+
+  arch_token="$(macho_pick_arch_token "$requested_arch" "${arch_tokens[@]}" || true)"
+  if [[ -z "$arch_token" ]]; then
+    echo "Error: requested Mach-O slice '$requested_arch' is not present. Available slices: $MACHO_ARCH_LIST" >&2
+    return 1
+  fi
+
+  if [[ -z "$output_dir" ]]; then
+    echo "Error: output directory is required when resolving a universal Mach-O target." >&2
+    return 1
+  fi
+
+  mkdir -p "$output_dir"
+  thin_target="$output_dir/$(basename "$target").${arch_token}"
+  lipo -thin "$arch_token" "$target" -output "$thin_target"
+
+  MACHO_ANALYSIS_TARGET="$thin_target"
+  MACHO_SELECTED_ARCH_TOKEN="$arch_token"
+  MACHO_SELECTED_ARCH="$(macho_normalize_arch "$arch_token")"
+}
+
+macho_write_metadata() {
+  local metadata_path="$1"
+
+  {
+    echo "ORIGINAL_TARGET: $MACHO_ORIGINAL_TARGET"
+    echo "ANALYSIS_TARGET: $MACHO_ANALYSIS_TARGET"
+    echo "MACHO_UNIVERSAL: $MACHO_IS_UNIVERSAL"
+    if [[ "$MACHO_IS_UNIVERSAL" == "yes" ]]; then
+      echo "MACHO_ARCHES: $MACHO_ARCH_LIST"
+      echo "MACHO_SELECTED_ARCH: $MACHO_SELECTED_ARCH"
+      echo "MACHO_SELECTED_ARCH_TOKEN: $MACHO_SELECTED_ARCH_TOKEN"
+    fi
+  } > "$metadata_path"
+}

--- a/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/triage.sh
+++ b/plugins/jingjing2222/rust-reverse-engineering-skill/skills/rust-reverse-engineering/scripts/triage.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: triage.sh [OPTIONS] <binary-or-archive>
+
+Options:
+  --macho-arch ARCH   Select a specific universal Mach-O slice before triage
+  -h, --help          Show this help message
+EOF
+}
+
+TARGET=""
+MACHO_ARCH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --macho-arch)
+      MACHO_ARCH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Error: unknown option $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      TARGET="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$TARGET" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! -e "$TARGET" ]]; then
+  echo "ERROR: target does not exist: $TARGET"
+  exit 2
+fi
+
+pick_tool() {
+  for tool in "$@"; do
+    if command -v "$tool" >/dev/null 2>&1; then
+      echo "$tool"
+      return 0
+    fi
+  done
+  return 1
+}
+
+FILE_TOOL="$(pick_tool file || true)"
+STRINGS_TOOL="$(pick_tool strings llvm-strings gstrings || true)"
+READELF_TOOL="$(pick_tool readelf llvm-readelf greadelf || true)"
+NM_TOOL="$(pick_tool nm llvm-nm gnm || true)"
+OBJDUMP_TOOL="$(pick_tool objdump llvm-objdump gobjdump || true)"
+RUSTFILT_TOOL="$(pick_tool rustfilt || true)"
+OTOOL_TOOL="$(pick_tool otool || true)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/macho-slice.sh"
+
+if [[ -z "$FILE_TOOL" || -z "$STRINGS_TOOL" || -z "$NM_TOOL" ]]; then
+  echo "ERROR: missing one of required tools: file, strings, nm/llvm-nm"
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+macho_resolve_target "$TARGET" "$MACHO_ARCH" "$TMPDIR/macho"
+ANALYSIS_TARGET="$MACHO_ANALYSIS_TARGET"
+
+FILE_OUT="$("$FILE_TOOL" "$ANALYSIS_TARGET" 2>/dev/null || true)"
+FORMAT="unknown"
+ARCH="unknown"
+
+case "$FILE_OUT" in
+  *ELF*) FORMAT="ELF" ;;
+  *Mach-O*) FORMAT="Mach-O" ;;
+  *PE32*|*MS\ Windows*|*PE32+*) FORMAT="PE/COFF" ;;
+  *current\ ar\ archive*) FORMAT="archive" ;;
+  *archive\ random\ library*) FORMAT="archive" ;;
+esac
+
+case "$FILE_OUT" in
+  *x86-64*|*x86_64*) ARCH="x86-64" ;;
+  *aarch64*|*ARM64*|*arm64*) ARCH="aarch64" ;;
+  *ARM*) ARCH="arm" ;;
+  *80386*|*Intel\ 80386*) ARCH="x86" ;;
+  *RISC-V*) ARCH="riscv" ;;
+esac
+
+STRIPPED="unknown"
+if [[ "$FILE_OUT" == *"not stripped"* ]]; then
+  STRIPPED="no"
+elif [[ "$FILE_OUT" == *"stripped"* ]]; then
+  STRIPPED="yes"
+fi
+
+DEBUG_INFO="none"
+if [[ "$FORMAT" == "ELF" && -n "$READELF_TOOL" ]]; then
+  if "$READELF_TOOL" -S "$ANALYSIS_TARGET" 2>/dev/null | grep -Eq '\.(z?debug_info|z?debug_line|z?debug_str|z?debug_abbrev)\b'; then
+    DEBUG_INFO="DWARF"
+  fi
+elif [[ "$FORMAT" == "Mach-O" && -n "$OTOOL_TOOL" ]]; then
+  if "$OTOOL_TOOL" -l "$ANALYSIS_TARGET" 2>/dev/null | grep -Eq '__DWARF|__debug_'; then
+    DEBUG_INFO="DWARF/dSYM-hint"
+  fi
+elif [[ "$FORMAT" == "PE/COFF" ]]; then
+  if "$STRINGS_TOOL" -a "$ANALYSIS_TARGET" 2>/dev/null | grep -Eiq '\.pdb($|\\)'; then
+    DEBUG_INFO="PDB-hint"
+  fi
+fi
+
+RAW_SYMBOLS="$TMPDIR/raw-symbols.txt"
+RAW_STRINGS="$TMPDIR/raw-strings.txt"
+DEMANGLED="$TMPDIR/demangled.txt"
+
+"$NM_TOOL" -an "$ANALYSIS_TARGET" >"$RAW_SYMBOLS" 2>/dev/null || true
+"$STRINGS_TOOL" -a "$ANALYSIS_TARGET" >"$RAW_STRINGS" 2>/dev/null || true
+
+if [[ -n "$RUSTFILT_TOOL" ]]; then
+  "$RUSTFILT_TOOL" <"$RAW_SYMBOLS" >"$DEMANGLED" 2>/dev/null || cp "$RAW_SYMBOLS" "$DEMANGLED"
+else
+  cp "$RAW_SYMBOLS" "$DEMANGLED"
+fi
+
+rust_score=0
+evidence=()
+
+if grep -Eq '(^|[^A-Za-z0-9])_R[A-Za-z0-9_]+' "$RAW_SYMBOLS"; then
+  rust_score=$((rust_score + 2))
+  evidence+=("v0-mangled-symbols")
+fi
+
+if grep -Eq '_ZN[^ ]*17h[0-9a-f]{16}E' "$RAW_SYMBOLS"; then
+  rust_score=$((rust_score + 2))
+  evidence+=("legacy-mangled-symbols")
+fi
+
+if grep -Eq '(^|[^A-Za-z0-9])(core|alloc|std)::' "$DEMANGLED"; then
+  rust_score=$((rust_score + 2))
+  evidence+=("demangled-runtime-namespaces")
+fi
+
+if grep -Eiq 'rust_begin_unwind|panic_fmt|core::panicking|alloc::|std::|\.rustc' "$RAW_STRINGS"; then
+  rust_score=$((rust_score + 1))
+  evidence+=("rust-runtime-strings")
+fi
+
+RUST_CONFIDENCE="low"
+if [[ "$rust_score" -ge 4 ]]; then
+  RUST_CONFIDENCE="high"
+elif [[ "$rust_score" -ge 2 ]]; then
+  RUST_CONFIDENCE="medium"
+fi
+
+EXPORTED_COUNT="$("$NM_TOOL" -g "$ANALYSIS_TARGET" 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
+IMPORTED_COUNT=0
+if [[ "$FORMAT" == "ELF" && -n "$READELF_TOOL" ]]; then
+  IMPORTED_COUNT="$("$READELF_TOOL" -Ws "$ANALYSIS_TARGET" 2>/dev/null | grep -c ' UND ' || true)"
+elif [[ "$FORMAT" == "Mach-O" && -n "$OTOOL_TOOL" ]]; then
+  IMPORTED_COUNT="$("$OTOOL_TOOL" -L "$ANALYSIS_TARGET" 2>/dev/null | tail -n +2 | wc -l | tr -d ' ' || echo 0)"
+elif [[ "$FORMAT" == "PE/COFF" && -n "$OBJDUMP_TOOL" ]]; then
+  IMPORTED_COUNT="$("$OBJDUMP_TOOL" -p "$ANALYSIS_TARGET" 2>/dev/null | grep -c 'DLL Name:' || true)"
+fi
+
+TOP_NAMESPACES="$TMPDIR/namespaces.txt"
+grep -Eo '([A-Za-z_][A-Za-z0-9_]*::){1,}' "$DEMANGLED" 2>/dev/null \
+  | sed 's/::$//' \
+  | cut -d: -f1 \
+  | grep -Ev '^(core|alloc|std|panic_unwind|unwind|compiler_builtins|hashbrown|test)$' \
+  | sort | uniq -c | sort -nr | head -10 >"$TOP_NAMESPACES" || true
+
+echo "ORIGINAL_TARGET: $TARGET"
+echo "ANALYSIS_TARGET: $ANALYSIS_TARGET"
+echo "MACHO_UNIVERSAL: $MACHO_IS_UNIVERSAL"
+if [[ "$MACHO_IS_UNIVERSAL" == "yes" ]]; then
+  echo "MACHO_ARCHES: $MACHO_ARCH_LIST"
+  echo "MACHO_SELECTED_ARCH: $MACHO_SELECTED_ARCH"
+  echo "MACHO_SELECTED_ARCH_TOKEN: $MACHO_SELECTED_ARCH_TOKEN"
+fi
+echo "TARGET: $ANALYSIS_TARGET"
+echo "FILE: $FILE_OUT"
+echo "FORMAT: $FORMAT"
+echo "ARCH: $ARCH"
+echo "STRIPPED: $STRIPPED"
+echo "DEBUG_INFO: $DEBUG_INFO"
+echo "RUST_CONFIDENCE: $RUST_CONFIDENCE"
+if [[ ${#evidence[@]} -gt 0 ]]; then
+  echo "RUST_EVIDENCE: $(IFS=, ; echo "${evidence[*]}")"
+else
+  echo "RUST_EVIDENCE: none"
+fi
+echo "EXPORTED_SYMBOLS: $EXPORTED_COUNT"
+echo "IMPORTED_SYMBOL_HINTS: $IMPORTED_COUNT"
+
+echo
+echo "=== candidate namespaces ==="
+if [[ -s "$TOP_NAMESPACES" ]]; then
+  cat "$TOP_NAMESPACES"
+else
+  echo "(none recovered)"
+fi
+
+echo
+echo "=== interesting strings ==="
+grep -Eim 20 'rust_begin_unwind|panic|core::|alloc::|std::|tokio|serde|reqwest|hyper|mio|tracing|clap|prost|tonic|openssl|ring' "$RAW_STRINGS" || true

--- a/plugins/ndycode/oc-chatgpt-multi-auth/README.md
+++ b/plugins/ndycode/oc-chatgpt-multi-auth/README.md
@@ -3,12 +3,10 @@
 <!--
 Badges: CI + OpenSSF Scorecard will turn green once Phase 3 Batch A (CI workflow + Scorecard workflow) lands and runs its first job. Until then they may render as "no status" / 404 — that is expected and self-resolves automatically.
 -->
-[![CI](https://github.com/ndycode/oc-codex-multi-auth/actions/workflows/ci.yml/badge.svg)](https://github.com/ndycode/oc-codex-multi-auth/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/oc-codex-multi-auth.svg)](https://www.npmjs.com/package/oc-codex-multi-auth)
 [![npm downloads](https://img.shields.io/npm/dw/oc-codex-multi-auth.svg)](https://www.npmjs.com/package/oc-codex-multi-auth)
 [![Node.js Version](https://img.shields.io/node/v/oc-codex-multi-auth.svg)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ndycode/oc-codex-multi-auth/badge)](https://securityscorecards.dev/viewer/?uri=github.com/ndycode/oc-codex-multi-auth)
 
 Use your ChatGPT Plus/Pro subscription inside OpenCode with OAuth login, GPT-5/Codex model presets, and multi-account failover.
 
@@ -119,6 +117,36 @@ Detailed configuration lives outside this README:
 - [Getting Started](docs/getting-started.md) for install and first-run setup
 - [Configuration Reference](docs/configuration.md) for config keys, env vars, and fallback behavior
 - [Config Templates](config/README.md) for modern vs legacy OpenCode examples
+
+## Credential Storage
+
+By default, this plugin stores OAuth refresh tokens as a V3 JSON file under the per-project path determined by `lib/storage/paths.ts`. File permissions are restricted (`0o600` on the file, `0o700` on containing directories) on platforms that honour them.
+
+### Optional: OS-native keychain
+
+Set `CODEX_KEYCHAIN=1` in the environment to store credentials in the OS keychain instead:
+
+- **macOS**: Keychain
+- **Windows**: Credential Manager
+- **Linux**: libsecret (requires a running secret service such as GNOME Keyring or KWallet)
+
+The opt-in is strict: only the literal value `"1"` enables the keychain backend. Any other value (unset, `"0"`, `"false"`, `""`, `"yes"`, ...) leaves behavior identical to earlier releases. Existing users see zero change by default.
+
+When enabled on an existing install, the plugin auto-migrates the JSON file into the keychain on the next credential write and renames the original as `accounts.json.migrated-to-keychain.<timestamp>` for rollback. The original is never deleted automatically.
+
+Use the `codex-keychain` tool to inspect and manage the backend:
+
+```bash
+codex-keychain status     # which backend is active, is the keychain reachable
+codex-keychain migrate    # force-migrate on-disk JSON to the keychain now
+codex-keychain rollback   # restore the most recent .migrated-to-keychain.<ts> backup
+```
+
+### Keychain fallback
+
+If the OS keychain is unavailable (Linux without secret service, permission denied, locked session, missing native module), the plugin logs a clear warning and falls back to the JSON backend for that operation. Credentials are never silently lost.
+
+See [SECURITY.md](SECURITY.md#credential-storage-backends) for the threat model that applies to each backend.
 
 ## Troubleshooting
 

--- a/plugins/ndycode/oc-chatgpt-multi-auth/SECURITY.md
+++ b/plugins/ndycode/oc-chatgpt-multi-auth/SECURITY.md
@@ -22,6 +22,23 @@ This plugin handles sensitive OAuth tokens. To protect your security:
 - Implement automatic token refresh
 - Use industry-standard authentication practices
 
+### Credential Storage Backends
+
+Two backends are supported. The default has not changed in this release.
+
+| Backend | Enabled by | Where tokens live | Threat model |
+|---------|-----------|-------------------|--------------|
+| JSON (default) | always on | `~/.opencode/projects/<project-key>/oc-codex-multi-auth-accounts.json`, file mode `0o600`, directory mode `0o700` on POSIX. A `.gitignore` entry is auto-written when the storage path sits inside a git repo. | Plaintext on the local filesystem. Any local user or process that can read the file can read the refresh token. Protect the home directory like you would protect `~/.ssh`. |
+| OS keychain (opt-in) | `CODEX_KEYCHAIN=1` | macOS Keychain / Windows Credential Manager / Linux libsecret, stored under service name `oc-codex-multi-auth` and account key `accounts:<project-storage-key>` (or `accounts:global`). | Token ciphertext is managed by the OS keychain. Unlocked session required to read. Credentials survive loss of the JSON file. Still only as strong as the user's OS login password / keychain unlock. |
+
+Migration and fallback rules:
+
+- Switching the env var ON migrates the on-disk JSON into the keychain on the next save and renames the JSON file as `<path>.migrated-to-keychain.<timestamp>` for rollback. The original is never deleted automatically.
+- If a keychain call fails (native module missing, keychain locked, permission denied, unsupported Linux without a secret service), the plugin logs a warning and falls back to the JSON backend for that operation. Credentials are never silently lost.
+- Turn the opt-in OFF by unsetting `CODEX_KEYCHAIN` and running `codex-keychain rollback` to restore the JSON file from the most recent `.migrated-to-keychain.<ts>` backup.
+
+Log redaction applies uniformly to both backends. Refresh tokens, access tokens, and id tokens are replaced before any log line is written.
+
 ⚠️ **What you should do:**
 - Never share your `~/.opencode/` directory
 - Do not commit OAuth tokens to version control

--- a/plugins/ndycode/oc-chatgpt-multi-auth/package-lock.json
+++ b/plugins/ndycode/oc-chatgpt-multi-auth/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc-codex-multi-auth",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
+        "@napi-rs/keyring": "~1.2.0",
         "@openauthjs/openauth": "^0.4.3",
         "@opencode-ai/plugin": "^1.2.9",
         "hono": "4.12.14",
@@ -737,6 +738,225 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+      "integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.2.0",
+        "@napi-rs/keyring-darwin-x64": "1.2.0",
+        "@napi-rs/keyring-freebsd-x64": "1.2.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.2.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+      "integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+      "integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@openauthjs/openauth": {

--- a/plugins/ndycode/oc-chatgpt-multi-auth/package.json
+++ b/plugins/ndycode/oc-chatgpt-multi-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "OpenCode plugin for Codex-first GPT-5 workflows with ChatGPT Plus/Pro OAuth, multi-account rotation, and guided setup",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -96,6 +96,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@napi-rs/keyring": "~1.2.0",
     "@openauthjs/openauth": "^0.4.3",
     "@opencode-ai/plugin": "^1.2.9",
     "hono": "4.12.14",

--- a/plugins/sendbird/cc-plugin-codex/.codex-plugin/plugin.json
+++ b/plugins/sendbird/cc-plugin-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Claude Code Plugin for Codex. Delegate code reviews, investigations, and tracked tasks to Claude Code from inside Codex.",
   "author": {
     "name": "Sendbird, Inc.",

--- a/plugins/sendbird/cc-plugin-codex/package.json
+++ b/plugins/sendbird/cc-plugin-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-plugin-codex",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Claude Code Plugin for Codex by Sendbird",
   "type": "module",
   "author": {

--- a/plugins/sendbird/cc-plugin-codex/skills/adversarial-review/SKILL.md
+++ b/plugins/sendbird/cc-plugin-codex/skills/adversarial-review/SKILL.md
@@ -52,15 +52,20 @@ Argument handling:
 - It does not support `--scope staged` or `--scope unstaged`.
 - Unlike `$cc:review`, it can still take extra focus text after the flags.
 - The companion review process itself always runs in the foreground. Background mode only changes how Codex launches that command.
+- For the detailed execution contract, treat the internal runtime reference at `../../internal-skills/review-runtime/runtime.md` as supporting guidance only. It is an internal reference document, not a public skill to invoke.
 
 Foreground flow:
 - Run:
   `node "<installed-plugin-root>/scripts/claude-companion.mjs" adversarial-review --view-state on-success <arguments with --wait/--background removed>`
+- Foreground adversarial review belongs to the main Codex thread. Do not spawn a review subagent, do not invoke a generic review-runner role, and do not proxy this foreground path through any background worker abstraction.
+- Do not fall back to raw `claude`, `claude-code`, `claude review`, `bash -lc ...claude...`, or any other direct Claude CLI syntax when the companion path is available. The foreground syntax contract here is the installed companion command above, not a hand-rolled Claude invocation.
+- If the installed companion command fails, surface that failure. Do not silently retry foreground adversarial review through a different CLI shape, a generic review runner, or a custom shell wrapper.
 - Present the companion stdout faithfully.
 - Do not fix anything mentioned in the review output.
 
 Background flow:
 - For background adversarial review, use Codex's built-in `default` subagent instead of a detached background shell command.
+- Do not satisfy background adversarial review by using a generic `claude_review_runner`-style helper role, raw Claude CLI, or any other review executor that bypasses the installed companion command.
 - Never satisfy background adversarial review by running the companion command itself with shell backgrounding such as `&`, `nohup`, detached `spawn`, or any equivalent direct background process launch.
 - Background here means "spawn the forwarding child via `spawn_agent` and do not wait in the parent turn." The companion adversarial-review command inside that child still runs once, in the foreground, inside the child thread.
 - Before spawning the built-in child, capture the review job id plus routing context in one call:
@@ -85,6 +90,9 @@ Background flow:
   - run exactly one shell command
   - execute:
     `node "<installed-plugin-root>/scripts/claude-companion.mjs" adversarial-review --view-state defer <arguments with --wait/--background removed>`
+  - run that command as one blocking foreground shell-tool call, not as a background terminal/session
+  - do not request a shell session id, poll a shell session later, or return before the companion command exits
+  - if the available shell tool is `exec_command`, call it once in non-interactive mode and wait for command exit in that same call
   - include `--owner-session-id <owner-session-id>` only when the parent resolved a non-empty owner session id
   - include `--job-id <reserved-job-id>` when the parent reserved one
   - never leave an empty routing placeholder such as `--owner-session-id  --job-id`

--- a/plugins/sendbird/cc-plugin-codex/skills/rescue/SKILL.md
+++ b/plugins/sendbird/cc-plugin-codex/skills/rescue/SKILL.md
@@ -82,9 +82,10 @@ Subagent launch:
 - If it returns an empty `parentThreadId`, continue without parent wake-up instead of blocking the rescue.
 - This parent wake-up attempt is now the default for background built-in rescue on persistent Codex/Desktop threads. It is still best-effort and should silently degrade on one-shot `codex exec` runs.
 - For the built-in rescue path, the parent thread owns prompt shaping. The built-in child should stay a pure executor.
+- For the built-in rescue path, treat the internal runtime reference at `../../internal-skills/cli-runtime/runtime.md` as the command-building contract for the forwarding worker. It is an internal reference document, not a public skill to invoke.
 - If the built-in rescue request is vague, chatty, or a follow-up, the parent may tighten only the task text before composing the exact companion command.
 - Prefer passing a small structured `<parent_context>` block instead of forked thread history when the child needs a little prior context.
-- Use the `task-prompt-shaping` internal rules as guidance for that parent-side tightening:
+- Use the internal prompt-shaping reference at `../../internal-skills/task-prompt-shaping/prompt-shaping.md` as deeper guidance for that parent-side tightening. It is an internal reference document, not a public skill to invoke.
   - preserve user intent and add no new repo facts
   - prefer a short delta instruction for resume follow-ups
   - when helpful, use compact blocks such as `<task>`, `<output_contract>`, and `<default_follow_through_policy>`
@@ -119,6 +120,9 @@ Subagent launch:
 - The built-in rescue path must use a compact strict forwarding message. It must:
   - identify the child as a transient forwarding worker for Claude Code rescue
   - include exactly one shell command to run
+  - run that command as one blocking foreground shell-tool call, not as a background terminal/session
+  - do not request a shell session id, poll a shell session later, or return before the companion command exits
+  - if the available shell tool is `exec_command`, call it once in non-interactive mode and wait for command exit in that same call
   - for foreground rescue only, tell the child to return that command's stdout text exactly, with no preamble, summary, code fence, trimming, normalization, or punctuation changes
   - tell the child to ignore stderr progress chatter such as `[cc] ...` lines and preserve only the stdout-equivalent final result text
   - if a parent thread id is provided for experimental background notification, allow one extra `send_input` call after a successful shell result and before finishing

--- a/plugins/sendbird/cc-plugin-codex/skills/review/SKILL.md
+++ b/plugins/sendbird/cc-plugin-codex/skills/review/SKILL.md
@@ -50,15 +50,20 @@ Argument handling:
 - `$cc:review` is native-review only. It does not support staged-only review, unstaged-only review, or extra focus text.
 - If the user needs custom review instructions or more adversarial framing, they should use `$cc:adversarial-review`.
 - The companion review process itself always runs in the foreground. Background mode only changes how Codex launches that command.
+- For the detailed execution contract, treat the internal runtime reference at `../../internal-skills/review-runtime/runtime.md` as supporting guidance only. It is an internal reference document, not a public skill to invoke.
 
 Foreground flow:
 - Run:
   `node "<installed-plugin-root>/scripts/claude-companion.mjs" review --view-state on-success <arguments with --wait/--background removed>`
+- Foreground review belongs to the main Codex thread. Do not spawn a review subagent, do not invoke a generic review-runner role, and do not proxy this foreground path through any background worker abstraction.
+- Do not fall back to raw `claude`, `claude-code`, `claude review`, `bash -lc ...claude...`, or any other direct Claude CLI syntax when the companion path is available. The foreground syntax contract here is the installed companion command above, not a hand-rolled Claude invocation.
+- If the installed companion command fails, surface that failure. Do not silently retry foreground review through a different CLI shape, a generic review runner, or a custom shell wrapper.
 - Present the companion stdout faithfully.
 - Do not fix anything mentioned in the review output.
 
 Background flow:
 - For background review, use Codex's built-in `default` subagent instead of a detached background shell command.
+- Do not satisfy background review by using a generic `claude_review_runner`-style helper role, raw Claude CLI, or any other review executor that bypasses the installed companion command.
 - Never satisfy background review by running the companion command itself with shell backgrounding such as `&`, `nohup`, detached `spawn`, or any equivalent direct background process launch.
 - Background here means "spawn the forwarding child via `spawn_agent` and do not wait in the parent turn." The companion review command inside that child still runs once, in the foreground, inside the child thread.
 - Before spawning the built-in child, capture the review job id plus routing context in one call:
@@ -83,6 +88,9 @@ Background flow:
   - run exactly one shell command
   - execute:
     `node "<installed-plugin-root>/scripts/claude-companion.mjs" review --view-state defer <arguments with --wait/--background removed>`
+  - run that command as one blocking foreground shell-tool call, not as a background terminal/session
+  - do not request a shell session id, poll a shell session later, or return before the companion command exits
+  - if the available shell tool is `exec_command`, call it once in non-interactive mode and wait for command exit in that same call
   - include `--owner-session-id <owner-session-id>` only when the parent resolved a non-empty owner session id
   - include `--job-id <reserved-job-id>` when the parent reserved one
   - never leave an empty routing placeholder such as `--owner-session-id  --job-id`

--- a/plugins/useorgx/orgx-codex-plugin/package.json
+++ b/plugins/useorgx/orgx-codex-plugin/package.json
@@ -1,11 +1,23 @@
 {
   "name": "@useorgx/codex-plugin",
   "version": "0.1.0",
-  "description": "OrgX Codex plugin with MCP access and initiative-aware skills",
+  "description": "OrgX Codex plugin with MCP access, initiative-aware skills, and a Sovereign Execution peer sidecar.",
   "type": "module",
   "private": true,
+  "bin": {
+    "orgx-codex-peer": "lib/peer/cli.mjs"
+  },
+  "exports": {
+    ".": "./lib/peer/peer.mjs",
+    "./peer": "./lib/peer/peer.mjs"
+  },
   "scripts": {
-    "check": "node scripts/verify-plugin.mjs"
+    "check": "node scripts/verify-plugin.mjs",
+    "test": "node --test lib/peer/peer.test.mjs",
+    "peer:start": "node lib/peer/cli.mjs"
+  },
+  "dependencies": {
+    "@useorgx/orgx-gateway-sdk": "github:useorgx/orgx-gateway-sdk"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary
- add `Rust Reverse Engineering` to the `Tools & Integrations` section in `README.md`
- sync generated marketplace artifacts and mirrored plugin bundle content required by this repository's validation flow
- fix the pre-existing `Related Projects` alphabetical ordering so the README ordering check passes

## Validation
- `python3 scripts/check-alphabetical.py README.md`
- `python3 scripts/generate_plugins_json.py`

## Notes
- Running the repository's sync script updates mirrored plugin snapshots under `plugins/` in addition to the new listing entry.
