### PR TITLE
Add Codebase Recon plugin to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Claude Code Harness](https://github.com/dadwadw233/claude-code-harness) - Harness blueprint skill for turning vague agent ideas into concrete designs for request assembly, control loops, memory, permissions, recovery, and extension planes.
 - [Claude Code Skills](https://github.com/alirezarezvani/claude-skills) - 223 production-ready skills, 23 agents, and 298 Python tools across 9 domains — engineering, marketing, product, compliance, and more.
 - [Claude Octopus](https://github.com/nyldn/claude-octopus) - Multi-LLM orchestration dispatching to 8 providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) with Double Diamond workflows, adversarial review, and safety gates.
+- [Codebase Recon](https://github.com/yujiachen-y/codebase-recon-skill) - Analyze git history to understand a codebase before reading any code — auto-scales by repo size and cross-references hotspots with bug magnets to surface high-risk files, bus factor, and team momentum.
 - [Codex Agenteam](https://github.com/yimwoo/codex-agenteam) - Specialist AI agents (researcher, PM, architect, developer, QA, reviewer) orchestrated as a configurable team pipeline.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.


### PR DESCRIPTION
## Summary

Adds [Codebase Recon](https://github.com/yujiachen-y/codebase-recon-skill) under **Community Plugins → Development & Workflow**. It's a Codex plugin that analyzes git history to give a fast, evidence-based read on a codebase before you open any source files — surfaces hotspots, bug magnets, bus factor, momentum, and high-risk files (hotspot ∩ bug-magnet).

## Validation against `CONTRIBUTING.md`

- [x] Public GitHub repo
- [x] Valid `.codex-plugin/plugin.json` manifest ([link](https://github.com/yujiachen-y/codebase-recon-skill/blob/main/plugins/codebase-recon/.codex-plugin/plugin.json))
- [x] Functional — installs and shows in `/plugins` on Codex 0.125.0 via `codex plugin marketplace add yujiachen-y/codebase-recon-skill`
- [x] Concise one-line description
- [x] Author link in description
- [x] Alphabetized within section (between *Claude Octopus* and *Codex Agenteam*)
- [x] One plugin in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)