### PR TITLE
Add Kachilu Browser plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -305,6 +305,18 @@
       "category": "Tools & Integrations"
     },
     {
+      "name": "kachilu-browser",
+      "source": {
+        "source": "local",
+        "path": "./plugins/kachilu-inc/kachilu-browser"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tools & Integrations"
+    },
+    {
       "name": "kicad-happy",
       "source": {
         "source": "local",

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
+- [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.

--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-04-19",
-  "total": 43,
+  "last_updated": "2026-04-22",
+  "total": 44,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -268,6 +268,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/avivsinai/jenkins-cli/main/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Kachilu Browser",
+      "url": "https://github.com/kachilu-inc/kachilu-browser",
+      "owner": "kachilu-inc",
+      "repo": "kachilu-browser",
+      "description": "Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/kachilu-inc/kachilu-browser/main/.codex-plugin/plugin.json"
     },
     {
       "name": "KiCad Happy",

--- a/plugins/kachilu-inc/kachilu-browser/.codex-plugin/plugin.json
+++ b/plugins/kachilu-inc/kachilu-browser/.codex-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "kachilu-browser",
+  "version": "0.0.5",
+  "description": "Browser automation CLI and MCP tools for AI agents, with human-like browser control and WSL2 Windows Chrome support.",
+  "author": {
+    "name": "Kachilu Inc."
+  },
+  "homepage": "https://github.com/kachilu-inc/kachilu-browser",
+  "repository": "https://github.com/kachilu-inc/kachilu-browser",
+  "license": "SEE LICENSE IN LICENSE",
+  "keywords": [
+    "browser",
+    "automation",
+    "chrome",
+    "mcp",
+    "agent"
+  ],
+  "skills": "./skills",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Kachilu Browser",
+    "shortDescription": "Automate a real browser through OpenClaw MCP tools.",
+    "longDescription": "Kachilu Browser gives OpenClaw agents a local browser automation control plane with accessibility snapshots, visible UI actions, CAPTCHA-aware workflows, and WSL2 Windows Chrome support.",
+    "developerName": "Kachilu Inc.",
+    "category": "Productivity",
+    "capabilities": [
+      "Browser Automation",
+      "MCP Tools"
+    ],
+    "websiteURL": "https://github.com/kachilu-inc/kachilu-browser"
+  }
+}

--- a/plugins/kachilu-inc/kachilu-browser/.mcp.json
+++ b/plugins/kachilu-inc/kachilu-browser/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "kachilu_browser": {
+      "command": "node",
+      "args": [
+        "./scripts/mcp-server.mjs"
+      ],
+      "connectionTimeoutMs": 60000
+    }
+  }
+}

