### PR TITLE
Add Emdash Skills to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The score is best used as a quick trust signal and triage summary (not the only 
 - [awesome-coding-agents](https://github.com/e2b-dev/awesome-ai-agents#readme) - Curated list of AI coding agents.
 - [awesome-mcp-servers](https://github.com/wong2/awesome-mcp-servers#readme) - MCP server directory.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) - Voice-enabled audio layer for coding agents with ambient soundscapes, event-driven SFX, and optional cloud TTS/ASR interaction.
+- [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS for AI coding tools with 94 reference docs, 18 agents, and cross-tool support (Claude Code, Codex, Cursor, Copilot, 30+ more).
 - [HOL Plugin Registry](https://hol.org/registry/plugins) - Browse plugins with scanner-backed security analysis and trust scores.
 
 ## Plugin Trust Scores


### PR DESCRIPTION
## Summary

Adds [Emdash Skills](https://github.com/megabytespace/claude-skills) to the **Related Projects** section.

- 14-category autonomous product-building OS for AI coding tools
- 94 reference docs, 18 agents, cross-tool support (Claude Code, Codex, Cursor, Copilot, 30+ more)
- Entry placed alphabetically between EchoCoding and HOL Plugin Registry
- Follows existing entry format