### PR TITLE
Add Mobazha — decentralized e-commerce skills plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.
 - [MorningAI](https://github.com/octo-patch/MorningAI) - AI news tracking skill that monitors 80+ entities across 6 sources (Reddit, HN, GitHub, Hugging Face, arXiv, X) and generates scored daily reports with infographics and message digests.
+- [Mobazha](https://github.com/mobazha/mobazha-skills) - Decentralized e-commerce skills — deploy self-hosted stores, import products from Shopify/Amazon, configure custom domains and Telegram bots, set up Tor privacy, and manage your store via MCP.
 - [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.
 - [OpenProject](https://github.com/varaprasadreddy9676/team-codex-plugins) - Team collaboration via OpenProject integration.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.


### PR DESCRIPTION
## Plugin Details

- **Name:** Mobazha
- **Repo:** https://github.com/mobazha/mobazha-skills
- **Category:** Tools & Integrations
- **Description:** Decentralized e-commerce skills — deploy self-hosted stores, import products from Shopify/Amazon, configure custom domains and Telegram bots, set up Tor privacy, and manage your store via MCP.

## Checklist

- [x] Public GitHub repository
- [x] Includes `.codex-plugin/plugin.json` manifest
- [x] Functional and well-documented
- [x] One plugin per PR
- [x] Alphabetized within category
- [x] All links work