--- a/plugins/kachilu-inc/kachilu-browser/LICENSE
+++ b/plugins/kachilu-inc/kachilu-browser/LICENSE
@@ -1,0 +1,25 @@
+Kachilu Browser License
+
+Copyright (c) 2026 Kachilu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+This license does not grant permission to use the trade names, trademarks,
+service marks, logos, or branding of Kachilu Inc., except as required for
+reasonable and customary use in describing the origin of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL KACHILU INC. OR
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/kachilu-inc/kachilu-browser/README.md
+++ b/plugins/kachilu-inc/kachilu-browser/README.md
@@ -1,0 +1,80 @@
+# Kachilu Browser
+
+`kachilu-browser` is an anti-bot-aware browser automation CLI for AI agents such
+as Codex and Claude.
+
+<p align="center">
+  <img src="docs/reCAPTCHA.gif" alt="Kachilu Browser detecting a reCAPTCHA challenge" width="100%">
+</p>
+
+> CAPTCHA in the way? The LLM detects it through the SKILL and hands off
+> completion automatically. Nothing complicated.
+
+Human-like interaction is the default. When reCAPTCHA v2/v3 or Cloudflare
+Turnstile appears, `kachilu-browser` detects the challenge and routes completion
+through the local CLI/browser flow.
+
+WSL2 is first-class: agents running in Linux can control the Windows-side
+browser profile you actually use, instead of a separate WSL-only browser.
+
+Free to use. Local by design. No hosted relay, no telemetry, no external control
+plane between the agent and your browser.
+
+## Install
+
+```bash
+npm install -g kachilu-browser
+kachilu-browser onboard
+```
+
+When this page appears, tick the checkbox so the agent can connect to your browser:
+
+![Remote debugging permission checkbox](docs/remote-debugging.png)
+
+## OpenClaw
+
+```bash
+openclaw plugins install kachilu-browser
+openclaw gateway restart
+```
+
+OpenClaw uses the same npm package bundle, so no separate package name or extra
+install script is needed.
+
+## Onboarding targets
+
+- If `--target` is omitted in an interactive terminal, `kachilu-browser onboard` prompts for the host target
+- In non-interactive runs, pass `--target codex`, `--target claudecode`, or `--target claudedesktop`
+- For Codex and Claude Code on WSL2, `onboard` persists `KACHILU_BROWSER_AUTO_CONNECT_TARGET=windows` and auto-detected `KACHILU_BROWSER_WINDOWS_LOCALAPPDATA` unless you override them
+- When targeting Windows browsers from WSL2, `onboard` also ensures `%USERPROFILE%\.wslconfig` has `[wsl2] networkingMode=mirrored` and reports when `wsl --shutdown` is required
+- `codex`: writes `~/.codex/config.toml` and links `~/.codex/skills/kachilu-browser`
+- `claudecode`: writes `~/.claude.json` and links `~/.claude/skills/kachilu-browser`
+- `claudedesktop`: writes the Claude Desktop local MCP config. Use `claude-desktop` as an equivalent alias.
+- Claude Desktop Skills are distributed as `kachilu-browser-skill.zip` on GitHub Releases and must be uploaded through Claude Desktop's Skills UI.
+
+## MCP control plane
+
+Agents should keep using the MCP prepare/exec workflow whenever the tools are available, including after context compaction or resume. This preserves the host-managed session, profile, and WSL2 Windows-browser target from the MCP env block.
+
+Raw `kachilu-browser` shell commands are a fallback for environments without MCP, explicit CLI requests, or intentional local WSL/Linux browser work. On WSL2, a raw shell command can miss `KACHILU_BROWSER_AUTO_CONNECT_TARGET=windows` and launch or control a WSL2-local browser instead of the intended Windows browser.
+
+Successful prepare and exec responses include `controlPlane: "mcp"` and `followUpTool: "kachilu_browser_exec"` so agents can preserve the MCP route across context compaction and long-running resumes.
+
+## Release model
+
+- Native binaries are built from the private source repo.
+- The npm package bundles available native binaries so `npm install -g kachilu-browser` works without exposing the private source tree.
+- The source repo must provide `KACHILU_BROWSER_RELEASE_TOKEN` so it can create this repo's GitHub Release and push synced tags.
+- This public repo publishes the npm package via npm Trusted Publishing after the package already exists on npm.
+- The very first npm publish for `kachilu-browser` must be done manually with `npm publish --access public`.
+- If the package was unpublished, npm blocks republishing the same package name for 24 hours.
+- This repo's publish workflow also refuses to publish if the package does not yet exist on npm.
+- The npm package downloads matching native binaries from GitHub Releases only when the current platform binary was not bundled in the package.
+
+## Commands
+
+```bash
+kachilu-browser --help
+kachilu-browser onboard --help
+node scripts/mcp-server.mjs
+```

