### PR TITLE
Add Tool Advisor to Development & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.
 - [tailtest](https://github.com/avansaber/tailtest-codex) - Hook-powered test generation -- detects files changed during an agent turn and instructs Codex to write and run tests automatically. Zero config, 8 languages.
+- [Tool Advisor](https://github.com/dragon1086/claude-skills) - Read-only meta-skill that scans your MCP servers, skills, plugins, and CLI tools, then suggests up to three ranked approaches (Methodical / Fast / Deep) with a copy-paste Quick Action table.
 - [VibePortrait](https://github.com/dadwadw233/VibePortrait) - Developer personality portrait generator — analyzes AI conversation history to produce MBTI type (16 color themes), capability radar, developer rating, 3-dimension famous match, and a persona skill that lets any AI "think like you".
 
 ### Tools & Integrations
@@ -108,8 +109,8 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.
-- [MorningAI](https://github.com/octo-patch/MorningAI) - AI news tracking skill that monitors 80+ entities across 6 sources (Reddit, HN, GitHub, Hugging Face, arXiv, X) and generates scored daily reports with infographics and message digests.
 - [Mobazha](https://github.com/mobazha/mobazha-skills) - Decentralized e-commerce skills — deploy self-hosted stores, import products from Shopify/Amazon, configure custom domains and Telegram bots, set up Tor privacy, and manage your store via MCP.
+- [MorningAI](https://github.com/octo-patch/MorningAI) - AI news tracking skill that monitors 80+ entities across 6 sources (Reddit, HN, GitHub, Hugging Face, arXiv, X) and generates scored daily reports with infographics and message digests.
 - [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.
 - [OpenProject](https://github.com/varaprasadreddy9676/team-codex-plugins) - Team collaboration via OpenProject integration.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.


### PR DESCRIPTION
## Summary

Adds **[Tool Advisor](https://github.com/dragon1086/claude-skills)** to the **Development & Workflow** section of the community plugin list.

Tool Advisor is a read-only meta-skill that scans the active environment (MCP servers, skills, plugins, CLI tools) and produces up to three ranked approach options (Methodical / Fast / Deep) for any task, plus a copy-paste Quick Action table. It amplifies prompt context without ever mutating the repo — Iron Rule 1 of the skill forbids edits, installs, and executors.

Requested by a community user in [dragon1086/claude-skills#4](https://github.com/dragon1086/claude-skills/issues/4).

## Plugin Details

- **Repository**: https://github.com/dragon1086/claude-skills
- **Manifest**: `.codex-plugin/plugin.json` (v3.5.1)
- **Category**: Productivity / Interactive
- **License**: MIT

## Local Verification

Ran the same scanner used by the PR Gate (`codex-plugin-scanner` 2.0.12):

- `verify`: **PASS** — all 12 checks green (manifest required fields, interface metadata, capability enumeration, skill frontmatter, skill references, asset size, etc.)
- `lint`: **policy_pass=True**, effective_score **85** — only low/info/medium findings; zero high-severity, so the gate's `fail_on_severity: high` is satisfied.

Alphabetical check (`scripts/check-alphabetical.py`) passes for all five sections after the change.

Codex 0.118.0 confirmed locally: `codex exec` invokes the skill and reads `name=tool-advisor version=3.5.1` correctly.

## Drive-by Fix

Swapped **Mobazha** ↔ **MorningAI** in the _Tools & Integrations_ section. The existing ordering violated the alphabetical rule (Mobazha should precede MorningAI, but it was listed after). This is a one-line cleanup so the alphabetical CI stays green for future PRs.

## Test Plan

- [x] `python3 scripts/check-alphabetical.py README.md` → all sections sorted
- [x] `codex-plugin-scanner verify /path/to/claude-skills` → PASS
- [x] `codex-plugin-scanner lint /path/to/claude-skills` → no high-severity findings
- [x] Plugin loads in local Codex CLI 0.118.0 (skill auto-discovered, version reported correctly)