### PR TITLE
Add tailtest: auto test generation plugin for Codex CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin for Codex, Claude Code, and Cline with structured planning, review, and verification guardrails.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.
+- [tailtest](https://github.com/avansaber/tailtest-codex) - Automatically generates and runs tests for every file Codex creates or modifies. Stop hook detects changed files via mtime sweep, queues them, and instructs Codex to write and run tests. 8 languages (Python, TypeScript, JavaScript, Go, Ruby, PHP, Java, Rust). Zero config, zero commands.
 - [VibePortrait](https://github.com/dadwadw233/VibePortrait) - Developer personality portrait generator — analyzes AI conversation history to produce MBTI type (16 color themes), capability radar, developer rating, 3-dimension famous match, and a persona skill that lets any AI "think like you".
 
 ### Tools & Integrations


### PR DESCRIPTION
## Summary

Adds [tailtest](https://github.com/avansaber/tailtest-codex) to the Development & Workflow section.

tailtest is a Codex CLI plugin that automatically generates and runs tests for every file Codex creates or modifies. The Stop hook detects changed source files via mtime sweep, queues them, and instructs Codex to write and run tests. Zero config, zero commands.

- **8 languages:** Python, TypeScript, JavaScript, Go, Ruby, PHP, Java, Rust
- **Mechanism:** Stop hook (fires after every Codex turn) + mtime sweep
- **Install:** `git clone https://github.com/avansaber/tailtest-codex ~/.codex/plugins/tailtest`
- **Repo:** https://github.com/avansaber/tailtest-codex
- **License:** Apache 2.0