--- a/plugins/kachilu-inc/kachilu-browser/package.json
+++ b/plugins/kachilu-inc/kachilu-browser/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "kachilu-browser",
+  "version": "0.0.5",
+  "description": "Browser automation CLI for AI agents",
+  "type": "module",
+  "files": [
+    ".codex-plugin/plugin.json",
+    ".mcp.json",
+    "bin/kachilu-browser.js",
+    "bin/kachilu-browser-*",
+    "scripts",
+    "skill-data/core",
+    "skills/kachilu-browser",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "install.sh"
+  ],
+  "bin": {
+    "kachilu-browser": "bin/kachilu-browser.js"
+  },
+  "scripts": {
+    "mcp:server": "node scripts/mcp-server.mjs",
+    "setup:codex": "node scripts/onboard.mjs --target codex",
+    "setup:claudecode": "node scripts/onboard.mjs --target claudecode",
+    "setup:claudedesktop": "node scripts/onboard.mjs --target claudedesktop",
+    "onboard": "node scripts/onboard.mjs",
+    "postinstall": "node scripts/postinstall.js"
+  },
+  "keywords": [
+    "browser",
+    "automation",
+    "headless",
+    "chrome",
+    "cdp",
+    "cli",
+    "agent"
+  ],
+  "license": "SEE LICENSE IN LICENSE",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kachilu-inc/kachilu-browser.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kachilu-inc/kachilu-browser/issues"
+  },
+  "homepage": "https://github.com/kachilu-inc/kachilu-browser",
+  "devDependencies": {}
+}

--- a/plugins/kachilu-inc/kachilu-browser/skills/kachilu-browser/SKILL.md
+++ b/plugins/kachilu-inc/kachilu-browser/skills/kachilu-browser/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: kachilu-browser
+description: Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, logging in to sites, posting to social apps, handling CAPTCHA workflows, or automating browser actions. When MCP tools are available, prefer kachilu_browser_prepare_workspace plus kachilu_browser_exec over raw shell commands so host-managed sessions, WSL2 Windows-browser targeting, and profile settings are preserved.
+allowed-tools: Bash(npx kachilu-browser:*), Bash(kachilu-browser:*)
+hidden: true
+---
+
+# kachilu-browser
+
+Browser automation CLI for AI agents. Chrome/Chromium via CDP with
+accessibility-tree snapshots and compact `@eN` element refs.
+
+Install: `npm i -g kachilu-browser && kachilu-browser install`
+
+## Start Here
+
+This file is a discovery stub, not the usage guide. Before running any
+`kachilu-browser` command, load the actual workflow content from the CLI:
+
+```bash
+kachilu-browser skills get core             # start here: workflows, MCP-first routing, CAPTCHA, troubleshooting
+kachilu-browser skills get core --full      # include references and templates when needed
+```
+
+The CLI serves skill content that matches the installed version, so instructions
+do not drift when the package is upgraded. The core guide contains the Kachilu
+human-like interaction defaults, MCP routing rules, rich composer safeguards,
+CAPTCHA workflow, and the command reference.
+
+For MCP hosts such as OpenClaw, keep using the same prepared workspace session
+across related browser work in one user request, even when moving between sites
+such as LinkedIn and X. The `site` hint is for routing only. Do not close the
+workspace between those steps unless the user explicitly wants cleanup. If the
+daemon still exists but the browser connection is gone, treat that workspace as
+stale and reconnect instead of reusing it.
+
+## Critical Fallback
+
+If an element-targeted click fails but the visible cursor is already on the
+intended button or control, take a screenshot/capture and confirm the cursor is
+on target. Then click at the current cursor position:
+
+```bash
+kachilu-browser mouse down left
+kachilu-browser mouse up left
+kachilu-browser snapshot -i
+```
+
+Use this after visual confirmation instead of repeating the same failing ref or
+locator click.


### PR DESCRIPTION
## Summary
- add `Kachilu Browser` to the Community Plugins list in `README.md`
- place it under `Tools & Integrations` in alphabetical order
- update generated marketplace artifacts and add the mirrored plugin bundle

## Plugin
- https://github.com/kachilu-inc/kachilu-browser
- Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.

## Validation
- confirmed the repository is public
- confirmed the plugin includes `.codex-plugin/plugin.json`