### PR TITLE
ci: add universal-design-principles

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -209,6 +209,18 @@
       "category": "Development & Workflow"
     },
     {
+      "name": "universal-design-principles",
+      "source": {
+        "source": "local",
+        "path": "./plugins/HDeibler/universal-design-principles"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development & Workflow"
+    },
+    {
       "name": "vibe-portrait",
       "source": {
         "source": "local",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  OpenAI <a href="https://openai.com/index/codex-plugins/">launched plugins for Codex</a> on March 26, 2026, packaging skills, MCP servers, and app integrations into shareable, installable bundles across the Codex app, CLI, and IDE extensions.
+  OpenAI <a href="https://openai.com/academy/codex-plugins-and-skills/">documents plugins and skills for Codex</a>, packaging skills, MCP servers, and app integrations into shareable, installable bundles across the Codex app, CLI, and IDE extensions.
 </p>
 
 <br>
@@ -118,6 +118,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [tailtest](https://github.com/avansaber/tailtest-codex) - Hook-powered test generation -- detects files changed during an agent turn and instructs Codex to write and run tests automatically. Zero config, 8 languages.
 - [Tartiner Labs](https://github.com/tartinerlabs/skills) - Agent skills for git workflows, GitHub automation, security audits, code refactoring, and project tooling.
 - [Tool Advisor](https://github.com/dragon1086/claude-skills) - Read-only meta-skill that scans your MCP servers, skills, plugins, and CLI tools, then suggests up to three ranked approaches (Methodical / Fast / Deep) with a copy-paste Quick Action table.
+- [Universal Design Principles](https://github.com/HDeibler/universal-design-principles) - Cross-agent UX and product-design marketplace with a root Codex collection plugin, five focused plugin bundles, and 137 Agent Skills for design review, accessibility, layout, interaction, cognition, and product polish.
 - [VibePortrait](https://github.com/dadwadw233/VibePortrait) - Developer personality portrait generator — analyzes AI conversation history to produce MBTI type (16 color themes), capability radar, developer rating, 3-dimension famous match, and a persona skill that lets any AI "think like you".
 - [Writer's Loop](https://github.com/xxsang/writers-loop) - Structured AI writing workflow for planning, critique, revision, translation, style distillation, and opt-in local preference learning.
 

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-05-02",
-  "total": 53,
+  "total": 54,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -178,6 +178,16 @@
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/dragon1086/claude-skills/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Universal Design Principles",
+      "url": "https://github.com/HDeibler/universal-design-principles",
+      "owner": "HDeibler",
+      "repo": "universal-design-principles",
+      "description": "Cross-agent UX and product-design marketplace with a root Codex collection plugin, five focused plugin bundles, and 137 Agent Skills for design review, accessibility, layout, interaction, cognition, and product polish.",
+      "category": "Development & Workflow",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/HDeibler/universal-design-principles/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "VibePortrait",

--- a/plugins/HDeibler/universal-design-principles/.codex-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "universal-design-principles",
+  "version": "1.0.0",
+  "description": "A cross-agent UX and product-design skill collection covering perception, cognition, interaction, aesthetics, accessibility, robustness, and process.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": [
+    "design",
+    "ux",
+    "ui",
+    "accessibility",
+    "product-design",
+    "agent-skills"
+  ],
+  "skills": "./plugins/",
+  "interface": {
+    "displayName": "Universal Design Principles",
+    "shortDescription": "UX and product-design skills for AI agents.",
+    "developerName": "Hunter D",
+    "category": "Design",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "longDescription": "A cross-agent UX and product-design skill collection covering perception, cognition, interaction, aesthetics, accessibility, robustness, and process.",
+    "websiteURL": "https://github.com/HDeibler/universal-design-principles"
+  }
+}

--- a/plugins/HDeibler/universal-design-principles/.codexignore
+++ b/plugins/HDeibler/universal-design-principles/.codexignore
@@ -1,0 +1,7 @@
+.git/
+.DS_Store
+**/.DS_Store
+tmp/
+temp/
+.cache/
+scratch/

--- a/plugins/HDeibler/universal-design-principles/LICENSE
+++ b/plugins/HDeibler/universal-design-principles/LICENSE
@@ -1,0 +1,39 @@
+MIT License
+
+Copyright (c) 2026 Hunter D
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+# Notes on attribution
+
+This software is a derivative *working library* inspired by the principle
+taxonomy popularized in *Universal Principles of Design* (Lidwell, Holden, &
+Butler, Rockport Publishers, 2003). The principle names and high-level
+taxonomy are drawn from that source, used here as a research reference under
+fair use. All prose, examples, code, anti-patterns, and analyses in this
+repository are written in the authors' own words, drawing on the broader
+publicly available design and HCI research literature (Wertheimer, Hick,
+Fitts, Norman, Nielsen, Tufte, Lynch, WCAG, Lavie & Tractinsky, Csikszentmihalyi,
+Zajonc, and many others).
+
+This software is not affiliated with, endorsed by, or sponsored by Rockport
+Publishers, the Lidwell-Holden-Butler authors, or any other rightsholder of
+the original book. See `ATTRIBUTION.md` for a fuller breakdown of sources.

--- a/plugins/HDeibler/universal-design-principles/README.md
+++ b/plugins/HDeibler/universal-design-principles/README.md
@@ -1,0 +1,371 @@
+<div align="center">
+
+# Universal Design Principles
+
+**A cross-agent skill marketplace of 42 framework-agnostic UX & product-design principles, drawn from *Universal Principles of Design* (Lidwell, Holden, Butler, 2003) and the broader design and HCI research literature.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Plugins: 5](https://img.shields.io/badge/plugins-5-success.svg)](#whats-inside)
+[![Skills: 137](https://img.shields.io/badge/skills-137-informational.svg)](docs/principle-index.md)
+[![Principles: 42](https://img.shields.io/badge/principles-42-informational.svg)](docs/principle-index.md)
+[![Lines: ~35.7k](https://img.shields.io/badge/content-~35.7k%20lines-lightgrey.svg)](#repository-stats)
+
+[Getting Started](docs/getting-started.md) · [Architecture](docs/architecture.md) · [Principle Index](docs/principle-index.md) · [How Skills Trigger](docs/how-skills-trigger.md) · [Attribution](ATTRIBUTION.md) · [Contributing](CONTRIBUTING.md)
+
+</div>
+
+---
+
+## What this is
+
+A **working library** of design principles, packaged as portable Agent Skills plus native plugin metadata for Claude Code, Codex, and Cursor. Install one or more plugins and your agent gains access to curated skills that fire automatically whenever you work on UX, UI, or product design — regardless of design system, SDK, framework, or platform.
+
+Each principle is built as a **reference-grade entry**: a router-style `SKILL.md` (~350–500 lines), 2–4 sub-aspect skills for context-specific application (~200–300 lines each), and per-skill `references/` deep-dive files with origins, research lineage, and worked patterns. The result is a library an agent can apply with the same depth as a senior designer who has internalized the canon.
+
+## Why a plugin marketplace?
+
+Many products today are built and reviewed by AI agents. The quality of their design judgment depends heavily on what they've been taught to attend to. Without a working library of principles, an agent will produce designs that are competent on average but blind in specific ways — the typography will drift, hierarchy will collapse on the third screen, the error states will be afterthoughts, the interaction patterns will be inconsistent across surfaces.
+
+This marketplace gives your agent the same canon that experienced designers have internalized over years. Instead of one giant prompt, the canon is split across **five composable plugins** so you can install only what you need:
+
+| Plugin | What it teaches | Skills |
+|---|---|---:|
+| **[Perception & Hierarchy](plugins/perception-and-hierarchy-principles/)** | How the eye groups elements, where it lands first, what makes a composition read as ordered | 34 |
+| **[Cognition & Learnability](plugins/cognition-and-learnability-principles/)** | Mental models, complexity reduction, memory load, how new users get oriented | 33 |
+| **[Interaction & Control](plugins/interaction-and-control-principles/)** | Affordance, feedback, errors, user agency, Fitts's Law for touch targets | 29 |
+| **[Aesthetics & Emotion](plugins/aesthetics-and-emotion-principles/)** | Beauty, perceived quality, brand voice, flow, persuasive form | 17 |
+| **[Process & Robustness](plugins/process-and-robustness-principles/)** | Iteration, accessibility, reliability under stress, what to prune | 24 |
+
+Each plugin contains a **router skill** (which triggers on the plugin's category and points the agent at the right principle), one main skill **per principle**, and **2–4 sub-aspect skills** for principles whose application varies meaningfully by context (e.g., Hick's Law has different shapes in menus vs. defaults vs. pricing).
+
+## Installation
+
+Pick the agent you actually use. The same `skills/<skill-name>/SKILL.md` folders are the source of truth for every install path; only the plugin manifest or destination directory changes.
+
+| Agent | Best install path | This repo provides |
+|---|---|---|
+| Claude Code | Native plugin marketplace | `.claude-plugin/marketplace.json` and per-plugin `.claude-plugin/plugin.json` |
+| Codex | Native plugin marketplace, or direct Agent Skills | `.agents/plugins/marketplace.json` and per-plugin `.codex-plugin/plugin.json` |
+| Cursor | Cursor plugin flow, or project rules fallback | `.cursor-plugin/marketplace.json` and per-plugin `.cursor-plugin/plugin.json` |
+| Gemini CLI | Link or copy Agent Skills | Plain `skills/*/SKILL.md` folders |
+| Copilot, Windsurf, and other agents | Native rules or `AGENTS.md` fallback | Portable skill folders plus a compact rule/instruction pattern |
+
+The packaging follows the [Agent Skills open format](https://agentskills.io/), where each skill is a folder containing `SKILL.md` and optional supporting files.
+
+### Claude Code
+
+In Claude Code, add this repository as a plugin marketplace and install the plugins you want:
+
+```text
+/plugin marketplace add HDeibler/universal-design-principles
+/plugin install perception-and-hierarchy-principles@universal-design-principles
+/plugin install cognition-and-learnability-principles@universal-design-principles
+```
+
+Use `/plugin` to browse the remaining plugins. Claude Code plugin skills are namespaced by plugin, so a skill is available as `/perception-and-hierarchy-principles:hierarchy` when explicitly invoked. Claude can also load skills automatically when the task matches a skill description.
+
+For a local checkout instead of GitHub shorthand:
+
+```bash
+git clone https://github.com/HDeibler/universal-design-principles.git ~/code/universal-design-principles
+```
+
+Then run:
+
+```text
+/plugin marketplace add ~/code/universal-design-principles
+```
+
+Reference: [Claude Code plugins](https://code.claude.com/docs/en/plugins), [Claude Code skills](https://code.claude.com/docs/en/skills), and [Claude plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces).
+
+### Codex
+
+Codex can install this repository either as one collection plugin or as five focused plugin bundles.
+
+For the single collection plugin, use the root Codex manifest. This is the best path for directories that expect one plugin per repository:
+
+```bash
+npx codex-marketplace add HDeibler/universal-design-principles --plugin --project
+```
+
+For the five focused plugin bundles, use the repo marketplace:
+
+```bash
+npx codex-marketplace add HDeibler/universal-design-principles --plugins --project
+```
+
+Codex can also use this repository as a repo-scoped plugin marketplace because it includes `.agents/plugins/marketplace.json` and each focused plugin includes `.codex-plugin/plugin.json`.
+
+```bash
+codex plugin marketplace add HDeibler/universal-design-principles
+codex
+```
+
+Inside Codex, open the plugin directory:
+
+```text
+/plugins
+```
+
+Choose the `Universal Design Principles` marketplace and install one or more plugins.
+
+If you only want the skills without plugin metadata, copy the skill folders into a standard Codex skills directory:
+
+```bash
+git clone https://github.com/HDeibler/universal-design-principles.git ~/code/universal-design-principles
+mkdir -p ~/.agents/skills
+cp -R ~/code/universal-design-principles/plugins/*-principles/skills/* ~/.agents/skills/
+```
+
+Restart Codex after copying or installing. Codex scans `.agents/skills` in the repository, parent directories, `$HOME/.agents/skills`, admin locations, and bundled system skills.
+
+Reference: [Codex plugins](https://developers.openai.com/codex/plugins), [Codex plugin authoring](https://developers.openai.com/codex/plugins/build), [Codex skills](https://developers.openai.com/codex/skills), and [AGENTS.md discovery](https://developers.openai.com/codex/guides/agents-md).
+
+### Cursor
+
+Cursor has first-class plugin and rules surfaces. This repository includes a Cursor marketplace manifest and per-plugin manifests, matching the structure used by Cursor's official plugin repository.
+
+```bash
+git clone https://github.com/HDeibler/universal-design-principles.git ~/code/universal-design-principles
+```
+
+In Cursor, open the command palette, choose **Add Plugin**, and point Cursor at the GitHub repository URL or the local checkout path:
+
+```text
+https://github.com/HDeibler/universal-design-principles
+~/code/universal-design-principles
+```
+
+If you are not using Cursor plugins yet, use a project rule as a lightweight fallback:
+
+```mdc
+---
+description: Use Universal Design Principles when working on UX, UI, product design, visual hierarchy, interaction design, accessibility, or design critique.
+alwaysApply: false
+---
+
+When the task involves UX or product design, consult the Universal Design Principles skill repository and prefer the most specific principle skill before giving recommendations.
+```
+
+Save that as `.cursor/rules/universal-design-principles.mdc`. Cursor project rules can be `Always`, `Auto Attached`, `Agent Requested`, or `Manual`; `Agent Requested` is the best fit for this kind of optional design expertise.
+
+Reference: [Cursor rules](https://docs.cursor.com/context/rules), [Cursor plugin marketplace](https://cursor.com/plugins), and the [Cursor official plugin repo](https://github.com/cursor/plugins).
+
+### Gemini CLI
+
+Gemini CLI supports Agent Skills directly. Link each plugin's `skills/` directory into your user skill store:
+
+```bash
+git clone https://github.com/HDeibler/universal-design-principles.git ~/code/universal-design-principles
+
+for plugin in ~/code/universal-design-principles/plugins/*-principles; do
+  gemini skills link "$plugin/skills" --scope user
+done
+
+gemini skills list
+```
+
+Use `--scope workspace` instead of `--scope user` when you want the skills available only in the current project. You can also copy selected skill folders into `.gemini/skills/`, `.agents/skills/`, `~/.gemini/skills/`, or `~/.agents/skills/`.
+
+Reference: [Gemini CLI Agent Skills](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/skills.md), [Gemini skills getting started](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/tutorials/skills-getting-started.md), and [Gemini CLI extensions](https://google-gemini.github.io/gemini-cli/docs/extensions/).
+
+### Copilot, Windsurf, and other agents
+
+For agents that do not yet load `SKILL.md` folders as skills, use their native rule format to point the agent at this repository, or copy a short subset of the relevant principle guidance into that rule system.
+
+For GitHub Copilot, use `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, or `AGENTS.md` depending on your editor surface. For Windsurf, use `.windsurf/rules/*.md` or `AGENTS.md`. For any agent that supports the `AGENTS.md` convention, add a root-level `AGENTS.md` with a compact instruction such as:
+
+```md
+# Design guidance
+
+When working on UX, UI, product design, visual hierarchy, interaction design,
+accessibility, or design critique, use the Universal Design Principles skills
+from https://github.com/HDeibler/universal-design-principles. Prefer the most specific principle
+skill for the task, and use the reference files only when the answer needs
+research depth.
+```
+
+Reference: [GitHub Copilot custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions), [Windsurf rules](https://docs.windsurf.com/windsurf/cascade/memories), and [AGENTS.md](https://github.com/agentsmd/agents.md).
+
+### Directory structure recommendation
+
+This repository now uses a **parallel-manifest, single-source skill structure**:
+
+```text
+universal-design-principles/
+├── .claude-plugin/marketplace.json
+├── .cursor-plugin/marketplace.json
+├── .agents/plugins/marketplace.json
+├── plugins/
+│   ├── perception-and-hierarchy-principles/
+│   │   ├── .claude-plugin/plugin.json
+│   │   ├── .codex-plugin/plugin.json
+│   │   ├── .cursor-plugin/plugin.json
+│   │   └── skills/
+│   │       └── <skill-name>/SKILL.md
+│   └── ...
+└── ...
+```
+
+This is the best structure for the current ecosystem because Claude, Codex, and Cursor each expect different manifest directories, while all of them can consume the same underlying Agent Skills. The root-level marketplace manifests stay where each client expects discovery metadata, and the installable packages live under `plugins/` with one shared `skills/` tree per package. Duplicating the skills into agent-specific folders would create drift and break deep links.
+
+See **[docs/getting-started.md](docs/getting-started.md)** for a more detailed walkthrough including verification steps and troubleshooting.
+
+## Quick example
+
+After installing one of the plugins (say, **Cognition & Learnability**), you can use it like this in any agent conversation:
+
+```
+You: I'm designing a settings page for a SaaS dashboard. The product has
+     accumulated about 60 settings across 8 categories. Help me think
+     through the structure.
+
+Agent: [loads the cognition-router → progressive-disclosure skill]
+       Looking at this through the lens of progressive disclosure and
+       the 80/20 rule: roughly 12 of those 60 settings probably account
+       for 80% of actual changes. Surface those in a clear default view,
+       and tuck the remaining ~50 behind clearly-labeled disclosure...
+```
+
+The skills fire automatically based on the conversation context. You don't have to remember to invoke them.
+
+For more concrete usage examples, see [docs/getting-started.md](docs/getting-started.md).
+
+## Anatomy of a principle
+
+Take **Hick's Law** as an example. Inside `plugins/cognition-and-learnability-principles/skills/`, you'll find:
+
+```
+hicks-law/
+├── SKILL.md                                  # the principle's main entry (~450 lines)
+└── references/
+    └── lineage.md                            # origins, Hick (1952), Hyman (1953), modern empirical work
+
+hicks-law-menus/
+├── SKILL.md                                  # how Hick's Law applies to menus specifically
+└── references/
+    └── menu-design-patterns.md               # patterns and anti-patterns
+
+hicks-law-defaults/
+├── SKILL.md                                  # how Hick's Law applies to defaults
+└── references/
+    └── defaults-recipes.md
+
+hicks-law-pricing/
+├── SKILL.md                                  # how Hick's Law applies to pricing pages
+└── references/
+    └── pricing-tier-strategies.md
+```
+
+Each main `SKILL.md` includes:
+
+1. **Definition** — Plain-language definition in our own words.
+2. **Origins and research lineage** — Where the principle comes from, who studied it, what evidence supports it.
+3. **When to apply** — Surfaces and decisions where the principle is decisive.
+4. **When NOT to apply** — Contexts where the principle backfires or doesn't transfer.
+5. **Worked examples** — Multiple cross-domain examples with code or diagrams.
+6. **Anti-patterns** — Common misapplications and how to recognize them.
+7. **Heuristic checklist** — Concrete questions to ask before shipping.
+8. **Related principles** — What to read next.
+9. **See also** — Links to `references/` and to sub-aspect skills.
+
+For the full architecture, see **[docs/architecture.md](docs/architecture.md)**.
+
+## What's inside
+
+```
+universal-design-principles/
+├── .codex-plugin/
+│   └── plugin.json                         # Codex root collection plugin manifest
+├── .agents/
+│   └── plugins/
+│       └── marketplace.json                # Codex marketplace manifest
+├── .claude-plugin/
+│   └── marketplace.json                    # Claude Code marketplace manifest
+├── .cursor-plugin/
+│   └── marketplace.json                    # Cursor marketplace manifest
+├── docs/                                   # cross-plugin documentation
+│   ├── getting-started.md
+│   ├── architecture.md
+│   ├── how-skills-trigger.md
+│   └── principle-index.md
+├── plugins/
+│   ├── perception-and-hierarchy-principles/    # 34 skills + Claude/Codex/Cursor plugin manifests
+│   ├── cognition-and-learnability-principles/  # 33 skills + Claude/Codex/Cursor plugin manifests
+│   ├── interaction-and-control-principles/     # 29 skills + Claude/Codex/Cursor plugin manifests
+│   ├── aesthetics-and-emotion-principles/      # 17 skills + Claude/Codex/Cursor plugin manifests
+│   └── process-and-robustness-principles/      # 24 skills + Claude/Codex/Cursor plugin manifests
+├── README.md
+├── CONTRIBUTING.md
+├── ATTRIBUTION.md
+├── CHANGELOG.md
+├── LICENSE
+├── .gitignore
+└── .gitattributes
+```
+
+Browse the **[Principle Index](docs/principle-index.md)** for the alphabetical list with direct links into the relevant `SKILL.md`.
+
+## Repository stats
+
+| Metric | Count |
+|---|---:|
+| Plugins | 5 |
+| Principles built | 42 |
+| Skills (`SKILL.md` files) | 137 |
+| Reference deep-dives (`references/*.md` files) | 137 |
+| Lines of original content | ~35,700 |
+
+The 2003 first edition of *Universal Principles of Design* contains exactly **100 principles**. We have built 42 of them at reference-grade depth — the principles most relevant to modern product, web, and software UX. Each per-plugin `README.md` lists the next-priority builds; contributions are welcome.
+
+## Source attribution
+
+This repository owes its **principle names and taxonomy** to:
+
+> Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design: 100 Ways to Enhance Usability, Influence Perception, Increase Appeal, Make Better Design Decisions, and Teach through Design*. Rockport Publishers. ISBN 1-59253-007-9.
+
+Each principle entry's **definitions, prose, code examples, anti-patterns, and analyses are written in our own words**, drawing on the broader design and HCI research literature: Wertheimer's Gestalt psychology, Hick (1952) and Hyman (1953) on choice latency, Fitts (1954) on motor capacity, Norman's *Design of Everyday Things* and *Emotional Design*, Nielsen's usability work, Tufte on information design, Lynch's *Image of the City* on wayfinding, the W3C WCAG framework on accessibility, Lavie & Tractinsky on aesthetic-usability, Csikszentmihalyi on flow, Zajonc on the mere-exposure effect, and many others.
+
+**The book is a starting point; this plugin set is a working tool.** It is not a substitute for the book. If you find this useful, please buy the book — it remains an essential reference and the source of the editorial taxonomy this repository builds on.
+
+For a complete attribution breakdown — including how this repository used the source book, every key research source, and our content-originality commitments — see **[ATTRIBUTION.md](ATTRIBUTION.md)**.
+
+## How this repository is intended to be used
+
+- **By AI coding agents:** install one or more plugins or skill folders; the skills fire automatically when you work on design tasks; the agent applies the principle vocabulary in its reasoning and outputs.
+- **By human designers:** the `SKILL.md` files are written as standalone documents you can read directly. Many designers use the repository as a personal reference even without an AI tool.
+- **By teaching contexts:** the `references/lineage.md` files trace the research lineage of each principle and are useful as teaching material.
+- **By contributors:** see [CONTRIBUTING.md](CONTRIBUTING.md) — the repository is designed to grow incrementally toward covering all 100 principles.
+
+## Companion plugins
+
+This repository is the **vendor-neutral** version of the design principle library. Examples are in plain HTML, CSS, and conceptual pseudocode, with cross-domain examples from web, mobile, print, physical product, and information design. You should be able to apply any of these principles whether you're working in shadcn/ui, Material, Carbon, Tamagui, Ant Design, Bootstrap, vanilla CSS, SwiftUI, Jetpack Compose, Figma, or whiteboard markers.
+
+If a sibling repository ships that maps these principles to a specific design system (e.g., `universal-design-shadcn`), it will be linked here. The two are designed to compose: this one teaches the principle, the other shows how to apply it via specific primitives.
+
+## Contributing
+
+Contributions are welcome and held to a high prose-quality bar. See **[CONTRIBUTING.md](CONTRIBUTING.md)** for:
+
+- Structural conventions for adding a new principle.
+- The quality bar for prose, examples, and references.
+- Attribution rules.
+- The pull-request process.
+
+For new-principle proposals, please open an issue first to discuss scope and audience.
+
+## License
+
+This repository is licensed under the [MIT License](LICENSE). The principle names and high-level taxonomy are drawn from *Universal Principles of Design* (Lidwell, Holden, Butler, 2003) under fair use as a research reference; all prose and examples are original work licensed under MIT. See [ATTRIBUTION.md](ATTRIBUTION.md) and [LICENSE](LICENSE) for details.
+
+## Acknowledgments
+
+To William Lidwell, Kritina Holden, and Jill Butler — for assembling the editorial taxonomy that makes a repository like this possible. To the researchers cited in the per-principle `references/lineage.md` files — whose primary work is the actual substance behind every entry. To the teams building agent skill, plugin, and rules infrastructure — for making a marketplace of design principles a useful artifact rather than just a library no one reads.
+
+---
+
+<div align="center">
+
+**[Browse all 42 principles →](docs/principle-index.md)**
+
+</div>

--- a/plugins/HDeibler/universal-design-principles/SECURITY.md
+++ b/plugins/HDeibler/universal-design-principles/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Report security issues by opening a private security advisory on GitHub or by
+emailing hunterd107@gmail.com.
+
+This marketplace packages prompt-only agent skills. It does not bundle MCP
+servers, hooks, scripts, executable dependencies, credentials, or networked
+services.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/.claude-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/.claude-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/claude-plugin.json",
+  "name": "aesthetics-and-emotion-principles",
+  "displayName": "Aesthetics & Emotion Principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for aesthetics, perceived quality, brand personality, and emotional response. Covers Aesthetic-Usability Effect, Archetypes, Form Follows Function, Wabi-Sabi, Exposure Effect, and Immersion. Drawn from the aesthetic and emotion-related entries of 'Universal Principles of Design' (Lidwell, Holden, Butler, 2003) and the broader design and consumer-psychology literature.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HDeibler/universal-design-principles.git",
+    "directory": "plugins/aesthetics-and-emotion-principles"
+  },
+  "category": "design",
+  "keywords": [
+    "design",
+    "ux",
+    "aesthetics",
+    "emotion",
+    "brand",
+    "archetypes",
+    "wabi-sabi",
+    "immersion",
+    "flow",
+    "exposure-effect",
+    "universal-design-principles"
+  ]
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/.codex-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "aesthetics-and-emotion-principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for aesthetics, perceived quality, brand personality, and emotional response. Covers Aesthetic-Usability Effect, Archetypes, Form Follows Function, Wabi-Sabi, Exposure Effect, and Immersion.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": [
+    "design",
+    "ux",
+    "aesthetics",
+    "emotion",
+    "brand",
+    "archetypes",
+    "wabi-sabi",
+    "immersion"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Aesthetics & Emotion Principles",
+    "shortDescription": "Beauty, perceived quality, brand voice, and emotional response.",
+    "developerName": "Hunter D",
+    "category": "Design",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "longDescription": "Framework-agnostic design principles for aesthetics, perceived quality, brand personality, and emotional response. Covers Aesthetic-Usability Effect, Archetypes, Form Follows Function, Wabi-Sabi, Exposure Effect, and Immersion.",
+    "websiteURL": "https://github.com/HDeibler/universal-design-principles"
+  }
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/.codexignore
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/.codexignore
@@ -1,0 +1,7 @@
+.git/
+.DS_Store
+**/.DS_Store
+tmp/
+temp/
+.cache/
+scratch/

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/.cursor-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/.cursor-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "aesthetics-and-emotion-principles",
+  "displayName": "Aesthetics & Emotion Principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for aesthetics, perceived quality, brand personality, and emotional response. Covers Aesthetic-Usability Effect, Archetypes, Form Follows Function, Wabi-Sabi, Exposure Effect, and Immersion.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": ["design", "ux", "aesthetics", "emotion", "brand", "archetypes", "wabi-sabi", "immersion"],
+  "category": "design",
+  "tags": ["aesthetics", "emotion", "brand", "archetypes", "flow", "wabi-sabi"],
+  "skills": "./skills/"
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/LICENSE
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/LICENSE
@@ -1,0 +1,39 @@
+MIT License
+
+Copyright (c) 2026 Hunter D
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+# Notes on attribution
+
+This software is a derivative *working library* inspired by the principle
+taxonomy popularized in *Universal Principles of Design* (Lidwell, Holden, &
+Butler, Rockport Publishers, 2003). The principle names and high-level
+taxonomy are drawn from that source, used here as a research reference under
+fair use. All prose, examples, code, anti-patterns, and analyses in this
+repository are written in the authors' own words, drawing on the broader
+publicly available design and HCI research literature (Wertheimer, Hick,
+Fitts, Norman, Nielsen, Tufte, Lynch, WCAG, Lavie & Tractinsky, Csikszentmihalyi,
+Zajonc, and many others).
+
+This software is not affiliated with, endorsed by, or sponsored by Rockport
+Publishers, the Lidwell-Holden-Butler authors, or any other rightsholder of
+the original book. See `ATTRIBUTION.md` for a fuller breakdown of sources.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/README.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/README.md
@@ -1,0 +1,21 @@
+# aesthetics-and-emotion-principles
+
+Framework-agnostic design principles for aesthetics, perceived quality, brand personality, and emotional response.
+
+## Status
+
+| Skill cluster | State |
+|---|---|
+| `aesthetics-router` | ✅ Complete |
+| **Aesthetic-Usability Effect** | ✅ Complete (reference-grade) |
+| **Archetypes** + `brand-voice` + `storytelling-arcs` | ✅ Complete |
+| **Form Follows Function** + `as-axiom` + `success-criteria` | ✅ Complete |
+| **Wabi-Sabi** + `wabi-sabi-imperfection` + `wabi-sabi-restraint` | ✅ Complete |
+| **Exposure Effect** + `exposure-onboarding` + `exposure-redesign-risk` | ✅ Complete |
+| **Immersion** + `immersion-flow` + `immersion-distraction-cost` | ✅ Complete |
+
+17 skills, each with a `references/` deep-dive file.
+
+## Planned
+
+After this batch, priority next builds: `attractiveness-bias`, `baby-face-bias`, `face-ism-ratio`, `most-average-facial-appearance-effect`, `prospect-refuge`, `savanna-preference`, `nudge`, `veblen-effect`, `golden-ratio`, `serial-position-effects`.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/SECURITY.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Report security issues by opening a private security advisory on GitHub or by
+emailing hunterd107@gmail.com.
+
+This marketplace packages prompt-only agent skills. It does not bundle MCP
+servers, hooks, scripts, executable dependencies, credentials, or networked
+services.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/aesthetic-usability-effect/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/aesthetic-usability-effect/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: aesthetic-usability-effect
+description: 'Use this skill when the design''s perceived quality affects whether users will tolerate friction, give the product a chance, or judge it as well-made — which is most consumer-facing surfaces, marketing, onboarding, first-run, and any moment where an unfamiliar user is forming a quick judgment. Trigger when designing landing pages, sign-up flows, first-time UX, app store screenshots, demo videos, sales decks, or any surface where the user''s first impression matters and friction is unavoidable. Also trigger when defending why "polish" matters on a working product, or when the user asks "should we ship the spartan version or invest in design?"'
+---
+
+# Aesthetic-Usability Effect
+
+The Aesthetic-Usability Effect is the empirical finding that users perceive aesthetically pleasing designs as easier to use — even when objectively measured usability is identical or worse. Beauty buys patience: users tolerate friction in beautiful interfaces and abandon ugly ones over the same friction.
+
+## Definition (in our own words)
+
+When users encounter a design they find visually appealing, they (1) judge it as more usable than they would judge an objectively-equivalent unattractive design, (2) tolerate more friction before abandoning, (3) attribute usability problems to themselves ("I must be doing it wrong") rather than to the system, and (4) report higher satisfaction with the experience overall. This is not a temporary halo; it persists across the early phase of using a product, and only erodes once concrete usability failures stack up beyond the patience the aesthetic earned.
+
+## Origins and research lineage
+
+- **Kurosu and Kashimura (1995)**, working with ATM interfaces, reported that subjects rated aesthetically-pleasing layouts as more usable, even when their actual usability scored similarly to less attractive alternatives. The finding was striking enough to launch a research line.
+- **Tractinsky (1997)** replicated the effect with Israeli ATM users, demonstrating that the relationship was not culture-specific.
+- **Lavie and Tractinsky (2004)** developed instruments to measure perceived aesthetics along two dimensions ("classical" — order, clarity, symmetry — and "expressive" — creativity, originality, fascination), and showed that classical aesthetics in particular correlate strongly with perceived usability.
+- **Norman (2004)** in *Emotional Design* proposed a theoretical mechanism: positive affect broadens cognitive flexibility, making users more tolerant of difficulty. Negative affect narrows focus and exaggerates problems.
+- **Sonderegger & Sauer (2010)** showed the effect persists in longitudinal use, though it diminishes as users accumulate genuine usability data.
+
+## Why this principle matters
+
+A design is rarely judged in a vacuum. The user has options, attention is finite, and patience for new tools is short. The aesthetic-usability effect is one of the strongest determinants of *whether the user will give the product a chance long enough to discover its actual usability*. A product that is functionally great but visually rough will lose users to a product that is functionally adequate but visually appealing — for the same task, with the same user.
+
+The effect is most decisive at:
+
+- **First impression** (the first 5–15 seconds with a new product).
+- **Friction moments** (any time the user hits a snag — they're more forgiving on a beautiful product).
+- **Comparison contexts** (the user is choosing between options).
+
+The effect is *least* decisive in:
+
+- **Habitual professional use** (users who've been using a tool daily for years care little about polish — they care that it doesn't break).
+- **High-stakes operations** where reliability dominates (medical, aerospace, financial trading).
+
+## When to apply
+
+- **Marketing and landing pages.** Where every visitor is making a snap judgment.
+- **Onboarding and first-run.** Where the user has no commitment yet.
+- **App store screenshots, demo videos, sales decks.** Where the design *is* the product to the viewer.
+- **Pricing and conversion surfaces.** Where the aesthetic affects perceived quality and willingness to pay.
+- **Empty states and celebration moments.** Where polish carries meaning.
+
+Restated: any time the user is *choosing whether to engage*, beauty matters disproportionately.
+
+## When NOT to apply
+
+- **As a substitute for usability.** The aesthetic-usability effect tilts perception, but it doesn't repair actual usability failures. A beautiful form that's confusing to fill in will frustrate users — they'll just blame themselves at first, and the product later.
+- **In sustained-use professional tools.** The traders, the developers, the ICU nurses, the air-traffic controllers — they've used your tool for thousands of hours. Polish is decoration; reliability is everything.
+- **When polish steals from clarity.** A "beautiful" design that obscures the next step, hides important information behind subtle cues, or applies aesthetic conventions inappropriate to the task is worse than a plain one. Beauty must serve the function, not compete with it.
+- **When the user is in a stressful or emotional context.** Beauty matters less when the user is panicking about a payment failure or trying to recover from data loss; clarity matters more.
+
+## What "aesthetic" means in this context
+
+The Lavie/Tractinsky distinction is useful:
+
+- **Classical aesthetics** — order, clarity, symmetry, alignment, restraint, proportion. The aesthetic of a well-tailored suit, a Helvetica-set Swiss poster, a clean industrial product. This dimension correlates most strongly with perceived usability. Designs that score high on classical aesthetics feel "professional" and "competent."
+- **Expressive aesthetics** — creativity, originality, special effects, personality. The aesthetic of a striking illustration, a memorable animation, a bold brand voice. This dimension correlates more weakly with perceived usability but more strongly with perceived attractiveness and emotional connection.
+
+For most software UI, classical aesthetics are the higher-leverage investment. They work without straining; they age well; they don't compete with content. Expressive aesthetics are powerful in moments (a hero illustration, a launch animation) but draining in sustained surfaces.
+
+## How to invest in aesthetic-usability
+
+Concrete moves that buy the aesthetic-usability effect without trading off actual usability:
+
+### 1. Default to a polished baseline
+
+Use a credible UI library (Radix, Material, shadcn/ui, Carbon, Polaris) rather than building primitives from scratch. The default styling of these libraries is calibrated for classical aesthetics — proportions, spacing, type, contrast — and represents thousands of designer-hours of refinement.
+
+A spartan in-house framework signals "engineered, not designed" — even when the engineering is excellent.
+
+### 2. Spend on type, color, and spacing first
+
+The fastest way to lift perceived quality:
+
+- **Type:** a quality typeface (Inter, IBM Plex, Söhne, system stack), a clear scale, generous leading, restrained weights.
+- **Color:** a thoughtful palette with neutrals as the workhorse and color as accent. Avoid flat-default-grey for everything; tint neutrals slightly toward the brand.
+- **Spacing:** a consistent rhythmic scale (Fibonacci-like progression), generous whitespace, deliberate proximity.
+
+These three carry more perceived-quality weight than any single visual flourish.
+
+### 3. Eliminate the obvious
+
+Rough edges erode the aesthetic-usability effect quickly:
+
+- Misaligned elements.
+- Inconsistent spacing.
+- Mismatched type weights for the same role.
+- Off-color status badges.
+- Loading states that flash or jitter.
+- Text that breaks into single-word last lines.
+- Images at wrong aspect ratios that get squished.
+
+A polished design isn't one with more features; it's one with fewer rough edges.
+
+### 4. Invest in micro-moments
+
+Small, well-crafted moments compound:
+
+- A satisfying focus ring animation.
+- A quick fade-in on content load (not a slow elaborate cascade).
+- A success toast with a tasteful check icon.
+- A loading skeleton that approximates the final layout.
+
+These moments are individually inexpensive and collectively communicate care. Avoid heavy motion or "look at me" effects — restraint reads as confident.
+
+### 5. Photography and illustration matter
+
+If your product has hero imagery, screenshots, or illustrations, their quality affects perceived professionalism more than almost any other element. A great photograph or illustration on a mediocre layout outperforms a great layout with stock-photo cliché. If the budget exists for one investment in a marketing surface, this is often the right place.
+
+## Worked examples
+
+### Example 1: a sign-up form with rough edges (anti-pattern)
+
+```html
+<form>
+  <h1 style="font-family: Arial; font-size: 24px;">Sign up</h1>
+  <p>Enter your details.</p>
+  <input type="text" placeholder="Name" style="border: 1px solid #888; padding: 4px;" />
+  <input type="email" placeholder="Email" style="border: 1px solid #888; padding: 4px; margin-top: 5px;" />
+  <input type="password" placeholder="Password" style="border: 1px solid #888; padding: 4px; margin-top: 5px;" />
+  <button style="background: blue; color: white; border: 0; padding: 6px 12px; margin-top: 10px;">Submit</button>
+</form>
+```
+
+Functionally complete. Aesthetically rough: default-stack font, thin grey borders, inconsistent margins, a saturated-blue submit button with no proportion to the form. The user judges the product as amateur and brings less patience to whatever comes next.
+
+### Example 2: same form, polished baseline
+
+```html
+<style>
+  body { font-family: 'Inter', system-ui; color: hsl(0 0% 12%); }
+  .signup { max-width: 400px; padding: 2rem; display: grid; gap: 1.5rem; }
+  .signup h1 { font-size: 1.5rem; font-weight: 600; }
+  .signup p { color: hsl(0 0% 45%); margin-top: -1rem; }
+  .field { display: grid; gap: 0.375rem; }
+  .field label { font-size: 0.875rem; font-weight: 500; }
+  .field input {
+    height: 2.5rem; padding: 0 0.75rem;
+    border: 1px solid hsl(0 0% 88%);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+  }
+  .field input:focus-visible {
+    outline: 2px solid hsl(220 90% 50%);
+    outline-offset: 1px;
+    border-color: transparent;
+  }
+  .submit {
+    height: 2.5rem; padding: 0 1.25rem;
+    background: hsl(0 0% 12%); color: white;
+    border: 0; border-radius: 0.375rem;
+    font-size: 0.875rem; font-weight: 500;
+    cursor: pointer;
+  }
+  .submit:hover { background: hsl(0 0% 25%); }
+</style>
+
+<form class="signup">
+  <div>
+    <h1>Create your account</h1>
+    <p>One minute and you're in.</p>
+  </div>
+  <div class="field">
+    <label for="name">Full name</label>
+    <input id="name" type="text" />
+  </div>
+  <div class="field">
+    <label for="email">Email</label>
+    <input id="email" type="email" />
+  </div>
+  <div class="field">
+    <label for="password">Password</label>
+    <input id="password" type="password" />
+  </div>
+  <button class="submit">Create account</button>
+</form>
+```
+
+Same fields, same actions, same flow. The polish — type, color, spacing, focus ring, label placement — is what shifts perception. Users on the second form will tolerate the same login problem as a hiccup; users on the first will conclude the product is broken.
+
+### Example 3: dashboard polish
+
+A bare-data-table dashboard versus the same data with: tabular numerals in numeric columns, consistent right-alignment, a quiet hairline between rows, a sticky header with subtle blur on scroll, and a thoughtful empty state when filters return no results. None of these change what the dashboard *does*. All of them shift whether the user feels they're using a precise tool or a duct-taped one.
+
+## Anti-patterns
+
+- **Polish-as-substitute.** A beautiful interface that hides what the user actually needs to do. The aesthetic earns initial trust; the broken flow squanders it within a session or two.
+- **Imitation polish.** Adopting visual conventions without understanding (drop shadows everywhere, gradients on every button, oversized icons in tinted squares). Reads as cargo-culted and ages quickly.
+- **Inconsistent polish.** A polished sign-up flow leading to a 1998-era settings page. Worse than uniformly plain — the contrast highlights the unpolished surface.
+- **Polish at the cost of accessibility.** Beautiful low-contrast text, gorgeous animation that triggers vestibular disorders, elegantly tiny tap targets. The beauty earns nothing if substantial users can't use it.
+- **Aesthetic theater for serious tools.** A dashboard for a hospital tracking critical patient metrics doesn't need delight animations; it needs clarity, correctness, and reliability. Polish for the sake of polish on serious tools reads as unserious.
+
+## Heuristics
+
+1. **The 5-second test.** Show the design to someone for 5 seconds, hide it, ask what they think the product does and what kind of company makes it. Their answer is heavily informed by the aesthetic-usability effect.
+2. **The friction-tolerance test.** Compare abandonment on a known friction point (e.g., email verification) across two design polish levels. The polished version typically loses fewer users to the same friction.
+3. **The "would you trust this with money?" test.** If the user would hesitate to enter payment info on this surface, polish is too low — even if functionality is fine.
+4. **The detail audit.** Pick 5 random elements (a form field, a button, a heading, a separator, a hover state). Are they consistent in size, weight, color, and spacing with the rest of the design? Inconsistencies erode perceived quality.
+
+## Trade-offs and warnings
+
+- **Polish is not a strategy.** It's an enabler. A product that succeeds on polish alone is rare; usually polish helps a sound product convert better at the margin.
+- **Polish has diminishing returns.** Going from rough to polished is enormous lift; going from polished to "ultra-premium" is small lift for big cost. Know where you are on the curve.
+- **Polish ages.** Heavy expressive aesthetics (gradients, glassmorphism, neumorphism, brutalism) tend to date quickly. Classical aesthetics age more gracefully because they rely on enduring visual fundamentals.
+- **Polish must serve the audience.** The aesthetic that earns trust from a B2B audience differs from the aesthetic that earns trust from a Gen Z consumer audience. Don't import an aesthetic from a domain whose codes don't match your users.
+
+## Related principles
+
+- **`form-follows-function`** — beauty derived from function ages well; decorative beauty doesn't.
+- **`wabi-sabi`** — a counterpoint: imperfection can read as authentic, not unpolished, in some contexts.
+- **`hierarchy`** (perception) — strong hierarchy is a major component of "classical" aesthetic.
+- **`alignment`** and **`proximity`** (perception) — small alignment failures cost more than designers expect.
+- **`signal-to-noise-ratio`** (perception) — high SNR designs typically score high on classical aesthetics.
+- **`consistency`** (cognition) — perceived polish and perceived consistency are the same property in different language.
+
+## Final note
+
+The aesthetic-usability effect is sometimes used to argue that "design doesn't matter as long as the function is there" or, conversely, "you can ship anything as long as it looks good." Both are wrong. The effect is a *modulator*: it amplifies the upside of good function and dampens the downside of friction. Build the function; invest in the polish; let the two compound.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/aesthetic-usability-effect/references/research-and-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/aesthetic-usability-effect/references/research-and-cases.md
@@ -1,0 +1,77 @@
+# Aesthetic-usability effect: research and cases
+
+A reference complementing the `aesthetic-usability-effect` SKILL.md with a deeper look at the research history and real-world case studies.
+
+## Research history
+
+### The original ATM studies
+
+- **Kurosu, M. & Kashimura, K.** (1995). "Apparent usability vs. inherent usability: experimental analysis on the determinants of the apparent usability." *CHI Conference Companion*. Studied Japanese ATM users and found that aesthetically-pleasing layouts were rated more usable than less attractive layouts of equivalent functional design.
+- **Tractinsky, N.** (1997). "Aesthetics and apparent usability: empirically assessing cultural and methodological issues." *CHI Proceedings*. Replicated with Israeli users, ruling out culture as the explanation.
+- **Tractinsky, N., Katz, A. S., Ikar, D.** (2000). "What is beautiful is usable." *Interacting with Computers*, 13(2), 127–145. Combined results and theoretical framing.
+
+### Refinements
+
+- **Lavie, T. & Tractinsky, N.** (2004). "Assessing dimensions of perceived visual aesthetics of web sites." *International Journal of Human-Computer Studies*, 60(3), 269–298. Identified two distinct dimensions of perceived web aesthetics: **classical** (clean, clear, symmetric, organized) and **expressive** (creative, fascinating, original, sophisticated). The classical dimension correlates strongly with perceived usability; the expressive dimension correlates with attractiveness.
+- **Sonderegger, A. & Sauer, J.** (2010). "The influence of design aesthetics in usability testing: effects on user performance and perceived usability." *Applied Ergonomics*. Showed the effect persists in real task performance — beautiful interfaces produced *measurably* better task performance, not just perception of usability.
+- **Norman, D.** (2004). *Emotional Design*. Proposed a theoretical mechanism: positive affect broadens cognitive flexibility, making users more tolerant of friction.
+
+## Sample effect sizes
+
+A few illustrative findings from the empirical literature:
+
+- Aesthetic ratings explain ~30–40% of variance in perceived usability ratings across web sites.
+- Conversion rates can lift 15–30% on identical funnels with redesigned aesthetics — though some of this comes from improved actual usability, not just perception.
+- A/B tests in mature products show smaller effects (5–10%) — because users have already committed and have actual usability data.
+
+The pattern: aesthetics matters most at first impression and decreases as actual experience accumulates.
+
+## Case studies
+
+### Mailchimp's brand evolution
+
+Mailchimp started with a folksy, illustrated brand — playful, memorable, distinctive. As they targeted larger customers, they added layers of polish without losing the playfulness. The aesthetic served both the small-business audience (approachable) and trust signals for larger customers (well-crafted).
+
+### Apple's first iPhone
+
+The original iPhone hardware and software design were considerably ahead of competing devices in aesthetic refinement. Reviews of usability often cited "feels easier to use" without users being able to articulate specific functional advantages. Some of this was real (multi-touch, capacitive screen); much was the aesthetic-usability effect.
+
+### Stripe's developer experience
+
+Stripe entered a market (payments) dominated by clunky, enterprise-grade developer tools. Their aesthetic — clean docs, well-typeset code samples, considered illustration — earned developer trust before any technical superiority was evaluated. Other developer tools have since adopted Stripe-influenced aesthetics for the same reason.
+
+### Notion vs. early competitors
+
+Notion entered a crowded notes/wiki market. Their aesthetic (clean type, restrained color, generous whitespace, well-crafted illustrations) lifted them visibly above competitors with similar feature sets. Users frequently described Notion as "easier to use" even when feature comparisons were close.
+
+## When the effect doesn't apply
+
+- **Well-known utilities.** Once a user has been using a tool for years, aesthetics matters far less than reliability and familiarity.
+- **Crisis interfaces.** Healthcare, emergency, financial-trading interfaces are evaluated on speed and accuracy under stress, not on aesthetics. Polish that obscures essentials is a liability.
+- **Habitual professional tools.** Accounting software, ERP systems, scientific instruments — users will tolerate dated aesthetics if functionality is established.
+
+## Practical implication: where to invest
+
+If the budget is constrained, invest aesthetic effort in (in order):
+
+1. **First-impression surfaces** — landing page, sign-up, first-run.
+2. **Conversion surfaces** — pricing, checkout, upgrade.
+3. **High-frequency surfaces** — dashboards, primary work surfaces (where users return repeatedly and aesthetic accumulates).
+4. **Marketing and brand surfaces** — where the audience is forming an opinion.
+
+Lower priority for initial investment:
+
+- Admin panels and internal tools (functionality dominates).
+- Documentation (clarity dominates).
+- Backend monitoring (correctness dominates).
+
+## Resources
+
+- **Norman, D.** *Emotional Design* (2004) and *The Design of Everyday Things* (2013, expanded edition).
+- **Lavie & Tractinsky** papers (cited above).
+- **Refactoring UI** — practical aesthetic-quality investments.
+- **Material Design**, **Apple HIG**, **Microsoft Fluent** — three rigorous aesthetic systems documented publicly.
+
+## Closing
+
+The aesthetic-usability effect is one of the most-replicated findings in HCI. It's also the most often used as a stick to beat designers with ("just make it pretty and conversion will follow"). The honest reading: beautiful interfaces lift the floor of user patience, but they don't repair fundamental usability problems. Build both.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/aesthetics-router/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/aesthetics-router/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: aesthetics-router
+description: 'Use this skill whenever a design task involves the felt quality of an interface — beauty, polish, brand voice, persuasion, emotional response, marketing surfaces, hero sections, onboarding tone, empty/celebration states, illustrations, mascots, avatars. Trigger when the user mentions tone, polish, brand, "feels cold/cheap/premium," personality, voice, mascot, hero, "make it more delightful," or asks how a screen should make the user feel. Framework-agnostic. Routes the model to the right aesthetics principle in this plugin.'
+---
+
+# Aesthetics & emotion — router
+
+This plugin holds the principles that govern how an interface *feels* — beautiful, premium, friendly, trustworthy, alarming. They matter most on expressive surfaces (marketing, brand, onboarding) and least on instrumental surfaces (data tables, settings).
+
+## Principles in this plugin
+
+Each principle has its own skill (with sub-aspect skills where useful). Principles marked **[full]** have reference-grade skill files; the rest are planned and will be added in subsequent passes.
+
+### Perceived quality
+
+- **`aesthetic-usability-effect`** — beautiful designs are perceived as more usable.
+- **`form-follows-function`** — form should derive from function; gratuitous decoration costs trust.
+- **`wabi-sabi`** — beauty in imperfection, asymmetry, transience.
+- **`veblen-effect`** — desirability that increases with price.
+- **`most-average-facial-appearance-effect`** — average faces are perceived as attractive.
+
+### Personality and tone
+
+- **`archetypes`** — recurring character patterns inform brand voice.
+- **`anthropomorphic-form`** — humanlike features evoke warmth.
+- **`baby-face-bias`** — round, big-eyed forms evoke trust and protectiveness.
+- **`attractiveness-bias`** — attractive subjects credited with unrelated positive traits.
+- **`phonetic-symbolism`** — sounds carry inherent connotations (sharp/soft, fast/slow).
+- **`personas`** — fictional users that anchor design decisions to a coherent audience.
+
+### Persuasion and emotional pull
+
+- **`exposure-effect`** — repeated exposure increases preference.
+- **`scarcity`** — perceived scarcity increases desirability.
+- **`supernormal-stimulus`** — exaggerated cues that out-compete natural ones.
+- **`immersion`** — flow state, distraction-free, full-attention.
+
+### Evolutionary biases
+
+- **`biophilia-effect`** — affinity for living things and natural patterns.
+- **`savanna-preference`** — preference for open landscapes with scattered cover.
+- **`prospect-refuge`** — preference for vantage points that allow seeing without being seen.
+- **`hunter-nurturer-fixations`** — gendered attention patterns (controversial).
+- **`face-ism-ratio`** — ratio of head to body shifts perceived authority vs. emotion.
+- **`waist-to-hip-ratio`** — body-shape bias in portraiture.
+- **`uncanny-valley`** — near-human faces that fail "human" cues evoke revulsion.
+
+## Heuristic for which to read first
+
+- **Designing a marketing landing page** → `aesthetic-usability-effect`, `archetypes`, `exposure-effect`.
+- **Choosing a brand voice** → `archetypes`, `phonetic-symbolism`, `anthropomorphic-form`.
+- **Designing a mascot or avatar** → `anthropomorphic-form`, `baby-face-bias`, `uncanny-valley`, `most-average-facial-appearance-effect`.
+- **Premium tier marketing** → `veblen-effect`, `aesthetic-usability-effect`.
+- **Onboarding tone** → `archetypes`, `storytelling` (cognition), `aesthetic-usability-effect`.
+- **Empty / celebration states** → `wabi-sabi`, `anthropomorphic-form`.
+
+## Cross-plugin pointers
+
+- For *visual* hierarchy and grouping, see `perception-and-hierarchy-principles`.
+- For *learnability*, see `cognition-and-learnability-principles`.
+- For *behavior*, see `interaction-and-control-principles`.
+- For *accessibility*, see `process-and-robustness-principles`.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/aesthetics-router/references/further-reading.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/aesthetics-router/references/further-reading.md
@@ -1,0 +1,50 @@
+# Further reading: aesthetics and emotion
+
+External sources for the aesthetics-related principles.
+
+## Foundational
+
+- **Norman, D.** (2004). *Emotional Design: Why We Love (or Hate) Everyday Things*. Three-level theory of emotional response (visceral, behavioral, reflective). The strongest single source for understanding how aesthetics ties to product success.
+- **Tractinsky, N., Katz, A. S., Ikar, D.** (2000). "What is beautiful is usable." *Interacting with Computers*. Foundational empirical work on the aesthetic-usability effect.
+- **Lavie, T. & Tractinsky, N.** (2004). "Assessing dimensions of perceived visual aesthetics of web sites." *International Journal of Human-Computer Studies*. Two-dimension model (classical + expressive aesthetics).
+
+## Brand and persuasion
+
+- **Cialdini, R.** *Influence: The Psychology of Persuasion* (1984). Six classic persuasion principles, all relevant to design.
+- **Heath, C. & Heath, D.** *Made to Stick* (2007). What makes ideas memorable — concrete, credible, emotional, story-rich.
+- **Mark, M. & Pearson, C. S.** *The Hero and the Outlaw: Building Extraordinary Brands Through the Power of Archetypes* (2001). The marketing-archetype framework.
+
+## Aesthetics and beauty
+
+- **Albers, J.** *Interaction of Color* (1963). Foundational treatment of perceptual color relationships.
+- **Itten, J.** *Design and Form* (1963).
+- **Maeda, J.** *The Laws of Simplicity* (2006). Ten design rules; especially good on subtraction.
+
+## Industrial and product design
+
+- **Rams, D.** "Ten Principles for Good Design" (1970s onward). The minimalism-and-restraint canon. Also collected in *Less and More: The Design Ethos of Dieter Rams*.
+- **Kelley, T.** *The Art of Innovation* (2001) and *The Ten Faces of Innovation* (2005). Design-thinking and process from IDEO.
+
+## Behavioral and psychological
+
+- **Ariely, D.** *Predictably Irrational* (2008). Cognitive biases relevant to aesthetic and pricing decisions.
+- **Kahneman, D.** *Thinking, Fast and Slow* (2011). System 1 / System 2 cognition; framing effects.
+- **Eyal, N.** *Hooked* (2014). Habit-forming design (use ethically).
+- **Fogg, B. J.** *Persuasive Technology* (2003). Captology — the early work on technology-as-persuasion.
+
+## Online tools and references
+
+- **Refactoring UI** (refactoringui.com) — Steve Schoger and Adam Wathan; many practical aesthetic-quality observations.
+- **Dribbble / Behance** — visual aesthetic exploration; useful for trend awareness, sometimes harmful for novice designers (over-imitating decorative styles).
+- **Material Design** (material.io) and **Apple HIG** (developer.apple.com/design) — both contain extensive aesthetic guidance for their respective platforms.
+
+## A note on dark patterns
+
+Many aesthetic-and-emotion principles can be used unethically — to manipulate rather than serve. Resources for spotting and avoiding dark patterns:
+
+- **Brignull, H.** *Deceptive Patterns* (deceptive.design). Catalog of common manipulative UI patterns.
+- **EU GDPR / California CCPA / FTC enforcement actions** — increasingly penalizing dark patterns. Worth tracking the regulatory landscape.
+
+## Closing
+
+Aesthetic principles intersect ethics more than other UX principles do — beauty earns trust the user may give too freely; persuasion earns conversion the user may regret. Use these tools well, and be willing to defend choices in front of a thoughtful customer.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes-brand-voice/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes-brand-voice/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: archetypes-brand-voice
+description: 'Use this skill when picking a brand archetype, propagating it across product and marketing surfaces, or auditing brand-voice consistency. Trigger when designing the voice of microcopy, marketing pages, support tone, or any brand-facing communication. Sub-aspect of `archetypes`; read that first.'
+---
+
+# Brand voice through archetypes
+
+A brand's archetype propagates through every customer-facing surface: homepage copy, ad voice, product microcopy, support tone, error messages, packaging, even the way receipts are worded. Coherence reinforces the archetype; inconsistency dilutes it.
+
+## Picking an archetype
+
+Three questions:
+
+1. **What's the product genuinely for?** A safety-critical product can't credibly be the *Outlaw*; a creative product can't credibly be the *Sage* alone.
+2. **What does the audience want from this category?** Customers buying accounting software want trust (Sage / Caregiver), not transformation (Magician).
+3. **What's the company genuinely capable of being?** Brand archetypes that misalign with the team's actual identity feel performative.
+
+The intersection of product fit, audience fit, and company fit narrows the archetype choice substantially.
+
+## Propagating an archetype
+
+Once chosen, the archetype shapes:
+
+### Voice and copy
+
+Each archetype implies a register:
+
+- **Sage**: measured, knowledgeable, precise. Avoid hyperbole.
+- **Outlaw**: irreverent, challenging, anti-establishment.
+- **Caregiver**: warm, supportive, considerate.
+- **Jester**: playful, surprising, light.
+- **Hero**: action-oriented, triumphant, achievement-focused.
+- **Magician**: visionary, transformative, evocative.
+
+Microcopy across the product should follow. A *Sage* product's error message: "We weren't able to verify the account." A *Jester* product's: "Hmm, we couldn't find that account. Did you typo it?"
+
+### Visual style
+
+Each archetype has visual associations:
+
+- *Sage*: clean, restrained, often serif typography, muted palette.
+- *Outlaw*: bold, edgy, high contrast, often dark.
+- *Caregiver*: warm colors, friendly typography, photography of people.
+- *Magician*: rich gradients, mysterious imagery, otherworldly visuals.
+
+### Iconography and characters
+
+If the brand has a mascot or character, design it to embody the archetype. A *Caregiver* mascot has soft features, gentle posture; an *Outlaw* mascot has sharp angles, defiant pose.
+
+### Stories
+
+Marketing stories should feature the archetype's core arc. A *Hero* brand tells stories of users overcoming challenges; a *Caregiver* brand tells stories of being supported through difficulty.
+
+## Coherence audit
+
+Across your product and marketing, audit:
+
+- **Voice samples** from 5 random microcopy strings — do they share a register?
+- **Visual style** across landing page, product UI, error states, packaging.
+- **Color and typography** consistent or scattered?
+- **Story tone** in case studies and testimonials.
+- **Support voice** in chat, email, knowledge base.
+
+Inconsistencies are debt; pay them down deliberately.
+
+## Common voice failures
+
+- **Mixed archetypes across teams.** Marketing writes one voice; product writes another; support is a third.
+- **Aspirational mismatch.** The brand wants to be a *Magician* but the product is utility-grade. The mismatch reads as inflated.
+- **Generic voice.** "Professional, friendly, helpful" — no archetype, no personality.
+- **Trend-chasing.** Adopting an archetype because it's currently popular rather than because it fits.
+
+## Heuristics
+
+1. **The 30-second test.** Read 5 random pieces of microcopy aloud. Does it sound like the same voice? If not, voice is fragmenting.
+2. **The new-writer onboarding.** A new content writer should be able to read your brand-voice doc and produce copy that sounds like the brand. If they can't, your archetype isn't documented.
+3. **The "what would [archetype] do?" check.** When facing a copy decision, ask: what would the [your archetype] say? The answer guides the choice.
+
+## Related sub-skills
+
+- **`archetypes`** (parent).
+- **`archetypes-storytelling-arcs`** — the narrative side.
+- **`phonetic-symbolism`** — word sounds reinforce archetype.
+- **`form-follows-function`** — visual style flows from purpose, including archetype.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes-brand-voice/references/voice-design-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes-brand-voice/references/voice-design-cases.md
@@ -1,0 +1,41 @@
+# Brand voice case reference
+
+A reference complementing `archetypes-brand-voice` with case examples.
+
+## Coherent voice cases
+
+- **Mailchimp** — *Jester* archetype with strong Everyman undertones. Playful microcopy, warm illustrations, irreverent style guide. Voice consistent from the marketing site to error messages to support replies.
+- **Patagonia** — *Explorer* archetype made coherent. Voice: passionate, environmentally conscious, story-driven. Visual: rugged, photographic. Operations match: explicit environmental commitments.
+- **Apple** — *Magician* in current era (transformative technology). Earlier era: *Outlaw* ("Think Different," "1984"). Voice: confident, declarative, future-oriented.
+- **Stripe** — *Sage*. Voice: clear, technical, authoritative without being cold. Documentation prose is widely cited as a model.
+- **Notion** — *Creator* with *Everyman* warmth. Voice: enabling, friendly, possibility-oriented.
+
+## Voice style-guide elements
+
+A documented brand voice typically covers:
+
+- **Personality traits** ("knowledgeable but warm," "playful but never silly").
+- **Tone variation** by context (energetic in marketing, calm in error messages).
+- **Word choices** (preferred and avoided terms).
+- **Sentence structure** (short and direct; long and reflective).
+- **Punctuation conventions** (Oxford comma; em-dash usage).
+- **Formality** (sentence case vs. title case; first-person plural vs. third-person).
+
+A 2-page voice guide is enough for most teams; longer ones rarely get read.
+
+## Audit method
+
+For an existing product:
+
+1. Sample 5–10 random pieces of copy from across the product and marketing.
+2. Read aloud. Do they sound like the same voice?
+3. If not, name the inconsistencies.
+4. Pick one voice; rewrite the off-tone samples.
+
+Repeat quarterly; voice drift is constant without intervention.
+
+## Resources
+
+- Mailchimp's public voice and tone guide (mailchimp.com/styleguide).
+- 18F content guide (US gov; well-documented voice work).
+- Stripe Press writing.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes-storytelling-arcs/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes-storytelling-arcs/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: archetypes-storytelling-arcs
+description: 'Use this skill when designing narrative content — landing pages, case studies, onboarding flows, marketing campaigns, sales decks, ad arcs. Trigger when picking how to frame a customer story, when writing a launch campaign, or when the user mentions "this campaign feels flat" or "we need a better narrative." Sub-aspect of `archetypes`; read that first.'
+---
+
+# Storytelling arcs and the hero's journey
+
+Stories are the most efficient way to convey emotional truth. A list of features is forgotten; a story of a user transformed by a product is remembered. Archetypes structure stories — the hero's journey is the most-cited template — and using them deliberately makes marketing, onboarding, and case studies dramatically more effective.
+
+## The hero's journey (Campbell, 1949)
+
+Joseph Campbell distilled cross-cultural mythology into a single recurring pattern. The full version has 17 stages; the simplified product-narrative version has roughly 8:
+
+1. **Ordinary world** — the user's status quo (their pain, their constraint).
+2. **Call to adventure** — the product is introduced.
+3. **Hesitation** — the natural skepticism, the reasons not to.
+4. **Mentor** — the product (or its team) offers guidance.
+5. **Crossing the threshold** — first use, signing up.
+6. **Trials** — the work of using the product.
+7. **Reward** — the outcome, the transformation.
+8. **Return / sharing** — the user becomes an advocate.
+
+This arc structures most successful marketing campaigns, customer case studies, and product launches.
+
+## Applying to product narratives
+
+### Customer case studies
+
+A typical case study before applying the arc:
+
+> "Acme Corp uses our product. They report 40% productivity improvement."
+
+Same case study with the arc:
+
+> "Acme Corp's marketing team was spending 4 days a week on reports — too much manual work, too little strategy. They tried our product as an experiment. After two weeks of integration, they automated 70% of their reporting workflow. Today, the team spends those reclaimed days on campaigns that have driven a 30% increase in qualified leads."
+
+The arc gives the data emotional shape: pain → adventure → mentor → trials → reward.
+
+### Onboarding flows
+
+Onboarding can follow the arc:
+
+- Welcome screen acknowledges the pain (ordinary world).
+- Setup is the call (adventure).
+- Tutorial is the mentor.
+- First successful task is the threshold-crossing.
+- Building momentum is the trials.
+- Achievement screen is the reward.
+- "Invite teammates" is the return / sharing.
+
+### Landing pages
+
+Landing pages often follow a compressed arc:
+
+- Hero section: the call.
+- Problem section: the ordinary world.
+- Solution section: the mentor (your product).
+- Social proof: testimonials of others who completed the journey.
+- CTA: cross the threshold.
+
+### Marketing campaigns
+
+A multi-touch campaign can play out across emails, ads, and content over weeks:
+
+- Week 1: name the problem (ordinary world).
+- Week 2: introduce the solution (call).
+- Week 3: address objections (hesitation).
+- Week 4: demo / trial (mentor + threshold).
+- Week 5: success stories (reward).
+
+## Picking the user's role
+
+In product narratives, who is the hero? Three typical positionings:
+
+### The user is the hero; the product is the mentor
+
+The user's transformation is the story; the product enables it. Most user-facing marketing positions this way. The user sees themselves in the story; the product is the magical artifact.
+
+### The product is the hero
+
+Less common in modern marketing; more common in early advertising. The product itself is presented as the protagonist conquering the user's problem. Can feel inflated in modern contexts.
+
+### A different character is the hero
+
+Case studies often position a specific named customer as the hero. Their transformation is the story.
+
+The user-as-hero positioning is generally most effective because it lets the prospect insert themselves into the story.
+
+## Other arc patterns
+
+The hero's journey isn't the only arc:
+
+- **Three-act structure** (setup, confrontation, resolution) — used in films, drama, and many product demos.
+- **Problem-Agitation-Solution** (PAS) — common in copywriting.
+- **Before-After-Bridge** (BAB) — present current state, desired state, the path between.
+- **Story Brand framework** (Donald Miller) — a 7-part framework derived from Campbell's work, applied to brand messaging.
+
+Each is a structured way to give content emotional shape.
+
+## Anti-patterns
+
+- **All features, no narrative.** Bullet lists of features without the story of what they enable.
+- **Inflated narrative.** Treating routine product use as a hero's journey produces hyperbolic copy that erodes credibility.
+- **No transformation.** Stories that don't show change ("Customer uses our product. End.") fail to engage.
+- **Hero confusion.** Who is the protagonist? If unclear, the story flattens.
+- **Skipping the trials.** Stories that go directly from problem to triumph feel unrealistic; users know real adoption involves friction.
+
+## Heuristics
+
+1. **The "what's the transformation?" check.** Every effective narrative has a before/after. If your story has no transformation, it's not yet a story.
+2. **The hero clarity test.** Read your narrative. Who is the protagonist? If you can't tell in 3 seconds, fix.
+3. **The trial honesty.** Skipping over the work makes the story unbelievable. Brief acknowledgment of the friction makes the triumph credible.
+
+## Related sub-skills
+
+- **`archetypes`** (parent).
+- **`archetypes-brand-voice`** — voice consistency reinforces narrative.
+- **`storytelling`** (cognition) — narrative as memory aid.
+- **`framing`** (cognition) — how the story is framed affects user judgment.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes-storytelling-arcs/references/narrative-frameworks.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes-storytelling-arcs/references/narrative-frameworks.md
@@ -1,0 +1,52 @@
+# Narrative frameworks reference
+
+A reference complementing `archetypes-storytelling-arcs` with frameworks beyond Campbell's hero's journey.
+
+## Storytelling frameworks for product / marketing
+
+### Campbell's hero's journey
+17-stage cross-cultural narrative arc. Most-cited template; basis for many films and product narratives.
+
+### Three-act structure
+Setup, confrontation, resolution. Used in films, drama, product demos.
+
+### Problem-Agitation-Solution (PAS)
+Common in copywriting:
+- Problem: name the user's pain.
+- Agitation: amplify why it matters.
+- Solution: present your product.
+
+### Before-After-Bridge (BAB)
+- Before: current state.
+- After: desired state.
+- Bridge: how to get there (your product).
+
+### Story Brand framework (Donald Miller)
+7-part framework derived from Campbell:
+1. A character (the user)
+2. has a problem
+3. and meets a guide (your brand)
+4. who gives them a plan
+5. and calls them to action
+6. that ends in success
+7. or avoids failure
+
+Practical for marketing-page structuring.
+
+### Pixar's storytelling formula
+"Once upon a time... Every day... Until one day... Because of that... Because of that... Until finally... And ever since then..." A simple template that produces narrative arcs.
+
+## When to use which
+
+- **Hero's journey**: complete brand stories, multi-touch campaigns, case studies.
+- **PAS**: short-form copywriting (ads, emails).
+- **BAB**: landing pages, feature announcements.
+- **Story Brand**: brand messaging clarity exercises.
+- **Three-act**: product demos, sales decks.
+
+## Resources
+
+- Campbell, J. *The Hero with a Thousand Faces*.
+- Miller, D. *Building a Story Brand* (2017).
+- Pink, D. *To Sell Is Human* — story in persuasion.
+- Sachs, J. *Winning the Story Wars* — modern narrative-driven marketing.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: archetypes
+description: 'Use this skill when designing brand voice, marketing positioning, mascot or character design, narrative arcs in product onboarding, or any expressive surface where the design must communicate personality. Trigger when picking how a brand "feels" (rebellious, nurturing, sage-like), when designing storytelling for marketing, or when reviewing why a brand voice feels generic. Archetypes is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003), grounded in Jung''s analytical psychology and widely applied in branding, storytelling, and product personality.'
+---
+
+# Archetypes
+
+Archetypes are recurring patterns of theme, character, and form that resonate across cultures and centuries. They tap into shared psychological structures that humans seem to recognize without explicit teaching. A brand built around the *outlaw* archetype (Harley-Davidson) feels rebellious; a brand built around the *hero* archetype (Nike) feels triumphant. The archetype is doing work the user may not consciously identify but feels at an emotional level.
+
+## Definition (in our own words)
+
+An archetype is a familiar pattern of personality, story, or form that has accumulated meaning across many contexts. The hero who answers a call, faces trials, and returns transformed. The wise mentor. The trickster. The caregiver. These patterns appear in myths, literature, films, advertising, and product design — not because of cultural transmission alone, but because they correspond to something humans recognize across cultures. Designs that align with an archetype borrow its accumulated meaning; designs that don't align with any clear archetype feel undefined.
+
+## Origins and research lineage
+
+- **Carl G. Jung**, "The Archetypes and the Collective Unconscious" (Collected Works of C. G. Jung, Vol. 9, Part 1; translated by R. F. C. Hull, Princeton University Press, 1981). Jung proposed that humans share inherited psychological structures — archetypes — manifesting in dreams, myths, and literature across cultures. His work is the ancestor of all modern archetype application.
+- **Joseph Campbell**, *The Hero with a Thousand Faces* (Princeton University Press, 1949, 1968). Campbell distilled the cross-cultural pattern of the hero's journey: a prospective hero is called to adventure, refuses, meets a mentor, accepts the call, faces trials, defeats an enemy, returns transformed. Influenced filmmakers (Lucas, Spielberg, Coppola) and storytelling broadly.
+- **Margaret Mark & Carol S. Pearson**, *The Hero and the Outlaw: Building Extraordinary Brands Through the Power of Archetypes* (McGraw-Hill, 2001). Translated archetypes into brand-strategy vocabulary. Identified twelve core brand archetypes (innocent, sage, explorer, outlaw, magician, hero, lover, jester, everyman, caregiver, ruler, creator).
+- **Lidwell, Holden & Butler** (2003) compactly summarized the design implications and cautioned that reactions to archetypes vary across cultures — test on target audiences before committing.
+
+## Why archetypes matter
+
+Brands and products that align with an archetype communicate personality without explanation. Users intuitively understand "this product is for rebels" or "this brand is the wise authority" because the archetype pre-loads meaning. Without an archetype, a brand has to build personality from scratch — often producing diffuse, forgettable identity.
+
+The cost of misalignment: a brand whose visual style says one archetype and whose copy says another feels incoherent. Users sense the dissonance even if they can't articulate it.
+
+## The twelve brand archetypes (Mark & Pearson)
+
+| Archetype | Core motivation | Example brands |
+|---|---|---|
+| Innocent | Safety, simplicity, optimism | Coca-Cola, Dove |
+| Sage | Truth, knowledge | Google, BBC, MIT |
+| Explorer | Freedom, discovery | The North Face, Jeep, NASA |
+| Outlaw | Disruption, rebellion | Harley-Davidson, Virgin |
+| Magician | Transformation, vision | Apple, Disney, Tesla |
+| Hero | Mastery, triumph | Nike, FedEx |
+| Lover | Intimacy, beauty | Chanel, Victoria's Secret |
+| Jester | Joy, humor | Old Spice, Dollar Shave Club |
+| Everyman | Belonging, realism | IKEA, Levi's, Target |
+| Caregiver | Service, compassion | Johnson & Johnson, Volvo |
+| Ruler | Control, prosperity | Rolex, Mercedes-Benz |
+| Creator | Self-expression, innovation | LEGO, Adobe, Crayola |
+
+Each archetype has a distinct emotional register, vocabulary, and visual style. Picking one — and designing every surface to reinforce it — produces brand coherence.
+
+## When to apply
+
+- **Brand strategy** — pick an archetype that fits the product's purpose and audience.
+- **Marketing copy and visual design** — the archetype should propagate through every customer touch.
+- **Character or mascot design** — characters embody archetypes through appearance and behavior.
+- **Onboarding narratives** — the user as the hero of their own journey, with the product as mentor.
+- **Storytelling in case studies, sales materials, ads.**
+
+## When NOT to over-apply
+
+- **Internal tools / utilities** — archetypes are emotional positioning; an internal admin tool can be neutral.
+- **Compliance-driven content** — legal disclosures and accessibility statements need clarity, not personality.
+- **When the archetype doesn't fit the product** — forcing an "outlaw" archetype on a children's-education product creates dissonance.
+- **When testing reveals cross-cultural mismatch** — archetypes have universal cores but cultural variations in expression.
+
+## Voice consistency across an archetype
+
+If you commit to an archetype, every brand surface should reflect it. Picking the *Sage* archetype implies:
+
+- **Voice**: measured, knowledgeable, precise.
+- **Visual style**: clean, restrained, often minimalist.
+- **Color palette**: muted, often neutral or deep.
+- **Typography**: serious, credible (often serifs or technical sans).
+- **Imagery**: educational, factual, expert.
+
+Versus the *Jester*:
+
+- **Voice**: playful, irreverent, surprising.
+- **Visual style**: vibrant, often whimsical.
+- **Color palette**: bright, saturated.
+- **Typography**: distinctive, often custom.
+- **Imagery**: humorous, unexpected.
+
+Mixing these — Sage voice with Jester visuals — produces brand confusion.
+
+## The hero's journey in product onboarding
+
+Campbell's monomyth structures most successful narratives:
+
+1. **Ordinary world** — the user's current situation (their pain).
+2. **Call to adventure** — the product enters.
+3. **Refusal / hesitation** — natural skepticism.
+4. **Meeting the mentor** — onboarding, support, community.
+5. **Crossing the threshold** — first use, signing up.
+6. **Trials** — learning, encountering challenges.
+7. **Approach to the inmost cave** — committing seriously.
+8. **The ordeal** — the hard problem the product helps with.
+9. **Reward** — outcome, success.
+10. **The road back** — sustained use.
+11. **Resurrection** — transformation, becoming an advocate.
+12. **Return with the elixir** — sharing, recommending, evangelizing.
+
+Apple's "Think Different" ads, Nike's "Just Do It" campaigns, and most successful product narratives follow some variation. The user is the hero; the product is the mentor or the magical artifact that enables the journey.
+
+## Worked examples
+
+### Example 1: brand archetype consistency
+
+Patagonia is the *Explorer* archetype made coherent across every surface:
+
+- **Voice**: passionate, authentic, environmentally conscious.
+- **Visual style**: rugged, photographic, real people in real places.
+- **Product**: durable, designed for genuine outdoor use.
+- **Marketing**: stories of expedition and conservation.
+- **Operations**: explicit environmental commitments.
+
+The archetype isn't decoration; it shapes business decisions. This coherence is why Patagonia has unusual brand loyalty.
+
+### Example 2: archetype mismatch
+
+A company markets accounting software as if it were a *Magician* brand (transformative, visionary, life-changing). Customers buying accounting software want *Sage* (trustworthy, knowledgeable, accurate) or *Caregiver* (helpful, supportive). The mismatch produces marketing that feels inflated; trust suffers.
+
+The fix: align the archetype to what the product actually does and what the audience actually wants.
+
+### Example 3: onboarding as hero's journey
+
+A SaaS product onboarding:
+
+- **Ordinary world**: "Currently spending 4 hours a week on this task?"
+- **Call to adventure**: "Imagine getting that time back."
+- **Mentor**: "Here's how to start..."
+- **Trials**: First setup, first integration.
+- **Reward**: "You just saved 4 hours this week."
+- **Sharing**: "Tell your team how you did it."
+
+The narrative arc engages emotionally; the product is positioned as enabling the user's journey, not as the hero itself.
+
+## Cross-domain examples
+
+### Films
+
+Star Wars (A New Hope) is a textbook hero's journey: Luke (ordinary world: farm) → call (Princess Leia's message) → refusal → mentor (Obi-Wan) → trials (Tatooine, Death Star) → ordeal (rescue, escape) → reward (medal) → road back. Lucas explicitly drew on Campbell.
+
+Most blockbuster films follow some variation. The archetype works across cultures because the underlying journey resonates universally.
+
+### Advertising
+
+Nike's "Just Do It" + heroic athletes embodies the *Hero* archetype consistently for decades. Coke's "Open Happiness" + universal themes embodies the *Innocent*. Apple's early ads ("1984," "Think Different") embodied the *Outlaw*; later positioning shifted toward *Magician* (transformative technology).
+
+### Mythology
+
+Jung's original observation: archetypes recur across distant cultures. Trickster figures (Loki, Hermes, Anansi, Coyote) appear in independent mythologies. Hero figures (Hercules, Beowulf, Sun Wukong) follow similar arcs. The cross-cultural recurrence is what suggested archetypes to Jung.
+
+## Anti-patterns
+
+- **No clear archetype.** Brand voice diffuse; visual style undefined; users can't tell what the brand stands for.
+- **Mixed archetypes.** One ad is *Hero*, another is *Caregiver*, the homepage is *Sage*. Users sense incoherence.
+- **Archetype mismatch with product.** *Outlaw* positioning for accounting software; *Innocent* positioning for security software.
+- **Archetype as sole strategy.** Aligning with an archetype helps positioning but doesn't substitute for product quality, distribution, or pricing.
+- **Cultural-blind archetype use.** What reads as *Hero* in one culture may read differently in another.
+
+## Heuristics
+
+1. **The "what archetype is this brand?" test.** Show your brand to someone unfamiliar; ask what kind of personality it has. If they can't tell, you don't have an archetype.
+2. **The cross-surface consistency check.** Pick an archetype; audit every customer touch (homepage, ads, product copy, support, packaging). Inconsistencies undermine the archetype.
+3. **The audience-fit check.** Is your archetype what your audience actually wants from your category? Test before committing.
+
+## Related principles
+
+- **`mimicry`** — archetypes are patterns; mimicry borrows them.
+- **`storytelling`** — the hero's journey is the canonical archetype-driven story.
+- **`anthropomorphic-form`** — characters embody archetypes through humanlike features.
+- **`baby-face-bias`** — character design choices encode archetype.
+- **`personas`** — personas are user-side; archetypes are brand-side.
+- **`expectation-effect`** — archetypes set expectations the brand must meet.
+
+## Sub-aspect skills
+
+- **`archetypes-brand-voice`** — picking and propagating an archetype across brand surfaces.
+- **`archetypes-storytelling-arcs`** — using the hero's journey and similar arcs in product narrative.
+
+## Closing
+
+Archetypes are how brands borrow centuries of accumulated emotional meaning. A coherent archetype gives a product personality without explanation; an absent or muddled archetype produces forgettable brands. Pick deliberately; commit consistently; respect that not every audience or every culture reads the same archetype the same way.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes/references/jung-and-brand-applications.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/archetypes/references/jung-and-brand-applications.md
@@ -1,0 +1,46 @@
+# Archetypes: Jung and brand applications
+
+A reference complementing the `archetypes` SKILL.md with the historical and applied lineage.
+
+## Jungian roots
+
+Carl G. Jung proposed that humans share inherited psychological structures — archetypes — that appear in dreams, myths, and stories across cultures. Key works:
+
+- *The Archetypes and the Collective Unconscious* (Collected Works of C. G. Jung, Vol. 9, Part 1) — the foundational text.
+- *Symbols of Transformation* (1956) — extended treatment.
+
+Jung's claim of biological inheritance is contested in modern psychology, but the *observation* — that the same symbolic patterns recur across cultures — is well-documented even if its mechanism is debated.
+
+## Campbell and the monomyth
+
+Joseph Campbell's *The Hero with a Thousand Faces* (1949) distilled the cross-cultural hero's journey from Jungian roots and comparative mythology. Influenced filmmakers (George Lucas explicitly drew on Campbell for Star Wars), screenwriters, and modern storytelling broadly.
+
+## Mark and Pearson's brand framework
+
+Margaret Mark and Carol S. Pearson's *The Hero and the Outlaw* (2001) translated Jung's archetypes into a 12-archetype brand framework that has been widely adopted in marketing.
+
+The 12 archetypes map to four motivational drives:
+
+- **Stability / control**: Caregiver, Ruler, Creator.
+- **Belonging / enjoyment**: Jester, Everyman, Lover.
+- **Mastery / risk**: Hero, Outlaw, Magician.
+- **Independence / fulfillment**: Innocent, Sage, Explorer.
+
+Most successful long-lasting brands occupy one of these clearly. Brands that try to occupy multiple often dilute.
+
+## Cross-cultural variation
+
+While archetypes recur across cultures, their *expression* varies:
+
+- The "trickster" archetype appears as Loki (Norse), Hermes (Greek), Anansi (West African), Coyote (Native American). Same archetype; very different cultural expressions.
+- The "wise elder" appears in many cultures but with different gender, age, and authority profiles.
+- Color, shape, and behavior associations with archetypes vary regionally.
+
+For global brands: the underlying archetype may transfer; the local expression should adapt.
+
+## Resources
+
+- Jung, C. G. *The Archetypes and the Collective Unconscious*.
+- Campbell, J. *The Hero with a Thousand Faces* (1949).
+- Mark, M. & Pearson, C. S. *The Hero and the Outlaw* (2001).
+- Miller, D. *Building a Story Brand* (2017) — Campbell-derived brand framework.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-effect/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-effect/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: exposure-effect
+description: 'Apply the Exposure Effect (mere-exposure effect) — the well-documented finding that repeated exposure to something tends to increase liking for it. Use when launching new features, planning redesigns, building brand familiarity, or evaluating user resistance to change. Familiarity reads as comfort and trust; novelty reads as risk. The effect explains why redesigns generate disproportionate user backlash, why incremental change beats radical change, and why brand consistency over time builds value beyond any single design choice.'
+---
+
+# Exposure Effect
+
+> **Definition.** The exposure effect, also called the mere-exposure effect, is the psychological finding that repeated exposure to a stimulus tends to increase positive evaluation of it, independent of any conscious recognition. People come to like things they encounter often — songs, faces, brands, designs — even when they don't actively notice the repetition. The effect is robust, well-documented across decades of research, and has substantial design implications.
+
+The effect was first systematically studied by Robert Zajonc in 1968. Subjects shown unfamiliar stimuli (Chinese characters, made-up words, photographs of strangers) developed measurable preference for the items they'd been exposed to more frequently, even when they couldn't recall having seen them. The exposure was operating below conscious awareness; the preference appeared on its own.
+
+Subsequent research has confirmed the effect across many domains: faces, music, words, brand logos, abstract images, even unfamiliar political candidates. Repeated exposure shifts preference, with diminishing returns after substantial exposure.
+
+## Why this matters in design
+
+The exposure effect has several practical consequences for design.
+
+**Familiarity reads as comfort.** Users like the things they're used to. Designs they've seen many times feel approachable; designs they haven't feel risky.
+
+**Novelty reads as effort.** Users encountering something new have to learn it; learning costs effort; effort feels like cost. Even better-than-old designs face this initial resistance.
+
+**Brand consistency compounds.** Logos, color palettes, typography that stay consistent over years build accumulated familiarity. Users who've seen the brand a thousand times have a positive baseline that new audiences don't have.
+
+**Redesigns generate backlash.** Users who knew the old design have to relearn the new one; their familiarity-based preference for the old fights against the new. Even objectively-better redesigns trigger user complaints, often disproportionate to the actual change.
+
+**Incremental change beats radical change.** Small changes preserve enough familiarity to avoid triggering the resistance. Radical changes overwhelm the exposure-built preference and require accumulating new exposure.
+
+**First-encounter design matters.** A user's first impression sets the baseline; subsequent exposures build on it.
+
+## Applying the principle
+
+**Build familiarity deliberately.** For brand elements, prioritize consistency over time. The accumulated value of years of consistent use is larger than any single design improvement.
+
+**Plan redesigns carefully.** Major changes need extra communication, transition periods, and acknowledgment of user resistance. Small changes, frequently, beat large changes infrequently.
+
+**Use familiarity in marketing.** Repeated exposure to a brand, message, or product builds the baseline preference that supports purchase decisions. Marketing's value compounds over time.
+
+**Honor user familiarity in your product.** Don't change what users have learned without strong reason. The familiarity is itself an asset.
+
+**Recognize that "users will get used to it" is partly true.** New designs do build familiarity over time. But "they'll get used to it" understates the cost of the transition period.
+
+## When the effect is strongest
+
+The exposure effect is strongest when:
+
+- The stimulus is initially neutral (not strongly liked or disliked).
+- Exposures are frequent and at appropriate intervals.
+- The user isn't paying close attention (the effect operates partly subliminally).
+- The user has no strong external reason to evaluate the stimulus.
+
+It's weaker (or even reverses) when:
+
+- The stimulus is initially disliked. Repeated exposure to disliked things may not build liking and may actually intensify dislike.
+- Exposures are excessive. After enough exposure, additional exposure adds little.
+- The user is consciously evaluating. Conscious evaluation can override the unconscious preference.
+- The stimulus is associated with a negative experience.
+
+## Sub-skills in this cluster
+
+- **exposure-onboarding** — Using the exposure effect deliberately in onboarding and habit formation: how repeated, low-friction exposure builds familiarity and preference.
+- **exposure-redesign-risk** — Managing the risks of redesigns when users have built up exposure-based preference for the existing design.
+
+## Worked examples
+
+### A logo that stayed the same for 50 years
+
+A consumer brand has used essentially the same logo since the 1970s. The logo has been refined slightly over the decades but the overall form is recognizable. Users who grew up with the brand have decades of accumulated familiarity; the logo carries a strong positive baseline.
+
+A competitor decides to redesign their logo every 3–5 years to "stay current." Each redesign starts the familiarity-building from scratch; the brand never accumulates the same depth of recognition.
+
+The first brand has the exposure effect on its side. Restraint in branding pays compound returns over time.
+
+### A redesign that generated backlash
+
+A productivity tool ships a redesign that's objectively better in many ways: cleaner layout, better information hierarchy, faster performance. Users complain bitterly. Social media is full of complaints. Some users threaten to switch.
+
+What's happening: users had years of accumulated familiarity with the old design. Even though the new design is better, the familiarity-based preference for the old fights against it. The transition period is painful regardless of the underlying merit.
+
+The fix: better transition planning. Explicit communication about the changes. Optional access to old layouts during the transition. Help content that meets users where they were. Over time, users do build familiarity with the new design and the complaints subside.
+
+### A new brand entering a saturated market
+
+A new product enters a market dominated by established competitors. Even if the new product is better, users tend to default to the familiar competitor. The new product has to either:
+
+- Build familiarity through marketing exposure (expensive, time-consuming).
+- Provide such substantial value that users override the familiarity preference.
+- Find a niche where the established competitor isn't familiar.
+
+The exposure effect is part of why new products often fail despite being better; familiarity is a real asset.
+
+### A song that grows on you
+
+You hear a new song; you don't love it. You hear it again on the radio; it's a bit better. By the tenth time, you find yourself enjoying it. By the hundredth, you might call it a favorite.
+
+Music streaming algorithms exploit this directly: songs that get repeated play tend to be liked. The algorithm's success depends partly on the exposure effect.
+
+### A user-rejected feature that succeeds when phased in
+
+A team wants to add a feature that they believe will be valuable. They ship it; users complain it's confusing and unwanted. Usage is low; team considers reverting.
+
+Alternative approach: introduce the feature gradually, with help content, with framing that ties it to existing patterns. Let users encounter it repeatedly in low-pressure contexts. Over time, familiarity builds; the feature becomes accepted.
+
+The lesson: features that fail on first encounter sometimes succeed if introduced incrementally. The exposure effect needs time to operate.
+
+## Anti-patterns
+
+**Frequent redesigns for visual freshness.** Each redesign sacrifices accumulated familiarity. Unless the redesign is materially better, the cost outweighs the benefit.
+
+**Relying on "users will get used to it" without managing the transition.** True, but the transition period costs users (and you, in the form of complaints, churn, and support load). Plan for it.
+
+**Underestimating the value of familiarity.** A familiar pattern is often better than a slightly-better unfamiliar one because of the exposure effect. Verify that the new pattern is genuinely worth the relearning cost.
+
+**Confusing user resistance to redesigns with bad design.** Users complain about almost any change. Look at the substantive complaints, not just the volume.
+
+**Ignoring exposure in marketing.** Marketing's value compounds with exposure. A brand seen many times is more trusted than one seen once, regardless of message quality.
+
+**Strange or alienating first encounters.** A user's first encounter sets the baseline. A first encounter that's confusing or unpleasant primes negatively for all subsequent exposures.
+
+## Heuristic checklist
+
+Before changing a familiar element, ask: **How much accumulated familiarity exists?** Long-tenured users have more. **Is the change material enough to justify the resistance?** Marginal improvements often aren't. **What's the transition plan?** Explicit communication; gradual rollout; optional fallback. **Will the new design build its own familiarity over time?** Plan for the ramp.
+
+## Related principles
+
+- **Aesthetic-Usability Effect** — beautiful designs are perceived as more usable; familiar designs benefit from a similar halo.
+- **Mental Model** — users' mental models are built through exposure.
+- **Consistency** — internal consistency leverages exposure within the product; external consistency leverages exposure across products.
+- **Mimicry** — products that mimic familiar patterns inherit familiarity.
+- **Iteration** — small iterations preserve familiarity better than large ones.
+
+## See also
+
+- `references/lineage.md` — origins in psychology research, particularly Zajonc.
+- `exposure-onboarding/` — sub-skill on building familiarity through repeated exposure.
+- `exposure-redesign-risk/` — sub-skill on managing redesigns.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-effect/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-effect/references/lineage.md
@@ -1,0 +1,99 @@
+# Exposure Effect — origins and research lineage
+
+## Zajonc and the foundational research
+
+The exposure effect — also called the mere-exposure effect — was systematically documented by social psychologist Robert Zajonc in his 1968 paper "Attitudinal Effects of Mere Exposure" (*Journal of Personality and Social Psychology Monograph Supplement*). Zajonc demonstrated across multiple experiments that subjects developed measurable preference for stimuli they had been exposed to repeatedly, even when exposure was brief and the subjects couldn't recall having seen the stimuli.
+
+His experiments used unfamiliar Chinese characters, fabricated words, and photographs of unknown people. Subjects were exposed to some items more than others; later, asked to rate liking, they consistently preferred the more-frequently-seen items. The preference appeared without conscious recognition — subjects often denied having seen the items at all.
+
+Zajonc proposed that the effect operates at a basic affective level — the brain treats familiar stimuli as safer (because they haven't harmed us in past encounters) and assigns them positive valence. The mechanism is automatic and largely unconscious.
+
+## Subsequent research
+
+The exposure effect has been replicated extensively since 1968. Notable findings:
+
+**The effect operates across stimulus types.** Faces, music, words, abstract shapes, brand logos, even unfamiliar political candidates. Almost any neutral stimulus can be liked more through exposure.
+
+**The effect is strongest for moderately-novel stimuli.** Already-familiar stimuli show smaller exposure effects (they're already at high preference). Strongly disliked stimuli sometimes don't benefit from exposure and may show reverse effects.
+
+**Number of exposures matters but with diminishing returns.** The first few exposures produce the largest effect; additional exposures add less.
+
+**Subliminal exposure works.** Stimuli presented below conscious recognition still produce preference shifts. The effect doesn't require conscious processing.
+
+**The effect generalizes.** A subject exposed to one item often shows positive preference for related items (the same artist's other works, similar visual styles).
+
+**Spacing affects strength.** Exposures spaced over time produce stronger effects than massed exposures.
+
+**Context matters.** Exposure in pleasant or neutral contexts produces stronger preference than exposure in unpleasant contexts.
+
+## Marketing and consumer research
+
+The advertising industry has applied exposure-effect principles for decades, often without naming them. The basic logic: repeated exposure to a brand or message builds familiarity, familiarity builds preference, preference drives purchase. Frequency-based advertising metrics (impressions, reach × frequency) are essentially measures of exposure.
+
+Studies of brand recognition and consumer choice consistently find that more-familiar brands are preferred even when blind comparisons show no quality difference. The exposure effect is one of the most robust findings in marketing research.
+
+This explains some otherwise-puzzling consumer behaviors:
+- Why brand loyalty often exceeds quality differentials.
+- Why new entrants struggle even with better products.
+- Why advertising for established brands continues despite low marginal information value.
+- Why "share of voice" matters in marketing.
+
+## In design and HCI
+
+The exposure effect appears in design contexts in several ways:
+
+**User resistance to redesigns.** The most documented design implication. Users complain about redesigns disproportionately to the actual change because the old design has accumulated familiarity-based preference.
+
+**Convention strength.** Design patterns that have spread widely (the hamburger menu, the magnifying glass for search) gain user preference partly through exposure.
+
+**Brand consistency value.** Brands that maintain visual identity over years build a familiarity asset that more-volatile brands don't have.
+
+**First-impression importance.** The first encounter sets the baseline; subsequent exposures build from there. A bad first impression creates a difficult ramp for the exposure effect to climb.
+
+**Onboarding success.** Products that get users to repeated, low-friction interactions in the first session benefit from immediate exposure effects.
+
+## When the effect doesn't operate
+
+The exposure effect has limits:
+
+**Disliked stimuli may not improve.** Repeated exposure to something the user actively dislikes may not build liking and may intensify dislike. The effect favors neutral-to-positive starting points.
+
+**Conscious evaluation can override.** When subjects are asked to consciously evaluate stimuli, the unconscious exposure effect is reduced. Marketing's value comes partly from operating below conscious evaluation.
+
+**Saturation. **After enough exposure, additional exposure adds little. There's a ceiling.
+
+**Negative associations override.** Exposure paired with negative experiences builds negative association rather than positive preference.
+
+**Wear-out.** Some stimuli (advertising messages, songs) can be exposed too frequently in too short a time, creating annoyance rather than preference.
+
+These limits mean the exposure effect isn't a magic wand. It works best as a long-term strategy with appropriate stimulus selection.
+
+## Design tensions
+
+The exposure effect creates several design tensions:
+
+**Familiarity vs. innovation.** Improvements require novelty, but novelty fights against familiarity. Resolving this tension is one of the central challenges of long-lived product design.
+
+**Brand consistency vs. evolution.** Brands need to feel current but also maintain familiarity. Resolved by evolving slowly and continuously rather than radically and infrequently.
+
+**User research vs. exposure effects.** Users say they want change; their behavior often shows preference for the familiar. Survey data and behavior data can diverge here.
+
+**Designers' preferences vs. users'.** Designers see the product daily and grow tired of it; users see it less often and have stronger familiarity preference. Designers often want to redesign more than users want.
+
+## Empirical findings worth remembering
+
+- **Exposure builds preference for neutral or positive stimuli, with diminishing returns.**
+- **The effect operates partly unconsciously.**
+- **Strongly disliked stimuli don't usually benefit; may worsen.**
+- **Spaced exposure beats massed exposure.**
+- **First impression sets the baseline.**
+- **Familiarity-based preference can be substantial — often larger than quality differences in user choice.**
+
+## Sources informing this principle
+
+- Zajonc, R. B. (1968). Attitudinal Effects of Mere Exposure. *Journal of Personality and Social Psychology Monograph Supplement*.
+- Bornstein, R. F. (1989). Exposure and affect: Overview and meta-analysis of research, 1968–1987. *Psychological Bulletin*.
+- Kunst-Wilson, W. R., & Zajonc, R. B. (1980). Affective discrimination of stimuli that cannot be recognized. *Science*.
+- Various marketing and consumer-research literature on brand familiarity and frequency.
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*.
+- HCI literature on user resistance to redesigns (various sources, 1990s onward).

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-onboarding/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-onboarding/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: exposure-onboarding
+description: 'Use the exposure effect deliberately in onboarding and habit formation — getting users to repeated, low-friction encounters with the product so familiarity builds and preference forms. Use when designing onboarding flows, planning feature introductions, building user habits, or evaluating why users churn after first use. The exposure effect operates over time; products that get users to come back early benefit from accumulated familiarity that single-session products don''t.'
+---
+
+# Exposure Effect — onboarding and habit
+
+The exposure effect operates through repetition. A user who encounters your product once is at the start of the curve; a user who encounters it daily for a week is much further along. Designing onboarding to maximize early exposure — getting users back into the product repeatedly with low friction — builds the familiarity that supports long-term retention.
+
+## The first-week imperative
+
+Most product churn happens in the first week. Users who don't return within a week typically don't return at all. The mechanism is exposure: users who don't return haven't built enough familiarity for the exposure effect to operate. Their initial impression doesn't have time to consolidate.
+
+Products that successfully retain users almost always achieve high first-week return frequency. Whether this is by:
+
+- Genuinely useful daily-use cases (calendar, email, messaging).
+- Notification-driven re-engagement (within reasonable limits).
+- Ritual integration (a morning reading habit, a daily check-in).
+- Deliberate first-week onboarding that brings users back.
+
+The retention pattern is consistent: repeated exposure in the first week predicts long-term retention.
+
+## Designing for early exposure
+
+**Reduce friction to return.** The lowest-friction return is no friction at all — push notifications, email reminders, or other prompts. The next-lowest is one-tap return (an icon on the home screen, a saved tab). Anything that requires effort to return reduces return frequency.
+
+**Give users a reason to return.** New content, updated information, social interaction, scheduled events, recommendations. Each return has to deliver something; otherwise the exposure cost outweighs the benefit.
+
+**Make first sessions complete enough to return for.** A user who completes a meaningful task on first session has a positive memory to return to. A user who didn't complete anything has no positive baseline.
+
+**Build in natural use cycles.** Daily check-in, weekly review, morning catch-up — habits that align with users' existing routines.
+
+**Leverage notifications carefully.** Notifications can drive return but can also build resentment. The right level of notification varies by product and user; over-notification is the most common failure mode.
+
+## What "low friction" means
+
+Friction in this context is anything that costs the user time or attention to return to the product:
+
+- **High friction:** open a browser, type a URL, log in, navigate to the relevant section.
+- **Medium friction:** open a saved tab or bookmarked link, then navigate.
+- **Low friction:** open the app from the home screen.
+- **Very low friction:** tap a notification that takes you directly to the relevant content.
+- **Negative friction:** the relevant content surfaces ambient (a watch face, a widget, a daily email).
+
+Each step down the friction ladder dramatically increases the return rate. The exposure effect needs return; whatever friction you can eliminate from return makes the effect work harder for you.
+
+## Worked examples
+
+### A meditation app's first-week design
+
+A meditation app onboards users with:
+- Day 1: 5-minute introductory session; immediate value.
+- Day 2: notification reminder; another 5-minute session.
+- Day 3: notification with a curated session matching the user's first-day choice.
+- Day 4: a celebration of "3 days in a row" with a slightly longer session.
+- Day 5–7: continued reminders and varied content.
+
+By day 7, the user has had 5–7 exposures, has formed a small habit, and has experienced the product's value repeatedly. The exposure effect has operated; the user now likes the app more than they would after a single session.
+
+This pattern (reminders + valuable content + habit cues) is common across successful habit-forming apps.
+
+### A productivity tool that fails to onboard for return
+
+A productivity tool gets users to sign up. They complete onboarding. They use the tool for an hour, find some value. Then they don't return for 3 weeks; when they do, they've forgotten how it works. They get frustrated and stop using it.
+
+The failure: no mechanism to bring users back in the first week. Without repeated early exposure, the familiarity didn't consolidate; the next session felt like starting over; the product never became part of the user's routine.
+
+The fix: notification campaigns in the first week reminding users of the value; weekly digest emails; integration with calendar / email so the product surfaces in existing workflows.
+
+### A reading app with daily content
+
+A reading app delivers a curated article to users daily. Users open the app each morning to read the day's article. The content delivery is the return mechanism; the exposure effect operates through the daily ritual.
+
+Over weeks and months, users develop strong preference for the app. Even if a competitor launched with technically better features, the daily-habit familiarity would keep users with the original.
+
+### Notifications that backfire
+
+A new social app sends 5–10 notifications per day to new users to drive engagement. Initial engagement is high. After a week, users are exhausted; many uninstall the app or disable notifications.
+
+The mechanism: too much exposure, the wrong kind. The notifications became an annoyance rather than a positive prompt. The exposure effect requires positive or neutral experiences; pestering users creates negative association.
+
+The fix: calibrate notification frequency. Send fewer notifications; make each one more valuable. Let users control the cadence.
+
+### A B2B SaaS with weekly value
+
+A B2B analytics tool delivers a weekly summary email of insights from the user's data. Users open it once a week to see what's interesting. The email has a one-click path back to the full product.
+
+This pattern works for tools that don't need daily use but benefit from weekly check-ins. The weekly cadence is enough to maintain familiarity; the weekly email is the return mechanism.
+
+## Anti-patterns
+
+**Onboarding without ongoing engagement.** A great onboarding experience that ends after day 1. The user has been introduced to the product but isn't being brought back.
+
+**Over-notification.** Too many or too irrelevant notifications. Builds resentment rather than habit. The most common failure mode in product growth.
+
+**Friction at the return path.** A login required every time; an app that takes 10 seconds to load; a path to relevant content that takes 5 navigation steps. Each friction reduces return rate.
+
+**Generic re-engagement.** Notifications that don't show the user that the product has paid attention. "Come back to the app!" without specifics is less effective than "Your weekly summary is ready" or "John commented on your post."
+
+**Assuming users will come back on their own.** Most users won't. Without active re-engagement, the early-week exposure won't happen.
+
+**Deferring monetization until familiarity exists, but then not building familiarity.** Strategy of "we'll monetize later" only works if you actually build the user base; without exposure-driven retention, there's nothing to monetize later.
+
+## Heuristic checklist
+
+When designing for early exposure, ask: **What's the first-week return frequency we're targeting?** Be specific. **What's the mechanism for return?** Notifications, email, habit, ritual. **Is the friction to return low enough?** Each step costs return rate. **Does each return deliver something specific?** Generic "come back" isn't enough. **Are we calibrated to avoid annoyance?** Over-notification is the most common failure.
+
+## Related sub-skills
+
+- `exposure-effect` — parent principle on the mere-exposure phenomenon.
+- `exposure-redesign-risk` — sibling skill on managing accumulated familiarity during redesigns.
+- `feedback-loop` — early feedback supports the value that brings users back.
+- `mental-model` — the mental model is built through exposure.
+- `hierarchy` — first sessions should foreground the value; bury complexity.
+
+## See also
+
+- `references/onboarding-cadences.md` — patterns for first-week onboarding cadences.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-onboarding/references/onboarding-cadences.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-onboarding/references/onboarding-cadences.md
@@ -1,0 +1,146 @@
+# Onboarding cadences
+
+Patterns for first-week onboarding designed to maximize exposure and build familiarity.
+
+## Pattern: daily-habit cadence
+
+Designed for products that benefit from daily use (meditation, journaling, exercise tracking, language learning).
+
+**Day 1:** complete onboarding; immediate value experience (a 5-minute session, a short lesson, an initial entry).
+
+**Day 2:** notification at the same time as Day 1; encourage return; deliver another small valuable experience.
+
+**Day 3:** continued notification; vary the content slightly to maintain interest.
+
+**Day 4–5:** reinforce the building habit with a small celebration ("You're on a 4-day streak!").
+
+**Day 6–7:** maintain the cadence; introduce a new feature or deeper capability now that the user is engaged.
+
+**Week 2 onward:** reduce notification cadence to maintenance level; the habit is forming.
+
+This cadence works because daily exposure builds familiarity quickly and the daily ritual integrates the product into users' routines.
+
+## Pattern: weekly-rhythm cadence
+
+Designed for products that don't need daily use but benefit from weekly check-ins (analytics, financial summaries, content roundups, project updates).
+
+**Day 1:** complete onboarding; deliver immediate value; tell users about the weekly cadence ("You'll get a summary every Monday").
+
+**Day 8:** first weekly summary email/notification with personalized content from the past week.
+
+**Day 15, 22, 29:** continued weekly summaries; refine based on what users engage with.
+
+**Month 2 onward:** weekly cadence maintained; users have integrated the product into their weekly routine.
+
+This pattern works for products where daily use would be overkill but weekly engagement is valuable.
+
+## Pattern: trigger-driven re-engagement
+
+Designed for products users come to when something specific happens (event-based products, on-demand services).
+
+**Day 1:** complete onboarding; user knows what triggers will bring them back.
+
+**When trigger occurs:** the product reaches out (notification, email) at the moment of relevance.
+
+**Between triggers:** minimal contact; let the product wait for the next trigger.
+
+This pattern works for products where the value is real but irregular. The exposure effect builds through the relevant moments rather than through daily ritual.
+
+## Pattern: progressive-feature-disclosure cadence
+
+Designed for products with depth that needs gradual introduction.
+
+**Day 1:** complete onboarding; the user sees the simple-mode interface; completes a basic task.
+
+**Day 2–3:** notifications introduce one new feature each, related to what the user has been doing.
+
+**Day 4–7:** continued feature introductions; each tied to a real use case.
+
+**Week 2:** by now, the user has been exposed to most of the product's capabilities; depth becomes available without overwhelming.
+
+This pattern works for products that span novice and expert use. The early exposure is to the simple side; depth is introduced as familiarity builds.
+
+## Pattern: social-driven re-engagement
+
+Designed for products where other users are part of the value (social networks, collaboration tools, marketplaces).
+
+**Day 1:** complete onboarding; connect to other users (invite friends, join groups, find collaborators).
+
+**Day 2 onward:** notifications driven by other users' activity (someone replied, your team made progress, a new item appeared).
+
+**Long-term:** the social connections become the return mechanism; the product is a venue for ongoing interaction.
+
+This pattern is powerful but requires that other users actually exist and are active. Cold-start problems are real.
+
+## Components of effective cadences
+
+**Notifications:** the primary mechanism for bringing users back. Calibrate frequency carefully; over-notification is the most common failure.
+
+**Email:** lower-frequency than notifications but valuable for richer content and specific engagement.
+
+**In-product cues:** badges, streaks, progress indicators that give users a reason to return.
+
+**Calendar / time-based:** scheduled events users can plan around (a weekly meeting, a daily session).
+
+**External integration:** widgets on the home screen, watch faces, browser extensions that surface relevant content ambient.
+
+## Calibrating notification frequency
+
+Too few notifications: users forget the product exists; the exposure effect doesn't operate.
+
+Too many notifications: users get annoyed; uninstall the app or disable notifications; the effect reverses.
+
+The right level depends on:
+
+- **Product type.** Daily-use products tolerate daily notifications. Occasional-use products need fewer.
+- **Notification value.** A notification that brings something specific and valuable can be daily. A generic "come back" can be at most weekly.
+- **User preferences.** Different users want different frequencies. Provide controls.
+- **Time of day.** Notifications at appropriate moments (not in the middle of the night) maintain goodwill.
+
+A starting heuristic: send the minimum number of notifications that achieves the engagement goal. Add more only if measurement shows users want them.
+
+## Friction reduction for return
+
+Each step of friction reduces return rate. The hierarchy:
+
+**Highest friction (worst):** "Open browser, navigate to URL, log in, click around to find relevant content."
+
+**Lower:** "Open the app, navigate to the relevant section."
+
+**Even lower:** "Open the app to a homepage that shows what's new."
+
+**Lower still:** "Tap a notification that opens directly to the relevant content."
+
+**Lowest (best):** "See the relevant content surface ambient (widget, watch face, dashboard at-a-glance)."
+
+For each return path your users take, find ways to move down the friction ladder. Each step improves return rate.
+
+## Anti-patterns
+
+**The "ghost town" cadence.** No re-engagement at all. Users complete onboarding and never come back unless they remember on their own.
+
+**The "spammer" cadence.** Many notifications per day. Initial engagement spike, then mass uninstall.
+
+**The "irrelevant" cadence.** Notifications that don't match user interests. Users disable notifications; you've lost the channel.
+
+**The "fake urgency" cadence.** "Come back!! You're missing out!!" Users see through the artificial urgency and disengage.
+
+**The "no value at the destination" cadence.** Notifications that drive users back to a product that doesn't deliver something new. Users feel tricked.
+
+**The "rigid schedule" cadence.** Same notification at the same time every day regardless of context. Becomes background noise; loses effectiveness.
+
+## Measuring success
+
+Track metrics that reflect the exposure effect's operation:
+
+- **First-week return rate.** What % of users return at least N times in the first week?
+- **Habit formation rate.** What % of users have established a return pattern (daily, weekly, etc.) by day 30?
+- **Long-term retention.** What % of users active at day 30 are still active at day 90 / 180 / 365?
+
+If first-week return rate is low, the early exposure isn't happening. If habit formation rate is low, the product isn't sticking. If long-term retention is low despite habit formation, the product isn't continuing to deliver value.
+
+Each metric points to a different problem; treat accordingly.
+
+## Cross-reference
+
+For redesign-related exposure issues, see `exposure-redesign-risk`. For the parent principle, see `exposure-effect`.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-redesign-risk/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-redesign-risk/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: exposure-redesign-risk
+description: 'Manage the risks of redesigns when users have built up exposure-based preference for the existing design. Use when planning a major redesign, evaluating user backlash to changes, deciding between incremental and radical change, or recovering from a redesign that generated complaints. Users like what they''re used to; redesigns must be planned to manage the transition cost. Even objectively-better redesigns trigger resistance disproportionate to the actual change.'
+---
+
+# Exposure Effect — redesign risk
+
+The most common collision between the exposure effect and product practice: redesigns. Users have built up familiarity with the existing design through repeated exposure. The familiarity is itself an asset — it carries positive preference that the new design has to earn back. Even objectively-better redesigns trigger user resistance disproportionate to the change.
+
+Designers consistently underestimate this resistance. They see the new design as obviously better; they assume users will see it the same way; they're surprised when users complain bitterly about the loss of the familiar.
+
+Managing redesigns well means:
+
+1. Recognizing that the existing design has accumulated value beyond its intrinsic merit.
+2. Planning transitions that respect that value.
+3. Communicating thoughtfully about changes.
+4. Calibrating change size to what users can absorb.
+
+## Why redesigns generate disproportionate backlash
+
+Several factors compound:
+
+**Familiarity-based preference.** Users like the old design partly because they're used to it. The exposure effect operates; the preference is real even if not consciously articulated.
+
+**Learning cost.** The new design requires relearning. Even if the new design is more learnable for new users, existing users have to unlearn and relearn.
+
+**Loss aversion.** Users who have built up specific workflows experience the change as loss. Loss looms larger than equivalent gain.
+
+**Trust effects.** Redesigns often trigger suspicion ("why did they change this?"); users wonder if their interests are being served.
+
+**Vocal minority dynamics.** Most users adapt silently; the minority who complain are loud. The volume of complaint isn't proportional to the actual user population's distress.
+
+The result: even objectively-better redesigns generate disproportionate backlash. Designers should expect this and plan for it.
+
+## Calibrating change size
+
+The relationship between change size and backlash is non-linear:
+
+**Small changes** (a slight color tweak, an icon update, a minor layout adjustment): typically trigger little backlash. Most users don't even notice.
+
+**Medium changes** (a redesigned settings panel, a new navigation pattern, a feature renamed): trigger noticeable but manageable backlash. Some users complain; most adapt.
+
+**Large changes** (a new layout for the main view, a fundamental rethinking of the workflow): trigger substantial backlash. Even objectively-better designs require months of communication and transition support.
+
+**Radical changes** (the product looks and works very differently): can trigger user revolt. Even with the best execution, expect significant churn.
+
+The lesson: incremental change preserves enough familiarity to avoid major backlash. Radical change requires either great execution (with explicit communication and transition support) or accepting substantial pain.
+
+## Planning a redesign
+
+A well-planned redesign:
+
+**1. Justifies the change.** The existing design's familiarity-based value is real. The new design must earn its place by being substantially better, not just different.
+
+**2. Communicates in advance.** Users hear about the redesign before it ships. They have time to anticipate, plan, and prepare. Surprise redesigns trigger more backlash than expected ones.
+
+**3. Provides a transition period.** Both old and new designs available during the transition; users can adopt at their own pace. The transition reduces forced unlearning.
+
+**4. Offers explicit help for the transition.** Documentation, video tutorials, in-product tours that show users how the new design accomplishes what the old did.
+
+**5. Listens to feedback during the transition.** Users surface real issues that designers missed. Adjust based on feedback.
+
+**6. Times the rollout carefully.** Avoid major redesigns at peak business moments (year-end, tax season for tax software, major events for event-related products).
+
+**7. Has a fallback plan.** If the redesign generates major backlash, can the team partially or temporarily revert? Plan for this contingency.
+
+## When radical change is justified
+
+Sometimes radical change is needed. Specifically:
+
+- **The existing design has fundamental problems** that can't be incrementally fixed.
+- **The product's purpose has changed** and the design needs to reflect the new purpose.
+- **Technology constraints have shifted** in ways that allow much better designs.
+- **The competition has moved on** and users will leave for better-designed alternatives if you don't catch up.
+
+Even in these cases, plan the radical change carefully. Communicate extensively. Provide transition support. Accept that backlash will occur and have a plan for it.
+
+## Worked examples
+
+### A successful incremental evolution
+
+A long-standing product evolves continuously. Each release includes small refinements: slightly updated typography, slight color adjustments, a streamlined flow here and there. No release is a "redesign"; the cumulative effect over years is substantial change.
+
+Users barely notice. They adapt to each small change easily. The product feels current without ever triggering backlash.
+
+This is the gold standard: continuous evolution that respects familiarity while still moving forward.
+
+### A radical redesign that triggered backlash
+
+A productivity tool ships a major redesign with new layout, new navigation, new visual style. Users complain bitterly on social media. Power users threaten to switch products. Help center is overwhelmed with confused questions.
+
+Investigation reveals: the new design is objectively better in many ways, but the change is too large at once. Users who had years of accumulated familiarity are forced to relearn everything.
+
+Recovery plan:
+- Restore some familiar elements that users particularly missed.
+- Provide an "old layout" mode for users who want to migrate gradually.
+- Publish detailed migration guides.
+- Wait. Over months, the backlash subsides as users build familiarity with the new design.
+
+A year later, most users have adapted. The redesign was probably the right call; the execution was rough.
+
+### A failed redesign
+
+A web product ships a redesign that simplifies the interface but removes features power users depend on. Backlash is severe. The team holds firm; the features remain removed.
+
+Power users churn to competitors. The product loses its most-engaged audience. The simpler design appeals to a different audience that was supposed to grow but doesn't grow as fast as power users left.
+
+Net result: the product never recovers. The exposure-based preference of power users for the old design was tied to features they actually used; removing those features sent them away.
+
+The lesson: don't strip features users genuinely depend on, even in pursuit of simplification.
+
+### A successful gradual rollout
+
+A product plans a major redesign. Rather than shipping everything at once, they:
+
+- Roll out the new design to 5% of users first.
+- Measure: are users adopting? Are they completing tasks? Are they happy?
+- Adjust based on what's discovered.
+- Roll out to 25%, then 50%, then 100% over months.
+- The full rollout is on the team's schedule but driven by what each cohort experiences.
+
+The slower rollout costs time but produces a better outcome: issues are caught before affecting all users; the team can adjust; users have time to provide feedback.
+
+## Anti-patterns
+
+**Redesigning for the team's benefit.** A new visual style "because the old one feels dated to us." Users may not feel it's dated; the change costs them. Justify redesigns by user benefit, not designer aesthetic.
+
+**Surprise redesigns.** Shipping a redesign with no warning. Users open the product to find everything different. Maximum backlash.
+
+**Removing features in the redesign.** Users who depended on the removed features feel the loss intensely. If features must be removed, treat them as a separate decision, communicate clearly.
+
+**Holding firm against substantive feedback.** Some user complaints are about real problems with the new design, not just resistance to change. Distinguish the two; address the real issues.
+
+**Reverting at the first sign of backlash.** Some backlash is inevitable; reverting too quickly suggests the team doesn't believe in the new direction. Persistence is sometimes warranted.
+
+**Shipping radical change because a competitor did.** Following competitors into design changes that may not serve your users. Make decisions based on your users' actual needs.
+
+**Frequent redesigns.** Redesigning every few years sacrifices accumulated familiarity each time. Continuous evolution is better than periodic upheaval.
+
+## Heuristic checklist
+
+Before launching a redesign, ask: **Is the change substantively justified by user benefit?** If not, reconsider. **Is the change size calibrated to what users can absorb?** Smaller is safer. **Is there a transition plan?** Communication, gradual rollout, optional fallback. **Have we expected and planned for backlash?** Don't assume users will love it. **What's the contingency if backlash is severe?** Partial revert, longer transition, etc.
+
+## Related sub-skills
+
+- `exposure-effect` — parent principle on familiarity-based preference.
+- `exposure-onboarding` — sibling skill on building familiarity for new users.
+- `iteration` — small iterations preserve familiarity better than radical changes.
+- `consistency` — internal consistency over time builds the familiarity that redesigns risk.
+- `control-power-vs-simplicity` — simplification trade-offs that often trigger backlash.
+
+## See also
+
+- `references/redesign-playbook.md` — step-by-step playbook for executing major redesigns.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-redesign-risk/references/redesign-playbook.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/exposure-redesign-risk/references/redesign-playbook.md
@@ -1,0 +1,126 @@
+# Redesign playbook
+
+A step-by-step playbook for executing major redesigns while managing exposure-effect risks.
+
+## Phase 1: justify
+
+**Articulate the user benefit.** What specific user problems does the redesign solve? Be concrete. "Modernize the visual design" isn't a user benefit; "make it easier for users to find X" is.
+
+**Quantify if possible.** If the redesign improves measurable outcomes (task completion rate, time-to-value, user satisfaction), articulate the targets.
+
+**Compare against the cost.** The cost includes: the engineering work, the user transition cost, the risk of backlash, the risk of churn. Is the user benefit large enough to justify all of this?
+
+**Get sign-off from key stakeholders.** Including support (who will field user complaints), marketing (who will communicate the change), and leadership (who will hear the complaints).
+
+If the justification isn't strong, reconsider. Many proposed redesigns aren't actually worth the cost.
+
+## Phase 2: design
+
+**Design with the existing user in mind.** Power users have specific workflows they depend on. The new design should serve those workflows, even if it changes how they look.
+
+**Map the changes.** For each change, identify: what users currently do, how the new design changes that, what users will need to learn or unlearn.
+
+**Identify the riskiest changes.** Some changes will trigger more backlash than others. The riskiest changes should be the most justified.
+
+**Plan for migration.** For each change, what's the migration path? Documentation, in-product hints, support resources.
+
+**Test with users.** Before shipping, test the new design with representative users. Both new users (who'll see only the new design) and existing users (who have built-up familiarity).
+
+## Phase 3: communicate (pre-launch)
+
+**Announce in advance.** 30–90 days before launch, depending on scale.
+
+**Multiple channels.** Blog post, email to active users, in-product banner, social media. Different users encounter different channels.
+
+**Be specific about what's changing.** Don't be vague about "improvements." Tell users specifically what will look or work differently.
+
+**Explain the why.** Users tolerate change better when they understand the reasoning. Even users who disagree with the reasoning appreciate that it exists.
+
+**Acknowledge the costs.** "We know change is hard. Here's how we're trying to make it easier." Recognition of user investment in the existing design builds goodwill.
+
+**Open feedback channels.** Make it easy for users to share concerns or questions. Listen and respond.
+
+## Phase 4: gradual rollout
+
+**Start with a small percentage.** 1–10% of users. Watch for issues you didn't anticipate.
+
+**Measure during rollout.** Are users completing tasks? Are they happy? Are support tickets spiking?
+
+**Adjust based on what you learn.** Sometimes rollout reveals issues that need fixing before broader release.
+
+**Increase percentage over time.** 5% → 25% → 50% → 100% over weeks or months.
+
+**Allow users to opt out (where feasible).** A "use old layout" option gives users control during the transition. Plan to remove the option eventually but during transition, it reduces backlash.
+
+## Phase 5: support during transition
+
+**Documentation.** Detailed migration guides for major workflows. "If you used to do X, you now do Y."
+
+**Video tutorials.** Some users learn better from video than text. Both are useful.
+
+**In-product help.** Tooltips, banners, walkthroughs that show users the new patterns.
+
+**Customer support readiness.** Brief support team on the changes; provide them with quick-answers; expect ticket volume to spike.
+
+**Active feedback collection.** Ask users how the transition is going. Use the feedback to refine.
+
+**Transparent fix process.** When users report bugs or unintended consequences, fix them quickly and visibly. Demonstrating responsiveness rebuilds trust.
+
+## Phase 6: post-launch monitoring
+
+**Track key metrics.** User satisfaction, task completion, support ticket volume, churn rate. Compare to pre-launch baselines.
+
+**Listen to ongoing feedback.** Some issues only surface after broader use. Continue collecting feedback for months.
+
+**Plan for follow-up improvements.** No first ship is perfect. Schedule fast-follow improvements based on feedback.
+
+## Phase 7: long-term integration
+
+**Remove transitional fallbacks.** After enough time (3–6 months typically), remove "use old layout" options. The transition period ends.
+
+**Update documentation, marketing, training.** Old screenshots and references should be updated to reflect the new design.
+
+**Capture lessons.** Document what went well and what didn't. Use the learnings for future redesigns.
+
+## Variants for different change sizes
+
+**Small change.** Phases 2 and 7 may be all you need. Communicate briefly; no extensive rollout or transition support needed.
+
+**Medium change.** Skip the gradual rollout if confidence is high. Communicate; ship; support; refine.
+
+**Large change.** Use the full playbook. Don't skip phases.
+
+**Radical change.** Use the full playbook plus: longer transition periods, more communication, more transition support, possibly an extended dual-layout period.
+
+## Anti-patterns
+
+**Skipping the justification phase.** Redesigns that aren't actually justified by user benefit. The team finds out the hard way that change-for-change's-sake doesn't pay back.
+
+**Shipping with no advance communication.** Surprise redesigns trigger maximum backlash.
+
+**Big-bang releases without gradual rollout.** Issues that affect all users at once produce coordinated backlash.
+
+**Ignoring early feedback.** Backlash that gets worse over time often started with early signals that were dismissed.
+
+**Removing the transitional fallback too quickly.** Users still adapting need the option to revert; removing it before they're ready triggers a second wave of backlash.
+
+**Persisting with a redesign users genuinely hate.** Some redesigns are bad. Sometimes the right call is to revert or significantly modify. Distinguish "users resisting change" (will subside) from "users hating the new design" (won't subside).
+
+## A timeline template for major redesigns
+
+- **T-90 days:** justification finalized; communication plan drafted.
+- **T-60 days:** initial announcement to users; design finalized.
+- **T-30 days:** detailed announcements; migration content published.
+- **T-7 days:** final reminder; support team briefed.
+- **T-0:** rollout begins (5% of users).
+- **T+7 days:** rollout to 25% if metrics look healthy.
+- **T+14 days:** rollout to 50%.
+- **T+30 days:** rollout to 100%.
+- **T+30 to T+180:** transition support active; "old layout" option available.
+- **T+180:** transition support reduced; "old layout" option removed.
+
+This is a starting template; calibrate to your product and audience.
+
+## Cross-reference
+
+For onboarding-related exposure design, see `exposure-onboarding`. For the parent principle, see `exposure-effect`.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function-as-axiom/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function-as-axiom/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: form-follows-function-as-axiom
+description: 'Use this skill when applying the descriptive form-follows-function interpretation — functional clarity as a source of aesthetic quality. Trigger when designing tools, dashboards, or instrumental surfaces where every element should earn its presence. Sub-aspect of `form-follows-function`; read that first.'
+---
+
+# Form follows function as descriptive axiom
+
+The descriptive interpretation: beautiful design tends to result from purity of function. Every visible element has a purpose; nothing decorative without function. The result tends to be coherent, timeless, and pleasing without being explicitly "designed for beauty."
+
+## When the descriptive interpretation applies cleanly
+
+- **Industrial tools** (Leatherman, Dyson, Snap-on) — function-derived form is what users want.
+- **Information design** (Tufte-style charts, transit maps) — every mark earns its place.
+- **Working software UI** (IDEs, dashboards, admin panels) — clarity dominates.
+- **Type design** (Helvetica, Inter, IBM Plex) — function (legibility) drives the form.
+- **Architecture for utility** (warehouses, factories, infrastructure) — pure function reads as visually honest.
+
+In these contexts, the rule "strip what doesn't serve function" usually improves the result.
+
+## How to apply
+
+1. **Identify function clearly.** What does this design do? What's its primary purpose?
+2. **Audit each visible element.** Does it serve the function? If not, it's a candidate to cut.
+3. **Trust the result.** Function-derived form tends to be visually compelling without explicit decoration.
+
+## Worked examples
+
+### A monitoring dashboard
+
+Function: rapid comprehension of system state.
+
+Form-follows-function moves:
+- Strip decorative borders.
+- Use a minimal color palette; reserve color for status semantics.
+- Place key metrics in dominant positions.
+- Remove ornamental icons that don't aid comprehension.
+
+Result: a dashboard that feels designed even though no decoration was added.
+
+### A typeface
+
+Function: legibility at small sizes; durability across rendering environments.
+
+Form-follows-function moves:
+- Open counters (the spaces inside letters).
+- Distinctive characters (clear distinction between l, 1, I).
+- Optical adjustment for size (different shapes at different sizes).
+
+Result: a typeface like Inter or IBM Plex Sans that's beautiful precisely because every letter is shaped for reading.
+
+## When to depart from the descriptive interpretation
+
+- **Brand surfaces** where personality matters as much as function.
+- **Marketing materials** where attention is the function.
+- **Consumer products** competing on appeal.
+
+In these contexts, "strip what doesn't serve narrow function" loses to "include what serves broader function (including engagement and brand)."
+
+## Related sub-skills
+
+- **`form-follows-function`** (parent).
+- **`form-follows-function-success-criteria`** — defining what counts as function.
+- **`signal-to-noise-ratio`** — the operational version.
+- **`ockhams-razor`** — preferring simpler solutions.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function-as-axiom/references/descriptive-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function-as-axiom/references/descriptive-cases.md
@@ -1,0 +1,38 @@
+# Descriptive form-follows-function: case reference
+
+A reference complementing `form-follows-function-as-axiom` with case examples.
+
+## Iconic descriptive form-follows-function designs
+
+### Industrial design
+- **OXO Good Grips peeler** — handle shaped for grip; angled blade for cutting; nothing decorative.
+- **Eames Lounge Chair** — molded plywood and leather shaped for body; iconic without ornament.
+- **Braun T3 pocket radio** — Dieter Rams; clean controls, restrained palette.
+- **Anglepoise lamp** — articulating arm; counterweight visible; function is the form.
+
+### Software / type
+- **Helvetica** — letters shaped for legibility; widely adopted as a "neutral" sans-serif.
+- **The Unix command line** — function over decoration; aesthetics emerge from utility.
+- **Tufte's *Sparklines*** — data-rich tiny graphics with minimal chrome.
+
+### Architecture
+- **Mies van der Rohe's Seagram Building** — curtain-wall glass, exposed structure; "less is more" exemplified.
+- **Bridges by Robert Maillart** — concrete shaped by the loads it carries; structurally honest.
+- **Sydney Opera House** — function (acoustics, scale) shaped form, though here aesthetic intent was strong from the start.
+
+## Why descriptive form-follows-function works
+
+When every visible element has a purpose, the design tends to:
+
+- Feel coherent — nothing fights anything else.
+- Age well — function-driven shapes don't go out of style as quickly.
+- Communicate quality — visible purpose reads as competence.
+- Earn trust — no obvious extraneous claims.
+
+The mechanism: humans seem to recognize purposeful design intuitively, perhaps via the same pattern-detection that finds beauty in natural forms shaped by adaptation.
+
+## Resources
+
+- Rams, D. "Ten Principles for Good Design."
+- Lupton, E. *The ABCs of Bauhaus.*
+- Pye, D. *The Nature and Aesthetics of Design* (1978).

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function-success-criteria/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function-success-criteria/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: form-follows-function-success-criteria
+description: 'Use this skill when the team is in a form-vs-function debate and needs to step back to define what "success" actually means for the design. Trigger when stakeholders disagree about visual treatment, when a design feels off and no one can articulate why, or when reviewing a design against an unclear brief. Sub-aspect of `form-follows-function`; read that first.'
+---
+
+# Defining success criteria explicitly
+
+The book's reframe of form-follows-function: instead of asking "what should be omitted?", ask "what's critical to this design's success?". Then weigh form and function against those criteria. The discipline is making success criteria explicit rather than assuming.
+
+## Common implicit success criteria
+
+Without explicit criteria, teams default to assumed criteria — often without alignment:
+
+- Designer assumes: visual elegance.
+- Engineer assumes: implementation simplicity.
+- Product manager assumes: feature completeness.
+- Marketing assumes: brand differentiation.
+- Stakeholder assumes: stakeholder approval.
+
+When the assumed criteria differ, every design decision becomes contentious. Explicit criteria make decisions defensible.
+
+## Naming success criteria
+
+For a given design, candidates include:
+
+- **User performance** (speed, accuracy, error rate).
+- **User satisfaction / preference.**
+- **Business outcomes** (conversion, retention, revenue).
+- **Brand differentiation** (does this look unmistakably like us?).
+- **Accessibility / inclusion.**
+- **Implementation simplicity / cost.**
+- **Long-term maintainability.**
+- **Aesthetic / emotional response.**
+
+Most designs serve multiple criteria; the question is which dominate when they conflict.
+
+## A team exercise
+
+For a design in dispute:
+
+1. **List the criteria** the design should serve.
+2. **Rank them** by priority for this specific surface.
+3. **For each candidate design choice**, evaluate against the top 2–3 criteria.
+4. **Pick the choice** that does best on top criteria; accept trade-offs on lower ones.
+
+This conversation surfaces hidden disagreements about what the design is *for*. Resolving those usually resolves the surface debates.
+
+## Worked example
+
+A landing-page hero section is in dispute. Designer wants minimalist (one headline, one CTA); marketing wants rich (headline, deck, three feature bullets, social proof, primary + secondary CTA).
+
+Without explicit criteria, the debate is irresolvable. Each side has a defensible position.
+
+With explicit criteria:
+
+- **Conversion rate**: rich variants tend to convert better in A/B tests for new visitors. Marketing's position favored.
+- **Brand differentiation**: minimalist often differentiates better in cluttered spaces. Designer's position favored.
+- **Mobile experience**: minimalist tends to perform better on small screens. Designer's position favored.
+
+If conversion rate is the dominant criterion, marketing wins this round; ship rich and A/B test. If brand differentiation is dominant, designer wins. The criteria choice resolves the debate.
+
+## When form genuinely competes with function
+
+Some legitimate trade-offs:
+
+- **Visual polish vs. load time** — animations, large images cost performance.
+- **Brand differentiation vs. convention adherence** — distinctive design departs from familiar patterns.
+- **Aesthetic minimalism vs. discoverability** — fewer visible elements = harder to find features.
+- **Custom vs. native components** — custom looks distinctive but is more expensive and risks accessibility.
+
+Each trade-off should be made deliberately, with success criteria informing the choice.
+
+## Anti-patterns
+
+- **Implicit criteria.** Each team member assumes different criteria; debates are unresolvable.
+- **All-criteria-must-be-served.** Trying to optimize for everything produces designs that serve nothing well.
+- **Designer-as-arbiter.** "I'm the designer, so I get to decide" — without explicit criteria, this is unconvincing.
+- **Stakeholder-as-arbiter.** "The CEO likes it" — same problem.
+
+## Heuristics
+
+1. **The criteria-naming exercise.** Before designing, list and rank success criteria. Get team alignment.
+2. **The trade-off-explicitness check.** When trading off, name what's being sacrificed. "We're sacrificing brand differentiation for convention adherence."
+3. **The dominant-criterion test.** When stuck, ask: which criterion matters most for *this surface* (not in general)? That answer often resolves.
+
+## Related sub-skills
+
+- **`form-follows-function`** (parent).
+- **`form-follows-function-as-axiom`** — the descriptive interpretation.
+- **`hierarchy-of-needs`** (interaction) — Maslow-derived ordering of design needs.
+- **`flexibility-usability-tradeoff`** — explicit trade-off framing.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function-success-criteria/references/criteria-frameworks.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function-success-criteria/references/criteria-frameworks.md
@@ -1,0 +1,42 @@
+# Success criteria: framework reference
+
+A reference complementing `form-follows-function-success-criteria` with frameworks for naming criteria.
+
+## Frameworks for success criteria
+
+### Maslow's hierarchy adapted to design (Hierarchy of Needs)
+
+The book's Hierarchy of Needs principle adapts Maslow:
+
+1. **Functionality** (the basic requirements).
+2. **Reliability** (works consistently).
+3. **Usability** (easy to use).
+4. **Proficiency** (lets users do new things).
+5. **Creativity** (lets users express themselves).
+
+Each level is necessary before the next. Success criteria for a new product start at the bottom; mature products invest higher.
+
+### Norman's three levels of design
+
+Donald Norman's *Emotional Design* distinguishes:
+
+- **Visceral**: gut-level reaction to appearance.
+- **Behavioral**: pleasure of use; how it works.
+- **Reflective**: long-term meaning; what owning/using it says about you.
+
+Different products optimize different levels. Mass-market products often need all three; specialized tools may only need behavioral.
+
+### Jobs-to-be-done
+
+Clay Christensen's framework: users "hire" products to do specific jobs. Success criteria derive from how well the product does its job vs. alternatives.
+
+### OKRs and product metrics
+
+Modern product management defines explicit metrics: north-star metric, secondary metrics, guardrail metrics. Each is a success criterion the design must serve.
+
+## Resources
+
+- Norman, D. *Emotional Design* (2004).
+- Christensen, C. et al. "Know Your Customers' 'Jobs to Be Done'" (HBR, 2016).
+- Doerr, J. *Measure What Matters* (2018) — OKRs.
+- Lidwell, Holden, Butler — *Universal Principles of Design* (2003), Hierarchy of Needs entry.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: form-follows-function
+description: 'Use this skill when designing the visual or aesthetic layer of a product, deciding between expressive style and functional restraint, evaluating decorative elements, or arguing about whether a feature should ship plain vs. polished. Trigger when stakeholders ask "should we add visual flair to this?", when reviewing a design that "feels too decorated," or when picking between competing visual directions. Form Follows Function is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) and one of the most-quoted dictums in design — but its meaning depends on which interpretation (descriptive vs. prescriptive) you take.'
+---
+
+# Form Follows Function
+
+The phrase "form follows function" is one of the most-quoted in design — and one of the most variously interpreted. The book makes a useful distinction: the *descriptive* version observes that beautiful design tends to result from purity of function (without ornament for its own sake); the *prescriptive* version asserts that aesthetic considerations should be subordinate to functional ones. The descriptive version is usually right; the prescriptive version, taken too literally, produces designs that achieve their function but fail at being chosen.
+
+## Definition (in our own words)
+
+The principle holds that beauty in design results when the visible form derives clearly from the function the design serves. A well-engineered tool tends to be visually compelling because every visible feature has a purpose; arbitrary decoration tends to feel hollow because nothing earns its presence. The book's key clarification: this is descriptively useful (form often does follow function in good design), but not prescriptively reliable (you can't simply minimize ornamentation and expect to land on the best design — sometimes function and aesthetics genuinely trade off, and sometimes purely aesthetic choices serve the design's larger success).
+
+## Origins and research lineage
+
+- **Carlo Lodoli** (18th-century Italian Jesuit monk) is often credited as the original articulator. His architectural theories influenced later thinkers.
+- **Horatio Greenough** and **Louis Sullivan** popularized the phrase in the late 19th century. Sullivan's article "The Tall Office Building Artistically Considered" (*Lippincott's Magazine*, March 1896) framed it as the principle for the new skyscraper era: form should follow function rather than imitate prior styles.
+- **The Modernist movement** (early 20th century) — Bauhaus, International Style, mid-century industrial design — treated form-follows-function as a guiding doctrine. The result was an enormous body of work that influenced visual culture broadly.
+- **Peter Blake**, *Form Follows Fiasco: Why Modern Architecture Hasn't Worked* (Little, Brown, 1977). A counter-critique: pure form-follows-function modernism produced buildings users hated and societies couldn't sustain. Pure prescriptive interpretation has failure modes.
+- **Lidwell, Holden & Butler** (2003) compactly distinguished the two interpretations and noted that the prescriptive version focuses the designer on the wrong question ("what aspects of form should be omitted?") instead of the right one ("what aspects of the design are critical to success?").
+
+## Why this principle matters
+
+The descriptive insight is real and powerful: when every visible element of a design has a purpose, the design tends to feel honest, coherent, and timeless. Decoration without function tends to feel hollow, dated, or dishonest. Many of the most-admired designs (Apple's industrial design, Braun's appliances, Eames furniture, Helvetica typography) embody this descriptively.
+
+The prescriptive trap is also real: designs that aggressively strip ornament can become alienating, identity-less, or commercially unsuccessful. Some functional decisions genuinely benefit from aesthetic enhancement that isn't strictly "needed" — and audiences may reject the purely functional in favor of the more humane.
+
+The book's reframe is the practical move: instead of "minimize ornament," ask "what's critical to this design's success?" Sometimes the answer includes aesthetic considerations alongside functional ones.
+
+## Descriptive vs. prescriptive
+
+### Descriptive interpretation (usually right)
+
+Beautiful design *tends* to result from purity of function. A well-engineered industrial tool is often more visually compelling than the same tool laden with decorative chrome. A clean information graphic communicates more than the same data buried under chartjunk.
+
+The mechanism: form derived from function tends to be coherent, with every visible feature carrying meaning. Coherence reads as quality.
+
+### Prescriptive interpretation (often wrong)
+
+The prescription "aesthetic considerations should be secondary to functional ones" has a long history of failure modes:
+
+- **Brutalist architecture** that achieved its functional goals but produced spaces users hated.
+- **Software UIs** that "minimize ornament" by stripping affordance signifiers, leaving users unable to tell what's interactive (the post-2013 flat-design regression).
+- **Industrial products** that work perfectly but no one buys because they look unappealing.
+
+Aesthetic-Usability Effect (a separate principle in this plugin set) directly contradicts strict prescriptive form-follows-function: more-aesthetic products are perceived as more usable and tolerated through more friction, *even when actual function is identical*. Pure functional minimalism leaves performance on the table.
+
+## The book's reframe
+
+The book argues: instead of "what aspects of form should be omitted or traded for function?", ask "what aspects of the design are critical to success?". Then weigh form and function in light of those criteria.
+
+A watch designed for *speed and accuracy* should prioritize the digital display (function dominates). A watch designed for *aesthetic enjoyment* should prioritize a minimalist analog face (form dominates). Both are valid; the criteria for "success" determine the right balance.
+
+## When to apply (descriptive form-follows-function)
+
+- **Industrial design** where the product is functional first.
+- **Information graphics** where data communication is the goal.
+- **Interfaces for working tools** (IDEs, dashboards, admin panels).
+- **Type design** where reading speed is critical.
+- **Architectural functionalism** where buildings serve specific use cases.
+
+Stripping unnecessary ornament tends to improve these. The descriptive principle is usefully prescriptive *here*.
+
+## When pure prescriptive form-follows-function fails
+
+- **Brand-identity surfaces** where personality matters as much as efficiency.
+- **Marketing materials** where attention is the function.
+- **Consumer products** competing on aesthetic appeal.
+- **Spaces designed for sustained human occupation** where comfort and warmth matter.
+- **Products in mature categories** where functional differentiation is small and aesthetic differentiation is large.
+
+In these contexts, ornament that doesn't serve narrow function may serve broader success.
+
+## Worked examples
+
+### Example 1: industrial tool design
+
+A Leatherman multi-tool's form derives clearly from function: each blade is shaped for its task; the handle is shaped to be gripped; nothing decorative. The result is visually striking precisely because every feature is purposeful.
+
+A poorly-designed multi-tool with chrome curlicues would be aesthetically worse *and* functionally compromised. Form-follows-function here is descriptively and prescriptively right.
+
+### Example 2: a software dashboard
+
+A monitoring dashboard's primary function is rapid comprehension of system state. Tufte-style restraint (data-ink high; chartjunk low; chrome minimal) tends to produce dashboards that work well. Adding decorative gradients and heavy borders to "make it pop" usually degrades comprehension.
+
+Here the descriptive principle holds: function-derived form is more beautiful and more useful.
+
+### Example 3: a marketing landing page
+
+A landing page's primary function is conversion. Conversion is helped by emotional engagement, brand identity, social proof, and persuasion — not just clear information delivery. Pure functional minimalism (a heading, three feature bullets, one button) typically converts worse than a richer, more visually engaged page.
+
+Here strict prescriptive form-follows-function would harm. Aesthetic and emotional design serve function (conversion) at a higher level.
+
+### Example 4: the Hummer (the book's example)
+
+The book uses the Humvee/Hummer as an example: the original military Humvee was pure function; its aesthetic emerged from that. The civilian H1 and H2 inherited the visual language and added consumer aesthetic considerations. Both iterations represent compelling form derived from function, even though the H2 added explicitly aesthetic decisions on top of the original functional shape.
+
+### Example 5: a consumer-watch comparison
+
+The book contrasts a digital watch (form follows function: speed and accuracy) with a minimalist analog watch (form follows function: aesthetic enjoyment). Each is "correct" given different success criteria. The principle isn't "always pick one"; it's "be deliberate about what success means and let form follow that."
+
+## Cross-domain examples
+
+### Architecture
+
+Frank Lloyd Wright's organic architecture — buildings that emerge from their site and use — is descriptive form-follows-function at scale.
+
+Mies van der Rohe's "Less is more" took the prescriptive interpretation; produced spectacular buildings (the Seagram Building) and also spectacular failures (some Modernist housing projects). The interpretation isn't wrong; it's a tool that works for some contexts and fails in others.
+
+### Industrial design
+
+Dieter Rams' "Less, but better" is form-follows-function for consumer products. Rams' Braun designs influenced Apple's design language; both share the descriptive interpretation of the principle.
+
+### Software
+
+Modern minimalist UI design (post-2013 flat design) attempted prescriptive form-follows-function. The result was widespread affordance regression — users couldn't tell what was clickable. The course-correction since has restored signifiers (subtle shadows, hover states) — function (clear affordance) demanded form (visual signaling).
+
+### Type design
+
+Helvetica is the canonical form-follows-function typeface: every letter shaped for legibility, no ornament. Its widespread adoption across signage and print reflects descriptive form-follows-function — function-derived form aged well.
+
+## Anti-patterns
+
+- **Strict prescriptive minimalism that strips affordance.** "Form follows function" used as license to remove signifiers users need.
+- **Ornament for its own sake.** Decoration that doesn't serve any function (functional, emotional, brand). Hollow aesthetic.
+- **Form-follows-fashion.** Following current visual trends regardless of fit. Ages quickly.
+- **Functional purity that misses the broader function.** Optimizing for narrow function (efficiency) while missing wider function (engagement, emotion, brand).
+
+## Heuristics
+
+1. **The "what success means here" question.** Before applying form-follows-function, name what success looks like for this design. Is it efficiency, conversion, emotional engagement, brand identity, education? Function follows from that.
+2. **The decorative-element audit.** For each visible element, ask: does this serve any function (functional, emotional, brand)? If genuinely none, it's a candidate to cut.
+3. **The success-criteria check.** For trade-off decisions, ask: which choice does the least harm to the success criteria? That's the right answer — not "always pick function over form."
+
+## Related principles
+
+- **`aesthetic-usability-effect`** — directly tempers strict prescriptive form-follows-function; aesthetic quality affects perceived usability.
+- **`ockhams-razor`** — among solutions that work, prefer the simplest. Aligns with descriptive form-follows-function.
+- **`exposure-effect`** — familiar forms are preferred; trend-following form-follows-fashion ages poorly.
+- **`signal-to-noise-ratio`** — operational version applied to information design.
+- **`wabi-sabi`** — counterpoint that allows imperfection.
+
+## Sub-aspect skills
+
+- **`form-follows-function-as-axiom`** — the descriptive interpretation; functional purity as aesthetic source.
+- **`form-follows-function-success-criteria`** — defining success criteria explicitly so form-and-function trade-offs can be made deliberately.
+
+## Closing
+
+Form follows function is one of the most quoted and most misused principles in design. Used descriptively as a guide ("functional clarity tends to produce beautiful results"), it's powerful. Used prescriptively as a rule ("strip everything that isn't strictly functional"), it produces failure modes from cold architecture to unusable software. The discipline is recognizing which interpretation applies to the work at hand — and being honest about what counts as "function."

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function/references/sullivan-bauhaus-modernism.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/form-follows-function/references/sullivan-bauhaus-modernism.md
@@ -1,0 +1,50 @@
+# Form follows function: Sullivan, Bauhaus, and modernism
+
+A reference complementing the `form-follows-function` SKILL.md with the historical lineage.
+
+## Origins
+
+The phrase is most often attributed to **Louis Sullivan** in his article "The Tall Office Building Artistically Considered" (*Lippincott's Magazine*, March 1896). Sullivan argued that the new skyscraper era required a design philosophy distinct from prior architectural styles — buildings shaped by what they did, not by historical decoration.
+
+The underlying idea is older. **Carlo Lodoli** (18th-century Italian Jesuit monk) is credited as articulating the concept earlier in architectural theory. **Horatio Greenough** (American sculptor) developed similar ideas in the 1840s. Sullivan synthesized and popularized.
+
+## The Modernist movement
+
+Form follows function became the doctrine of 20th-century Modernism:
+
+- **Bauhaus** (1919–1933) — Walter Gropius, Mies van der Rohe, others taught form-derived-from-function across architecture, furniture, typography, and product design.
+- **International Style** in architecture — glass, steel, minimal ornament; buildings as functional volumes.
+- **Mid-century industrial design** — Eames, Saarinen, Ettore Sottsass shaped products by their use.
+- **Helvetica and Swiss typography** — letters shaped for legibility, free of ornament.
+
+Modernism's influence on subsequent design is enormous; current visual culture in product design, software UI, and brand identity descends substantially from it.
+
+## The counter-critique
+
+Peter Blake's *Form Follows Fiasco* (1977) and other late-20th-century critiques argued that pure prescriptive Modernism produced failures:
+
+- Brutalist buildings users hated.
+- Public-housing projects that destroyed community.
+- Sterile interiors lacking warmth.
+- "Anti-decoration" stance that was itself a stylistic decoration.
+
+The critique didn't reject the descriptive insight; it rejected the prescriptive over-application.
+
+## Modern interpretations
+
+Current design practice mostly takes a moderate position:
+
+- Function-derived form is generally good (descriptive).
+- Pure ornament-stripping isn't (prescriptive).
+- Aesthetic-Usability Effect shows polish matters even when not strictly functional.
+- Successful products combine functional clarity with thoughtful aesthetic enhancement.
+
+The book's reframe — define success criteria explicitly, then weigh form and function against them — is the practical synthesis.
+
+## Resources
+
+- Sullivan, L. "The Tall Office Building Artistically Considered" (1896).
+- Blake, P. *Form Follows Fiasco* (1977).
+- Bayer, H. et al. *Bauhaus: 1919–1928* (1938) — comprehensive Bauhaus documentation.
+- Rams, D. "Ten Principles for Good Design" — modern descriptive form-follows-function articulated for industrial design.
+- Norman, D. *Emotional Design* (2004) — argues for explicit aesthetic / emotional considerations alongside functional ones.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion-distraction-cost/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion-distraction-cost/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: immersion-distraction-cost
+description: 'Recognize and design against the cost of attention fragmentation — the disproportionate damage that even small interruptions do to focused work. Use when designing notification systems, evaluating whether a feature should interrupt the user, planning feature introductions, or auditing a product for unintended attention costs. The cost of breaking immersion is much higher than designers usually estimate; restraint in interruption is one of the most user-respectful design moves.'
+---
+
+# Immersion — distraction cost
+
+The cost of breaking immersion is disproportionate to the size of the interruption. A 5-second notification can cost 15+ minutes of focused work. A popup during a creative session can derail an idea that was just forming. A sudden modal during a flow state breaks not just the current moment but the user's relationship with the activity.
+
+Designers consistently underestimate this cost. The interruption looks small from the design side; from the user's side, it can be devastating. Users who experience repeated unnecessary interruptions develop chronic mistrust of the product — they can't relax into deep work because they're always braced for the next interruption.
+
+The discipline is to take attention seriously. Interrupt only when genuinely necessary. Defer interruptions to between sessions. Make peace with lower engagement metrics in service of better user wellbeing.
+
+## The cost of interruption
+
+Research on attention switching consistently finds:
+
+**Interruptions cost more than the interruption duration.** A 5-second interruption costs not just 5 seconds but the time to recover the previous mental state, often several minutes.
+
+**Some interruptions cost more than others.** Interruptions during creative or complex work cost more than interruptions during routine work. Interruptions that demand cognitive engagement (a question, a decision) cost more than interruptions that don't (a brief notification).
+
+**The cost compounds.** Multiple interruptions don't just add up; they multiply. A user interrupted 5 times in an hour has much less productive time than the simple subtraction would suggest.
+
+**The cost includes psychological strain.** Users in environments full of interruptions report stress, fatigue, and reduced satisfaction. The cognitive cost is paid in wellbeing as well as time.
+
+**Anticipated interruptions cost too.** A user who knows interruptions are coming is in a state of vigilance, which is itself attention-demanding. Even periods between interruptions are degraded by the expectation.
+
+The implication: minimize interruptions; defer them when possible; concentrate them in predictable windows when not possible.
+
+## Categorizing interruption necessity
+
+Different interruptions have different justifications. A useful taxonomy:
+
+**Critical / immediately actionable.** A genuinely urgent matter the user needs to know about right now. A security alert; a real-time emergency. These warrant immediate interruption.
+
+**Important / soon-actionable.** Matters that need user attention within hours but not within seconds. A new message from a collaborator; an alert about a system event. Can be deferred briefly.
+
+**Useful / eventually-actionable.** Updates the user might want to know about. New content; activity from connections; suggestions. Should be deferred to between sessions or batched.
+
+**Engagement-driven / not-actually-actionable.** "Come back!" notifications; "Don't miss out!" prompts; daily reminders. Almost always serve the product more than the user. Question whether they're warranted at all.
+
+The first two warrant interruption. The third should be batched. The fourth should usually be eliminated or sent only if explicitly requested.
+
+## When immersion design is the right priority
+
+Immersion-protecting design has costs:
+
+- Lower engagement metrics in the short term.
+- Less data on user activity (you're not asking them to interact with notifications).
+- Slower viral growth from features that depend on interruption.
+- Less effective monetization through ads or notifications.
+
+The benefits:
+
+- Users who genuinely concentrate produce better work / get more value.
+- Users develop trust in the product as a partner rather than an attention parasite.
+- Long-term retention often improves (users who get value stay; users who feel pestered leave).
+- Word-of-mouth from satisfied deep-users.
+
+The trade-offs are real. Products that prioritize immersion may be smaller but more loved than products that prioritize engagement metrics. Choose deliberately.
+
+## Designing for low distraction cost
+
+Several design moves reduce distraction cost:
+
+**Batch notifications.** Rather than sending notifications as events occur, batch them into digests delivered at predictable times.
+
+**Quiet hours / focus modes.** User-configurable periods when notifications are suppressed entirely.
+
+**Notification preferences.** Let users tune which notifications they receive. Defaults should be conservative.
+
+**Defer non-urgent prompts to between sessions.** Don't ask users to do something during deep work; ask between sessions.
+
+**Quiet ambient indicators.** When the user needs to know something but doesn't need to act on it, use ambient indicators (a small badge, a status color) that the user can notice without being interrupted.
+
+**Smart batching by context.** Notify when the user is between activities, not during them. Many products can detect this from usage patterns.
+
+**Honor system-level focus settings.** Operating systems have focus modes; honor them in your product.
+
+**Eliminate notifications that don't serve the user.** Engagement-driven notifications often serve the product, not the user. Be honest about this.
+
+## Worked examples
+
+### A productivity tool with batched notifications
+
+A productivity tool delivers notifications in three batches per day: morning, midday, evening. Throughout the day, events accumulate; they're delivered together at the next batch.
+
+The user experience: focused work without interruption between batches; predictable check-in moments to process accumulated updates. Users report higher satisfaction with the batched approach than with the previous real-time approach.
+
+### A messaging app that respects focus modes
+
+A messaging app integrates with the operating system's focus modes. When the user is in "Focus" mode, the app suppresses all but explicitly-marked-urgent messages. The user can configure what counts as urgent.
+
+The result: deep work is protected. Messages still arrive but are queued for review when focus mode ends.
+
+### A creative tool with no in-session interruptions
+
+A drawing app sends no notifications, prompts, or banners during a drawing session. Updates and announcements are delivered between sessions, in a "what's new" surface the user visits voluntarily.
+
+Users describe the app as "respectful" — a rare quality in current products.
+
+### A social app that interrupts excessively
+
+A social app sends real-time notifications for every event: new posts from connections, likes on the user's posts, friends opening the app. Users feel their attention is being constantly fragmented. Some leave for quieter alternatives; others disable notifications and effectively use the app less.
+
+The fix: dramatically reduce notification frequency. Batch most events. Reserve real-time notifications for genuinely urgent matters (direct messages to the user, etc.).
+
+### A meditation app that protects sessions
+
+A meditation app suspends all device notifications (with permission) during sessions. The user's phone is effectively in airplane mode for the session duration. After the session, notifications resume.
+
+This is going to lengths most apps don't, but it's appropriate for the product's purpose. The session experience is protected.
+
+## Anti-patterns
+
+**Notifications as the primary engagement mechanism.** A product that depends on notifications to drive return is often interrupting users more than they'd want.
+
+**Real-time notifications for non-urgent events.** Most events users care about are not actually urgent. Real-time delivery is overkill and costly.
+
+**Sound and vibration for routine notifications.** Visual notifications can be ignored if not relevant; sound and vibration force attention.
+
+**Notifications that demand action.** "Tap to view!" is a interruption that requires user engagement to dismiss; preferable to make notifications informational rather than action-demanding.
+
+**Engagement-driven notifications with no user value.** "Don't miss out!" "We miss you!" These serve the product, not the user. Question whether they're warranted.
+
+**Disabling user controls over notifications.** Forcing users to receive certain notifications. Users learn to ignore the entire channel.
+
+**Modal interruptions during productive work.** A modal that demands attention during a creative session. Worse than a notification because it can't be dismissed without engagement.
+
+## Heuristic checklist
+
+When considering an interruption, ask: **Is this genuinely urgent?** If not, defer or batch. **Does the user need to act on this in seconds?** If not, real-time delivery is unnecessary. **Will this serve the user, or primarily the product?** Be honest about who benefits. **Can this be batched with other notifications?** Batching reduces total interruption count. **Have I given the user control over when and what to be notified about?** Defaults should be conservative.
+
+## Related sub-skills
+
+- `immersion` — parent principle on sustained focused attention.
+- `immersion-flow` — sibling skill on designing for flow.
+- `forgiveness` — interruptions that demand action without recovery options compound the cost.
+- `feedback-loop` — feedback during the activity supports flow; notifications about other things break it.
+
+## See also
+
+- `references/notification-design.md` — practical patterns for designing notification systems that respect attention.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion-distraction-cost/references/notification-design.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion-distraction-cost/references/notification-design.md
@@ -1,0 +1,144 @@
+# Notification design — patterns
+
+Practical patterns for designing notification systems that respect user attention.
+
+## The notification taxonomy
+
+Categorize notifications by urgency and required action:
+
+**Critical / immediate.** True emergencies. Security alerts. Real-time conversations the user is actively in. Warrant immediate interruption.
+
+**Important / soon.** Things the user wants to know within hours. Direct messages from collaborators. Significant updates to active work. Can be deferred briefly; should be batched.
+
+**Useful / eventually.** Updates the user might want. Non-urgent activity from connections. Suggestions. Should be delivered in digest form.
+
+**Engagement / not actually urgent.** "Come back!" messages. Daily reminders. "Don't miss out!" Often serve the product more than the user; question necessity.
+
+Different categories warrant different delivery patterns.
+
+## Pattern: real-time only for the critical category
+
+Reserve real-time push notifications for genuinely critical or important matters. Default users to not receiving real-time notifications for the eventually-or-engagement categories.
+
+## Pattern: batched delivery
+
+For the important and useful categories, batch notifications:
+
+- **Hourly digest.** For users who want frequent updates.
+- **Daily digest.** Default for most users.
+- **Weekly digest.** For low-frequency products or users who prefer minimal contact.
+
+The batched delivery dramatically reduces interruption count without losing the information.
+
+## Pattern: configurable preferences
+
+Let users choose what they receive and when:
+
+- **Per-category controls.** Different notifications for different categories.
+- **Quiet hours.** No notifications during user-specified periods (typically nights and weekends).
+- **Channel selection.** Push vs. email vs. in-app, by category.
+- **Frequency control.** Real-time vs. batched, with batch size configurable.
+
+Conservative defaults; comprehensive controls.
+
+## Pattern: in-app indicators for non-urgent updates
+
+For updates that don't warrant interruption but the user might want to see, use in-app indicators (a badge on a navigation item, a "new" indicator on a panel) rather than push notifications. The user discovers the update when they next visit the app.
+
+This pattern works for products users return to regularly. It doesn't work for products users only visit when notified.
+
+## Pattern: smart timing
+
+When notifications must be delivered, time them well:
+
+- **Avoid late nights and early mornings.** Even non-urgent notifications during sleep hours feel intrusive.
+- **Match user time zone.** A 9am notification means very different things in different time zones.
+- **Detect and respect user activity.** Some products can detect when users are in deep work and suppress non-urgent notifications.
+- **Batch by natural break points.** Deliver at the end of a focus session, not during one.
+
+## Pattern: notification content that respects user time
+
+For each notification, ask: does the user need to know this in this much detail right now?
+
+- **Brief, scannable.** Notifications should communicate the essential in a glance.
+- **Don't demand action.** Informational notifications are preferable to action-demanding ones. Let the user choose to act.
+- **Provide context.** Why is this notification appearing? Users who understand notifications trust them more.
+- **Avoid clickbait.** Notifications that overstate urgency or relevance damage trust.
+
+## Pattern: respecting system focus modes
+
+Modern operating systems have focus modes (iOS Focus, Android Do Not Disturb, macOS Focus). Honor them in your product.
+
+- When the user is in a focus mode, suppress all but explicitly-marked-urgent notifications.
+- Provide a way to mark notifications as urgent (so users can configure focus modes to allow them).
+- Don't override focus modes for marketing or engagement notifications.
+
+## Pattern: notification fatigue prevention
+
+Watch for signs of fatigue:
+
+- Users disabling notifications in settings.
+- Click-through rate dropping over time.
+- App uninstalls correlating with notification volume.
+- Survey feedback about notifications.
+
+When fatigue signs appear, reduce notification volume, not increase it. The instinct to "send better notifications more often" usually backfires.
+
+## Pattern: opt-in for new notification types
+
+When introducing a new kind of notification, default to off. Let users opt in. This:
+
+- Respects users who have already calibrated their notification preferences.
+- Limits backlash from a new noise source.
+- Provides cleaner data on whether the notification type is wanted.
+
+The alternative (default-on, with opt-out) generates short-term engagement gains and long-term trust damage.
+
+## Pattern: end-of-session opportunities
+
+Some prompts that aren't notifications can still wait for between-session moments:
+
+- Onboarding tips after the user completes a task.
+- Feature suggestions when the user returns from being away.
+- Survey requests at moments of obvious value delivery.
+
+These prompts are less intrusive than notifications because they appear in the product's natural flow.
+
+## Anti-patterns
+
+**Notification flooding.** Many notifications per day. Users habituate, then disable, then leave.
+
+**Notifications that don't match content.** "Important update!" with trivial content. Trust erodes.
+
+**Notifications that demand engagement.** "Tap to claim your reward!" Effectively forced interactions.
+
+**Notifications without preferences.** No way for users to control what they receive.
+
+**Override of focus modes.** Notifications during user-declared focus periods. Maximum trust damage.
+
+**Sound and vibration on routine notifications.** Audio reinforcement for non-urgent matters; teaches users to ignore.
+
+**Marketing pretending to be useful.** "Your weekly summary" that's actually a sales pitch. Discovered, never trusted again.
+
+**Engagement notifications dressed as user-serving.** Notifications crafted to look like the user's friend or product activity but really driven by engagement metrics.
+
+## Measurement
+
+Track notification-related metrics:
+
+- **Click-through rate.** Are users engaging with notifications? Declining CTR signals fatigue.
+- **Disable rate.** What % of users disable notifications after the first day? First week?
+- **Attribution.** What percentage of returning users are notification-driven vs. organic?
+- **User-reported satisfaction.** Surveys can reveal whether users feel notifications are valuable or annoying.
+
+Optimize for sustainable engagement rather than peak engagement. A higher CTR achieved by sending fewer better notifications beats a lower CTR from sending more.
+
+## A simple test
+
+Look at your own notifications from your own product. Would you, as a user, want to receive these? Are they timed appropriately? Are they valuable? Or do they feel like noise?
+
+The dogfooding test catches a lot of issues before users do.
+
+## Cross-reference
+
+For the parent principle, see `immersion`. For flow design, see `immersion-flow`.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion-flow/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion-flow/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: immersion-flow
+description: 'Design for flow specifically — calibrate challenge to skill, provide immediate feedback, set clear goals, foreground the activity. Use when designing tools for skilled work (writing, drawing, programming, music), games, learning experiences, or any context where sustained engagement is the goal. Flow is the most-researched aspect of immersion; the conditions for it are specific and the design moves that support it are well-documented.'
+---
+
+# Immersion — flow
+
+Flow is the optimal state of immersion: full engagement with an activity, challenge matched to skill, action and awareness merged, time perception altered, the activity intrinsically rewarding. Designing for flow means setting up the conditions Csikszentmihalyi's research identifies and protecting them from interruption.
+
+The conditions are specific. The design moves that support them are concrete. Flow is one of the most well-defined design goals in this entire principle library; the work is execution, not invention.
+
+## The conditions checklist
+
+For each design decision, check whether it supports or undermines the flow conditions:
+
+**Clear goals.** Does the user know what they're trying to accomplish? Is the goal concrete enough to focus on?
+
+**Immediate feedback.** Are the user's actions producing visible results in real time?
+
+**Challenge-skill calibration.** Is the activity hard enough to require focus but not so hard as to overwhelm?
+
+**Concentration support.** Is the interface foregrounding the activity and removing distractions?
+
+**Sense of control.** Does the user feel they're directing the activity?
+
+**Loss of self-consciousness.** Is the design quiet enough that the user isn't reminded of being observed or measured?
+
+**Autotelic experience.** Is the activity intrinsically rewarding, or is it framed in terms of external rewards?
+
+A design that satisfies all these supports flow. A design that violates one or more works against it.
+
+## Calibrating challenge to skill
+
+The most distinctive flow-design move: meeting the user at their skill level.
+
+**For tools:** layered control. Beginners get sensible defaults and guided paths; experts get full capability and deeper customization. The same tool should support both audiences.
+
+**For games:** adaptive difficulty. The game adjusts based on player performance. Too-easy levels are skipped or accelerated; too-hard levels offer optional hints or accessibility options.
+
+**For learning:** scaffolded progression. Concepts build on each other; each new concept is challenging at the user's current skill but achievable.
+
+**For creative work:** progressive depth. Simple paths for early work; complex options for advanced work. Both available; users navigate to what fits.
+
+The principle: never impose a fixed challenge level on a user with variable skill. Either calibrate or provide options.
+
+## Designing for clear goals
+
+Many products have unclear goals. The user opens the product, but it's not clear what they're meant to do. This is fine for some products (open-ended creative tools) but not for others.
+
+For activities where flow is the goal:
+
+**State the goal clearly.** "Write 500 words today." "Complete this lesson." "Finish this level."
+
+**Show progress toward the goal.** A progress bar, a counter, a visible advancement.
+
+**Make the goal achievable in a session.** Goals that span multiple sessions may not produce flow; they're too distant.
+
+**Let the user set their own goals when appropriate.** Some flow comes from self-set goals.
+
+## Designing for immediate feedback
+
+Flow requires that users see the effect of their actions in real time. Latency of more than a few hundred milliseconds breaks the action-awareness merger.
+
+**Snappy interactions.** Buttons respond instantly; controls update visibly; results appear quickly.
+
+**Live preview.** When the user is creating something, show what they're creating as they create it.
+
+**Real-time validation.** When the user is providing input, indicate whether it's valid as they type, not after they submit.
+
+**Smooth animation.** Transitions that show what changed; nothing snapping or popping.
+
+Slow systems are flow-killers. Investment in performance is investment in immersion.
+
+## Designing for concentration
+
+The concentration condition is mostly about removing distractions:
+
+**Single focal point.** The interface should foreground the user's activity. Other elements should be visually muted or removed.
+
+**Quiet animation.** Animations should be functional, not decorative. No flourishes that don't communicate.
+
+**No notifications during the activity.** Defer notifications to between sessions.
+
+**No interruptions for engagement.** Popups, prompts, banners all break concentration.
+
+**Focus mode.** Many tools benefit from a "focus mode" or "zen mode" that hides chrome during deep work.
+
+## Designing for the autotelic experience
+
+Flow is autotelic — the activity is rewarding for its own sake. Designs that reframe activities in terms of external rewards (badges, streaks, social comparisons) can actually reduce flow.
+
+**Make the activity itself the reward.** Writing should feel rewarding because writing is rewarding, not because of word counts or streaks.
+
+**Keep metrics in the background.** Measurement is fine; foregrounding it during the activity isn't.
+
+**Avoid social comparison during the activity.** "Friends" features that show what others are doing can be motivating between sessions but distracting during them.
+
+**Resist gamification reflex.** Adding game-like elements (points, levels, badges) to non-game activities sometimes helps but often distracts from the intrinsic value.
+
+## Worked examples
+
+### A writing tool designed for flow
+
+A focused writing app: clean canvas, comfortable typography, no toolbar visible during typing, no notifications, no metrics displayed during the writing session. Word count is available on request but doesn't update live in a visible counter.
+
+The user opens the app and writes. The activity is the experience. Time passes; words accumulate; the user is in the writing.
+
+This is flow design at its purest.
+
+### A code editor with adaptive depth
+
+A code editor's default surface is approachable: standard layout, common shortcuts, helpful auto-completion. Power users can customize keybindings, install extensions, configure language servers. The same editor adapts to skill level.
+
+Both audiences can experience flow: the novice with the supported defaults, the expert with the customized environment.
+
+### A drawing tool with calibrated difficulty
+
+A drawing app offers different brush behaviors. For beginners, brushes have helpful guides (line smoothing, automatic shape correction). For advanced users, brushes can be configured precisely for the user's hand and style.
+
+Each user gets a brush experience matched to their skill. Both can enter flow.
+
+### A meditation app designed for flow
+
+A meditation session: brief setup (timer, sound choice), then the screen darkens. No notifications. No interruptions. Just the user and the practice.
+
+The activity is the entire focus. The app's design supports the user being in the activity rather than thinking about it.
+
+### A game with broken flow
+
+A puzzle game has good core gameplay but interrupts every 3 puzzles with a popup ("Watch an ad to continue!" "Try our new mode!" "Daily reward!"). Players who wanted flow leave. Players who stay tolerate the interruptions but don't experience flow.
+
+The fix: defer interruptions to between sessions, not during gameplay.
+
+## Anti-patterns
+
+**Notifications during the activity.** Each notification breaks the action-awareness merger.
+
+**Metrics displayed during the activity.** Word counts, time trackers, scores updating live. The user attends to the metric, not the activity.
+
+**Interruptions for engagement.** Popups during the activity. Each one fragments attention.
+
+**Forced social features.** Notifications about what friends are doing during the activity.
+
+**Misaligned challenge.** Tools too easy or too hard for the user's skill. Bores or frustrates.
+
+**Streak penalties.** Streaks that end if you skip a day. The penalty creates anxiety that reduces flow.
+
+**Cluttered interface during the activity.** Too many panels, indicators, badges, all visible during the work.
+
+**Latency.** Slow response to user actions. Breaks immediate feedback.
+
+**Over-gamification.** Adding game-like elements to non-game activities. Sometimes helps; often distracts from intrinsic motivation.
+
+## Heuristic checklist
+
+When designing for flow, ask: **Is the goal clear?** Users need to know what they're doing. **Is feedback immediate?** Latency breaks flow. **Is challenge calibrated to user skill?** Adaptive depth or layered control. **Are distractions removed during the activity?** Interruptions defeat flow. **Is the activity its own reward?** Foreground intrinsic value, not external metrics.
+
+## Related sub-skills
+
+- `immersion` — parent principle on sustained focused attention.
+- `immersion-distraction-cost` — sibling skill on the cost of attention fragmentation.
+- `feedback-loop` — flow requires immediate feedback.
+- `control-power-vs-simplicity` — challenge-skill calibration through layered control.
+- `progressive-disclosure` — depth that meets users at their skill level.
+
+## See also
+
+- `references/flow-design-checklist.md` — a checklist for auditing a design against flow conditions.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion-flow/references/flow-design-checklist.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion-flow/references/flow-design-checklist.md
@@ -1,0 +1,109 @@
+# Flow design — checklist
+
+A practical checklist for auditing a design against the conditions for flow.
+
+## Goal clarity
+
+- [ ] When the user opens the product, do they know what to do?
+- [ ] Is the activity's goal explicit, or implicit but obvious?
+- [ ] For multi-step activities, is each step's goal clear?
+- [ ] Do users have ways to set their own goals when appropriate?
+
+## Feedback immediacy
+
+- [ ] Do user actions produce visible results within ~200ms?
+- [ ] Are state changes animated smoothly to show what changed?
+- [ ] Is there real-time validation where appropriate (typing, drawing, etc.)?
+- [ ] Do error states surface quickly with clear messages?
+
+## Challenge-skill calibration
+
+- [ ] Does the product have layered depth so different skill levels can use it?
+- [ ] Are there scaffolds for novices (defaults, guides, tutorials)?
+- [ ] Are there capabilities for experts (customization, shortcuts, advanced features)?
+- [ ] Is the difficulty appropriate for the user's actual skill level?
+- [ ] Does the product adapt as skill grows (more capability becomes accessible)?
+
+## Concentration support
+
+- [ ] Is there a clear focal point on each screen?
+- [ ] Is the chrome (sidebars, headers, etc.) minimal during deep activity?
+- [ ] Are notifications deferred during the activity?
+- [ ] Are interruptions (popups, banners) eliminated during the activity?
+- [ ] Is there a "focus mode" or equivalent for deep work?
+
+## Sense of control
+
+- [ ] Does the user feel they're directing the activity?
+- [ ] Are unexpected things avoided (the system doing things the user didn't ask for)?
+- [ ] When the system does act automatically, is the action visible and undoable?
+- [ ] Are settings and controls discoverable when needed?
+
+## Self-consciousness reduction
+
+- [ ] Are metrics about the user's performance hidden during the activity?
+- [ ] Are social-comparison features minimized during the activity?
+- [ ] Is the design quiet enough that users aren't reminded of being measured?
+
+## Autotelic experience
+
+- [ ] Is the activity itself rewarding, or framed in terms of external rewards?
+- [ ] Are gamification elements (points, badges, streaks) thoughtful, or reflexive?
+- [ ] Does the design respect the user's intrinsic motivation?
+
+## Anti-pattern check
+
+- [ ] No notifications during deep activity.
+- [ ] No popups or modals during the activity.
+- [ ] No live-updating metrics in peripheral vision during the activity.
+- [ ] No social comparison shown during the activity.
+- [ ] No latency that breaks immediate feedback.
+- [ ] No streak penalties that create anxiety.
+- [ ] No cluttered interface that competes for attention.
+- [ ] No misaligned challenge (too easy or too hard for the audience).
+
+## Specific design questions
+
+**For tools:**
+- Can a power user customize keybindings, shortcuts, defaults?
+- Can a beginner get started without learning the customization?
+- Is there a clear progression from beginner to expert use?
+
+**For games:**
+- Does difficulty adapt or offer adjustment?
+- Are there clear short-term goals (the current level, the current quest)?
+- Is feedback during play crisp (action-result connection clear)?
+
+**For learning:**
+- Are concepts scaffolded so each is achievable at the user's skill?
+- Are there clear small wins along the path?
+- Is feedback on practice exercises immediate?
+
+**For creative work:**
+- Is the canvas the focal point?
+- Are tools accessible without dominating?
+- Is there a "draft" mode for early-stage work?
+
+**For reading:**
+- Is the prose layout clean?
+- Are interruptions during reading minimized?
+- Is the typography comfortable for sustained reading?
+
+**For meditation / reflection:**
+- Is the session experience quiet?
+- Are notifications suspended during the session?
+- Does the design support sustained attention rather than fragmenting it?
+
+## A simple test
+
+Watch a user use the product for 30+ minutes. Note:
+
+- Do they ever appear to enter a focused state (less head movement, less looking at peripheral things, sustained engagement with a single area)?
+- What breaks the focused state (a notification, an unclear next step, a slow response)?
+- Do they describe the experience afterward as engaging or fragmenting?
+
+The observation is more reliable than self-report. Users in flow don't report it as such; they just describe the experience as good.
+
+## Cross-reference
+
+For the cost of distraction specifically, see `immersion-distraction-cost`. For the parent principle, see `immersion`.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: immersion
+description: 'Apply the principle of Immersion — designing for sustained focus and engagement, where the user becomes absorbed in the activity and loses awareness of the surrounding environment. Use when designing for creative work, deep reading, gameplay, learning, or any activity that benefits from extended focused attention. Immersion requires removing distractions, providing clear feedback, calibrating challenge to skill, and respecting the user''s flow state. Modern attention-driven products often work against immersion in pursuit of engagement metrics; designs that genuinely serve immersion are increasingly distinctive.'
+---
+
+# Immersion
+
+> **Definition.** Immersion is the experience of being so absorbed in an activity that awareness of the external environment fades. The user is fully engaged with the task at hand; time perception alters; effort feels effortless. The closely-related concept of "flow" (Mihaly Csikszentmihalyi) describes the optimal state of immersion: high challenge matched to high skill, clear goals, immediate feedback, and absorption in the activity itself rather than in metrics about it.
+
+Immersion is what makes some products feel essentially different from others. A truly immersive reading experience (a great book, a well-designed e-reader) is unlike scrolling through a feed; an immersive game is unlike a casual mobile game; an immersive creative tool is unlike a productivity app. The difference is the user's mental state: in immersion, they're absorbed; outside it, they're alternating attention.
+
+Many modern products are designed for the opposite: maximizing engagement metrics through interruption, notification, and attention capture. These products are often financially successful but produce a different user experience — one of fragmentation rather than absorption.
+
+The choice to design for immersion is increasingly distinctive. Products that respect deep attention and support flow states are rarer than products that interrupt it.
+
+## Conditions for immersion
+
+The flow research (Csikszentmihalyi and many others) identifies several conditions for immersion:
+
+**Clear goals.** The user knows what they're trying to do; the goal is concrete enough to focus on.
+
+**Immediate feedback.** The user can see the effect of their actions in real time. They know whether they're succeeding or failing.
+
+**Challenge matched to skill.** The activity is hard enough to require focus but not so hard as to overwhelm. Too easy = boredom; too hard = frustration.
+
+**Action and awareness merge.** The user isn't thinking about the activity from outside; they're inside it.
+
+**Concentration on the task.** The user's attention is fully on the activity, not split between it and other concerns.
+
+**Sense of control.** The user feels they are directing the activity, not being directed by it.
+
+**Loss of self-consciousness.** The user isn't worrying about how they appear or being judged; they're just doing.
+
+**Altered sense of time.** Hours feel like minutes (or minutes feel like hours, depending on the activity).
+
+**Autotelic experience.** The activity is intrinsically rewarding; the user is doing it for its own sake, not for an external reward.
+
+When these conditions align, immersion happens. When they don't, the user's attention fragments.
+
+## Designing for immersion
+
+Several design moves support immersion:
+
+**Remove distractions.** Anything in the periphery competing for attention works against immersion. Notifications, popups, ads, animated banners, sticky elements — all reduce focus.
+
+**Provide clear, immediate feedback.** The user's actions should produce visible results quickly. Unclear or delayed feedback breaks the action-awareness merger.
+
+**Calibrate difficulty.** Tools should match the user's skill level. Too easy and the user gets bored; too hard and they give up. Many tools succeed by adapting to skill (more guidance for novices; more capability for experts).
+
+**Single focal point.** The interface should foreground one thing — the user's current activity. Everything else should recede.
+
+**Quiet animation and interaction.** Subtle, fast, organic. Not distracting from the activity.
+
+**Generous space and rhythm.** Cramped layouts work against absorption; spacious ones support it.
+
+**Avoid metrics about the activity (in the moment).** The user is in the activity; metrics about the activity (your streak, your time, your score) take them out of it. Some products defer metrics to between-session reviews.
+
+**Honor the activity's natural rhythm.** Some activities benefit from no breaks; others from clear chapter breaks. Design respects the activity's structure.
+
+## When immersion is the right design goal
+
+**Creative work.** Writing, drawing, music production, design. Sustained focused attention is essential.
+
+**Deep reading.** Books, long-form articles, dense documentation.
+
+**Learning.** Sustained study, working through problems, building skills.
+
+**Games.** Many games depend on flow for their core experience.
+
+**Meditation and reflection.** The activity is precisely about sustained attention.
+
+**Skilled physical activities.** Tools that support sustained physical-skill activities (e.g., a guitar tuner used during practice) should not interrupt the activity.
+
+## When immersion isn't the goal
+
+**Quick utilities.** A tool used for 30 seconds doesn't need to support immersion; it needs to do its job and leave.
+
+**Reference / lookup.** Find an answer; close the tab. Immersion isn't the point.
+
+**Notification-driven workflows.** Some products are inherently about responding to incoming events; immersion would conflict with the purpose.
+
+**Casual entertainment.** Some entertainment is appropriately casual; immersion isn't necessary.
+
+The principle is: when the activity benefits from sustained focused attention, design for immersion. When it doesn't, design for the appropriate other goal.
+
+## Sub-skills in this cluster
+
+- **immersion-flow** — Designing for flow specifically: clear goals, immediate feedback, challenge calibration. The most-researched aspect of immersion.
+- **immersion-distraction-cost** — The cost of breaking immersion: how interruptions cost cognitive resetting time, how notifications fragment attention, how to design environments that protect attention.
+
+## Worked examples
+
+### A writing tool designed for immersion
+
+A focused writing tool: a clean canvas, a single column of text, no toolbar at the top, no notifications. The user types; words appear. There are no badges, no streaks, no metrics displayed during writing. Word count is available but in a small corner, easy to ignore.
+
+The tool is intentionally quiet. The activity (writing) is the entire focus. Users who need this kind of tool find it; products that interrupt their writing with notifications or social features feel hostile.
+
+### An e-reader designed for immersion
+
+A reading app: pages of text, generous margins, a typeface designed for sustained reading, soft tap-to-turn pagination. No social features in the reading view. No notifications. The chrome is minimal and recedes after a moment.
+
+The user is reading; the design supports being in the book.
+
+### A code editor in focus mode
+
+Some code editors offer a "focus mode" or "zen mode" that hides all panels except the editor itself. The developer sees only their code; everything else is out of view.
+
+The mode is requested at moments of deep work. The editor is otherwise full-featured but knows when to step back.
+
+### A creative tool with adaptive difficulty
+
+A drawing tool offers different brush-control options based on user skill. Beginners get gentle defaults; advanced users can configure brushes precisely. The tool meets the user at their skill level, supporting flow.
+
+This is challenge-skill calibration in action: the same tool feels approachable to a beginner and powerful to an expert because it adapts.
+
+### A meditation app designed for immersion
+
+A meditation app starts a session with a brief setup (timer, sound), then becomes silent. No notifications during the session. The screen dims. The user's attention has nothing to compete with.
+
+This is immersion as the entire product. The app's value is precisely that it supports focused attention.
+
+### A game with notification interruptions that fail at immersion
+
+A puzzle game launches with frequent in-game popups: "Daily reward available!" "Friend just beat your score!" "Try our new mode!" The popups appear during gameplay, breaking concentration.
+
+Players who wanted immersion leave for quieter games. Players who stay tolerate the interruptions but don't experience flow. The game's engagement metrics may look fine; the experience quality is poor.
+
+The fix: defer notifications until between sessions. Let the actual gameplay be uninterrupted.
+
+## Anti-patterns
+
+**Notifications during the activity.** A notification arrives while the user is in deep work. They look at it. They lose 15 minutes of attention rebuilding. The cost compounds across each notification.
+
+**Metrics displayed during the activity.** A streak counter, a time tracker, a score that updates live. The user attends to the metric instead of the activity.
+
+**Forced social comparison.** "Your friend just X." Pulls the user out of their own activity into comparison with others.
+
+**Interruptions for "engagement."** Popups, banners, modal prompts that drive action. Each one fragments attention.
+
+**Misaligned challenge.** A tool too easy or too hard for the user's skill level. Either bores or frustrates.
+
+**Cluttered interface during the activity.** Too many panels, too many indicators, too many things in peripheral vision.
+
+**Penalties for stopping.** A streak that ends if you skip a day. The penalty creates anxiety that reduces enjoyment of the activity.
+
+## Heuristic checklist
+
+When designing for immersion, ask: **Does the design protect the user's attention during the activity?** Or does it compete for it? **Is feedback during the activity supportive or distracting?** Quiet, fast feedback supports; loud, slow feedback distracts. **Is challenge calibrated?** Too easy = boredom; too hard = frustration. **Are notifications and interruptions deferred to between sessions?** If not, you're working against immersion. **Does the interface have a clear focal point?** Single focus supports immersion.
+
+## Related principles
+
+- **Form Follows Function** — immersive design has form that follows the function of supporting sustained attention.
+- **Signal-to-Noise Ratio** — immersion requires high signal-to-noise; distractions are noise.
+- **Wabi-Sabi (restraint)** — restraint supports immersion; clutter undermines it.
+- **Aesthetic-Usability Effect** — beautiful, calming designs support the entry into flow.
+- **Mental Model** — immersion depends on a stable mental model the user can operate within.
+- **Feedback Loop** — flow requires immediate feedback.
+
+## See also
+
+- `references/lineage.md` — origins in flow research, attention research, and design theory.
+- `immersion-flow/` — sub-skill on designing for flow specifically.
+- `immersion-distraction-cost/` — sub-skill on the cost of attention fragmentation.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/immersion/references/lineage.md
@@ -1,0 +1,122 @@
+# Immersion — origins and research lineage
+
+## Csikszentmihalyi and flow research
+
+The concept of "flow" was systematically articulated by psychologist Mihaly Csikszentmihalyi (pronounced "chick-sent-me-high") starting in the 1970s and elaborated through decades of research. His 1990 book *Flow: The Psychology of Optimal Experience* brought the concept to a wide audience.
+
+Csikszentmihalyi's research method was novel: experience sampling. Subjects carried pagers that beeped at random intervals; when paged, subjects recorded what they were doing and how they felt. Over many subjects and many years, patterns emerged about when people reported feeling most engaged and satisfied.
+
+The patterns converged on the description of "flow":
+
+- Clear goals and immediate feedback.
+- Challenge matched to skill level.
+- Action and awareness merge.
+- Concentration on the task at hand.
+- Sense of personal control.
+- Loss of self-consciousness.
+- Time perception altered.
+- The activity is intrinsically rewarding (autotelic).
+
+People reported experiencing flow during a wide variety of activities: rock climbing, chess, surgery, programming, music performance, religious ritual, cooking, gardening. The activity didn't matter as much as the conditions.
+
+Csikszentmihalyi argued that flow is one of the most positive emotional states humans can experience — and that life satisfaction correlates strongly with how often people experience it.
+
+## The challenge-skill model
+
+Central to Csikszentmihalyi's work is the challenge-skill model. Activities can be plotted on a 2D space with challenge on one axis and skill on the other:
+
+- **Low challenge, low skill:** apathy.
+- **Low challenge, high skill:** boredom.
+- **High challenge, low skill:** anxiety.
+- **High challenge, high skill:** flow.
+
+The flow state is achieved when challenge and skill are both high and well-matched. As skill grows, the challenge needs to grow too; otherwise the activity becomes boring.
+
+This has design implications. Tools that adapt to skill level (more capability for advanced users) tend to support flow longer than tools that don't.
+
+## Attention research
+
+The flow research connects to broader research on human attention:
+
+**Selective attention.** Humans can focus on one stream of information while filtering out others. The ability is finite and effortful.
+
+**Attention switching.** Switching between tasks has measurable costs in time and accuracy. Even brief interruptions take significant time to recover from.
+
+**Cognitive load.** Working memory is limited. Tasks that exceed working-memory capacity are exhausting; tasks well below it are unstimulating.
+
+**Mind wandering.** A default state when attention isn't engaged. Often unpleasant; people report higher happiness when focused on the task at hand.
+
+These findings reinforce the value of designing for sustained attention. Each interruption costs more than people intuit; each well-supported flow session generates more satisfaction than its raw productivity might suggest.
+
+## In digital design
+
+Digital environments have a complicated relationship with immersion. On one hand, computers and phones enable activities (writing, programming, designing, playing games) that can produce deep flow. On the other hand, the same devices are increasingly designed for the opposite: maximum engagement through interruption, notification, and attention capture.
+
+The "attention economy" — products that monetize user attention through advertising — pushes design toward fragmentation rather than absorption. Notifications, scroll-driven feeds, autoplay videos, social-comparison metrics all serve attention-capture goals at the expense of immersion.
+
+Some products explicitly resist this trend:
+
+- iA Writer, Bear, and other "distraction-free" writing tools.
+- Reader-mode browsers that strip ads and chrome.
+- Dedicated e-readers with minimal interface.
+- "Focus mode" features in IDEs and productivity tools.
+- Time-limited social-media tools that remove infinite scrolling.
+
+These products have niche but loyal audiences who specifically value immersion.
+
+## Design implications
+
+Several design principles emerge from immersion research:
+
+**Calibrate challenge to skill.** Tools should adapt to user skill levels. Power users need depth; novices need scaffolding.
+
+**Provide immediate feedback.** Users need to see the effect of their actions in real time. Delayed or unclear feedback breaks flow.
+
+**Single focal point.** Interfaces should foreground one thing at a time. Cluttered interfaces with many competing elements work against immersion.
+
+**Defer interruptions.** Notifications, prompts, and other interruptions should be deferred to between sessions, not during them.
+
+**Minimize chrome during deep work.** Tools that hide their UI during deep use ("focus mode") support immersion better than tools that always show controls.
+
+**Respect the activity's natural rhythm.** Some activities benefit from no breaks; others have natural chapter breaks. Design respects the structure.
+
+**Quiet aesthetic.** Loud animations, bold colors, busy textures all compete for attention. Calm aesthetics support sustained focus.
+
+## Critiques and complications
+
+The flow framework has critics:
+
+- **Difficulty measuring flow scientifically.** Self-report is the primary tool; subjective.
+- **Cultural specificity.** Some critics argue flow is a Western, individualistic conception of optimal experience.
+- **Risk of overuse.** Some "addictive" experiences mimic flow without producing the satisfaction; gambling and some video games can produce engagement that subjects later describe as not actually rewarding.
+- **Inequity.** The conditions for flow (autonomy, challenge calibration, feedback) aren't equally available to all workers; the framework can be used to romanticize work that isn't actually empowering.
+
+These critiques don't undermine the design value of immersion but suggest using the framework thoughtfully rather than as universal prescription.
+
+## Connection to wellbeing
+
+Csikszentmihalyi argued that frequent flow experiences correlate with higher life satisfaction. Subsequent research has supported this in various forms.
+
+The implication for design: products that support immersion may contribute more to user wellbeing than products that fragment attention, even if attention-fragmenting products produce higher engagement metrics.
+
+This is one of the central tensions in contemporary product design. Engagement metrics are easy to measure; user wellbeing is harder. Many companies optimize the easier metric and harm the harder one.
+
+Designers who genuinely care about users have to push back against attention-capture defaults. The push-back can be costly in growth metrics; the long-term effect on user trust and product value can be substantial.
+
+## Empirical findings worth remembering
+
+- **Flow requires challenge matched to skill.** Adaptive difficulty supports flow.
+- **Immediate feedback is essential.** Delayed feedback breaks flow.
+- **Interruptions cost more than people intuit.** A "quick" notification can cost 15+ minutes of recovery.
+- **Frequent flow correlates with higher life satisfaction.**
+- **Attention-capture design is in tension with immersion.** Products optimize one or the other; rarely both.
+
+## Sources informing this principle
+
+- Csikszentmihalyi, M. (1990). *Flow: The Psychology of Optimal Experience*.
+- Csikszentmihalyi, M. (1996). *Creativity: Flow and the Psychology of Discovery and Invention*.
+- McGonigal, J. (2011). *Reality Is Broken*. (On flow in games.)
+- Crawford, M. B. (2015). *The World Beyond Your Head*. (On the attention economy.)
+- Newport, C. (2016). *Deep Work*. (Practical applications of flow research.)
+- Various HCI literature on attention, distraction, and notification design.
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design* (expanded editions).

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi-imperfection/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi-imperfection/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: wabi-sabi-imperfection
+description: 'Design intentional imperfection that reads as warmth — subtle asymmetry, hand-drawn elements, organic textures, intentional irregularities. Use when adding human warmth to a digital design, distinguishing from competitors with uniform design systems, designing for personal or creative contexts. The skill is making imperfection look intentional and refined rather than sloppy or broken; the line between "designed warmth" and "looks unfinished" is narrow.'
+---
+
+# Wabi-Sabi — imperfection
+
+Designing intentional imperfection is the half of wabi-sabi that adds warmth through irregularity, asymmetry, and visible craft. Done well, the imperfection reads as deliberate and refined — the work of someone who cared enough to break the grid in a chosen way. Done poorly, it reads as broken or unfinished.
+
+The challenge is calibration. Too little imperfection and the design reverts to standard digital uniformity; too much and it feels chaotic. The most successful applications use small, deliberate imperfections in otherwise-disciplined designs, so the imperfection reads as character rather than as failure.
+
+## What "intentional imperfection" looks like
+
+**Subtle asymmetry.** A layout that's mostly grid-aligned but lets one element sit slightly off. A button with off-center text. A logo positioned slightly above center. The asymmetry is small enough to feel intentional, large enough to be noticed.
+
+**Hand-drawn elements.** Illustrations or icons that show the artist's hand — visible brushstrokes, varied line weights, irregularities in the form. These contrast with vector-precise elements and add visual texture.
+
+**Organic textures.** Backgrounds that suggest paper, watercolor, fabric, or other natural materials — rather than flat colors or smooth gradients. The texture reads as material rather than as digital surface.
+
+**Variable typography.** A typeface that has subtle character variations (humanist serifs are often like this), or hand-set text with intentional kerning irregularities. Contrasts with mathematically-uniform display type.
+
+**Variable spacing and rhythm.** Layouts where vertical spacing isn't perfectly uniform — some sections breathe more than others, creating a more editorial feel.
+
+**Imperfect alignment used deliberately.** A pull-quote that breaks the column. A photo that bleeds past its frame. A subhead that hangs into the margin.
+
+**Visible craft cues.** Marks that suggest process — a sketch underneath a finished illustration, a draft note in the margin, an "in progress" feel in non-final surfaces.
+
+## Calibrating imperfection
+
+The right level of imperfection depends on context:
+
+**More imperfection welcomed:**
+- Personal / creative products (journals, art tools, meditation).
+- Editorial content (magazines, long-form blogs).
+- Brand-identity moments (marketing surfaces, hero illustrations).
+- Hand-craft or artisanal product categories.
+- Newer products experimenting with distinctive aesthetics.
+
+**Less imperfection welcomed:**
+- Functional UI (buttons, forms, navigation).
+- Data displays.
+- Critical-action interfaces.
+- Enterprise / professional contexts.
+- Accessibility-critical surfaces.
+
+A single product can use different levels of imperfection in different surfaces. The hero illustration on the marketing site can be hand-drawn; the in-app dashboard can be precise. Each register serves its context.
+
+## What's the difference between designed imperfection and sloppy?
+
+The difference often comes down to:
+
+**Intent.** Designed imperfection is chosen; sloppy is accidental. The designer can articulate why each imperfection is there.
+
+**Refinement.** Designed imperfection is well-crafted within its irregularity. The hand-drawn line is well-drawn even though it's hand-drawn. Sloppy is not crafted at all.
+
+**Restraint.** Designed imperfection is selectively applied. Some elements are perfect; others are imperfect. Sloppy is uniform low quality.
+
+**Coherence.** Designed imperfection has a consistent register — the imperfections feel of-a-piece. Sloppy varies randomly.
+
+If the imperfection feels uncertain ("did they mean this?") it's not yet designed; it's still on the way to being something. Refine it until the intent is clear.
+
+## Worked examples
+
+### A meditation app's hero illustration
+
+A meditation app's hero illustration is a hand-drawn ink wash of a mountain landscape — visible brushstrokes, subtle imperfections in the lines, watercolor-like color pooling. The illustration sits within a precisely-aligned page layout (typography is set, navigation is precise).
+
+The contrast is the point: the illustration brings warmth and reflection; the surrounding UI provides functional clarity. Both elements serve the product.
+
+### A handwritten signature in a confirmation email
+
+A confirmation email signs off with a handwritten signature (an SVG of an actual signature) rather than a typed name. The handwritten element reads as personal — the rest of the email is professionally formatted. The signature does small but real work in establishing brand warmth.
+
+### A note app that uses a serif with humanist character
+
+A note-taking app uses a humanist serif (something like Charter, Source Serif, or IBM Plex Serif) for body text. The typeface has subtle character variation — slightly varied stroke widths, organic curves, a sense of having been written rather than computed. Compared to a geometric sans-serif, it feels more personal.
+
+This is wabi-sabi at the typography level. The imperfection is in the typeface design, applied uniformly within the product.
+
+### Tilted cards that cross into sloppy
+
+A product designs cards that are tilted at random angles for "warmth." Each card sits at a slight rotation. The intent is to feel hand-arranged. The result feels broken — users wonder if the layout has rendered incorrectly.
+
+The fix: either align all the cards (commit to precision) or use larger, more deliberate rotations (commit to the imperfection register clearly). The middle ground reads as bug.
+
+### Hand-drawn icons among vector ones
+
+A product mixes hand-drawn icons (for category headings) with vector-precise icons (for actions). The two sets have different intent: the hand-drawn ones feel personal and warm; the vector ones feel functional and precise. The mix communicates hierarchy: "this is a heading you'll engage with thoughtfully" vs. "this is an action you'll take quickly."
+
+When done well, the mix is coherent: each icon set is well-crafted within its register; the use of each is consistent.
+
+## Anti-patterns
+
+**Reflexive sloppy.** Adding imperfection without intent. A jumbled layout that's not organized either by precision or by deliberate asymmetry.
+
+**Imperfection in functional UI.** A submit button that's slightly tilted or has hand-drawn text. Functional UI benefits from precision; imperfection here reads as broken.
+
+**Inconsistent register.** Some surfaces wabi-sabi, others highly precise, with no logic to which is which. Users get confused.
+
+**Imperfection that hurts accessibility.** Hand-drawn typography that's hard to read; asymmetric layouts that confuse screen readers; organic textures that reduce contrast for low-vision users.
+
+**Imperfection without restraint.** Wabi-sabi imperfection is supposed to coexist with overall restraint. Combined with maximalism, it just adds to the chaos.
+
+**Cultural surface adoption.** Calling something "wabi-sabi" because it has tilted elements, without engaging with the deeper aesthetic philosophy. The work feels shallow.
+
+## Heuristic checklist
+
+When designing imperfect elements, ask: **Is this imperfection intentional, or accidental?** Be able to articulate the intent. **Is it refined within its irregularity?** Hand-drawn should still be well-drawn. **Is the register appropriate for the context?** Personal / creative welcomes more; functional / data resists. **Will it scale across the product or just this surface?** Hand-crafted elements have maintenance costs. **Does it hurt accessibility?** If yes, reconsider. **Is the design overall restrained, so the imperfection has room to breathe?** Imperfection plus richness equals chaos.
+
+## Related sub-skills
+
+- `wabi-sabi` — parent principle on the aesthetic of imperfection and restraint.
+- `wabi-sabi-restraint` — sibling skill on the absence-of-decoration half.
+- `aesthetic-usability-effect` — warmth contributes to perceived usability.
+- `archetypes` — Caregiver, Creator, and Sage archetypes align with wabi-sabi register.
+
+## See also
+
+- `references/imperfection-techniques.md` — practical techniques for adding deliberate imperfection.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi-imperfection/references/imperfection-techniques.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi-imperfection/references/imperfection-techniques.md
@@ -1,0 +1,129 @@
+# Imperfection techniques
+
+Practical techniques for adding deliberate imperfection that reads as warmth rather than as broken.
+
+## Technique: humanist typography
+
+Choose typefaces designed with humanist warmth rather than geometric precision:
+
+- **Serif:** Charter, Source Serif, IBM Plex Serif, Garamond, Caslon, Lyon.
+- **Sans-serif:** Inter (subtle warmth), Open Sans, Source Sans 3, Atkinson Hyperlegible.
+- **Display:** typefaces with intentional character variation; calligraphic feel.
+
+These typefaces have subtle character variations that read as more personal than fully geometric or modernist typefaces.
+
+## Technique: hand-drawn elements
+
+Add hand-drawn or hand-drawn-feeling elements:
+
+- **Illustrations.** Real hand-drawn illustrations or vector illustrations that imitate hand-drawn lines.
+- **Icons.** Hand-drawn icon sets for categories where warmth matters.
+- **Decorative elements.** Hand-drawn dividers, ornaments, marginalia.
+- **Signatures.** SVG signatures in correspondence.
+
+Sources for hand-drawn assets:
+- Commission from illustrators.
+- Stock libraries with hand-drawn collections.
+- AI-generated (with care; verify they don't look generic).
+
+## Technique: organic textures
+
+Use textures that suggest material origins:
+
+- **Paper textures.** Subtle grain or fiber visible in backgrounds.
+- **Watercolor washes.** Bleeding color, varied saturation.
+- **Brush strokes.** Visible texture in painted backgrounds or accent elements.
+- **Natural patterns.** Wood grain, stone, fabric.
+
+Calibrate carefully — too much texture becomes visual noise. Use sparingly, in surfaces where it serves (hero areas, special-occasion designs, brand-identity moments).
+
+## Technique: subtle asymmetry
+
+Break the grid in deliberate ways:
+
+- **Off-center logos.** Logo positioned slightly above or to the side of geometric center.
+- **Bleeding elements.** Photos or illustrations that extend past their containers.
+- **Variable column widths.** A layout where columns aren't all the same width.
+- **Irregular vertical rhythm.** Sections with intentionally varied spacing rather than uniform.
+
+The asymmetry should feel composed, not random. Test by asking: does this feel arranged or accidental?
+
+## Technique: variable kerning and tracking
+
+For headlines and special typographic moments:
+
+- **Hand-set kerning.** Adjust spacing of individual letter pairs for visual balance rather than relying on the default.
+- **Optical sizing.** Use typefaces with optical-size variants designed for different sizes.
+- **Subtle weight variation.** Combine regular and slightly-bold within a single phrase for emphasis.
+
+These techniques are advanced; they take time and attention. Reserve for high-visibility surfaces.
+
+## Technique: kintsugi-inspired repairs
+
+The Japanese art of repairing broken pottery with gold-mixed lacquer makes the breakage visible and beautiful. Translated to digital design:
+
+- **Visible edits.** Show that something was changed, with grace rather than hiding it. A subtle indication that "this section was added later" can feel more authentic than seamless integration.
+- **Visible history.** Edit history, version annotations, change logs that read as part of the design rather than as administrative metadata.
+
+This is a sophisticated technique that few products use. When done well, it conveys authenticity and care.
+
+## Technique: pencil sketches in working surfaces
+
+For tools where users are creating:
+
+- **Sketchy elements.** Drawing tools that have a "sketchy" mode with hand-drawn-looking output.
+- **Concept-stage indications.** A "concept" or "draft" mode that visually distinguishes from final outputs.
+- **Editable hand-drawn elements.** Tools that let users add pencil-style annotations to clean documents.
+
+These give users a way to express the messy creative process within an otherwise clean tool.
+
+## Technique: editorial rhythm
+
+For long-form content:
+
+- **Pull quotes.** Larger text breaking the body, set differently from body type.
+- **Drop caps.** Decorative initial letters at the start of sections.
+- **Marginalia.** Notes in the margins, sidenotes, callouts.
+- **Varied paragraph length.** Resist the temptation to make all paragraphs uniform.
+
+Editorial design has long traditions of visual variety in service of reading. Bring some of those into web typography.
+
+## Technique: animation imperfection
+
+Animations don't have to be perfectly smooth:
+
+- **Slight overshoot.** Animations that overshoot the target slightly and settle (spring physics).
+- **Variable timing.** Different elements animating at slightly different rates.
+- **Stagger.** Multiple items appearing in sequence rather than simultaneously.
+
+These give animation an organic feel rather than a mechanical one.
+
+## Anti-patterns
+
+**Imperfection at random.** Asymmetry without composition. Should feel arranged.
+
+**Imperfection in functional UI.** Submit buttons, form fields, navigation should remain precise. Reserve imperfection for warmth-appropriate surfaces.
+
+**Imperfection that hurts contrast.** Decorative textures that reduce text contrast. Test accessibility.
+
+**Inconsistent application.** Some sections wabi-sabi, others modern minimalist, with no logic. Users can't form expectations.
+
+**Imperfection at the cost of legibility.** Hand-drawn typography that's hard to read. Function still matters.
+
+**Faux-vintage that reads as kitsch.** Heavy texture filters, faux-aged photos, sepia tones applied uniformly. The aesthetic becomes affected.
+
+## Production considerations
+
+**Maintenance cost.** Hand-drawn elements need to be commissioned or created for each new use. Vector elements scale; hand-drawn don't.
+
+**Performance.** Textured backgrounds, complex illustrations, animation effects all cost render time. Balance against performance budgets.
+
+**Localization.** Hand-drawn elements with text need to be redrawn for each language. Plan for international.
+
+**Accessibility.** All visual elements need accessible alternatives. Hand-drawn icons need text labels; textured backgrounds need to maintain text contrast.
+
+**Design system integration.** Wabi-sabi elements often live outside the systematic design system. Document them clearly so other designers know where they're meant to be used.
+
+## Cross-reference
+
+For the restraint half of wabi-sabi, see `wabi-sabi-restraint`. For the parent principle, see `wabi-sabi`.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi-restraint/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi-restraint/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: wabi-sabi-restraint
+description: 'Apply wabi-sabi restraint — the discipline of leaving things out, of resisting decoration, of letting empty space and silence do design work. Use when designing reading-focused interfaces, paring back accumulated clutter, choosing between decoration and absence, or evaluating whether each element earns its place. Restraint is the often-overlooked half of wabi-sabi: the imperfection side gets attention, but the principle is equally about modesty and the elegance of what''s not there.'
+---
+
+# Wabi-Sabi — restraint
+
+The other half of wabi-sabi: restraint. The discipline of leaving things out, of resisting decoration, of letting empty space carry the design. Where the imperfection side adds warmth through visible craft, the restraint side adds elegance through what's not there.
+
+The two halves work together. Pure imperfection without restraint becomes kitsch. Pure restraint without imperfection becomes cold minimalism. The Japanese tea room embodies both: the materials are humble and slightly irregular (imperfection), but the space is sparse and uncluttered (restraint).
+
+In digital design, restraint is often the more useful half. Most products suffer from too much decoration, not too little. Too many features competing for attention; too many visual flourishes; too many options the user has to evaluate. Restraint corrects this.
+
+## What restraint looks like
+
+**Generous whitespace.** Empty space around content lets the content breathe. The absence is doing design work.
+
+**Single focal point per view.** Each screen has one primary thing the user is meant to focus on; supporting elements step back.
+
+**Limited color palette.** Five or six colors with clear roles, used disciplined, rather than fifteen colors used arbitrarily.
+
+**Few typefaces.** Two or three typefaces (or weights of one), not a typographic zoo.
+
+**Resistance to decoration.** No element added unless it earns its place. Visual elements serve function, not just visual interest.
+
+**Silence in interaction.** Not every action needs animation; not every state needs a visual flourish. Quiet interactions for quiet moments.
+
+**Resistance to feature creep.** Features added only when they earn their place. The product stays focused.
+
+**Editorial discipline in copy.** Words used carefully; nothing added that doesn't say something. Brevity and precision.
+
+## Why restraint matters
+
+Restraint produces several benefits:
+
+**Focus.** Users know where to look. The single focal point is unambiguous.
+
+**Speed.** Less to render, fewer choices to make, faster to use.
+
+**Maintainability.** Fewer elements means fewer things to update, fix, or redesign.
+
+**Timelessness.** Trends in decoration date quickly; restrained designs age well.
+
+**Elegance.** Simplicity reads as refinement; clutter reads as lack of editorial discipline.
+
+**Approachability.** A spare design feels welcoming; a busy design feels intimidating.
+
+The cost of restraint is that it requires saying no — often to suggestions for additions, decorations, features. The discipline is unglamorous but valuable.
+
+## When restraint is the right register
+
+Restraint fits almost any context, but is especially valuable in:
+
+**Reading-focused products.** Articles, documentation, e-books. Anything where the user needs to focus on text.
+
+**Functional tools.** Products where the user is doing real work; visual decoration distracts.
+
+**Premium / luxury brands.** Restraint reads as confidence; decoration reads as trying too hard.
+
+**Mature products.** Once a product has accumulated complexity, restraint is the corrective.
+
+**International audiences.** Restrained designs translate more cleanly across cultures than richly decorated ones.
+
+## When too much restraint becomes a problem
+
+Restraint can be overdone:
+
+**Coldness.** Pure restraint without warmth can feel sterile. Combine with selective imperfection.
+
+**Loss of brand identity.** A maximally restrained product may not differentiate. Some products need character; restraint alone doesn't provide it.
+
+**Over-stripping for aesthetic.** Removing things users actually need because "restraint." Function still matters.
+
+**Interface that doesn't communicate.** A button with no visible affordance because "restraint." Users need cues to interact.
+
+The line between elegant restraint and stark coldness is real. Calibrate based on the product's purpose.
+
+## Worked examples
+
+### A reading-focused content site
+
+A long-form content site uses extreme restraint:
+- Single column of text, generous margins.
+- Two typefaces (a body serif and a display serif).
+- Minimal chrome (a small header, no sidebar, no footer ads).
+- Generous whitespace around images and pull quotes.
+- No autoplay video, no popup, no scroll-triggered effects.
+
+The restraint serves reading. The user can focus on the content; the design steps back. This is restraint as functional virtue.
+
+### A SaaS dashboard with restraint
+
+A SaaS dashboard uses restraint in its design system:
+- Five colors with clear roles (primary, secondary, success, warning, error).
+- One typeface in three weights.
+- Consistent spacing on a single scale.
+- Cards with subtle backgrounds rather than borders.
+- No animation other than functional state changes.
+
+The dashboard reads as professional and considered. New features can be added without fighting decoration; the design system has room.
+
+### A product that strips too much
+
+A productivity app aggressively simplifies: removes labels under icons; removes button borders; uses very low color contrast for "subtle" feel. The result: users can't tell what's clickable, can't read low-contrast text, can't navigate. The restraint went past elegance into dysfunction.
+
+The fix: restore enough cues for the interface to communicate. Restraint is a means, not an end.
+
+### A meditation app combining restraint and warmth
+
+A meditation app uses restraint in its primary chrome (clean layout, generous whitespace, single typeface) but adds warmth in selected moments (hand-drawn opening illustration, occasional watercolor textures, warm color palette).
+
+The combination is the right register: restraint for function, warmth for emotional moments. Both halves of wabi-sabi working together.
+
+### A landing page with restraint
+
+A startup's landing page has:
+- A single headline.
+- A subhead.
+- A single CTA button.
+- An image (or no image).
+- Minimal navigation.
+
+That's it. No animated background, no scrolling effects, no testimonial carousel, no fold-after-fold of features. The restraint reads as confidence: the product speaks for itself.
+
+This is the opposite of the typical maximalist landing page. Both can work; restrained landing pages tend to age better and convert better for considered purchases.
+
+## Anti-patterns
+
+**Restraint at the cost of communication.** Removing labels, lowering contrast, removing affordances. The interface stops working.
+
+**Cold restraint without warmth.** Pure minimalism with no human touch. Reads as institutional or sterile.
+
+**Restraint as default styling.** Stripping things by reflex without considering whether they were earning their place.
+
+**Restraint that doesn't extend to features.** A visually-restrained product crammed with features. The visual restraint is undermined by feature complexity.
+
+**Restraint inconsistent with audience.** A startup using ultra-restrained design when its audience expects energy and personality.
+
+**Confusing minimal with simple.** A minimal-looking interface that's actually deeply complex (just hidden behind layers of disclosure). True restraint extends through the design, not just the surface.
+
+## Heuristic checklist
+
+When applying restraint, ask: **Does each element earn its place?** If not, remove it. **Is whitespace doing design work?** Generous whitespace can carry meaning. **Are there too many colors / typefaces / styles?** Reduce to the minimum that serves. **Is the restraint coming at the cost of function?** Communication should not be sacrificed for aesthetic. **Is restraint balanced with appropriate warmth?** Pure restraint can be cold; combine with selective wabi-sabi imperfection.
+
+## Related sub-skills
+
+- `wabi-sabi` — parent principle on imperfection and restraint.
+- `wabi-sabi-imperfection` — sibling skill on the warmth-through-imperfection half.
+- `signal-to-noise-ratio` — restraint maximizes signal.
+- `ockhams-razor` — the razor and restraint align: prefer simpler when equivalent.
+- `form-follows-function` — restraint helps form follow function.
+
+## See also
+
+- `references/restraint-checklist.md` — practical checklist for applying restraint to existing designs.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi-restraint/references/restraint-checklist.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi-restraint/references/restraint-checklist.md
@@ -1,0 +1,147 @@
+# Restraint — checklist for application
+
+A practical checklist for applying wabi-sabi restraint to existing designs.
+
+## Audit your design system
+
+**How many colors are in active use?**
+- Goal: 5–7 colors with clear semantic roles.
+- If more: consolidate. Some colors should be variants; some should be eliminated.
+
+**How many typefaces?**
+- Goal: 2–3 typefaces (or weights of one).
+- If more: pick the strongest and eliminate the rest.
+
+**How many type sizes?**
+- Goal: 5–8 sizes on a clear scale.
+- If more: collapse to scale values; remove ad-hoc sizes.
+
+**How many shadow / elevation levels?**
+- Goal: 5–7 levels.
+- If more: consolidate.
+
+**How many corner radii in use?**
+- Goal: 2–3 (sharp, slight, rounded).
+- If more: consolidate.
+
+**How many animation durations / easings?**
+- Goal: 3–4 each.
+- If more: consolidate.
+
+Each consolidation is an act of restraint. The result is a more cohesive, more maintainable design system.
+
+## Audit your screens
+
+**Is there a single focal point on each screen?**
+- One primary action, one primary message, one primary visual emphasis.
+- If multiple competing focal points: pick one and demote the rest.
+
+**Is every visible element earning its place?**
+- For each element, ask: what does this do? If "decoration" or "fills space," consider removing.
+- Especially: badges, callouts, animated highlights, gradient overlays.
+
+**Is whitespace generous?**
+- Margins around content, padding inside containers, vertical breathing room between sections.
+- Crowded screens benefit from more space, almost always.
+
+**Are there elements added "to fill space"?**
+- These are the easiest to remove. Empty space is fine.
+
+**Is there visual noise that doesn't carry information?**
+- Decorative borders, drop shadows on every element, gradient backgrounds, textures applied uniformly.
+- Each adds visual weight; each should be justified.
+
+## Audit your features
+
+**How many features does the product have?**
+- The exact number isn't the point; the question is whether each earns its place.
+
+**Which features have low usage?**
+- See `ockhams-feature-pruning` for the audit process.
+- Features that don't serve users well are candidates for removal.
+
+**Which features overlap in function?**
+- Multiple ways to accomplish the same task. Consolidate to one.
+
+**Which features were added for one customer?**
+- These often outlive their original purpose. Re-evaluate.
+
+## Audit your settings
+
+**How many user-configurable settings exist?**
+- Each setting is a decision the user has to make (or default they may not love).
+- Question whether each setting needs to be configurable.
+
+**Which settings are rarely changed from default?**
+- These could probably just be defaults; remove the configurability.
+
+**Which settings does the team forget the meaning of?**
+- A sign that the setting has accumulated past its usefulness.
+
+## Audit your copy
+
+**Is the copy concise?**
+- Every word should serve. Cut filler.
+
+**Is the tone consistent?**
+- Mixed registers (formal in some places, casual in others) reduce coherence.
+
+**Are there places where less text would be clearer?**
+- Often, yes.
+
+**Is there UI text that just states the obvious?**
+- "Click here to..." when the button is clearly clickable.
+- "This is the X section..." when the heading already says X.
+
+## Audit your animations
+
+**Do all the animations serve communication?**
+- Each animation costs render time and user attention. If it doesn't communicate, it's noise.
+
+**Are animations consistent in timing and easing?**
+- Inconsistent animation reads as patched.
+
+**Are there animations that frequent users would want to skip?**
+- Honor reduced-motion preferences; consider whether the animations should be quicker.
+
+## Process restraint
+
+**Are decisions made deliberately, or accumulated?**
+- Restraint requires saying no. Build the muscle for that.
+
+**Is feature addition harder than feature removal?**
+- It should be roughly symmetrical. If addition is easy and removal is hard, complexity will accumulate.
+
+**Is there a regular pruning cadence?**
+- Quarterly or semi-annual review of features, settings, complexity.
+
+**Are designers and engineers held to restraint principles?**
+- A team value that's articulated and reinforced.
+
+## A practical exercise
+
+Pick one screen of your product. Open it. Apply this exercise:
+
+1. List every visible element on the screen.
+2. For each element, identify what it does and why it's there.
+3. Identify the elements you can't articulate the value of.
+4. Consider removing those elements.
+5. Look at the result. Is it cleaner? Does it still work? If yes, ship the simpler version.
+
+This exercise often reveals that 10–30% of visible elements aren't earning their place. Removing them produces immediate improvement.
+
+## Anti-patterns to avoid
+
+**Restraint at the cost of usability.** Don't strip affordances; users need to know what's clickable. Don't lower contrast; text needs to be readable. Don't remove labels; users need to know what things do.
+
+**Restraint by reflex.** Stripping things just because stripping feels virtuous. Verify that what you're removing wasn't earning its place.
+
+**Inconsistent restraint.** Stripping some sections and not others. The product feels patched together.
+
+**Cold restraint.** Pure minimalism without warmth or character. Combine with selective imperfection.
+
+**Restraint as a one-time event.** Restraint is a discipline, not a project. The pressure for additions is constant; restraint has to be ongoing.
+
+## Cross-reference
+
+For the imperfection half of wabi-sabi, see `wabi-sabi-imperfection`. For the parent principle, see `wabi-sabi`. For pruning accumulated complexity, see `ockhams-feature-pruning`.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: wabi-sabi
+description: 'Apply the principle of Wabi-Sabi — the aesthetic embrace of imperfection, impermanence, and naturalness. Use when designing for warmth and authenticity, creating spaces that feel lived-in rather than sterile, choosing handcrafted-feeling materials over machined perfection, or evaluating whether a design feels too polished and impersonal. Wabi-sabi resists the digital-design tendency toward pixel-perfect uniformity in favor of subtle asymmetry, organic textures, and the visible mark of process. Used appropriately, it produces designs that feel human; used reflexively, it produces fake-looking sloppiness.'
+---
+
+# Wabi-Sabi
+
+> **Definition.** Wabi-sabi is a Japanese aesthetic philosophy centered on the beauty of imperfection, impermanence, and naturalness. *Wabi* connotes simplicity, rustic refinement, and the elegance of restraint; *sabi* connotes the patina of age, the beauty of weathering, and the marks of use. Together they describe an aesthetic that finds beauty in the asymmetric, the irregular, the modest, the worn — qualities the dominant Western aesthetic of perfection, symmetry, and uniformity often rejects.
+
+In design, wabi-sabi serves as a counterweight to the relentless polish of modern digital aesthetics. Pixel-perfect grids, algorithmic uniformity, smoothed gradients, machine precision — all produce designs that can feel sterile, impersonal, untouched by human hand. Wabi-sabi asks: is the perfect actually best? Or does some imperfection produce a warmth that perfection lacks?
+
+The principle isn't included in the 2003 first edition of *Universal Principles of Design* but appears in expanded editions, where it's positioned as a useful antidote to the over-perfect tendencies of computer-aided design. It's most useful in modern UX as a counterbalance to the homogenization of design systems.
+
+## Why wabi-sabi matters in design
+
+Most design tools and processes push toward perfection by default. Auto-aligned grids, snapped-to-pixel layouts, mathematically-derived color palettes, perfectly consistent components. The result is technically excellent and emotionally cold. Many products from the 2010s onward have a sameness about them — competently designed, almost interchangeable, lacking warmth.
+
+Wabi-sabi reintroduces humanity. Subtle asymmetry. Texture that suggests material, not just rendering. Hand-drawn elements among the geometric. Imperfections that read as authentic rather than broken. The result, when done well, is design that feels made for humans by humans.
+
+Used appropriately, wabi-sabi:
+
+- **Adds warmth.** Slight irregularities suggest care and craft.
+- **Distinguishes from competitors.** When everyone else is using the same design system, deliberate imperfection stands out.
+- **Conveys authenticity.** A handwritten note feels more personal than a typed one; a slightly-tilted card feels more genuine than a perfectly-aligned one.
+- **Communicates organic process.** Some products genuinely benefit from feeling crafted (artisanal goods, journals, creative tools) rather than mass-produced.
+
+Used inappropriately, wabi-sabi:
+
+- **Reads as broken.** Imperfections that look like bugs rather than choices.
+- **Reduces accessibility.** Asymmetric layouts can hurt users who depend on consistent structure.
+- **Feels affected.** Aesthetic imperfection in a context that doesn't warrant it can feel performative.
+- **Increases maintenance burden.** Hand-crafted elements are harder to scale and maintain than systematic ones.
+
+## When wabi-sabi is the right register
+
+Some product categories naturally welcome wabi-sabi:
+
+**Personal / intimate products.** Journals, notes apps, meditation tools, personal finance — products users engage with reflectively. Subtle warmth supports the personal register.
+
+**Creative tools.** Drawing apps, music production, writing tools — products that make things. Some imperfection acknowledges that creation is a messy process.
+
+**Cultural / artisanal products.** Bookstores, craft marketplaces, slow-food platforms — products whose subject matter is itself wabi-sabi-aligned.
+
+**Editorial content.** Magazines, blogs, newsletters — long-form content that benefits from typographic warmth and varied rhythm rather than uniform grids.
+
+**Brand differentiation moments.** Marketing surfaces, hero illustrations, special-occasion designs — places where standing out matters.
+
+## When wabi-sabi is the wrong register
+
+Some contexts demand precision and reject imperfection:
+
+**Critical-action interfaces.** Medical, financial, safety-critical UI. Users need to be sure of what they're seeing; imperfection undermines that.
+
+**Data-dense displays.** Spreadsheets, dashboards, analytical tools. Users need to scan and compare; asymmetry hurts.
+
+**High-volume UI.** The settings panel, the form, the table. Functional elements that benefit from systematic consistency.
+
+**Enterprise / institutional contexts.** B2B SaaS, government, compliance tools. The audience expects precision; informal imperfection reads as unprofessional.
+
+**Accessibility-critical contexts.** Asymmetric or irregular elements can hurt users with vision differences or cognitive disabilities.
+
+The principle is selective. Apply where warmth helps; restrain where precision matters.
+
+## Sub-skills in this cluster
+
+- **wabi-sabi-imperfection** — Designing intentional imperfection that reads as warmth rather than as broken: subtle asymmetry, organic textures, hand-drawn elements.
+- **wabi-sabi-restraint** — The other half of wabi-sabi: simplicity, restraint, the absence of decoration. The discipline of leaving things out.
+
+## Worked examples
+
+### A meditation app with warmth
+
+A meditation app uses subtle wabi-sabi cues: a slightly-imperfect hand-drawn logo (rather than a precision-vector logo), illustrations with visible brushstrokes, soft asymmetric backgrounds suggesting watercolor. The chrome is otherwise clean and functional.
+
+The result feels personal and reflective — appropriate for the product's purpose. A perfectly-precise design would feel cold for this category.
+
+### A note-taking app with restraint
+
+A note-taking app uses wabi-sabi restraint: minimal chrome, generous whitespace, a serif typeface with humanist warmth, gentle separators rather than hard borders. The interface gets out of the way; the user's content is the focal point.
+
+The restraint here is wabi-sabi at the absence-of-decoration level. The app feels modest and refined.
+
+### A B2B SaaS that misapplies wabi-sabi
+
+A B2B analytics tool's marketing site uses hand-drawn illustrations, slightly tilted cards, and informal typography. The marketing reads as casual and friendly. But the product itself — used by enterprise buyers for serious analysis — feels at odds with the marketing's register. Buyers expect precision; the wabi-sabi feels mismatched.
+
+The fix: keep the marketing warm if it serves brand differentiation, but ensure the product itself reads as precise and trustworthy. Or align both registers — but probably toward the precision side, given the audience.
+
+### A personal finance app
+
+A personal finance product uses wabi-sabi cues throughout: warm typography, slight irregularities in card layouts, hand-illustrated charts. The intent is to feel personal and approachable.
+
+But: the audience needs to trust the numbers. Slight asymmetry in chart layout can read as data unreliability. The wabi-sabi register may be undermining the product's core promise.
+
+The fix: keep wabi-sabi in non-data surfaces (onboarding, marketing, brand moments) and apply precision in data displays. Use the right register for each context within the same product.
+
+### A bookstore website
+
+An online bookstore uses wabi-sabi extensively: slightly tilted book covers, organic textures suggesting paper and ink, varied rhythm rather than rigid grids, hand-set typography with intentional kerning irregularities. The product (books, reading) is itself wabi-sabi-aligned, so the design echoes it.
+
+The result feels like a real bookstore — handcrafted, curated, personal. A precision-design would feel more like a generic e-commerce site.
+
+## Anti-patterns
+
+**Wabi-sabi as decoration.** Adding imperfection without purpose. Tilted cards because "it looks designed," not because the design needs them.
+
+**Confusing imperfection with sloppy.** True wabi-sabi imperfection is deliberate and refined. Sloppy work is broken and unfinished. The two are not the same.
+
+**Wabi-sabi at scale.** Hand-crafted elements that work in a small studio don't scale to global design systems. Either commit to the maintenance or use the principle selectively.
+
+**Wabi-sabi in the wrong register.** Applying the aesthetic to enterprise, financial, medical, or other precision-required contexts.
+
+**Wabi-sabi without restraint.** Imperfection plus richness equals chaos. Wabi-sabi lives alongside restraint; combining it with maximalism produces visual noise.
+
+**Cultural appropriation issues.** Using wabi-sabi as a stylistic veneer without engaging with its philosophical roots. The aesthetic comes from a specific cultural tradition; surface adoption can read as shallow.
+
+## Heuristic checklist
+
+When considering wabi-sabi cues, ask: **Does my product's category and audience welcome warmth?** If not, restrain. **Is the imperfection deliberate and refined, or just sloppy?** Sloppy doesn't help. **Does the imperfection hurt accessibility or scanability?** If yes, reconsider. **Will this scale?** Hand-crafted elements have maintenance costs. **Am I using wabi-sabi to differentiate, or just for decoration?** Decoration without purpose adds nothing.
+
+## Related principles
+
+- **Aesthetic-Usability Effect** — wabi-sabi can contribute to perceived usability through warmth.
+- **Form Follows Function** — wabi-sabi is not anti-functional; the imperfection should serve the product's purpose.
+- **Archetypes** — some brand archetypes (Caregiver, Sage, Outlaw) align with wabi-sabi register; others don't.
+- **Signal-to-Noise Ratio** — wabi-sabi restraint maximizes signal; the imperfection side is asking which "noise" is actually warmth.
+- **Mimicry** — wabi-sabi often mimics organic / natural / handmade qualities.
+
+## See also
+
+- `references/lineage.md` — origins in Japanese aesthetic philosophy.
+- `wabi-sabi-imperfection/` — sub-skill on designing deliberate imperfection.
+- `wabi-sabi-restraint/` — sub-skill on the absence of decoration.

--- a/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/aesthetics-and-emotion-principles/skills/wabi-sabi/references/lineage.md
@@ -1,0 +1,99 @@
+# Wabi-Sabi — origins and aesthetic lineage
+
+## Japanese aesthetic philosophy
+
+Wabi-sabi (侘寂) developed over centuries in Japan, drawing on Zen Buddhism, the tea ceremony, and the broader cultural valuation of impermanence and natural beauty. The two terms have distinct origins.
+
+**Wabi (侘)** originally meant "loneliness" or "rustic simplicity" — the spare, unadorned beauty of solitary mountain dwellings, of unembellished pottery, of restraint. The term was elevated through the writings of tea masters in the 15th and 16th centuries, particularly Sen no Rikyū, who refined the tea ceremony around principles of simplicity, modesty, and asymmetry. A wabi tea cup is unglazed in places, unevenly thrown, perhaps repaired with gold (kintsugi) — beautiful precisely because of its modesty and individuality.
+
+**Sabi (寂)** originally meant "withered" or "rusted" — the beauty that comes from age, weathering, and the passage of time. The patina on bronze, the silvering of weathered wood, the moss on stones, the subtle erosion of stone steps worn by centuries of feet. Sabi celebrates what time does to materials: not decay as failure, but as accumulated history visible in the object.
+
+Together, wabi-sabi describes an aesthetic that finds beauty in:
+
+- **Imperfection.** The asymmetric, the irregular, the partial.
+- **Impermanence.** The fading, the changing, the transient.
+- **Incompleteness.** The unfinished, the suggested rather than the fully drawn.
+- **Modesty.** The understated, the restrained.
+- **Naturalness.** The unforced, the organic.
+
+The aesthetic stands in deliberate contrast to perfectionist traditions (Western classical, modernist, machined precision) that seek symmetry, completeness, and uniformity.
+
+## In Japanese arts
+
+Wabi-sabi is foundational to many Japanese arts:
+
+- **The tea ceremony.** Spaces are deliberately spare. Tools show their material origins. Imperfections in pottery (the dimple in a tea bowl) are valued.
+- **Architecture.** Traditional teahouses use unworked materials; structural irregularities are celebrated.
+- **Garden design.** Japanese gardens favor asymmetry, irregular paths, weathered stones over geometric formality.
+- **Pottery.** Raku ware and other traditional pottery embraces firing irregularities. Kintsugi (golden-joinery) repairs broken pottery with lacquer mixed with gold, making the breakage visible and beautiful.
+- **Calligraphy.** Each stroke shows the artist's hand; perfection isn't the goal.
+- **Haiku.** The form values restraint, suggestion, imperfection.
+
+The aesthetic is not a single style but a sensibility that pervades many forms.
+
+## Western reception
+
+Wabi-sabi has been variously interpreted in Western design contexts since the mid-20th century. Notable points:
+
+- **The Studio Pottery movement** (Bernard Leach, Shoji Hamada, and others mid-century) brought wabi-sabi influence into Western ceramics.
+- **Architects like Frank Lloyd Wright** drew on Japanese aesthetic principles, including wabi-sabi-influenced asymmetry and material naturalness.
+- **The Slow Movement** (Slow Food, Slow Design) of the 1990s onward shares wabi-sabi sensibilities about restraint, naturalness, and craft.
+- **Leonard Koren's *Wabi-Sabi for Artists, Designers, Poets and Philosophers*** (1994) brought the concept to Western design audiences.
+- **The handmade craft revival** (post-2000) emphasizes wabi-sabi values of authenticity and craft over mass production.
+
+These reception have sometimes been criticized as superficial — adopting the aesthetic without engaging with the deeper philosophy. Reasonable application requires more than just adding imperfection to a Western design tradition.
+
+## In modern design
+
+Wabi-sabi appears in modern design contexts in several ways:
+
+**Material design choices.** Natural wood grain rather than uniform veneers; visible textures rather than smooth finishes; weathered metal rather than polished.
+
+**Typography choices.** Humanist typefaces with character variation; subtle kerning irregularities; hand-drawn elements alongside set type.
+
+**Layout choices.** Asymmetric grids; varied rhythms; intentional inconsistencies that suggest editorial care.
+
+**Illustration style.** Hand-drawn or digitally-imitated-hand-drawn elements; visible brushstrokes; pencil sketches.
+
+**Brand voice.** Warm, personal, occasional informality; resistance to corporate-speak.
+
+In digital design specifically, wabi-sabi can serve as a counterweight to design-system uniformity. When every product uses the same design tokens and components, distinctive imperfection becomes a source of differentiation.
+
+## When the aesthetic transfers and when it doesn't
+
+Wabi-sabi's transferability to digital design is contested:
+
+**Arguments for:** Digital design has trended toward sterile uniformity. Wabi-sabi reintroduces warmth and humanity. Some product categories (personal, creative, reflective) genuinely benefit from the register.
+
+**Arguments against:** Wabi-sabi was developed for material objects (pottery, architecture, gardens) where imperfection has substance. Digital interfaces lack the material substrate that gives physical imperfection its character. Digital wabi-sabi can read as performative or affected.
+
+The honest position: wabi-sabi cues can help digital design when applied thoughtfully and selectively, but the principle doesn't translate fully. The full aesthetic depends on materiality, time, and embodied experience that digital interfaces don't provide.
+
+## Cultural sensitivity
+
+Wabi-sabi is part of a specific cultural tradition. Adopting the aesthetic without engagement with that tradition risks:
+
+- **Surface appropriation.** Using the look without the substance.
+- **Misrepresentation.** Calling something "wabi-sabi" when it's just sloppy.
+- **Commercialization of cultural heritage.** Using cultural concepts to sell products without acknowledgment.
+
+Designers drawing on wabi-sabi should engage seriously with the philosophy, attribute thoughtfully, and resist reducing it to a stylistic veneer.
+
+## Empirical findings on imperfection in design
+
+Some research on the perception of imperfection in design:
+
+- **Slight asymmetry can read as more authentic** than perfect symmetry, especially in personal or warm contexts.
+- **Visible craft is sometimes preferred** to mass-produced perfection (the consumer market for handmade goods, slow design, etc.).
+- **Hand-drawn elements** tend to read as more inviting and less institutional than vector-precise ones.
+- **The effect is context-dependent.** What reads as warmth in one context (a personal app) reads as broken in another (a financial dashboard).
+
+## Sources informing this principle
+
+- Sen no Rikyū (16th century). Various writings on the tea ceremony.
+- Koren, L. (1994). *Wabi-Sabi for Artists, Designers, Poets and Philosophers*.
+- Suzuki, D. T. (Various). Writings on Zen and Japanese aesthetics.
+- Tanizaki, J. (1933). *In Praise of Shadows*.
+- Yanagi, S. (1972). *The Unknown Craftsman*.
+- *Universal Principles of Design* (expanded editions, post-2003).
+- Various writings on the Slow Design movement.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/.claude-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/.claude-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/claude-plugin.json",
+  "name": "cognition-and-learnability-principles",
+  "displayName": "Cognition & Learnability Principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for cognition, mental models, complexity reduction, and learnability. Covers Hick's Law, Wayfinding, Progressive Disclosure, 80/20 Rule, Chunking, Mental Model, Recognition Over Recall, Consistency, Mimicry, and Iconic Representation. Drawn from the cognition-related entries of 'Universal Principles of Design' (Lidwell, Holden, Butler, 2003) and the broader HCI literature (Norman, Miller, Nielsen, Krug).",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HDeibler/universal-design-principles.git",
+    "directory": "plugins/cognition-and-learnability-principles"
+  },
+  "category": "design",
+  "keywords": [
+    "design",
+    "ux",
+    "cognition",
+    "mental-models",
+    "learnability",
+    "memory",
+    "consistency",
+    "iconography",
+    "wayfinding",
+    "progressive-disclosure",
+    "universal-design-principles"
+  ]
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/.codex-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "cognition-and-learnability-principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for cognition, mental models, complexity reduction, and learnability. Covers Hick's Law, Wayfinding, Progressive Disclosure, 80/20 Rule, Chunking, Mental Model, Recognition Over Recall, Consistency, Mimicry, and Iconic Representation.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": [
+    "design",
+    "ux",
+    "cognition",
+    "mental-models",
+    "learnability",
+    "memory",
+    "consistency",
+    "wayfinding"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Cognition & Learnability Principles",
+    "shortDescription": "Mental models, memory load, complexity, and learnability.",
+    "developerName": "Hunter D",
+    "category": "Design",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "longDescription": "Framework-agnostic design principles for cognition, mental models, complexity reduction, and learnability. Covers Hick's Law, Wayfinding, Progressive Disclosure, 80/20 Rule, Chunking, Mental Model, Recognition Over Recall, Consistency, Mimicry, and Iconic Representation.",
+    "websiteURL": "https://github.com/HDeibler/universal-design-principles"
+  }
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/.codexignore
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/.codexignore
@@ -1,0 +1,7 @@
+.git/
+.DS_Store
+**/.DS_Store
+tmp/
+temp/
+.cache/
+scratch/

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/.cursor-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/.cursor-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "cognition-and-learnability-principles",
+  "displayName": "Cognition & Learnability Principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for cognition, mental models, complexity reduction, and learnability. Covers Hick's Law, Wayfinding, Progressive Disclosure, 80/20 Rule, Chunking, Mental Model, Recognition Over Recall, Consistency, Mimicry, and Iconic Representation.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": ["design", "ux", "cognition", "mental-models", "learnability", "memory", "consistency", "wayfinding"],
+  "category": "design",
+  "tags": ["cognition", "mental-models", "memory", "learnability", "iconography", "consistency"],
+  "skills": "./skills/"
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/LICENSE
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/LICENSE
@@ -1,0 +1,39 @@
+MIT License
+
+Copyright (c) 2026 Hunter D
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+# Notes on attribution
+
+This software is a derivative *working library* inspired by the principle
+taxonomy popularized in *Universal Principles of Design* (Lidwell, Holden, &
+Butler, Rockport Publishers, 2003). The principle names and high-level
+taxonomy are drawn from that source, used here as a research reference under
+fair use. All prose, examples, code, anti-patterns, and analyses in this
+repository are written in the authors' own words, drawing on the broader
+publicly available design and HCI research literature (Wertheimer, Hick,
+Fitts, Norman, Nielsen, Tufte, Lynch, WCAG, Lavie & Tractinsky, Csikszentmihalyi,
+Zajonc, and many others).
+
+This software is not affiliated with, endorsed by, or sponsored by Rockport
+Publishers, the Lidwell-Holden-Butler authors, or any other rightsholder of
+the original book. See `ATTRIBUTION.md` for a fuller breakdown of sources.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/README.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/README.md
@@ -1,0 +1,25 @@
+# cognition-and-learnability-principles
+
+Framework-agnostic design principles for cognition, mental models, complexity reduction, and learnability.
+
+## Status
+
+| Skill cluster | State |
+|---|---|
+| `cognition-router` | ✅ Complete |
+| **Hick's Law** + `menus` + `defaults` + `pricing` | ✅ Complete (reference-grade) |
+| **Wayfinding** + `physical-spatial-metaphors` + `search-and-recovery` + `breadcrumbs-and-context` | ✅ Complete |
+| **Progressive Disclosure** + `defaults-and-tucking` + `disclosure-affordances` | ✅ Complete |
+| **80/20 Rule** + `feature-prioritization` + `redesign-targeting` | ✅ Complete |
+| **Chunking** + `form-grouping` + `numeric-and-otp` | ✅ Complete |
+| **Mental Model** + `system-vs-interaction` + `mismatch-and-onboarding` | ✅ Complete |
+| **Recognition Over Recall** + `pickers-and-palettes` + `recents-and-suggestions` | ✅ Complete |
+| **Consistency** + `consistency-internal` + `consistency-external` | ✅ Complete |
+| **Mimicry** + `mimicry-surface` + `mimicry-behavioral` | ✅ Complete |
+| **Iconic Representation** + `iconic-resemblance` + `iconic-arbitrary-and-symbolic` | ✅ Complete |
+
+33 skills, each with a `references/` deep-dive file.
+
+## Planned
+
+After this batch, priority next builds: `visibility`, `inverted-pyramid`, `serial-position-effects`, `stickiness`, `garbage-in-garbage-out`, `cost-benefit`, `learnability`, `hierarchy-of-needs`.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/SECURITY.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Report security issues by opening a private security advisory on GitHub or by
+emailing hunterd107@gmail.com.
+
+This marketplace packages prompt-only agent skills. It does not bundle MCP
+servers, hooks, scripts, executable dependencies, credentials, or networked
+services.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-feature-prioritization/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-feature-prioritization/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: 80-20-feature-prioritization
+description: 'Use this skill when scoping a roadmap, prioritizing features, planning an MVP, or deciding what to ship and what to defer. Trigger when the user asks "what should we build next?", "is this feature worth it?", "should we ship feature X?", or when reviewing a feature backlog. Sub-aspect of `80-20-rule`; read that first.'
+---
+
+# 80/20 in feature prioritization
+
+The most direct application of the 80/20 rule: deciding which features to invest in. Most products accumulate features over time; many of those features see little use. The discipline is identifying the critical fraction worth deepening and the long tail worth either tucking or removing.
+
+## The prioritization framework
+
+For each feature (proposed or existing), gather:
+
+### 1. Usage signal
+
+If the feature exists: how many users engage with it? How often? Is engagement growing or declining?
+
+If the feature is proposed: how many users say they want it? Is that signal coming from a vocal minority or a representative sample?
+
+### 2. Value signal
+
+When the feature is used, how much value does it produce? A rarely-used feature that produces enormous value when used (year-end tax export) may be more important than a frequently-used one that produces marginal value (a counter widget).
+
+### 3. Effort signal
+
+What does it cost to build, maintain, support, and document?
+
+### 4. Strategic signal
+
+Does the feature reinforce a competitive position, retain a key customer segment, or enable future capabilities?
+
+The 80/20 cut isn't pure usage — it weights usage by value. A rarely-used essential feature stays in the critical fraction. A frequently-used decorative one might not.
+
+## Decision matrix
+
+A simple 2×2 to organize:
+
+```
+                    Low value          High value
+                    ───────────         ──────────
+Low effort     │  Cleanup later   │   Ship now
+High effort    │  Don't build     │   Major investment
+```
+
+The tricky cases are the diagonals: low-effort + low-value tasks accumulate as "death by a thousand cuts" if not pruned; high-effort + high-value tasks need ruthless scoping or they slip schedule.
+
+## Roadmap shaping
+
+The 80/20 view of a roadmap:
+
+- **The critical 20%** of planned work should account for ~80% of expected user impact. If the planned work is spread evenly across many small features, you're probably underweighting the few that matter most.
+- **The trailing 80%** of planned work should be either skipped or radically scoped down.
+
+A useful exercise: take a quarterly roadmap. For each item, estimate user impact and engineering effort. Sort by impact-per-effort. Cut the bottom half. The team's quarter is suddenly half the size with most of the impact preserved.
+
+## When the 80/20 cut hurts
+
+- **Power-user retention.** A feature only 5% of users touch may be the reason that 5% (often the highest-paying segment) chose your product.
+- **Compliance and accessibility.** Required by law or ethics; can't be dropped.
+- **Foundational capability.** A feature whose value is in *enabling* other features. Search isn't valuable in itself; it's valuable because it makes everything findable.
+- **Trust signals.** Audit logs, exportable data, account deletion. Rarely used directly but their presence reassures prospects.
+
+These deserve a different evaluation than pure-usage 80/20 would suggest.
+
+## Roadmap anti-patterns
+
+- **The feature factory.** Every quarter ships 10 features. Most are small. None move metrics. Time fragments across all of them.
+- **The pet feature.** A senior leader's favorite that doesn't show up in user research but ships every quarter.
+- **The "and one more thing."** A small tweak added to a major feature that doubles its scope.
+- **The unfinished long tail.** Features shipped but never polished, growing into a maintenance burden.
+- **The roadmap by request.** Building features customers asked for without checking whether they reflect underlying needs (often the underlying need is met by a different feature you already have).
+
+## Worked example: pruning a settings page
+
+A SaaS product's settings page has 38 controls. Usage analytics:
+
+- 7 controls used by ≥50% of users monthly.
+- 14 used by 10–50%.
+- 17 used by <10%.
+
+Of the trailing 17:
+- 5 are needed for compliance (audit log, data export, account deletion). Keep.
+- 4 are integrations with services the product team is winding down. Remove from settings; deprecate.
+- 8 are legacy options most users have never touched. Move to "Advanced" disclosure; review for removal in a future cycle.
+
+Result: settings page now shows ~7+5 (12 controls) primary; 14 secondary; rest tucked. Maintenance burden drops; common use is faster.
+
+## Heuristics
+
+1. **The "what does the data say?" check.** Usage analytics before opinion. If the data isn't available, instrument first; decide later.
+2. **The "who would scream?" test.** For features in the trailing 80%, ask. Each scream is a candidate to retain (or relocate); silence is permission to cut.
+3. **The "would we build this today?" test.** For each existing feature, imagine you were starting fresh. Would you build it? If no, it's a candidate for deprecation.
+4. **The retention attribution.** Pair feature usage with retention/expansion data. Features used by retained users may be more valuable than raw usage suggests.
+
+## Related sub-skills
+
+- **`80-20-rule`** (parent).
+- **`80-20-redesign-targeting`** — the within-existing-product version of the same prioritization.
+- **`hicks-law`** — every feature is an option; cutting features cuts decision cost.
+- **`progressive-disclosure`** — alternative to cutting: tucking.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-feature-prioritization/references/prioritization-frameworks.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-feature-prioritization/references/prioritization-frameworks.md
@@ -1,0 +1,53 @@
+# Feature prioritization frameworks
+
+A reference complementing `80-20-feature-prioritization` with the most-cited frameworks for prioritization.
+
+## RICE scoring
+
+(Reach × Impact × Confidence) / Effort. From Intercom's product team. For each feature:
+
+- **Reach** — number of users affected per period.
+- **Impact** — value per user (qualitative scale: 0.25 minimal, 0.5 low, 1 medium, 2 high, 3 massive).
+- **Confidence** — how sure you are of the estimates (percentage).
+- **Effort** — engineer-months.
+
+Higher score → higher priority. RICE forces explicit estimation; the act of estimating often surfaces hidden assumptions.
+
+## ICE scoring
+
+Impact × Confidence × Ease (or sometimes Reach × Impact × Confidence). Simpler than RICE; faster to apply but more subjective.
+
+## Kano model
+
+Categorizes features by user reaction:
+
+- **Must-haves**: features users expect; absence damages perception.
+- **Performance features**: more is better; users notice both presence and degree.
+- **Delighters**: unexpected wins; users don't expect, but value when present.
+- **Indifferent**: users don't notice either way.
+- **Reverse**: features users actively dislike.
+
+The 80/20 implication: must-haves and performance features earn priority; indifferent and reverse should be cut.
+
+## MoSCoW prioritization
+
+Must / Should / Could / Won't. Common in agile contexts. Forces explicit categorization rather than open-ended backlog ranking.
+
+## Cost of delay
+
+Estimates the dollar cost of *not* shipping a feature this period. Forces explicit thinking about urgency vs. raw value.
+
+## Opportunity solution tree
+
+(Teresa Torres, *Continuous Discovery Habits*) Maps outcome → opportunities → solutions. Helps avoid the trap of building solutions in search of problems.
+
+## Choosing a framework
+
+For most teams, RICE or ICE is enough. Kano is useful for new-feature investigation. Opportunity solution trees suit teams doing continuous discovery. The framework matters less than the discipline of using *something* explicit rather than vibes.
+
+## Resources
+
+- **Sean McBride / Intercom**: "RICE: Simple prioritization for product managers."
+- **Torres, T.** *Continuous Discovery Habits* (2021).
+- **Kano, N.** original 1984 work; many modern summaries.
+- **Cagan, M.** *Inspired* — broader product-management thinking.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-redesign-targeting/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-redesign-targeting/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: 80-20-redesign-targeting
+description: 'Use this skill when scoping a redesign or refactor — choosing which existing surfaces deserve full attention and which can be left mostly alone. Trigger when the user asks "where should we focus our redesign?", "do we need to redo all of this?", or when planning incremental design improvements with limited capacity. Sub-aspect of `80-20-rule`; read that first.'
+---
+
+# 80/20 in redesign targeting
+
+A common failure mode of redesigns: trying to redo everything. The result is years-long projects that ship late, lose institutional context, and arrive in a state no better than incremental updates would have produced. The 80/20 rule applied to redesign: identify the surfaces that produce most of user pain or business value; concentrate redesign effort there; leave the rest alone or batch into a maintenance pass.
+
+## How to identify high-value surfaces
+
+### 1. Pain analysis
+
+Where do users struggle? Sources:
+- Support ticket categorization (which surfaces generate the most "how do I..." or "I can't..." tickets)
+- Session recordings and rage-click analytics
+- Drop-off / abandonment metrics (where users leave the funnel)
+- Time-on-task for primary flows (where users get stuck)
+
+The 80/20 cut: ~20% of surfaces typically account for ~80% of pain.
+
+### 2. Traffic analysis
+
+Where do users actually spend time? A beautiful but rarely-visited page deserves less polish than an ugly but constantly-used one.
+
+Cross-reference traffic with the surface's role: a low-traffic but business-critical surface (Settings → Billing) earns redesign even if traffic alone wouldn't justify it.
+
+### 3. Business-impact analysis
+
+Conversion surfaces (sign-up, checkout, upgrade) often punch above their traffic weight. A 5% lift on a low-traffic checkout might exceed a 30% lift on a high-traffic blog.
+
+### 4. Strategic-fit analysis
+
+Some surfaces represent the brand or category position. The marketing home page, the first-run experience, the demo screen for sales. These deserve disproportionate attention because they shape perception of the whole product.
+
+## The redesign 80/20 plan
+
+A typical redesign plan that respects 80/20:
+
+```
+Phase 1 (the critical 20% — heavy investment)
+  - Top 3–5 user-facing surfaces by pain × traffic × business impact
+  - Full redesign: research, design, build, polish, A/B test
+  - Often 60–70% of the project budget
+
+Phase 2 (the meaningful tail — moderate investment)
+  - Next 10–15 surfaces
+  - Update to new design system; fix obvious issues; don't redesign whole flows
+  - 20–30% of budget
+
+Phase 3 (the rest — minimal investment)
+  - All remaining surfaces
+  - Apply new design system tokens; update components; cosmetic only
+  - 10% of budget
+
+Phase 4 (revisit)
+  - Six months in: re-measure. The "rest" that wasn't redesigned might still be performing fine.
+  - For surfaces that turn out to be problematic, fold into the next cycle.
+```
+
+Phases 1–3 ship over the course of the project; Phase 4 is the post-mortem that informs the next cycle.
+
+## When the 80/20 cut hurts
+
+- **Design system consistency.** If only 20% of surfaces get the new design and 80% don't, the product feels visually fragmented. Mitigation: even surfaces that don't get full redesign should adopt the design system tokens (color, type, spacing) for consistency.
+- **Migration burden.** Mixing old and new components creates maintenance complexity. Plan for the eventual deprecation of old components even if you're not redesigning every surface that uses them.
+- **Edge-case surfaces.** A surface used by 1% of users might be the *only* surface for a critical use case. The 80/20 cut shouldn't drop it.
+
+## Anti-patterns
+
+- **The Big Bang redesign.** Two-year project to redesign everything. Ships late, loses context, doesn't move metrics.
+- **Surface-by-surface without strategy.** Each surface designed independently with no shared system. Result: visual inconsistency.
+- **Pet-surface focus.** The team enjoys redesigning the most fun surfaces (marketing landing) while neglecting the highest-pain ones (settings, billing).
+- **No measurement.** A redesign ships with no before/after metrics. The team can't tell if it worked.
+
+## Heuristics
+
+1. **The pain-traffic matrix.** Plot surfaces by pain × traffic. Concentrate redesign on the top-right quadrant.
+2. **The "would users notice?" check.** For each candidate surface, ask: if we redesigned this and showed users, would they tell us it's better? If "probably not," lower priority.
+3. **The conversion-impact estimate.** For business-critical surfaces, estimate revenue impact of a 10% lift. Surfaces where 10% lift is meaningful deserve A/B tested redesign; surfaces where it isn't deserve cosmetic-only updates.
+4. **The post-redesign metric.** Define metrics before the redesign ships. If you can't measure improvement, you didn't redesign for the right reason.
+
+## Related sub-skills
+
+- **`80-20-rule`** (parent).
+- **`80-20-feature-prioritization`** — applied to new feature planning rather than redesign.
+- **`iteration`** (process) — redesigns benefit from iterative releases, not big bangs.
+- **`factor-of-safety`** (process) — redesign with safety: A/B test, kill-switch, rollback paths.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-redesign-targeting/references/redesign-case-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-redesign-targeting/references/redesign-case-patterns.md
@@ -1,0 +1,59 @@
+# Redesign case patterns
+
+A reference complementing `80-20-redesign-targeting` with case patterns from observed redesigns.
+
+## The "ship of Theseus" redesign
+
+Some products redesign continuously, surface by surface, never doing a single big-bang redesign. Linear, Notion, Stripe, GitHub all follow this pattern: every quarter, a few surfaces get attention; the system evolves incrementally.
+
+Pros: low risk per release; learnings compound; team always shipping.
+
+Cons: visual fragmentation between old and new; team must maintain design-system discipline so the surfaces remain cohesive.
+
+## The big-bang redesign
+
+A multi-quarter project that redesigns most of the product at once. Target.com's 2017 redesign, Reddit's 2018, Twitter's various redesigns.
+
+Pros: cohesive launch moment; teams can rally around shared milestones; users feel the change.
+
+Cons: high risk; users object to abrupt change; if metrics tank, hard to revert; opportunity cost of not shipping other things during the redesign.
+
+In aggregate, big-bang redesigns underperform incremental ones — most show flat or declining metrics for 3–6 months post-launch as users re-learn.
+
+## The hidden-A/B redesign
+
+Major surfaces are redesigned and quietly tested in parallel for weeks before the new design replaces the old. Facebook, Google, and Amazon use this approach for high-traffic surfaces.
+
+Pros: data-driven; you can kill bad redesigns; users get the better version.
+
+Cons: requires substantial engineering investment in testing infrastructure; not feasible for smaller teams.
+
+## Deprecation paths for the long tail
+
+Surfaces that the redesign chose *not* to update need a plan:
+
+- **Adopt new design system** for visual consistency, even without redesigning interaction.
+- **Mark for future review** in a tracker; revisit annually.
+- **Plan deprecation** for surfaces that aren't worth keeping.
+- **Migrate users** off surfaces that are being removed.
+
+The trailing 80% deserves *some* attention even if not full redesign — usually maintenance and design-system updates.
+
+## Anti-pattern: redesign without metrics
+
+A surface ships in new design with no before/after measurement. Six months later, no one can answer whether the redesign worked.
+
+Always define metrics before shipping a redesign:
+
+- Time-on-task for primary flows.
+- Conversion rate for funnel surfaces.
+- Support-ticket categorization changes.
+- Qualitative satisfaction (NPS, in-product surveys).
+
+If you can't define a metric, the redesign was probably aesthetic-only — fine, but be honest about that.
+
+## Resources
+
+- **NN/g** articles on redesign measurement and incremental design system rollouts.
+- **Brignull, H.** writings on dark patterns to avoid in redesigns.
+- **Product redesign case studies** from major companies (often presented at conferences like Config, Smashing).

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-rule/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-rule/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: 80-20-rule
+description: 'Use this skill whenever the design has many features, controls, or content elements and decisions about which to prioritize matter — feature roadmaps, redesign scoping, IA decisions, dashboard design, settings page audits, marketing content prioritization, or any design with many candidates competing for attention. Trigger when the user asks "what should we focus on?", "should we add another feature?", "what can we cut?", or when reviewing a UI cluttered with rarely-used controls. The 80/20 rule (Pareto principle) is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) and one of the most quoted across design, business, and engineering.'
+---
+
+# The 80/20 Rule
+
+The 80/20 rule (also called the Pareto principle, after Italian economist Vilfredo Pareto) is the empirical observation that, in many systems, a small fraction of inputs produces most of the outputs — roughly 80% of effects from 20% of causes. The exact numbers vary (sometimes 70/30, sometimes 90/10) but the shape — a heavily uneven distribution — recurs across economics, management, software usage, and design.
+
+For designers, the principle's central use is *prioritization*: identify the 20% of features or content that produces 80% of the value, design that 20% well, and let the remaining 80% receive proportionally less effort.
+
+## Definition (in our own words)
+
+In most large systems, effects aren't distributed evenly across causes. A small minority of features account for the bulk of usage. A small minority of users generate most of the support tickets. A small minority of bugs cause most of the crashes. A small minority of tasks consume most of the time. The 80/20 rule names the pattern and suggests that designers should put their effort where it produces the most return: the critical 20%, not the trailing 80%.
+
+## Origins and research lineage
+
+- **Vilfredo Pareto** (1848–1923), Italian economist. Originally observed that approximately 20% of Italians owned 80% of the land. The pattern proved remarkably general.
+- **Joseph M. Juran** (1951), in *Quality Control Handbook*. Generalized the pattern from economics to industrial quality control: a small fraction of defect causes accounted for most defects. Juran called this "the vital few and the trivial many," a phrasing still used.
+- **Lidwell, Holden & Butler** (2003) compactly stated the design implications: focus design and testing effort on the critical 20%, and minimize or remove non-critical functions in the trailing 80%.
+- **Software analytics studies** (Microsoft, Salesforce, Atlassian, and many others published in product-design literature) consistently observe 80/20-shaped distributions in feature usage. The Microsoft Office team's data showed that the most-used 20% of features accounted for the bulk of user time; the long tail of features was rarely touched.
+
+## Why the 80/20 rule matters
+
+Design effort is finite. Spreading it evenly across all features means each receives shallow attention. Concentrating it on the critical 20% means those features are world-class; the remaining 80% can be functional-but-unrefined.
+
+The principle's secondary use: it reframes what looks like "we have a lot of features" as "we have a few critical features and a long tail." That reframe shifts decisions about what to surface (the 20%), what to tuck (the 80%), what to cut (the deep tail), and where to invest performance, polish, and onboarding effort.
+
+## When to apply
+
+- **Feature prioritization.** Roadmap planning, MVP scoping, "what should we ship next?" decisions.
+- **IA decisions.** What's primary nav vs. tucked behind disclosure; what's surfaced on a dashboard vs. a sub-page.
+- **Performance optimization.** Most performance bottlenecks come from a small fraction of code paths. Profile first; optimize what matters.
+- **Onboarding design.** Teach the 20% first; let users discover the rest naturally.
+- **Settings page design.** Surface frequently-changed settings; tuck the rest.
+- **Bug triage.** A small fraction of bug categories cause most user pain. Fix those first.
+- **Documentation.** The 20% of content covering the most-asked questions earns the most polish.
+
+## When NOT to apply (or when to be careful)
+
+- **When you don't have data.** The 80/20 rule is empirical; assuming a distribution without evidence can lead you to optimize the wrong 20%. Get usage analytics before declaring the critical fraction.
+- **In safety-critical domains.** A rarely-used safety feature (eject seat, emergency stop) is in the trailing 80% by usage but the critical 0.001% by consequence. Don't strip it.
+- **Compliance and accessibility features.** May be rarely used but legally or ethically required. Outside the 80/20 framing.
+- **Power-user tools that retain power users.** A small group of power users may account for outsize loyalty, retention, or expansion revenue. Their tools matter even if they're a small fraction of total clicks.
+- **When the trailing 80% creates competitive moats.** A rarely-used integration may be the reason a small but loyal customer segment chose your product. Surveying might reveal value invisible to click-data.
+
+## How to identify the critical 20%
+
+Three approaches, often combined:
+
+### 1. Usage analytics
+
+Look at click data, page views, feature adoption rates. Sort by frequency; the top items by frequency are usually the critical fraction.
+
+Caveats:
+- Frequency isn't always value. A feature used once per quarter (year-end reports) may be more important than one used daily (search).
+- Feature usage in a launched product is shaped by what's been *promoted* — features tucked deep in the IA may be unused because they're hard to find, not because no one wants them.
+
+### 2. Task analysis
+
+Identify the user's primary tasks. Map features to tasks. Features that participate in multiple primary tasks are critical; features that participate in none are candidates for removal.
+
+Approach: write down the 5–10 most common user goals. For each, list the features required. Features that show up in many goals are critical; features that show up in no goal are suspect.
+
+### 3. Customer interviews and segmentation
+
+Ask users directly: which features couldn't they live without? Which would they hardly miss?
+
+Caveats:
+- Users often overstate the value of features they rarely use ("I might need it someday").
+- Power users speak loudly; majority users are quiet. Triangulate.
+
+## Worked examples
+
+### Example 1: dashboard widget prioritization
+
+Imagine a dashboard with 16 widgets. Analytics show:
+
+- 4 widgets are interacted with by >70% of users on most visits.
+- 6 widgets are interacted with by 20–60% of users sometimes.
+- 6 widgets are interacted with by <10% of users.
+
+The 80/20 redesign:
+
+- The 4 frequent widgets become primary (top of page, prominent sizing).
+- The 6 medium-use widgets become secondary (collapsed by default or placed below the fold).
+- The 6 rarely-used widgets move to a "Reports" sub-page (still accessible; not on the main dashboard).
+
+Most users see a focused dashboard; the long tail remains for users who need it.
+
+### Example 2: form field prioritization in a sign-up flow
+
+A sign-up flow asks for 12 fields. Analytics show drop-off jumps after field 6.
+
+The 80/20 redesign:
+- Identify the 4 fields the system *requires* to function (email, password, plan, agreement).
+- Identify 2 fields highly correlated with retention (use-case selection, team size).
+- Defer the remaining 6 fields to "later" — collected progressively as the user uses the product.
+
+Sign-up completion rises; data quality improves over time.
+
+### Example 3: support documentation focus
+
+A docs site has 200 pages. Analytics show:
+- 20 pages account for 80% of total page views.
+- 50 pages account for 95%.
+- 150 pages have <100 views per year.
+
+The 80/20 docs investment:
+- The top 20 pages get rewriting, screenshots, video walkthroughs.
+- The middle 30 pages get review and freshening.
+- The trailing 150 pages get a "needs review" tag and are revisited annually.
+
+Resources flow to where readers are; the long tail receives custodial attention only.
+
+### Example 4: settings page audit
+
+A Settings page exposes 38 controls in one long scroll. Usage analytics:
+- 7 controls used by >50% of users per visit.
+- 14 used by 5–20%.
+- 17 used by <5%.
+
+The 80/20 redesign (combining with `progressive-disclosure`):
+- The 7 frequent controls are primary, visible on the entry settings page.
+- The 14 medium controls are grouped behind expanded sections or sub-pages.
+- The 17 rare controls move to "Advanced," with a search affordance for finding them.
+
+The page reads as 7 controls, not 38; the 17 rare are still reachable.
+
+## Cross-domain examples
+
+### Business: revenue distribution
+
+In most companies, ~20% of customers generate ~80% of revenue. Sales teams adapt: spend account-management effort on the critical fraction; lighter touch on the rest.
+
+The same observation in software: a small fraction of users (sometimes called "power users" or "whales" depending on context) account for outsize usage, support burden, or revenue. Product decisions weigh their needs disproportionately — sometimes appropriately, sometimes to the detriment of the broader user base.
+
+### Engineering: performance optimization
+
+Profiling consistently shows that a small fraction of code paths consume most CPU time. The optimization rule: don't optimize speculatively; profile first; concentrate effort on the hot paths revealed.
+
+### Logistics: warehouse layout
+
+Retail and logistics warehouses often arrange storage so the 20% of SKUs that account for 80% of orders are nearest the shipping dock. Walking distance is the cost being optimized.
+
+### Medicine: treatment focus
+
+A small fraction of patients consume most of healthcare resources. Population-health programs target this critical fraction with intensive case management, leaving the broader population on lighter-touch protocols.
+
+### Linguistics: word frequency
+
+A few hundred words account for most of typical conversation. Language-learning apps prioritize those — the 20% of vocabulary that produces 80% of comprehension — before tackling rarer words.
+
+## Anti-patterns
+
+- **Optimizing the wrong 20%.** Choosing the critical fraction by intuition rather than data. The team's pet features get priority; user-favorite features languish.
+- **Removing the trailing 80% without checking dependencies.** A rarely-used feature might be critical to a small but loyal segment whose departure costs more than the feature's maintenance.
+- **Assuming the distribution is symmetric.** Not all distributions are 80/20. Some are 90/10, some are 50/50. Measure your actual distribution; don't assume.
+- **80/20 as an excuse for under-investing in accessibility / safety / compliance.** These features are 80/20 outliers — rarely-used but high-consequence.
+- **Static 80/20 thinking.** The critical fraction shifts over time. Re-measure periodically; what was 20% three years ago may not be today.
+
+## Heuristics
+
+1. **Run a usage histogram.** Plot feature usage frequency. Look at the shape. Confirm it's heavily uneven before designing around an 80/20 assumption.
+2. **The "if we removed this, who would scream?" test.** For each feature in the trailing 80%, ask. Sometimes the answer is "no one"; sometimes it's "our biggest customer." Different responses, different actions.
+3. **The "what does the typical user need?" check.** For each surface, ask: what does the typical user need on this surface? Surface that. Tuck the rest.
+4. **The 80/20 squared check.** Within the critical 20%, the 80/20 may apply again — a few features dominate even within the dominant set. Drill in.
+
+## Related principles
+
+- **`progressive-disclosure`** — the structural mechanism for surfacing the 20% and tucking the 80%.
+- **`hicks-law`** — fewer visible options means faster decisions; 80/20 informs which options to make visible.
+- **`signal-to-noise-ratio`** (perception) — the 80/20 is the design layer where SNR decisions are made.
+- **`flexibility-usability-tradeoff`** (interaction) — every feature added affects usability; 80/20 helps you decide which trade-offs are worth it.
+- **`form-follows-function`** (aesthetics) — the function should derive from the 20% of needs that drive most of the use.
+- **`ockhams-razor`** — among solutions that work, prefer the simplest; 80/20 is a discipline of subtraction.
+
+## Sub-aspect skills
+
+- **`80-20-feature-prioritization`** — applying the rule to roadmap and scoping decisions.
+- **`80-20-redesign-targeting`** — applying the rule to redesign-pass focus and effort allocation.
+
+## Closing
+
+The 80/20 rule is more a discipline than a principle. The discipline is: don't believe your features are equally important; measure; concentrate effort. Designers who internalize this consistently produce sharper products than those who try to give every feature equal love.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-rule/references/pareto-distributions-and-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/80-20-rule/references/pareto-distributions-and-cases.md
@@ -1,0 +1,88 @@
+# Pareto distributions: research, history, and cases
+
+A reference complementing the `80-20-rule` SKILL.md with the historical origins and broader cases.
+
+## Vilfredo Pareto and the original observation
+
+Vilfredo Pareto (1848–1923) was an Italian engineer and economist who studied wealth distribution. In *Cours d'économie politique* (1896–1897), he documented that wealth in late-19th-century Italy followed a power-law distribution — roughly 20% of the population held 80% of the wealth. Pareto found similar distributions in tax records of other European countries.
+
+The pattern wasn't unique to Italy or to wealth. Pareto's work hinted at a broader empirical regularity that came to be called the **Pareto distribution** — a family of probability distributions where a small fraction of items account for a large fraction of values.
+
+## Joseph Juran and the design / business application
+
+Joseph M. Juran, in *Quality Control Handbook* (first edition 1951), generalized Pareto's observation to industrial quality control. Juran observed that in manufacturing-defect data, a small fraction of defect causes accounted for most defects. He coined "the vital few and the trivial many" — terminology that's stuck in business and design literature.
+
+Juran later wrote that the principle "is most useful when used as a guide to action" — directing effort to where it produces the most return. The phrase "Pareto principle" entered business vocabulary through Juran's work and the Total Quality Management movement.
+
+## Power-law distributions in software usage
+
+Studies of software-feature usage routinely show power-law-shaped distributions:
+
+- **Microsoft Office telemetry** (mid-2000s analyses) showed that the most-used 10–15% of features accounted for the bulk of user time. The long tail of features was exercised but rarely.
+- **Salesforce, Atlassian, and other enterprise SaaS providers** publish similar findings.
+- **Web analytics for content sites** typically show that top-traffic pages account for a small fraction of total pages but most page views.
+- **Mobile apps**: studies of feature adoption show similar patterns.
+
+The implication for design: the assumption "every feature is used roughly equally" is almost always wrong. The actual distribution is heavily uneven; designs that ignore this distribution (giving every feature equal prominence) are almost always sub-optimal.
+
+## When the 80/20 framing breaks down
+
+The "80/20" specifically is approximate. Real distributions vary:
+
+- **90/10**: even more skewed. Common in social media (1% of users produce most content; 99% lurk).
+- **70/30**: less skewed. Common in mature mass-market products where features have been pruned over time.
+- **Long-tail products**: products that monetize the trailing 80% (Amazon's millions of low-volume SKUs, Netflix's catalog of rarely-watched titles). Here the principle inverts — you make money on the tail.
+
+The discipline isn't applying "80/20" as a magic ratio; it's measuring the actual distribution and designing around its shape.
+
+## The math: power laws
+
+A Pareto distribution has the form:
+
+```
+P(X > x) ∝ x^(-α)
+```
+
+Where α is a shape parameter. When α is around 1.16, the distribution gives the classic 80/20 split. Larger α produces less-skewed distributions; smaller α gives more-skewed ones.
+
+You don't need this math day-to-day. What you need: recognize the shape (a few high-value items, a long tail of low-value items) when you see it, and design accordingly.
+
+## Cross-domain examples
+
+### Wealth and income
+
+The original observation. In modern data, wealth distributions in most countries are even more skewed than 80/20 — often closer to 90/10 or steeper.
+
+### Crime
+
+A small fraction of locations and individuals account for most crime in many cities. "Hot spot" policing concentrates resources accordingly.
+
+### Health
+
+A small fraction of patients consume most healthcare resources. "Super-utilizer" programs target this fraction with intensive case management.
+
+### Software bugs
+
+A small fraction of code modules generate most bug reports. Quality engineering focuses code-review and testing on these.
+
+### Customer support
+
+A small fraction of customers generate most tickets. Account-management programs identify and serve them differently.
+
+### Time use (personal productivity)
+
+20% of tasks often produce 80% of progress on a project. The "eat the frog first" approach prioritizes those tasks.
+
+## Cautions
+
+- **Don't apply 80/20 to safety / compliance.** A backup feature used 0.1% of the time may have prevented a catastrophe. Don't strip it.
+- **Don't apply 80/20 to features that *enable* others.** Search isn't valuable in itself; it's valuable because it makes everything findable.
+- **Re-measure regularly.** Distributions shift. The 20% that mattered three years ago may not now.
+- **Beware of vocal minorities.** Power users often request features they barely use. Listen but verify with usage data.
+
+## Resources
+
+- **Juran, J. M.** *Quality Control Handbook* (multiple editions, 1951 onward).
+- **Anderson, C.** *The Long Tail* (2006). The opposite case: products that monetize the trailing 80%.
+- **Microsoft / Salesforce engineering blogs** — public discussions of feature-usage analytics.
+- **Newman, M. E. J.** "Power laws, Pareto distributions and Zipf's law" (2005). The mathematical underpinnings.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking-form-grouping/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking-form-grouping/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: chunking-form-grouping
+description: 'Use this skill when designing or fixing long forms that ask the user for many fields — sign-up flows, profile setup, settings panels, checkout, intake forms, applications. Trigger when forms exceed ~6 fields, when users complain forms are "too long," when seeing high mid-form drop-off, or when picking how to break a form into sections. Sub-aspect of `chunking`; read that first.'
+---
+
+# Chunking applied to forms
+
+A form with 25 fields in one continuous scroll is a wall. The same 25 fields organized into 4–5 named sections of 5–6 fields each is a list of small tasks. The total content is identical; the perceived complexity drops dramatically.
+
+## When to chunk a form
+
+- The form has more than ~7 fields.
+- Drop-off analytics show users abandoning mid-form.
+- Users describe the form as "long," "complicated," or "I don't know where I am."
+- The fields fall into natural categories (account info, profile info, preferences).
+
+If the form is short (3–5 fields) or all fields belong to a single concept, chunking adds noise without benefit.
+
+## Section structure
+
+Three patterns for chunked forms:
+
+### Single-page with named sections
+
+All sections visible on one page; user scrolls through and fills in.
+
+```html
+<form class="long-form">
+  <section>
+    <h2>Account</h2>
+    <p class="hint">How you'll sign in.</p>
+    <!-- 4-5 fields -->
+  </section>
+
+  <section>
+    <h2>Profile</h2>
+    <p class="hint">How others see you.</p>
+    <!-- 4-5 fields -->
+  </section>
+
+  <section>
+    <h2>Workspace</h2>
+    <p class="hint">Set up your team space.</p>
+    <!-- 4-5 fields -->
+  </section>
+
+  <button>Create account</button>
+</form>
+```
+
+Pros: user sees total scope; can fill in any order; one save action.
+
+Cons: the scroll can still feel long; mid-form abandonment possible.
+
+### Accordion sections (one open at a time)
+
+Sections collapse to headers; user opens one at a time.
+
+Pros: less visual mass; user focuses on current chunk.
+
+Cons: total scope is hidden; users may not realize how many sections remain.
+
+### Multi-step wizard
+
+Each section is its own page; "Continue" advances; "Back" returns.
+
+Pros: focused attention on one chunk; easier mobile experience.
+
+Cons: more clicks; loss of context between steps; back-button management complexity.
+
+The right pattern depends on form length, mobile context, and whether the user benefits from seeing total scope (probably yes for sign-up; maybe not for long government forms).
+
+## Naming sections
+
+Section names should:
+
+- **Match the user's mental model** — "Profile" not "User Information Subsystem."
+- **Suggest what's inside** without requiring the user to open it.
+- **Be parallel** in grammar — all noun phrases, or all verb phrases, not mixed.
+
+Bad section names:
+
+- "Section 1 of 5" — generic; provides no structure.
+- "Required Information" — vague; everything is information.
+- "Etc." — gives up.
+
+Good section names:
+
+- "Account credentials"
+- "Notification preferences"
+- "Billing address"
+
+## Section progress signals
+
+For long single-page forms, a sticky table-of-contents or progress indicator helps:
+
+```html
+<aside class="form-toc">
+  <ol>
+    <li><a href="#account" class="done">Account</a></li>
+    <li><a href="#profile" class="active">Profile</a></li>
+    <li><a href="#workspace">Workspace</a></li>
+  </ol>
+</aside>
+```
+
+For multi-step wizards, a stepper:
+
+```html
+<nav class="stepper" aria-label="Progress">
+  <ol>
+    <li class="done">1. Account</li>
+    <li class="active">2. Profile</li>
+    <li>3. Workspace</li>
+  </ol>
+</nav>
+```
+
+Both let the user see where they are and how much remains.
+
+## Field count per section
+
+Aim for 4–7 fields per section. More than that and the section itself becomes a wall; less and the section overhead exceeds its benefit.
+
+If you find yourself with 12 fields in one logical section, ask:
+
+- Are all 12 actually required? (Often not; cut.)
+- Can the section split into two? (E.g., "Personal" and "Contact.")
+- Can some fields move to "later" via progressive disclosure?
+
+## Single-page vs. multi-step decision
+
+A useful matrix:
+
+| Length | Mobile-primary | Recommended |
+|---|---|---|
+| ≤ 5 fields | Either | Single page, no sections |
+| 6–15 fields | Desktop | Single page with named sections |
+| 6–15 fields | Mobile | Multi-step or accordion |
+| 16–30 fields | Either | Multi-step wizard |
+| 30+ fields | Either | Multi-step + reconsider scope |
+
+The question after 30+: do you really need all this data up front? Most products can defer 60% of fields until the user has experienced value.
+
+## Anti-patterns
+
+- **Sections without names.** Visual breaks (a horizontal rule) without headings provide visual chunking but no semantic chunking. The user doesn't know what's in each.
+- **Inconsistent section size.** Five fields, two fields, fourteen fields. The user can't predict what's coming.
+- **Required + optional mixed within sections.** A user finishing what looked like a required field discovers more required fields hidden among optional ones. Worse: discovers there are required fields in a section they thought was optional.
+- **Auto-advance on field change.** A field that automatically moves focus or advances steps when value changes surprises the user.
+- **Save state per section unclear.** Multi-step wizards that don't save state per step can lose user data on navigation.
+
+## Heuristics
+
+1. **The "name each section in 2–3 words" test.** If you can't, the chunking isn't meaningful.
+2. **The completion-rate audit.** If sign-up completion drops below ~70% (varies by industry), the form is too long; cut, defer, or chunk better.
+3. **The mobile walkthrough.** Walk the form on a 375px screen. Single-page sections that feel manageable on desktop often feel oppressive on mobile.
+
+## Related sub-skills
+
+- **`chunking`** (parent).
+- **`chunking-numeric-and-otp`** — chunking within field values.
+- **`progressive-disclosure`** — defer optional fields rather than showing them all.
+- **`proximity-form-fields`** (perception) — visual proximity within and between sections.
+- **`hicks-law`** — fewer fields = faster decisions.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking-form-grouping/references/long-form-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking-form-grouping/references/long-form-patterns.md
@@ -1,0 +1,56 @@
+# Long-form patterns: case reference
+
+A reference complementing `chunking-form-grouping` with field-grouping conventions and case patterns.
+
+## Empirical findings on form length and chunking
+
+NN/g and other usability research consistently finds:
+
+- **Form completion drops sharply** beyond ~10 fields without sectioning, regardless of field complexity.
+- **Sectioned forms outperform flat forms** of the same length by 20-40% on completion.
+- **Multi-step wizards outperform long single-page forms** on mobile but underperform on desktop where users can see scope.
+- **Save-resume support** (saving partial progress) reduces abandonment substantially for genuinely long forms (insurance applications, government).
+
+## Government / legal forms
+
+Tax forms, immigration forms, insurance applications: all genuinely long because the underlying information requires it. Patterns that work:
+
+- **Section-by-section flow** with named sections (Personal Info, Income, Deductions, Credits).
+- **Save-and-resume** built in.
+- **Progress indicator** showing total scope.
+- **Inline help** explaining unfamiliar terms.
+- **Pre-fill from prior submissions** when applicable (US 1040 from prior year's data).
+
+The form's length is irreducible; the design's job is making the length tolerable.
+
+## Sign-up flows
+
+Modern sign-up best practice: minimize required fields at registration; defer optional data to onboarding or profile-completion.
+
+- **2010-era pattern**: 12-field sign-up. High abandonment.
+- **Modern pattern**: 3-field sign-up (email, password, agreement). Optional data collected over time.
+
+The chunking discipline isn't just within the sign-up form; it's *across* sign-up + first-run + ongoing onboarding.
+
+## Multi-step wizard patterns
+
+Common conventions:
+
+- **Stepper at top** showing progress.
+- **Continue button** as primary action.
+- **Back button** preserved (don't break browser back).
+- **Step numbers in URLs** so users can deep-link.
+- **State persistence** so refresh / accidental nav doesn't lose data.
+
+Anti-patterns:
+
+- **Hidden total step count** ("Step 1 of ?"). Users want to know total scope.
+- **Steps that auto-advance** without user action. Surprise.
+- **Validation only on final step**. Users hit submit, find errors in step 2, navigate back, lose context.
+
+## Resources
+
+- **Wroblewski, L.** *Web Form Design* (2008) — comprehensive form-pattern reference.
+- **Jarrett, C. & Gaffney, G.** *Forms that Work* (2008).
+- **GOV.UK Design System** — government-grade form patterns.
+- **NN/g** — form-design research articles.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking-numeric-and-otp/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking-numeric-and-otp/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: chunking-numeric-and-otp
+description: 'Use this skill when designing inputs or displays for numeric strings — phone numbers, OTP / verification codes, credit card numbers, account IDs, license keys, currency, dates, social security numbers. Trigger when picking a format for displaying numbers, designing OTP entry UIs, or formatting identifiers in tables and receipts. Sub-aspect of `chunking`; read that first.'
+---
+
+# Chunking applied to numeric strings
+
+Numbers are the canonical chunking case. A 10-digit phone number, a 16-digit credit card, a 6-digit OTP — without chunking, these are working-memory overloads. With chunking, they're manageable.
+
+## Standard chunkings
+
+Conventions that have evolved across industries:
+
+| Type | Standard chunking | Example |
+|---|---|---|
+| US phone | 3-3-4 | 555-867-5309 |
+| International phone | varies; usually 2-3-3-2 or similar | +44 20 7946 0958 |
+| Credit card | 4-4-4-4 (most) or 4-6-5 (Amex) | 4242 4242 4242 4242 |
+| Social Security (US) | 3-2-4 | 123-45-6789 |
+| OTP / verification | 3-3 (6-digit) or 4-4 (8-digit) | 123-456 |
+| Bank account (US) | varies; often grouped with type | 110000000 → routing display |
+| ISBN | 1-3-3-5-1 (ISBN-13) | 978-3-16-148410-0 |
+| IP address | 4 octets separated by dots | 192.168.1.1 |
+| Date (ISO) | 4-2-2 | 2026-05-02 |
+| Currency | 3-digit groups | $1,234,567.89 |
+
+When in doubt, follow the convention. Users have already learned it.
+
+## OTP / verification code entry
+
+The most common modern chunking case in product UI. A 6-digit code from email or SMS, entered into a verification field.
+
+### Single field vs. chunked fields
+
+Single field:
+```html
+<input type="text" inputmode="numeric" maxlength="6" pattern="\d{6}" />
+```
+
+Chunked fields (one per digit):
+```html
+<div class="otp-input" role="group" aria-label="Verification code">
+  <input type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" />
+  <input type="text" inputmode="numeric" maxlength="1" />
+  <input type="text" inputmode="numeric" maxlength="1" />
+  <span class="separator" aria-hidden>—</span>
+  <input type="text" inputmode="numeric" maxlength="1" />
+  <input type="text" inputmode="numeric" maxlength="1" />
+  <input type="text" inputmode="numeric" maxlength="1" />
+</div>
+```
+
+The chunked version:
+
+- Visually matches how the code is presented in email/SMS.
+- Lets the user verify each digit's position mid-entry.
+- Auto-advances focus on each digit (with JS).
+- Supports paste-spread (paste into first input fills all).
+
+The single-field version is simpler to implement and supports SMS-autofill on iOS via `autocomplete="one-time-code"`. Modern apps often offer both: a single field on mobile (where autofill is critical) and chunked on desktop.
+
+### OTP UX details
+
+- **Auto-advance** focus to the next digit on input.
+- **Auto-back** focus to previous digit on backspace.
+- **Paste support**: pasting a 6-digit string into the first input should distribute across all six.
+- **`autocomplete="one-time-code"`** on at least one input enables iOS Messages autofill.
+- **Numeric keyboard on mobile** via `inputmode="numeric"`.
+- **Optional auto-submit** when the last digit is entered (debate: some users dislike auto-submit because it commits before they can verify).
+
+## Phone number entry
+
+Phone numbers vary widely by country. Patterns:
+
+- **US-only forms**: enforce 3-3-4 with format mask or chunked inputs.
+- **International forms**: use a country selector + a free-text number field; format on display rather than enforcing entry format.
+- **Dual-purpose** (international users + US-heavy): use [libphonenumber](https://github.com/google/libphonenumber) or similar to validate and format dynamically.
+
+```html
+<label>
+  Phone
+  <div class="phone-input">
+    <select name="country-code">
+      <option value="+1">🇺🇸 +1</option>
+      <option value="+44">🇬🇧 +44</option>
+      <!-- ... -->
+    </select>
+    <input type="tel" name="phone" placeholder="555-867-5309" />
+  </div>
+</label>
+```
+
+## Credit card display
+
+In production, never display full card numbers — show the last 4 digits chunked with masking:
+
+```
+**** **** **** 4242
+```
+
+For entry, use 4-4-4-4 chunking with auto-advance, paste support, and card-type detection:
+
+```html
+<input type="text" inputmode="numeric" autocomplete="cc-number"
+       placeholder="1234 5678 9012 3456" />
+```
+
+Built-in browsers and password managers handle most of this if you use the right `autocomplete` value.
+
+## Account IDs and identifiers
+
+For internal IDs (account IDs, transaction IDs, session IDs):
+
+- **Display chunked** if the user might read or transcribe them.
+- **Display monospaced** so digits and letters align (`font-family: monospace; font-variant-numeric: tabular-nums;`).
+- **Provide one-click copy** so users don't have to manually select.
+
+```html
+<div class="id-display">
+  <span class="id-value">ws_8f3c-7a92-1b04</span>
+  <button onclick="copyToClipboard('ws_8f3c-7a92-1b04')" aria-label="Copy">📋</button>
+</div>
+```
+
+The chunking aids reading aloud (support calls) and verification.
+
+## Currency
+
+Currency should always use locale-appropriate digit grouping:
+
+- US English: `$1,234,567.89` (3-digit groups, period decimal).
+- European: `€1.234.567,89` (period grouping, comma decimal).
+- Indian: `₹12,34,567.89` (mixed grouping: 2-2-3).
+
+Use `Intl.NumberFormat` to get this right per locale:
+
+```js
+new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+  .format(1234567.89);
+// "$1,234,567.89"
+```
+
+Numeric columns in tables should use `font-variant-numeric: tabular-nums` so digits align vertically.
+
+## Anti-patterns
+
+- **Continuous strings**: a 16-digit credit card with no chunking. Users can't verify.
+- **Inconsistent chunk sizes within a context**: phone numbers shown as 3-4-3 here and 5-2-3 there. Each format is a re-learn.
+- **Wrong locale grouping**: showing `1,234.56` to a German user (who reads it as 1,234.56 = roughly 1,234 plus 56/100 instead of 1234.56).
+- **Missing `inputmode`**: a numeric field that opens the alphabet keyboard on mobile. Easy fix; commonly missed.
+- **OTP with no auto-advance / paste support**: users tab manually between fields; if they paste, only the first field fills.
+- **Unmasked credit card display**: privacy and security violation. Always mask all but the last 4.
+
+## Heuristics
+
+1. **The "read it aloud" test.** Try reading the chunked number aloud. If it requires re-grouping mentally, the chunking is wrong.
+2. **The cross-locale check.** For currency and dates, test in at least 2–3 locales. Format mismatches are common.
+3. **The clipboard / autofill check.** Does pasting the user's clipboard into your input work cleanly? Do password managers fill correctly?
+4. **The mobile keyboard check.** Numeric inputs should produce numeric keyboards on mobile (`inputmode="numeric"`).
+
+## Related sub-skills
+
+- **`chunking`** (parent).
+- **`chunking-form-grouping`** — chunking at the form-section level.
+- **`legibility`** (perception) — tabular numerals for column alignment.
+- **`accessibility-perceivable`** (process) — number formatting affects screen-reader pronunciation.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking-numeric-and-otp/references/numeric-format-conventions.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking-numeric-and-otp/references/numeric-format-conventions.md
@@ -1,0 +1,96 @@
+# Numeric format conventions: cross-locale reference
+
+A reference complementing `chunking-numeric-and-otp` with the format conventions across regions and contexts.
+
+## Locale-specific number formatting
+
+| Locale | Thousand sep | Decimal sep | Example |
+|---|---|---|---|
+| US English | `,` | `.` | 1,234,567.89 |
+| UK English | `,` | `.` | 1,234,567.89 |
+| German | `.` | `,` | 1.234.567,89 |
+| French | space | `,` | 1 234 567,89 |
+| Indian | `,` (mixed grouping) | `.` | 12,34,567.89 |
+| Swiss | `'` | `.` | 1'234'567.89 |
+
+Use `Intl.NumberFormat` to produce locale-correct formatting:
+
+```js
+new Intl.NumberFormat('de-DE').format(1234567.89);
+// "1.234.567,89"
+```
+
+Hard-coding US format for an international audience is a common bug.
+
+## Phone number conventions
+
+Phone-number formatting varies dramatically by country. Some examples:
+
+- US: `(555) 867-5309` or `555-867-5309`
+- UK: `020 7946 0958`
+- Germany: `030 12345678`
+- Japan: `03-1234-5678`
+- France: `01 23 45 67 89`
+
+Rather than hard-coding any one format, use [libphonenumber](https://github.com/google/libphonenumber) (Google's library) for parsing and formatting. It handles country-code prefixes, regional norms, and edge cases.
+
+## Credit card chunking
+
+Most cards: 4-4-4-4 (16 digits). American Express: 4-6-5 (15 digits). Diner's Club: 4-6-4 (14 digits).
+
+Browsers and password managers handle most of this if you use the right `autocomplete` value:
+
+```html
+<input autocomplete="cc-number" />
+<input autocomplete="cc-exp" />
+<input autocomplete="cc-csc" />
+```
+
+Don't reinvent; let the platform handle.
+
+## Date format conventions
+
+| Locale | Format | Example |
+|---|---|---|
+| ISO 8601 | YYYY-MM-DD | 2026-05-02 |
+| US | MM/DD/YYYY | 05/02/2026 |
+| UK / most of Europe | DD/MM/YYYY | 02/05/2026 |
+| Japan / China | YYYY/MM/DD | 2026/05/02 |
+
+The ambiguity between US and European formats is a notorious bug source. For internal data, prefer ISO 8601. For user display, format per locale via `Intl.DateTimeFormat`:
+
+```js
+new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium' }).format(new Date());
+// "2 May 2026"
+```
+
+## Currency display
+
+Always use `Intl.NumberFormat` with `style: 'currency'`:
+
+```js
+new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' })
+  .format(1234567);
+// "￥1,234,567"
+```
+
+Note: Japanese yen has no decimal places by convention. Other currencies have different fraction digits. The Intl API handles this correctly per currency.
+
+## OTP on mobile: autofill
+
+iOS Messages and Android can autofill OTP codes from SMS into a single input that has `autocomplete="one-time-code"`:
+
+```html
+<input type="text" inputmode="numeric" autocomplete="one-time-code" />
+```
+
+This works on the *first* such input in the form. Chunked inputs (one per digit) typically only support autofill on the first; the JS must spread the pasted/autofilled value across the other inputs.
+
+For the best UX: detect autofill events and split the value automatically.
+
+## Resources
+
+- **libphonenumber** — Google's phone-number library.
+- **Intl** API on MDN — comprehensive locale-aware formatting.
+- **CLDR** (Unicode Common Locale Data Repository) — the authoritative source for locale conventions.
+- **Apple HIG and Material Design** — both document numeric input patterns.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: chunking
+description: 'Use this skill whenever the user must hold a sequence of items in working memory — phone numbers, OTP codes, account IDs, address strings, multi-step instructions, long forms, navigation menus with many items. Trigger when designing OTP / verification UIs, formatting numeric strings, breaking long forms into sections, grouping nav items, or reviewing surfaces that "have too many things at once." Chunking is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003), grounded in Miller''s classic working-memory research.'
+---
+
+# Chunking
+
+Chunking is the practice of grouping a long string of items into a smaller number of meaningful units, each containing a few items. The classic insight: working memory can hold only a handful of independent items, but each "item" can itself be a chunk containing several pieces. Phone numbers are easier to remember as `555-867-5309` (three chunks) than as `5558675309` (ten digits). The same principle applies broadly across UI design.
+
+## Definition (in our own words)
+
+Working memory is a small, short-lived store for the items the user is actively manipulating. Its capacity is roughly four to seven independent units. When information is presented as one long unbroken sequence, the user has to hold all of it as separate units and quickly hits the limit. When information is grouped into a few meaningful chunks, the same total content fits within the working-memory budget. Chunking is the design technique for fitting information to that budget.
+
+## Origins and research lineage
+
+- **George Miller**, "The Magical Number Seven, Plus or Minus Two: Some Limits on Our Capacity for Processing Information." *Psychological Review*, 1956, vol. 63, p. 81–97. The foundational paper. Miller observed that across many tasks (recalling lists, distinguishing tones, judging quantities), people maxed out at about 7 ± 2 items. The paper introduced "chunk" as the unit of measurement: an item could itself be made up of smaller items, but it counted as one chunk if treated as a unit.
+- **Nelson Cowan**, "The Magical Number Four in Short-Term Memory: A Reconsideration of Mental Storage Capacity." *Behavioral and Brain Sciences*, 2001, vol. 24, p. 87–114. Refined Miller's estimate downward. Cowan's analysis found that when chunks are *truly* independent (not aided by rehearsal or grouping), capacity is closer to 4 ± 1 than 7 ± 2. The "magical number" is now usually given as 4.
+- **Alan Baddeley**, *Working Memory* (1986) and *Working Memory, Thought, and Action* (2007). The standard reference work on the structure and limits of working memory.
+- **Lidwell, Holden & Butler** (2003) compactly summarized the design implications and warned about misapplication: chunking is for tasks involving *memory*, not for tasks involving *scanning* (like consulting a reference list).
+
+## Why chunking matters
+
+When users must hold multiple items in mind — to dial a phone number, type a confirmation code, follow multi-step directions, complete a multi-part form — the amount they can hold determines whether they succeed. Exceeding working memory means they make mistakes, look back, or give up.
+
+Chunking expands the effective capacity by packing more information into each chunk. A user can hold roughly 4 chunks; if each chunk contains 3 digits, that's 12 digits total — meaningful for phone numbers. Without chunking, 12 raw digits is well past the limit.
+
+Chunking also accelerates learning: chunked patterns become familiar units (the "555" prefix becomes one chunk, not three) and free up capacity for new information.
+
+## When to apply
+
+- **Numeric strings the user must type or read** — phone numbers, OTP codes, account numbers, IDs, dates, currency.
+- **Long forms** — group fields into named sections of 4–6 fields each.
+- **Navigation menus** — group items into named sections of 4–7 items each.
+- **Multi-step instructions** — break a 12-step process into three groups of four steps.
+- **Tables with many columns** — visually group columns by category if they're related.
+- **Dashboards with many widgets** — group widgets into themed regions.
+
+## When NOT to apply
+
+The book's specific warning: don't chunk reference content the user *scans* rather than *memorizes*.
+
+- **Long lists the user filters or searches** — a contact list with 200 entries shouldn't be chunked into "Contacts A–E, F–J, K–O..." because the user isn't memorizing it; they're scanning or searching. Forced chunking adds visual noise without cognitive benefit.
+- **Reference material the user looks up** — dictionary entries, documentation pages, settings pages where the user knows what they want. Search and clear labeling beat chunking.
+- **Continuous prose** — chunking sentences into "first 4 words, next 4 words, next 4 words" damages reading. Body text follows its own rhythm.
+
+The discriminator: are users *holding* the items in mind (apply chunking) or *finding* them (don't)?
+
+## Optimal chunk size
+
+Different sources give different numbers; the working consensus:
+
+- **Each chunk: 3–5 items.** More than 5 risks overflow within the chunk.
+- **Total chunks visible: 4–7.** More than 7 risks overflow across chunks.
+- **For numeric strings: typically 3–4 digits per chunk.** Phone numbers, credit cards, OTP codes all converged on this.
+
+These are heuristics; specific tasks may justify different sizes. The grouping should always be perceptually clear (visual gap, dash, slot separation).
+
+## Worked examples
+
+### Example 1: phone numbers
+
+Most common chunking case. A 10-digit US phone number formatted three ways:
+
+```
+5558675309        ← unchunked: 10 digits, hard to verify or recall
+555-867-5309      ← three chunks: 3-3-4
+(555) 867-5309    ← same three chunks, with area code marked
+555 867 5309      ← spaces instead of dashes
+```
+
+The chunked versions are easier to read aloud, easier to verify, easier to remember briefly. Most international phone formats follow similar logic.
+
+### Example 2: OTP / verification codes
+
+A 6-digit OTP entered into a single field is hard to verify mid-entry. Chunked input fields make each digit's position visible:
+
+```html
+<input type="text" inputmode="numeric" maxlength="6" />  <!-- unchunked -->
+
+<!-- vs. chunked input -->
+<div class="otp-input" role="group" aria-label="Verification code">
+  <input type="text" inputmode="numeric" maxlength="1" />
+  <input type="text" inputmode="numeric" maxlength="1" />
+  <input type="text" inputmode="numeric" maxlength="1" />
+  <span class="separator" aria-hidden>—</span>
+  <input type="text" inputmode="numeric" maxlength="1" />
+  <input type="text" inputmode="numeric" maxlength="1" />
+  <input type="text" inputmode="numeric" maxlength="1" />
+</div>
+```
+
+The chunked version (3-3) helps users verify they typed the right digits and matches the chunked format that's typically displayed in the originating email or SMS.
+
+### Example 3: long forms broken into sections
+
+A 24-field signup form is overwhelming. Group into 4 sections of ~6 fields each, with named headings:
+
+```html
+<form>
+  <section>
+    <h2>Account</h2>
+    <!-- 5 fields: email, password, name, etc. -->
+  </section>
+  <section>
+    <h2>Profile</h2>
+    <!-- 4 fields: title, bio, photo, etc. -->
+  </section>
+  <section>
+    <h2>Workspace</h2>
+    <!-- 6 fields: workspace name, members, etc. -->
+  </section>
+  <section>
+    <h2>Preferences</h2>
+    <!-- 5 fields: notifications, language, etc. -->
+  </section>
+</form>
+```
+
+The user holds in mind "I'm in the workspace section" rather than "I'm at field 17 of 24." Each section is a manageable chunk.
+
+### Example 4: navigation grouped by purpose
+
+A sidebar with 18 nav items is hard to scan; grouped into 3 themed sections of 6 items each:
+
+```html
+<nav>
+  <h3>Workspace</h3>
+  <ul>
+    <li><a href="/dashboard">Dashboard</a></li>
+    <li><a href="/projects">Projects</a></li>
+    <li><a href="/team">Team</a></li>
+    <li><a href="/calendar">Calendar</a></li>
+    <li><a href="/files">Files</a></li>
+    <li><a href="/inbox">Inbox</a></li>
+  </ul>
+  <h3>Reports</h3>
+  <ul>...</ul>
+  <h3>Settings</h3>
+  <ul>...</ul>
+</nav>
+```
+
+Users learn the section structure quickly and use it to predict where things live.
+
+### Example 5: address strings
+
+An address string is a chunked structure even when displayed compactly:
+
+```
+1234 Main Street, Apt 5B
+San Francisco, CA 94110
+```
+
+Two-line break separates "street" chunk from "city/state/zip" chunk. The internal commas chunk apartment from street and city from state from zip. Users parse and recall this far better than the same characters in one continuous line.
+
+### Example 6: multi-step instruction
+
+"To set up your account: Open Settings, click Notifications, choose Email, set frequency, save changes" — five steps in one sentence. Chunked as a numbered list:
+
+```
+1. Open Settings
+2. Click Notifications
+3. Choose Email
+4. Set frequency
+5. Save changes
+```
+
+Easier to follow; users can mark progress and look back at any step.
+
+## Cross-domain examples
+
+### Music
+
+Western music notation chunks notes into measures (typically 3 or 4 beats). Beats group into bars; bars group into phrases; phrases group into sections. Musicians read music as nested chunks, not as individual notes.
+
+### Reading
+
+Skilled readers don't process individual letters; they process chunks (common letter combinations, then whole words, then phrases). Speed reading techniques are largely about recognizing larger chunks more efficiently.
+
+### Chess
+
+Expert chess players recall positions vastly better than novices — not because their working memory is larger, but because they chunk pieces into meaningful patterns (a defensive formation, an opening structure). De Groot's classic studies (1965) showed that experts and novices recalled random piece arrangements equally; the expert advantage came entirely from recognizing meaningful chunks.
+
+### Telephone area codes
+
+Area codes are mnemonic chunks that group geography into recognizable units. "212" is Manhattan; "415" is San Francisco. The numeric chunk doubles as a categorical signal.
+
+## Anti-patterns
+
+- **Chunking what should be searched.** Forcing a long list into chunks the user must navigate when search would do.
+- **Chunks too large.** A "section" containing 20 items isn't a chunk; it's a list.
+- **Chunks too small.** A "section" containing 2 items isn't worth its overhead. Combine.
+- **Inconsistent chunk sizes within a sequence.** A 10-digit string chunked 5-2-3 is harder than 3-3-4 because the rhythm is irregular.
+- **Visual chunking that contradicts logical chunking.** Visual separators in places that don't match meaning ("123-4567-89" is structurally awkward even if visually chunked).
+- **Decorative grouping with no labels.** Grouping must be communicated via headings or visible regions. Just "putting space between things" without naming the groups misses the cognitive benefit.
+
+## Heuristics
+
+1. **Count chunks visible.** More than ~7? Reorganize or split.
+2. **Count items per chunk.** More than ~5? Split that chunk.
+3. **The "what's in this group?" test.** Can you name each chunk in 2–3 words? If yes, the chunking is meaningful. If no, the chunks are arbitrary; rethink.
+4. **The scanning vs. memorizing diagnostic.** Is the user holding this in mind, or finding it? If finding, chunking may be noise; replace with search and clear labeling.
+
+## Related principles
+
+- **`performance-load`** — chunking is the canonical reduction of cognitive load.
+- **`hicks-law`** — fewer visible options means faster decisions; chunking and Hick's Law often combine in nav design.
+- **`progressive-disclosure`** — disclosure works *between* chunks (show one section, hide others); chunking works *within* the visible content.
+- **`mnemonic-device`** — chunking is itself a mnemonic technique; explicit mnemonics layer on top.
+- **`signal-to-noise-ratio`** (perception) — well-chunked content has less perceptual noise.
+- **`proximity`** (perception) — proximity is the visual mechanism for showing chunks: closer items group, gaps mark boundaries.
+- **`hierarchy`** (perception) — chunked content carries a hierarchy of structure (sections > items).
+
+## Sub-aspect skills
+
+- **`chunking-form-grouping`** — applying chunking to long forms.
+- **`chunking-numeric-and-otp`** — applying chunking to numeric strings, OTP codes, and identifiers.
+
+## Closing
+
+Chunking is the cheapest cognitive lift available in design — it costs only structure, not new content. The discipline is recognizing when content is being held in working memory (chunk it) versus scanned for retrieval (don't add chunks; use search). When applied correctly, chunking turns "too much to hold" into "manageable."

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking/references/working-memory-research.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/chunking/references/working-memory-research.md
@@ -1,0 +1,78 @@
+# Working memory research and chunking depth
+
+A reference complementing the `chunking` SKILL.md with the cognitive-psychology background.
+
+## Miller (1956): the magical number seven
+
+George Miller's 1956 paper proposed that human short-term memory has a roughly fixed capacity of about 7 ± 2 items. The paper compiled evidence from many tasks: digit recall, word recall, tone discrimination, judgment of quantity. Across all of them, the limit landed around the same number.
+
+The paper's key contribution was the concept of *chunk*: the unit of measurement isn't bits or letters but meaningful chunks. A practiced reader holds whole words, not letters; an experienced chess player holds positions, not pieces.
+
+Miller also noted that experts can effectively expand capacity by chunking more efficiently — not by expanding raw capacity, but by recoding information into larger chunks.
+
+## Cowan (2001): the magical number four
+
+Nelson Cowan's *Behavioral and Brain Sciences* paper revisited Miller's number with the benefit of decades of follow-up research. Cowan's analysis: when you control for rehearsal, grouping, and other strategies that effectively cheat the limit, raw working memory capacity is closer to 4 ± 1.
+
+The "7±2" number is what people achieve with chunking and rehearsal; the "4±1" number is the underlying capacity.
+
+For design, this means:
+
+- The user's *unaided* working memory holds about 4 chunks.
+- With chunking aid (visual grouping, named sections), users can manage more.
+- Pushing past 4 chunks visible at once relies on the user doing the chunking themselves — reasonable for trained users, less so for casual.
+
+## Baddeley's working memory model
+
+Alan Baddeley's model (1986, refined since) breaks working memory into:
+
+- **Phonological loop**: holds verbal/auditory information for ~2 seconds; refresh by rehearsal.
+- **Visuospatial sketchpad**: holds visual/spatial information.
+- **Central executive**: coordinates and switches attention.
+- **Episodic buffer**: integrates information into coherent episodes.
+
+The model explains why visual chunking and verbal chunking are partly independent (you can hold roughly 4 visual chunks *and* 4 verbal chunks). Designs that exploit both modalities (a numbered list with visual structure) outperform purely-textual or purely-visual chunked content.
+
+## Expert vs. novice chunking
+
+Classic chess studies (de Groot 1965, Chase and Simon 1973) showed that:
+
+- Experts and novices recall random chess positions equally — both at ~4–7 pieces.
+- Experts recall *meaningful* positions (an opening, a checkmate setup) far better than novices.
+
+The expert advantage is entirely in chunk recognition. Years of practice teach the expert to recode many pieces into a single meaningful chunk.
+
+For UI design: the patterns your users learn become chunks. A daily user of your dashboard sees "the revenue panel" as one chunk; a new user sees ten distinct numbers. Familiar layouts let users hold more.
+
+## Cross-domain examples of chunking failures
+
+### Memorization of long passwords
+
+Users asked to remember a 12-character password (a wall of characters) struggle. Chunked passphrases ("correct horse battery staple" — XKCD's classic example) are easier because each word is one chunk and only 4 chunks total are needed.
+
+### Long phone trees ("press 1 for...")
+
+Phone IVR systems that present 7+ options exceed working memory. Users either pick wrong or ask the operator. Best practice: cap at 4–5 options per level; nest.
+
+### Wall-of-text user agreements
+
+A 20-page Terms of Service is a working-memory disaster. Users either don't read or skim and miss. Chunked summaries ("Here's what this agreement says: 1. We can change pricing with 30 days notice. 2. ...") move toward usability.
+
+### Driving directions
+
+"In 0.3 miles, turn right onto Elm Street, then immediately bear left onto Maple, then take the second right onto Oak" — multiple chunks, but each turn is a chunk. Modern GPS apps deliver one turn at a time precisely to avoid working-memory overload.
+
+## Design implications
+
+- **Estimate working memory budget per surface.** How many independent items must the user hold while completing this task? > 4 → restructure.
+- **Use perceptual grouping (proximity, similarity)** so chunking is automatic, not effortful.
+- **Use conventional chunkings** (phone-number formatting, OTP groups) so users don't have to compute the structure.
+- **Don't chunk reference content.** Working memory limits don't apply when users are scanning or searching, only when they're *holding*.
+
+## Resources
+
+- **Miller, G.** "The Magical Number Seven, Plus or Minus Two" (1956). *Psychological Review*.
+- **Cowan, N.** "The Magical Number Four in Short-Term Memory" (2001). *Behavioral and Brain Sciences*.
+- **Baddeley, A.** *Working Memory, Thought, and Action* (2007).
+- **Chase, W. G. & Simon, H. A.** "Perception in Chess" (1973). *Cognitive Psychology*.
+- **Sweller, J.** Cognitive load theory papers (1988 onward).

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/cognition-router/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/cognition-router/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cognition-router
+description: 'Use this skill whenever a design task involves cognition, mental models, learnability, complexity reduction, defaults, memory, scanning, or comprehension — regardless of framework or platform. Trigger when the user is designing forms, settings, onboarding, dashboards with many widgets, complex tables, navigation IA, search experiences, or any flow that has many options or asks the user to learn something new. Trigger when the user mentions "too complex," "too many options," "users keep getting confused," defaults, labels, copy, mental models, progressive disclosure, autocomplete, or ergonomics. Routes the model to the right cognition principle in this plugin.'
+---
+
+# Cognition & learnability — router
+
+This plugin holds the principles that govern how easily a user can understand, learn, and remember an interface. They are framework-agnostic and apply equally to web apps, mobile apps, desktop software, control panels, in-car displays, and printed forms.
+
+## Principles in this plugin
+
+Each principle has its own skill (with sub-aspect skills where useful). Principles marked **[full]** have reference-grade skill files; the rest are planned and will be added in subsequent passes.
+
+### Complexity reduction
+
+- **`hicks-law`** *[full]* — decision time grows with the log of the number of options.
+  - Sub-skills: `hicks-law-menus`, `hicks-law-defaults`, `hicks-law-pricing`.
+- **`80-20-rule`** — 80% of usage flows through 20% of features; design the default for the 80%.
+- **`chunking`** — group items into ~4±1 chunks so working memory can hold them.
+- **`performance-load`** — total cognitive + kinesthetic effort to do a task; minimize both.
+- **`progressive-disclosure`** — show only what's needed now; reveal advanced controls on demand.
+- **`satisficing`** — users pick the first acceptable option, not the optimal one.
+- **`ockhams-razor`** — among solutions that work, prefer the simplest.
+
+### Mental models and recognition
+
+- **`mental-model`** — users come with a model of how the system works; design to match it.
+- **`recognition-over-recall`** — recognizing is easier than remembering; show options.
+- **`visibility`** — features that aren't visible aren't used.
+- **`mapping`** — controls map onto what they affect.
+- **`constancy`** — visual properties remain stable across state changes.
+- **`iconic-representation`** — pictures are recognized faster than words but only when conventional.
+- **`mimicry`** — borrow successful familiar patterns rather than invent.
+- **`rosetta-stone`** — pair a known referent with a novel concept.
+
+### Chunking, scanning, and memory
+
+- **`inverted-pyramid`** — most important info first, then supporting detail.
+- **`five-hat-racks`** — five ways to organize: Location, Alphabet, Time, Category, Hierarchy.
+- **`advance-organizer`** — a structural preview before content (TOC, breadcrumbs).
+- **`serial-position-effects`** — first and last items are remembered best.
+- **`stickiness`** — memorable, concrete content earns repeat use.
+- **`storytelling`** — narrative encodes meaning more memorably than bullets.
+- **`picture-superiority-effect`** — images outlast text in memory.
+- **`mnemonic-device`** — explicit memory aids reduce recall cost.
+- **`propositional-density`** — meaning per visible mark; high density reads as polished.
+
+### Wayfinding and navigation
+
+- **`wayfinding`** *[full]* — orienting, choosing routes, monitoring progress, recognizing destinations.
+  - Sub-skills: `wayfinding-physical-spatial-metaphors`, `wayfinding-search-and-recovery`, `wayfinding-breadcrumbs-and-context`.
+- **`progressive-disclosure`** *[full]* — show what's needed now; tuck the rest behind explicit affordances.
+  - Sub-skills: `progressive-disclosure-defaults-and-tucking`, `progressive-disclosure-disclosure-affordances`.
+
+### Consistency and encoding
+
+- **`consistency`** — same things look and behave the same.
+- **`cognitive-dissonance`** — contradictions between expectation and behavior cost trust.
+- **`confirmation-bias`** — users notice what confirms their model and ignore what doesn't.
+- **`comparison`** — comparison is easier than evaluation.
+- **`depth-of-processing`** — interactive engagement yields better memory than passive reading.
+- **`priming`** — exposure shapes how a subsequent stimulus is processed.
+- **`framing`** — how information is framed changes the choice users make.
+- **`modularity`** — break complex systems into independent, recombinable units.
+- **`redundancy`** — multiple independent signals make critical info reliable.
+
+## Heuristic for which to read first
+
+- **Designing a long form or settings page** → `chunking`, `progressive-disclosure`, `hicks-law`, `mental-model`.
+- **Picking defaults** → `satisficing`, `80-20-rule`, `hicks-law-defaults`, `framing`.
+- **Picking an icon set** → `iconic-representation`, `recognition-over-recall`, `mimicry`.
+- **Designing a dashboard** → `propositional-density`, `chunking`, `inverted-pyramid`.
+- **Onboarding** → `mental-model`, `advance-organizer`, `depth-of-processing`, `storytelling`.
+- **Search / navigation IA** → `wayfinding`, `recognition-over-recall`, `five-hat-racks`, `visibility`.
+- **"Users keep getting lost"** → `wayfinding`, `wayfinding-breadcrumbs-and-context`, `wayfinding-search-and-recovery`.
+- **Settings / forms feel overwhelming** → `progressive-disclosure`, `chunking`, `hicks-law`.
+- **Reviewing a confusing flow** → `mental-model`, `cognitive-dissonance`, `consistency`.
+
+## Cross-plugin pointers
+
+- For *visual* layout and grouping, see `perception-and-hierarchy-principles`.
+- For *behavior* (errors, undo, target sizing, feedback), see `interaction-and-control-principles`.
+- For *aesthetic and tonal* decisions, see `aesthetics-and-emotion-principles`.
+- For *accessibility*, see `process-and-robustness-principles`.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/cognition-router/references/further-reading.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/cognition-router/references/further-reading.md
@@ -1,0 +1,42 @@
+# Further reading: cognition and learnability
+
+External sources for the cognition-related principles.
+
+## Foundational
+
+- **Norman, D.** (1988). *The Design of Everyday Things*. The single most-cited book in HCI; introduces affordance, mapping, mental models, and many other concepts that ground modern interaction design.
+- **Miller, G. A.** (1956). "The magical number seven, plus or minus two." *Psychological Review*. The chunking paper.
+- **Sweller, J.** (1988). "Cognitive load during problem solving." *Cognitive Science*. The foundational cognitive-load paper.
+- **Hick, W. E.** (1952) and **Hyman, R.** (1953). The Hick-Hyman Law original papers.
+
+## Applied HCI
+
+- **Krug, S.** (2000, 2014). *Don't Make Me Think*. Practical web usability; especially good on Hick's Law and Recognition over Recall.
+- **Cooper, A., Reimann, R., Cronin, D., Noessel, C.** *About Face: The Essentials of Interaction Design*. Comprehensive interaction design reference; particularly strong on personas and mental models.
+- **Nielsen, J.** *Usability Engineering* (1993) and many writings at nngroup.com — particularly on the 10 usability heuristics, which overlap heavily with this plugin.
+
+## Behavioral economics
+
+- **Thaler, R. & Sunstein, C.** (2008). *Nudge*. Defaults, choice architecture, satisficing.
+- **Kahneman, D.** (2011). *Thinking, Fast and Slow*. System 1 / System 2 cognition; framing; anchoring.
+- **Ariely, D.** (2008). *Predictably Irrational*. Cognitive biases relevant to UI/pricing decisions.
+
+## Mental models
+
+- **Norman, D.** (1983). "Some observations on mental models." A foundational paper.
+- **Johnson, J.** *Designing with the Mind in Mind* (2010, 2nd ed. 2014). Explicit translation of cognitive psychology into UI design rules.
+
+## Memory and attention
+
+- **Baddeley, A.** *Working Memory, Thought, and Action* (2007). The standard reference on working memory.
+- **Bargh, J. A.** Many papers on priming and unconscious cognition.
+
+## Online tools
+
+- **Laws of UX** (lawsofux.com). A clean reference site with many of these principles, including animated examples.
+- **NN/g articles** (nngroup.com). Searchable archive of HCI research summaries.
+- **WCAG documentation** (w3.org/WAI) — for the cognition-relevant accessibility criteria.
+
+## Closing thought
+
+Cognition principles age well because human cognition changes slowly. A book on web design from 2008 may feel dated; a book on cognitive psychology from 1988 still works. When in doubt, lean on the older sources for the underlying principle and the newer ones for current applications.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency-external/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency-external/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: consistency-external
+description: 'Apply external consistency — honoring conventions from outside your product (platform conventions, category conventions, established interaction patterns) so users can transfer their learning into your product. Use when designing for a specific platform (iOS, Android, web), entering an established product category (calendar, email, file manager), choosing icons or gestures, or deciding when to follow vs. lead a convention. External consistency reduces the learning cost for new users; deviating from it requires both a strong reason and explicit framing.'
+---
+
+# Consistency — external
+
+External consistency is honoring conventions that exist outside your product. The hamburger menu means "menu" because it means "menu" everywhere; the magnifying glass means "search"; pinch-to-zoom does what it does. Following these conventions lets users transfer their learning from other products directly into yours, with no onboarding cost.
+
+External consistency is most powerful for new users — they're using accumulated learning from years of other products. As users mature in your product, internal consistency starts to dominate, because their learning becomes mostly product-specific. But the first session, where conversion happens or doesn't, is largely about external consistency.
+
+## What external consistency includes
+
+Several distinct kinds of convention live "outside" your product.
+
+**Platform conventions.** iOS, Android, macOS, Windows, web — each platform has accumulated conventions that users expect from native apps on that platform. The platform-native back gesture, the platform-native scrollbar, the platform-native form-input behavior, the platform-native keyboard shortcut for save. Apple's Human Interface Guidelines, Android's Material Design, and similar documents codify these.
+
+**Category conventions.** Calendar apps look like calendars. Email apps look like email. File managers look like file managers. There's a strong, accumulated category-level expectation about layout, terminology, and interaction. Departing from category convention requires either a strong reason ("we're reimagining email") or accepting that users will have a steeper learning curve.
+
+**Web conventions.** Underlined blue text is a link. The browser's back button works. Hover states reveal interactivity. Forms submit on Enter. Tab traverses focus. These are the conventions of the web as a platform.
+
+**Domain conventions.** In specialized domains (medical software, financial software, design tools), there are conventions specific to the domain that users from that domain expect. A code editor uses certain symbols and color conventions; a CAD tool uses certain layouts; a music DAW uses certain interaction patterns. Domain conventions matter most for tools serving experts within the domain.
+
+**Cross-cultural conventions.** Some conventions are global (color of red light, the magnifying glass for search); others are regional (the dollar sign for money is dominant in dollar-using countries; in others, currency symbols vary). Globally deployed products need to verify which conventions actually transfer to their audience.
+
+## When to honor external conventions
+
+External conventions should be honored unless you have a strong reason not to. Specifically, honor conventions when:
+
+**Your audience comes to your product from many other products.** Web apps, mobile apps, productivity tools — most users have encountered hundreds or thousands of similar products. Their accumulated learning is your asset.
+
+**The convention solves the problem reasonably well.** The hamburger menu is fine. The magnifying glass for search is fine. They're not optimal in every case but they're widely understood, and the cost of teaching users a new pattern usually exceeds the gain from a slightly better one.
+
+**You're in an established category.** Email, calendar, chat, file management, e-commerce — these categories have decades of accumulated convention. Reinventing what a "send" button looks like is rarely worth it.
+
+**Users are casual or first-time.** Casual users have no patience for unfamiliar conventions; they'll abandon a product whose patterns they don't recognize within minutes.
+
+## When to break external conventions
+
+Sometimes deviation is warranted. Specifically, consider breaking external conventions when:
+
+**The convention is genuinely bad.** The floppy disk for "save" is increasingly anachronistic. The mailing-envelope for "email" is fine for now but won't be in twenty years. Following dying conventions just because they're conventional is sometimes wrong.
+
+**You have a fundamentally better pattern.** If your new pattern is significantly easier or faster, the cost of teaching users the new pattern can be paid back over the lifetime of their use. But the bar is high — users have a lot of accumulated learning at stake.
+
+**The convention doesn't apply to your case.** A convention that emerged in one context may not transfer cleanly to another. The "long-press for context menu" convention from desktop right-click doesn't translate well to all touch contexts.
+
+**You're explicitly reframing the category.** "We're reimagining email" is a frame that gives users permission to expect new patterns. The frame has to actually be in the marketing — users won't infer it from the product alone.
+
+In all these cases, the deviation should be deliberate, well-framed, and supported by onboarding. Sneaking in a non-conventional pattern without acknowledgment loses you users who don't know to expect it.
+
+## Worked examples
+
+### A web app that follows web conventions
+
+A team building a web-based project-management tool follows web conventions: the browser's back button works, links look like links, forms submit on Enter, search is in the upper-right with a magnifying glass icon, settings are reachable from a gear icon. Users from other web tools find it immediately familiar.
+
+The team's competitor reinvents some conventions: the back button doesn't work (it has its own in-app navigation history that overrides browser back), search uses a custom hexagon icon, settings are in a non-standard location. The competitor's product takes longer to learn, and users coming from elsewhere bounce more frequently.
+
+The lesson: web conventions are extremely strong. Reinventing them is almost always net-negative.
+
+### A mobile app that follows platform conventions
+
+An iOS app uses the system-native navigation bar (back button on the top-left, title in the center, action button on the top-right), the system-native swipe-back gesture, the system-native keyboard, the system-native share sheet, and the system-native modal presentation. iOS users find it familiar from the moment they open it.
+
+The same app's Android version uses Android conventions (navigation drawer, system back button, system share intent, Material Design components). Android users find it equally familiar.
+
+The product is consistent within itself in workflows and content but adapts its chrome to each platform. This is the right tradeoff for cross-platform mobile.
+
+### A category convention deliberately broken
+
+A weather app departs from the standard "current temperature, hourly forecast, daily forecast" layout in favor of an ambient-light visualization. The departure is deliberate; the marketing frames it as "Weather, reimagined as ambient atmosphere." The first-launch screen briefly explains the metaphor.
+
+Users who arrived via the framing accept the new pattern; users who arrived without the framing are confused. The framing is essential — it's what gives users permission to expect a new pattern instead of falling back on category expectations.
+
+### A domain convention used appropriately
+
+A code editor uses syntax highlighting (color conventions for keywords, strings, comments) following the conventions of every other code editor. Programmers expect this; departing from it would be an unforced error. The product extends the domain conventions in some places (custom semantic highlighting for specific frameworks) but doesn't replace them.
+
+### A convention misapplied to a new context
+
+A team building a smart-home app uses a "trash can" icon for "remove device from network." Users tap the icon expecting to delete the device's record; they're surprised to find that the device is now disconnected but the record remains. The trash-can convention misled them.
+
+The fix: use a different icon (a "disconnect" symbol or "unlink" icon) and a different label ("Remove from network") to signal that this is not a deletion. The convention was strong but wrong for this case.
+
+## Anti-patterns
+
+**Reinventing for novelty's sake.** A new icon for "search" because the magnifying glass feels overused. A new layout for the calendar because "we want to do something different." Novelty in convention costs the user; do it only when the new pattern is genuinely better, not for differentiation alone.
+
+**Following conventions that don't fit your audience.** A B2B SaaS product following consumer-mobile conventions (a hamburger menu hiding the main nav on a desktop browser) when its users are at desktops with screen real estate to spare. The convention is for a different context.
+
+**Following dying conventions out of habit.** The floppy disk for save when users no longer recognize it. The CD/DVD icon for media. Some conventions outlive their generation; reaching for them by reflex serves no one.
+
+**Half-following conventions.** Using the standard icon but with non-standard behavior (the magnifying glass that opens a generic filter panel rather than a search box). Worse than either fully following or fully replacing the convention, because users have stronger expectations about behavior than about appearance.
+
+**Ignoring platform conventions on platform-native apps.** Forcing iOS users to use Android-style navigation, or web users to use mobile-style chrome. Your product looks "out of place" on the platform and users feel the mismatch even if they can't articulate it.
+
+**Following one convention in some places, another in others, within the same product.** Internal inconsistency cancels the benefit of either external convention. Pick one source of convention and follow it consistently.
+
+## Heuristic checklist
+
+When designing a new pattern, ask: **Is there an established convention for this case?** If yes, default to it unless you have a strong reason. **What platform am I on, and what does that platform expect?** Honor platform conventions for the chrome of your app. **What category am I in, and what does that category expect?** Honor category conventions for the substance of your app. **If I'm breaking a convention, do I have a strong reason and an explicit framing?** Without both, reconsider.
+
+## Related sub-skills
+
+- `consistency` — parent principle on the four kinds of consistency.
+- `consistency-internal` — sibling skill on internal consistency.
+- `mimicry` — external consistency is a form of mimicking established patterns.
+- `recognition-over-recall` — external conventions are recognized rather than recalled.
+- `mapping-cultural` — cultural mappings are one specific form of external convention.
+- `iconic-representation` — icon conventions are external consistency at the icon level.
+
+## See also
+
+- `references/platform-conventions.md` — survey of major platform conventions and how to honor them.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency-external/references/platform-conventions.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency-external/references/platform-conventions.md
@@ -1,0 +1,180 @@
+# External consistency — platform conventions
+
+A survey of conventions from major platforms and contexts, with notes on what to honor and where conventions diverge.
+
+## iOS
+
+iOS users expect:
+
+- A navigation bar at the top with the back button at the upper-left (chevron + previous-screen title) and a single action button at the upper-right.
+- A tab bar at the bottom for primary navigation in apps with 2–5 main sections.
+- The system swipe-from-left-edge gesture to go back.
+- The system share sheet for sharing.
+- The system context menu (long-press) for additional actions on items.
+- Sheet-style modals (sliding up from the bottom) for detail flows.
+- The system keyboard with platform-native autocorrect and dictation.
+- Adherence to the "Done" / "Cancel" / "Edit" terminology in navigation actions.
+
+Apple's Human Interface Guidelines codify these. iOS users notice deviations even when they can't articulate them; the app feels "off" if it uses an Android-style hamburger menu, a custom share dialog, or a web-style top-level button bar.
+
+## Android
+
+Android users expect:
+
+- A top app bar with the navigation icon (drawer or back) on the left.
+- A bottom navigation bar or navigation drawer for primary navigation.
+- The system back button (gesture or hardware) to go back.
+- Material Design components (Floating Action Button for primary action, Cards for content blocks, Snackbars for transient feedback).
+- The system share intent for sharing.
+- Long-press for selection mode (entering multi-select).
+- The system text-selection toolbar.
+- Adherence to material elevation (cards casting shadows, FABs floating above content).
+
+Material Design documentation codifies these. Android is somewhat more tolerant of deviation than iOS because the platform is more diverse, but apps that diverge significantly from Material still feel out of place.
+
+## Web
+
+Web users expect:
+
+- The browser's back button works correctly. Single-page apps that break the back button are a notorious source of user frustration.
+- Underlined or differently-colored text is a link.
+- Hover states reveal interactivity.
+- Forms submit on Enter.
+- Tab traverses focus.
+- Cmd-F (Ctrl-F) opens browser find.
+- The browser's zoom controls work.
+- Right-click opens the browser context menu (with possible app additions).
+- Standard keyboard shortcuts work where their meaning carries over (Cmd-S for save, Cmd-Z for undo, Cmd-A for select all).
+
+The web's affordances are weaker than native platforms', so following conventions is more important — there's less platform polish to fall back on if you depart.
+
+## macOS
+
+macOS users expect:
+
+- The menu bar at the top of the screen (not in the window).
+- The window has traffic lights (close, minimize, zoom) at the upper-left.
+- Cmd as the primary modifier key (not Ctrl).
+- Standard keyboard shortcuts: Cmd-S, Cmd-Z, Cmd-W, Cmd-Q, Cmd-,
+- Right-click or Ctrl-click for context menu.
+- The system text-input controls with built-in spell-check.
+- Drag and drop between apps.
+- The system file open/save dialog.
+
+macOS conventions are deeply ingrained; users notice when an app forces Windows-style behavior (Ctrl modifier, in-window menu bar). Cross-platform desktop apps need to adapt their chrome per platform.
+
+## Windows
+
+Windows users expect:
+
+- An in-window menu bar (or ribbon, in some apps) and toolbar.
+- Standard keyboard shortcuts with Ctrl as the primary modifier.
+- The window-management chrome (close, maximize, minimize) at the upper-right.
+- Right-click for context menu.
+- The system file open/save dialog.
+- The system text-input controls.
+- Notifications via the system notification area.
+
+Windows is more tolerant of cross-platform UI because the platform itself is heterogeneous (desktop, tablet, surface, traditional), but native conventions still matter.
+
+## Web app SaaS conventions
+
+Within the world of SaaS web apps, additional conventions have emerged:
+
+- Top-bar navigation with logo on the left, primary nav in the center, account/notifications on the right.
+- A sidebar navigation pattern for products with many sections.
+- The Cmd-K (Ctrl-K) command palette for power-user navigation.
+- The "/" shortcut to focus a search box.
+- Avatar-and-menu in the upper-right for account access.
+- A help button (often a chat bubble or "?") in the lower-right.
+
+These conventions are softer than platform conventions, but they're now strong enough that products following them feel familiar to anyone who's used a SaaS tool in the last decade.
+
+## Category conventions: calendar
+
+Calendar apps follow strong category conventions:
+
+- Month, week, and day views available.
+- The month view shows a grid with days as cells and events as bars or text within cells.
+- The week view shows days as columns with hours as rows; events are positioned at their start time and sized to their duration.
+- "Today" is visually highlighted.
+- Click/tap on a date or time creates a new event.
+- Drag to move; resize at the bottom edge to extend.
+
+Departing from these conventions requires either a strong reframing or a niche audience.
+
+## Category conventions: email
+
+Email apps follow:
+
+- Inbox as a list of conversations; each row shows sender, subject, preview, time.
+- Click/tap to open; a reading pane (in dual-pane layouts) or full screen (in single-pane).
+- Reply, Reply All, Forward as primary actions on a message.
+- The trash, archive, and spam destinations.
+- The compose-window pattern with To/Cc/Bcc, Subject, Body.
+
+Email is one of the strongest category conventions; users have been using mail clients for decades. Even radical reinventions (Superhuman, Hey, Front) keep the core conventions and innovate around the edges.
+
+## Category conventions: file management
+
+File managers follow:
+
+- Hierarchical folder navigation with breadcrumbs or a tree.
+- List, grid, or column views toggle-able.
+- Right-click (or long-press on touch) for context menu with file operations.
+- Drag and drop to move; Cmd/Ctrl-drag to copy.
+- Cmd/Ctrl+C, X, V for copy, cut, paste.
+- The trash/recycle bin.
+
+File management has been stable since the 1980s; departing from these conventions is rarely worthwhile.
+
+## Domain conventions: code editors
+
+Code editors follow:
+
+- Monospace font for code.
+- Syntax highlighting with color conventions: keywords blue or purple, strings green or red, comments gray or italic.
+- Line numbers in the gutter.
+- Find and replace with Cmd-F (Ctrl-F) and Cmd-H (Ctrl-H).
+- "Go to line" with Cmd-G or Cmd-L.
+- Tab to indent (or smart auto-indent).
+- Bracket matching and auto-pairing.
+
+Programmers transferring between editors expect these conventions. Innovating in editor design happens around the edges (LSP integration, AI assistance) but rarely on the core conventions.
+
+## Domain conventions: design tools
+
+Design tools follow:
+
+- A canvas with infinite scroll/zoom.
+- Layers panel on one side.
+- Properties panel on the other.
+- The shape, text, and pen tools as primary creation tools.
+- Cmd-D for duplicate; Cmd-G for group.
+- Boolean operations (union, subtract, intersect).
+
+Figma, Sketch, Illustrator, and successors all follow these. Departing from them in a serious design tool is a strong claim.
+
+## Cross-cultural and accessibility caveats
+
+Some conventions don't transfer cleanly:
+
+- Reading direction (left-to-right vs. right-to-left) affects many spatial conventions: progress bars, slider directions, even icon orientations.
+- Color conventions (red = stop, green = go) are widely shared in industrialized cultures but have local variations.
+- Currency, date format, address format, name format all need localization.
+- Accessibility conventions (focus states, ARIA roles, keyboard equivalents) are universal — don't sacrifice them for visual coherence.
+
+For globally deployed products, verify each convention with the actual audience rather than assuming it transfers.
+
+## Decision framework
+
+When facing a design decision that touches a convention, ask:
+
+1. **Is there a dominant convention for this in my user's context?** Platform, category, web. If yes, default to it.
+2. **Do I have a strong reason to deviate?** "It would look better" is not strong enough. "We're reframing the category" might be.
+3. **If I deviate, am I framing it explicitly so users know to expect new patterns?** Without framing, deviation reads as broken.
+4. **Am I deviating in chrome, in substance, or both?** Substance can be product-specific; chrome should usually be platform-native.
+
+## Cross-reference
+
+For internal consistency within your product, see `consistency-internal`. For specific patterns of mimicking established conventions, see `mimicry`.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency-internal/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency-internal/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: consistency-internal
+description: 'Apply internal consistency — making your product coherent with itself across all surfaces, components, and flows. Use when designing or auditing component libraries, defining design tokens, settling cross-team naming conventions, planning a design-system rollout, integrating acquired or legacy code, or evaluating whether two features should share or diverge in their interaction model. Internal consistency is enforced through design systems, shared vocabularies, and process discipline; it erodes through hand-off losses, sprint-driven shortcuts, and team boundaries that don''t coordinate.'
+---
+
+# Consistency — internal
+
+Internal consistency is the property of a product being coherent with itself. Every screen, every flow, every component looks like it came from the same product, and equivalent operations behave the same way. Users transfer their learning across surfaces because the product rewards them for doing so.
+
+Internal consistency is hard to maintain by good intentions alone. Teams ship in parallel, designers move on, design tokens drift, components get forked. The systems that maintain consistency over years are the ones that build it into the production process — design systems with real components, design tokens enforced by code, lint rules that fail builds for off-system colors.
+
+## The mechanisms of internal consistency
+
+Internal consistency rests on a few mechanisms working together.
+
+**A design system with real components.** A library of buttons, inputs, modals, cards, tabs, etc., that is the canonical implementation. Designers compose with it; engineers use it; everyone gets the same behavior because there's only one implementation to use. The design system is not a documentation site full of screenshots — it's actual production components, code, and design tokens that flow through to the product.
+
+**Design tokens enforced by code.** Colors, spacings, typographic sizes, border-radii, shadows, animations — all defined as named tokens (`color.primary.500`, `spacing.4`, `radius.md`) and used through those names rather than as raw values. When a designer changes the canonical primary blue, every component that uses `color.primary.500` updates automatically. When an engineer hard-codes a custom blue, a lint rule flags it.
+
+**A shared vocabulary.** The same concepts have the same names across the product, the documentation, the marketing, and the support content. The "workspace" is always called the "workspace," not sometimes "team" and sometimes "org." The "save" action is always called "save," not sometimes "store" or "submit." Vocabulary drift is one of the easiest consistency violations to ship and one of the hardest to recover from once shipped.
+
+**Pattern documentation for non-component decisions.** Some design decisions don't fit neatly into components — when to use a modal vs. an inline form, when to redirect vs. open in a new view, how to handle empty states, how to handle errors. These need pattern documentation so teams making decisions can reach for the same answer.
+
+**Reviews and audits.** Design reviews and engineering reviews catch inconsistencies before they ship. Periodic audits across the live product catch the inconsistencies that slipped through. Both require ongoing investment, but the alternative — letting inconsistency accumulate until a major rebuild is needed — is more expensive.
+
+## Common sources of internal inconsistency
+
+Internal inconsistency creeps in through a few well-known channels.
+
+**Different teams building parallel features.** Team A and Team B both ship features in the same release. They consult the design system but encounter cases the system doesn't cover. Each team makes a reasonable local decision. The decisions differ. The product now has two ways to handle the same case.
+
+**Quick fixes under deadline pressure.** A bug needs to be fixed before launch. The designer is unavailable. The engineer makes a styling tweak that solves the immediate problem and ships. The tweak is now in production, slightly off-system, and may persist for years.
+
+**Acquisitions and integrations.** A product acquires another product. Two design systems collide. Without active integration work, both systems persist, with users encountering both depending on which surface they're in. The seam between them is visible and irritating.
+
+**Legacy that the design system never reached.** A part of the product was built before the design system existed and was never migrated. It's been working "well enough" for years, but it looks and behaves differently from everything around it.
+
+**Design system gaps.** The design system covers 80% of cases; the remaining 20% are ad-hoc. Without conscious effort, the ad-hoc patterns drift apart over time.
+
+**Tool fragmentation.** Different teams use different tools (one designs in Figma, another in Sketch, another sketches in Whimsical) without shared component libraries. Decisions made in different tools diverge.
+
+## Worked examples
+
+### A design system that prevents drift
+
+A product team adopts a design system with: a code library of React components, design tokens for color/spacing/typography, lint rules that fail builds for off-token values, a Figma library that mirrors the code components, and a small "design ops" team that owns the system.
+
+Two years later, despite shipping hundreds of features, the product still looks coherent. Drift is suppressed at production time. New components are added to the system rather than ad-hoc'd. Engineers can't even ship an off-system color without a lint failure. The discipline is in the tooling.
+
+The cost: the design system itself requires investment (perhaps 1–2 dedicated people for a mid-sized product). The benefit: every team is faster because they're not re-deciding fundamentals, and the product stays coherent.
+
+### A design system that lives only in screenshots
+
+Another team's design system is a documentation site with screenshots and prose ("Use the Primary button for primary actions, the Secondary for secondary"). There are no actual code components or design tokens enforced anywhere. Each engineering team implements buttons themselves, intending to follow the screenshots. They each implement slightly differently.
+
+Two years later, the product has a dozen subtly different button styles, and the design-system site no longer matches any of them. The system died because it didn't actually constrain production.
+
+The lesson: a design system that isn't part of the production pipeline isn't a system; it's documentation, and documentation drifts away from reality.
+
+### A vocabulary drift that ships to users
+
+A team building a project-management product calls the unit of work "task" in the main UI, "item" in the API, "issue" in the documentation, and "ticket" in the support tooling. Each name was reasonable in its local context. But users encountering multiple surfaces are confused: are tasks and issues the same thing?
+
+The fix is consolidation: pick one name, change all surfaces to use it, and update any external content. The effort is real; the alternative is paying a small confusion cost on every cross-surface interaction.
+
+### Two confirmation patterns
+
+A product has two confirmation flows shipped by different teams. One uses a modal: "Delete this? Cancel / Delete." The other uses an inline confirm with the button transforming into Yes/No. Users encountering one flow after the other are mildly confused.
+
+The fix: pick one pattern (the modal for high-stakes actions; the inline for low-stakes) and apply it consistently. If the two patterns reflect a real difference in stakes, document the rule and apply it everywhere; if they don't, consolidate to one.
+
+### Migrating a legacy section
+
+A 5-year-old section of the product was built before the current design system. It still works, but it looks visibly different: older typography, older button styling, older spacing. The team faces a choice: leave it (cheap, but the inconsistency persists) or migrate it (expensive, but resolves the inconsistency).
+
+The right call depends on usage. If the section is heavily used, migration is worth it because users encounter the inconsistency frequently. If it's lightly used, the migration cost may not be justified — but the section should at least be marked in the team's mental map as "out of system" so its inconsistency is acknowledged rather than denied.
+
+## Anti-patterns
+
+**Design system theater.** A beautifully documented design system that no one uses in production. The system exists; the actual product diverges from it; nothing enforces alignment. The effort spent on the documentation generates no consistency benefit.
+
+**Aggressive consistency masking real differences.** A product where every list looks the same, every detail page looks the same, every form looks the same — even though some lists need to scan-able and dense while others need to highlight one or two items per row. Forced consistency at the layout level can flatten meaningful differences.
+
+**Design system as straightjacket.** A design system so restrictive that teams can't accommodate genuine new patterns. They either work around the system (creating ad-hoc one-offs) or ship sub-optimal designs to stay within the system. Healthy design systems accommodate new patterns; rigid ones get bypassed.
+
+**Component sprawl.** A design system that started small and accumulated dozens of similar components. Six button variants, eight modal types, four table styles. Teams can't tell which one to use. Periodic consolidation is needed to keep the system usable.
+
+**Token drift.** Design tokens that started semantic (`color.primary`, `color.danger`) but accumulated literal aliases (`color.blue.500`, `color.red.500`) that bypass the semantic layer. Teams use the literal aliases for one-off cases and the semantic meaning erodes.
+
+**Inconsistent accessibility behavior.** All buttons look the same but have different focus styles, keyboard handling, or ARIA properties. Visual consistency without behavioral consistency is the worst case for users with assistive tech, who rely on behavioral consistency more than visual.
+
+## Heuristic checklist
+
+When auditing internal consistency, ask: **Is there a single source of truth for components, tokens, and patterns?** If not, build one. **Are off-system values enforced against, or just discouraged?** Discouragement is unreliable. **Do all teams know about and use the system?** A system unknown to half the teams is half a system. **When new patterns are introduced, do they get added to the system?** Systems that don't grow with the product become irrelevant. **Is vocabulary consistent across UI, API, docs, marketing, and support?** Cross-surface vocabulary drift is invisible until users complain.
+
+## Related sub-skills
+
+- `consistency` — parent principle on the four kinds of consistency.
+- `consistency-external` — sibling skill on external conventions.
+- `mental-model` — internal consistency lets users build a stable mental model of the product.
+- `recognition-over-recall` — consistent patterns strengthen recognition.
+- `progressive-disclosure` — even hidden depth should be consistent in pattern with visible features.
+
+## See also
+
+- `references/design-system-mechanics.md` — practical patterns for building, maintaining, and evolving design systems.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency-internal/references/design-system-mechanics.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency-internal/references/design-system-mechanics.md
@@ -1,0 +1,119 @@
+# Internal consistency — design-system mechanics
+
+Practical patterns for building, maintaining, and evolving a design system that actually keeps a product consistent over years.
+
+## Pattern: design tokens as the foundation
+
+Define a small set of named values for color, spacing, typography, border-radius, shadow, and animation. Components use the names; engineers never use raw values. When the canonical value changes, every component updates.
+
+A starter token set for color might be: `color.brand.primary`, `color.brand.secondary`, `color.semantic.success`, `color.semantic.warning`, `color.semantic.error`, `color.surface.base`, `color.surface.muted`, `color.surface.elevated`, `color.text.primary`, `color.text.muted`, `color.text.inverse`. Each maps to a literal value, but components reference the semantic name. This means a brand refresh changes one mapping; nothing else needs to change.
+
+For spacing, a 4px or 8px base scale (`spacing.0`, `spacing.1`, `spacing.2`, …) covers most cases. Use multiples of the base; resist arbitrary values like 13px or 22px.
+
+For typography, define a clear scale (`text.body.sm`, `text.body.md`, `text.heading.lg`, etc.) with size, weight, and line-height bundled together. This prevents ad-hoc combinations like "16px Inter Bold" that don't match anything in the system.
+
+## Pattern: component library shipped via package
+
+Components live in a package (`@yourcompany/ui` or similar) that all product code depends on. Updates ship as version bumps; teams pull updates explicitly. This gives the design system team a clear release cadence and gives product teams predictable upgrade timing.
+
+The library should include:
+
+- Core primitives (Button, Input, Select, Checkbox, Radio, Switch, etc.)
+- Composite components (Modal, Drawer, Card, Tabs, Table, Toast, etc.)
+- Layout primitives (Stack, Box, Grid, Spacer)
+- Token definitions accessible programmatically
+
+Components should be opinionated about appearance and unopinionated about content. They should accept content as props or children, and apply system styling automatically.
+
+## Pattern: linting and visual regression
+
+Lint rules catch off-system usage at code-review time. A few high-value rules:
+
+- Reject hex colors in component code (force use of token references)
+- Reject inline padding/margin values not on the spacing scale
+- Reject font-family declarations outside the token system
+- Warn on imports from outside the design system package
+
+Visual regression testing (Chromatic, Percy, BackstopJS, etc.) catches unintentional visual changes when components or tokens evolve. Snapshots from before and after a change are compared; differences are flagged for review.
+
+## Pattern: figma library mirroring code
+
+Designers work in Figma with a component library that mirrors the code components. Token values are synchronized between the two. When a designer changes a component, it triggers a code review for the corresponding component update.
+
+This requires investment to maintain (the two libraries can drift if not actively kept in sync), but it's the only pattern that prevents the "designed in Figma, implemented differently in code" failure mode.
+
+Tools like Figma Tokens, Style Dictionary, and dedicated team workflows can semi-automate the synchronization.
+
+## Pattern: pattern documentation for non-component decisions
+
+Some consistency questions don't fit into components: when to use a modal vs. inline, how to handle empty states, what tone to use in error messages, how to title pages.
+
+These need pattern documentation: short, opinionated guidance with examples. "When to use a modal: only for actions that interrupt the user's current task and require completion before continuing. For non-interrupting actions, use a Drawer. For confirmation of destructive actions, use the inline destructive-confirm pattern."
+
+The documentation should be on the same internal site as the component library, so designers and engineers reach for it as a single source.
+
+## Pattern: design-ops as a real team
+
+Internal consistency requires sustained ownership. A "design-ops" team — typically 1–3 people for a mid-sized product, more for larger ones — owns the design system, runs reviews, builds tokens, ships component updates, evangelizes adoption, and audits the live product for drift.
+
+Without ownership, the system erodes. With it, the system can sustain a coherent product across many years and teams.
+
+## Pattern: contribution model
+
+Product teams need a way to contribute new components or patterns when the system doesn't cover their case. The model usually looks like:
+
+1. Team identifies a need not covered by the system.
+2. Team builds the new component locally, with the design-ops team's review.
+3. If the pattern proves useful across teams, it migrates into the system.
+4. Other teams adopt the system version.
+
+This prevents the system from being a bottleneck (teams can ship without waiting) while keeping the system growing in the right direction (proven patterns get promoted).
+
+## Pattern: deprecation and migration
+
+When the system needs to evolve, old patterns get deprecated. The deprecation needs a clear timeline:
+
+- New: this is the canonical pattern; use it.
+- Deprecated: still works, but new uses should switch to the new pattern.
+- Removed: gone; remaining usages will break.
+
+Clear deprecation timelines with migration guides let product teams plan their work. Sudden removals create churn and erode trust in the system.
+
+## Pattern: cross-platform tokens
+
+For products that ship to web, iOS, Android, and possibly desktop, tokens should be defined once in a platform-neutral format (JSON, YAML) and exported to each platform's native format (CSS variables for web, asset catalogs for iOS, resources for Android). Tools like Style Dictionary support this.
+
+The benefit: a brand color change is one edit, propagating to every platform. The cost: the tooling pipeline needs to be built and maintained.
+
+## Pattern: token escape hatches
+
+Even the best design system needs occasional escape hatches. A truly novel surface (a marketing landing page, an experimental feature) may need values outside the system. Provide a clear escape mechanism (a "raw" token namespace, a known list of off-system colors) and require justification for its use. The escape hatch should be visible enough that uses can be tracked and consolidated over time.
+
+The failure mode is having no escape hatch (forcing teams to work around the system, often invisibly) or having too easy an escape hatch (everyone uses it and the system becomes optional).
+
+## Anti-patterns
+
+**The "documentation is the system" trap.** A beautifully designed Storybook or Zeroheight site that nobody uses in production. The documentation describes a system that doesn't exist in code.
+
+**The "no one owns it" trap.** A design system that depends on volunteer contributions from teams shipping product features. Without dedicated ownership, the system stagnates and drifts.
+
+**The "boil the ocean" trap.** Trying to ship a complete design system before any team uses it. Better to ship a minimal viable system (10 core components + tokens) and grow it organically based on real usage.
+
+**The "second system" trap.** Replacing an existing flawed-but-functional design system with a fully redesigned one. The migration takes years; the old and new systems coexist; the product becomes more inconsistent during the transition than it was before. Better to evolve the existing system in place.
+
+**The "component for every screen" trap.** Building a custom component for every unique-looking screen instead of composing from primitives. The library balloons; reuse drops; consistency erodes because each screen has its own one-off.
+
+## Audit pattern
+
+Periodically (quarterly or so), audit the live product for consistency drift:
+
+- Take screenshots of key surfaces.
+- Identify off-system colors, spacings, typography, components.
+- Categorize: legacy (predates the system), recent (drift), intentional (justified divergence).
+- Plan remediation for the recent drift; document the intentional divergence; schedule legacy migration where it's worth the cost.
+
+The audit itself is a forcing function: when teams know the audit is coming, they're less likely to ship off-system patterns.
+
+## Cross-reference
+
+For external consistency (with platform and category conventions outside your product), see `consistency-external`.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: consistency
+description: 'Apply the principle of Consistency — making similar things look and behave similarly so users can transfer learning across the interface. Use when designing component libraries, defining naming conventions, choosing whether to invent or borrow patterns, auditing across surfaces (web, mobile, email, support docs), or evaluating whether two features should share or diverge in their interaction model. Strong consistency reduces cognitive load and learnability cost; aggressive consistency can flatten meaningful differences. There are four kinds — aesthetic, functional, internal, external — each with different applications.'
+---
+
+# Consistency
+
+> **Definition.** Consistency is the principle that similar things should look and behave similarly, and that different things should look and behave differently. When two parts of a system serve the same function, they should be expressed the same way, so the user's learning about one transfers immediately to the other. When two parts serve different functions, they should be visually and behaviorally distinct, so the user is not misled into expecting the same behavior.
+
+The principle sounds simple and is, in practice, one of the hardest to apply well. The hard part is judging *what counts as similar*. Two buttons that share a visual style but trigger different kinds of actions are misleadingly consistent — they tell the user "we work the same way" when they don't. Two equivalents in the system that are styled differently for no good reason are inconsistent — they force the user to learn the same lesson twice. The skill is calibration: enough consistency to support transfer, enough variation to honor genuine differences.
+
+The classic taxonomy, due to Lidwell, Holden, and Butler, distinguishes four kinds of consistency.
+
+**Aesthetic consistency.** Visual style, typography, color, spacing, iconography. The interface looks like it belongs to one product, drawn from one design system. Aesthetic consistency builds brand recognition and signals craft. Its absence — components that obviously came from different libraries, typography that varies arbitrarily — signals that the team didn't coordinate.
+
+**Functional consistency.** Equivalent operations work the same way. The "save" gesture saves in every screen; the "delete" affordance deletes in every list; the "back" gesture goes back everywhere. Functional consistency lets users learn an interaction once and apply it throughout the product. Its absence creates "exception fatigue" — the user can't predict what any control will do without reading.
+
+**Internal consistency.** Within the product, similar things are similar. This combines aesthetic and functional consistency at the level of "we have one design system and we apply it." Internal consistency is what users notice as "this product feels coherent."
+
+**External consistency.** Across products and platforms, similar things follow shared conventions. The hamburger menu means menu in your app because it means menu in every app. The pinch gesture zooms because it zooms everywhere. External consistency is the user's transferred learning across products being honored. Its absence — your product reinventing standard patterns — creates avoidable friction.
+
+## Why this matters
+
+Every consistency violation costs the user a re-learning. When they navigate from one screen to another and discover the "Done" button is now in the top-right instead of the bottom, they spend a moment relocating it; over thousands of interactions, those moments compound. When they learn that swipe-left dismisses in your inbox but swipe-left archives in your other lists, they have to remember which surface they're on before acting. When they form an expectation from external conventions ("X means Y here, like everywhere else") and you violate it, they're surprised, and surprise in interaction is almost always a cost.
+
+The benefits of consistency compound in the other direction. Once a pattern is established, every additional surface that uses it gets the user's accumulated learning for free. A design system that's been used consistently for years means a new feature is half-learned before anyone touches it.
+
+## When to break consistency
+
+Consistency is a means, not an end. There are good reasons to break it.
+
+**The two cases are genuinely different.** A button that triggers a destructive action should be styled differently from a button that triggers a constructive one. A primary action should be visually weightier than a secondary action. A read-only display should not look like an editable field. These differences in styling reflect genuine differences in behavior and serve the user.
+
+**A new pattern is meaningfully better.** If a new interaction pattern is significantly easier or faster than an existing one, introducing it for that case (and migrating the existing case toward it over time) is better than preserving consistency with a worse pattern. The cost of inconsistency is paid temporarily; the benefit of the better pattern accrues forever.
+
+**The context demands it.** A "Save" button in a quick-edit modal should usually live in the modal, even if "Save" lives in the toolbar everywhere else. Local context overrides global pattern when the local case is self-contained.
+
+These breaks should be deliberate. The failure mode is breaking consistency by accident — through hand-off losses, quick fixes, or different teams making uncoordinated decisions — without the rationale that would justify it.
+
+## Diagnosing consistency problems
+
+A few symptoms suggest a consistency problem worth fixing.
+
+**Users hesitate at familiar-looking controls.** They reach for a button that looks like one they've used before, then pause to verify what it does. The visual consistency is misleading them about functional consistency.
+
+**Documentation needs to explain "in this screen" exceptions.** "On the dashboard, the search box uses syntax X; on the settings page, it uses syntax Y." Documentation for inconsistencies is a smell — it papers over a problem that should be fixed at the design level.
+
+**Users complete the same task differently in different parts of the product.** The same operation is achievable through inconsistent paths. Users build different mental models for what should be one thing.
+
+**New features feel "unlike the rest of the product."** When a new screen visibly came from outside the design system — different typography, different button styling, different spacing — it stands out as not belonging. This is internal aesthetic consistency failing.
+
+## Sub-skills in this cluster
+
+- **consistency-internal** — Maintaining consistency within your own product: design systems, component libraries, audit and enforcement, handling legacy patterns.
+- **consistency-external** — Honoring conventions from outside your product: platform conventions, category conventions, when to follow vs. when to lead.
+
+## Worked examples
+
+### A multi-platform product
+
+A productivity tool ships native apps for iOS, Android, web, and desktop. Each platform has its own conventions: iOS expects bottom tabs, Android expects a navigation drawer, web expects a top nav. Forcing one navigation pattern across all platforms violates external consistency on three of them. Honoring each platform's conventions violates internal consistency across the company's product.
+
+The right tradeoff is usually to honor external conventions (platform-native navigation patterns) while keeping internal consistency in everything that's the user's *content* (data model, terminology, workflows). The chrome adapts; the substance is consistent.
+
+### Two confirmation patterns in one product
+
+A product has two confirmation flows. In one, deleting an item shows a modal: "Delete this? Cancel / Delete." In the other, deleting shows an inline confirm: "Are you sure?" with Yes/No buttons appearing where the original button was. Both work. But users encountering the second flow after the first are momentarily confused — the action is the same but the interface is different.
+
+The fix: pick one pattern (the modal, if the action is high-stakes; the inline if it's low-stakes) and apply it consistently for all confirmations of similar weight. If two different weights of confirmation actually deserve different treatments, distinguish them deliberately and document the rule.
+
+### A button styling drift
+
+Over time, a product accumulates buttons in seven different shades of blue, three different border-radius values, and two different padding scales. Each individual choice was made in good faith — a designer fixing a specific issue, an engineer matching a design they had at hand — but the accumulated drift is visible. Users don't have a single "primary action" visual to learn; instead they see a sea of similar-but-not-identical buttons.
+
+The fix: a design-system audit, consolidating the variants down to a small set with clear semantic roles. Then ongoing enforcement (linting, design reviews) to prevent re-drift.
+
+### Inventing a new pattern when a convention exists
+
+A team designs a search interface using a custom icon and a custom keyboard shortcut, ignoring the magnifying glass and Cmd-F that users expect. The team's reasoning: "Our icon is more on-brand, and Cmd-F is taken by our other feature." The result: users don't recognize the search affordance and can't find the shortcut. External consistency would have served them better even at some brand cost.
+
+The fix: use the convention. If you really need to take Cmd-F for something else, find a different shortcut — but the search itself should look like search.
+
+### Honoring a convention while extending it
+
+A messaging product uses the standard send-on-Enter convention. They want to add the option to send on Cmd-Enter for users who prefer to use Enter for new lines. The right pattern is to honor both: Enter sends by default (matching the convention), and a setting lets users switch to Cmd-Enter (extending the convention). Users who don't change the setting get the expected behavior; users who switch get a workflow that matches their preference.
+
+This is consistency that honors external conventions while accommodating differences — the right balance.
+
+## When the principle is misapplied
+
+**Consistency for its own sake.** Forcing every screen into the same template even when the screens have meaningfully different content. The result is a product that's coherent but bland; the visual rhythm doesn't reflect the actual variety of content.
+
+**Aesthetic consistency masking functional inconsistency.** Two buttons that look identical (same color, same size, same icon style) but behave differently. The user learns the visual pattern and is then surprised when behavior doesn't match. Visual identity is a strong implicit promise of behavioral identity; honor it.
+
+**External consistency that actively hurts the user.** Some platform conventions are legacy and should be broken. Apple's "tap-and-hold for context menu" was historically inconsistent across apps and is still being normalized; in 2010, following the inconsistent convention was worse than picking a coherent pattern of your own. When a convention is genuinely bad and the cost of breaking it is small, do.
+
+**Premature consistency.** Locking down patterns too early in a product's life, before you know which patterns work. Better to allow some inconsistency in early development and consolidate as patterns prove themselves than to enforce consistency around patterns that turn out to be wrong.
+
+## Heuristic checklist
+
+Before making a design decision, ask: **Does an existing pattern in our product serve this case?** If yes, use it. **Does an external convention serve this case?** If yes, use it unless you have a strong reason not to. **If I'm departing from an existing pattern, is the new approach genuinely better, or am I just reinventing?** If the latter, stop. **If two cases look the same, do they behave the same?** If not, distinguish them visually so users can predict behavior.
+
+## Related principles
+
+- **Mental Model** — consistency lets users transfer their mental model across surfaces.
+- **Mapping** — consistent mappings reinforce each other; inconsistent ones interfere.
+- **Recognition Over Recall** — consistency strengthens recognition by stabilizing patterns.
+- **Affordance** — consistent affordances mean users can predict what's interactive.
+- **Mimicry** — consistency with external conventions is one form of mimicry.
+- **Iconic Representation** — consistent icon use across the product builds recognition.
+
+## See also
+
+- `references/lineage.md` — origins in HCI, design systems literature, and platform conventions.
+- `consistency-internal/` — sub-skill on internal consistency.
+- `consistency-external/` — sub-skill on external consistency.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/consistency/references/lineage.md
@@ -1,0 +1,74 @@
+# Consistency — origins and research lineage
+
+## Roots in human-factors engineering
+
+Consistency as a design principle predates HCI by several decades. Industrial human-factors research in the 1940s–1960s established that operator error rates rose dramatically when controls in similar contexts behaved differently. A canonical example: aircraft cockpits where the throttle, mixture, and propeller controls were physically similar but ordered differently across aircraft models. Pilots transitioning between models would, under stress, reach for the wrong control, sometimes catastrophically. Standardizing the order across the fleet reduced the error class.
+
+The same lesson appeared in industrial control rooms: when two consoles in the same plant used different conventions for the same operation (one rotated knobs clockwise to increase, the other counterclockwise), operators trained on one console made errors on the other. The principle that emerged was variously called "stimulus-response compatibility," "control-display compatibility," or simply "consistency." All point to the same finding: human performance is faster and more accurate when learned patterns transfer.
+
+## In HCI: design systems and consistency
+
+HCI inherited the principle in the 1980s and made it foundational. The Apple Human Interface Guidelines (1985) and the IBM Common User Access (1987) were among the first attempts to codify consistency at the platform level: every Macintosh app should have its menu bar at the top of the screen, with File first, then Edit; every IBM application should use the same keyboard shortcuts for the same operations. These guidelines were attempts to create *external* consistency across the entire ecosystem, so users could transfer their learning from one app to the next.
+
+The success of these guidelines was variable. Apple's discipline at the platform level (combined with strict app review later, on iOS) created strong cross-app consistency that became one of the platform's distinguishing features. IBM's CUA was less successful in part because it tried to enforce consistency across more diverse contexts (mainframe, OS/2, Windows) and the resulting compromises satisfied no one. The lesson: consistency at the platform level requires either strong central authority or strong shared incentives.
+
+The 1990s and 2000s saw the rise of internal design systems within product organizations. Component libraries — first as code libraries, later as Figma component libraries integrated with implementation — became the primary mechanism for enforcing internal consistency. The premise: if every team uses the same Button component, the same Input component, the same Modal component, you don't have to enforce consistency through review; it's built into the production process.
+
+This pattern has stuck and is now standard at any product organization beyond a small handful of designers. Material Design (Google, 2014), Carbon (IBM, 2015), Polaris (Shopify, 2017), and many others codified design systems publicly, both as internal tools and as guidance for partners.
+
+## Research on the cost of inconsistency
+
+The empirical literature on consistency converges on a few stable findings.
+
+**Inconsistent labels increase task time and error.** Studies of menu structures in the 1980s — particularly Card, Moran, and Newell's GOMS modeling work — showed that inconsistent labels (the same operation called "Save" in one menu and "Store" in another) measurably slowed expert users and confused novices.
+
+**Inconsistent shortcut keys cause persistent errors.** Users develop motor memory for keyboard shortcuts; when the same shortcut does different things in different contexts, errors persist long after the user has cognitively learned the difference.
+
+**Inconsistent visual styling causes mistrust.** Users who notice that parts of a product look different from each other rate the product as less professional and less trustworthy, even when they can't articulate what's wrong.
+
+**External consistency dominates internal consistency for novices.** A novice user benefits more from a product that follows external conventions (even if internally inconsistent) than from one that's internally consistent but invents its own conventions. The novice has more transferred learning to apply from external conventions than they've yet built up internal to the product.
+
+**Internal consistency dominates external consistency for experts.** A long-time user of a product benefits more from internal consistency, because their learning is now mostly product-specific. External convention violations matter less to them.
+
+This last finding has design consequences: products that need to convert novices into experts often start with strong external consistency and gradually introduce product-specific patterns as users mature. Products that primarily serve experts can afford to deviate from external conventions if the internal patterns are excellent.
+
+## The four kinds of consistency
+
+The Lidwell-Holden-Butler taxonomy of four kinds — aesthetic, functional, internal, external — is useful because it disentangles dimensions that often get conflated.
+
+**Aesthetic consistency** is purely visual: do things look like they came from one designer? It contributes to brand recognition and signals craft, but it doesn't directly help the user navigate.
+
+**Functional consistency** is behavioral: do equivalent operations work the same way? This is what most directly helps the user navigate, because it lets them transfer interaction patterns.
+
+**Internal consistency** combines both within the product: is the product coherent unto itself?
+
+**External consistency** combines both across products: does the product fit with the broader convention?
+
+A product can score high on aesthetic consistency (everything looks the same) and low on functional consistency (similar-looking things behave differently), and that combination is actually worse than the inverse, because the visual similarity creates false expectations.
+
+## Research on consistency in modern products
+
+Recent studies on cross-platform consistency (web/iOS/Android of the same product) confirm older findings: users expect consistency in workflows and content, accept variation in chrome and platform-specific gestures, and feel betrayed when something fundamental about the product behaves differently between platforms (a feature missing on one platform; an account behavior that diverges).
+
+The rise of micro-front-end architectures (where different teams build different parts of the same web product, often with different frameworks) has reintroduced consistency challenges that design systems were supposed to solve. The fix is usually a stricter design system, with code-level enforcement (linting, design tokens, shared components shipped via a registry).
+
+## When the consistency principle is misunderstood
+
+Two common misunderstandings:
+
+**"Consistency means everything looks the same."** This is aesthetic consistency taken to an extreme that flattens meaningful differences. A product with a single button style for primary, secondary, and destructive actions is too consistent; the user has lost the visual signal that would have helped them.
+
+**"External consistency means following every convention."** External conventions vary in quality and applicability. Some are useful (the magnifying glass for search); others are vestigial or actively harmful (the floppy disk for save in 2026). Following every convention indiscriminately produces a product that's coherent with the past and indifferent to its actual users.
+
+The principle is calibration, not maximization.
+
+## Sources informing this principle
+
+- Card, S. K., Moran, T. P., & Newell, A. (1983). *The Psychology of Human-Computer Interaction*.
+- Apple Human Interface Guidelines (multiple editions, starting 1985).
+- IBM Common User Access (1987).
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*. (Source of the four-part taxonomy.)
+- Nielsen, J. (1989). Coordinating user interfaces for consistency.
+- Norman, D. (1988). *The Design of Everyday Things*. (On the cost of mismatched conventions.)
+- Material Design documentation (Google, 2014–present).
+- Polaris (Shopify), Carbon (IBM), Lightning (Salesforce), and other public design systems.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-defaults/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-defaults/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: hicks-law-defaults
+description: 'Use this skill when the question is what to *pre-select* in a list of options — radio groups, dropdowns, configuration UIs, plan pickers, sign-up flows, settings. A strong default is the highest-leverage Hick''s Law mitigation: most users accept the default, paying almost no decision cost. Trigger when picking what''s selected on first load, when stakeholders argue "shouldn''t we let the user choose?", when designing wizards or onboarding, or when a UI has many options but most users want the same one. Sub-aspect of `hicks-law`; read that first if you haven''t already.'
+---
+
+# Hick's Law: defaults as the primary mitigation
+
+Strong defaults are the highest-leverage way to reduce Hick's Law cost. When the system pre-selects the most likely option, the user faces a much smaller decision: "accept the default" or "look at the alternatives." Most users accept; the decision is effectively zero cost. The minority who don't accept now do face the original Hick's Law cost — but only when their preferences differ from the default.
+
+## When to invest in a default
+
+A good default is worth the design effort when:
+
+- **One option is significantly more likely than the others.** If 60–80%+ of users want option X, defaulting to X serves most of them at no cost.
+- **The cost of "wrong" is recoverable.** Users can change the default after the fact without losing work.
+- **You can predict the right default from context.** User's locale, previous behavior, role, or the immediate task often disclose the right answer.
+- **The decision is low-stakes.** Financial commitments, irreversible actions, and privacy-affecting choices should *not* be defaulted; they should be deliberate.
+
+A bad default appears when:
+
+- Options are roughly equiprobable. Picking any one biases the user without serving them.
+- The cost of accepting the wrong default is high or hidden.
+- The default is set to serve the business (auto-checked "share my data with partners") rather than the user.
+
+## Levels of default
+
+Defaults vary in strength and cognitive cost:
+
+### Level 1: pre-selection (no commitment)
+
+The default option is highlighted/selected, but the user must explicitly confirm to proceed.
+
+```html
+<form>
+  <fieldset>
+    <legend>Email digest</legend>
+    <label><input type="radio" name="digest" value="off" /> Off</label>
+    <label><input type="radio" name="digest" value="daily" checked /> Daily (recommended)</label>
+    <label><input type="radio" name="digest" value="weekly" /> Weekly</label>
+  </fieldset>
+  <button>Continue</button>
+</form>
+```
+
+The user sees "Daily" pre-selected. They can change it; they must press Continue regardless. Low-pressure, ethical, effective.
+
+### Level 2: implicit acceptance
+
+The default is set silently; if the user doesn't change it, it takes effect when they continue.
+
+This is appropriate for non-consequential settings (sort order, theme preference). Less appropriate for material commitments.
+
+### Level 3: opt-out (the user must take action to escape the default)
+
+The default takes effect unless the user actively unchecks or selects another option. Common in privacy and notification settings.
+
+This crosses an ethical line in many contexts. Reserve it for choices where the default genuinely serves the user (e.g., critical security notifications on by default).
+
+### Level 4: forced default with disclosure
+
+A choice is made for the user with explicit disclosure — "We've set this for you based on your role; you can change it in settings."
+
+Useful when defaults are derived from earlier signals and the user might wonder why the system "knows" their preference.
+
+## Strategies for choosing the right default
+
+### Use known data
+
+If you know the user's locale, you know their currency, date format, language, timezone. Default to those.
+
+```html
+<select name="currency">
+  <option value="USD" selected>USD ($)</option>      <!-- defaulted from IP -->
+  <option value="EUR">EUR (€)</option>
+  <option value="GBP">GBP (£)</option>
+  …
+</select>
+```
+
+If you know the user's role, you know which features they're likely to use; default the dashboard view to those.
+
+### Use the most popular choice
+
+Run analytics. If 70% of teams pick "Standard" plan, default to Standard. If 80% of users want "All notifications," default to All.
+
+This works *until* the popular choice is popular only because it was the default — a feedback loop. Periodically test by flipping the default to a different option and measuring the new acceptance rate; if it's still 70%+, the default is genuinely matching preferences.
+
+### Use the safer choice
+
+When in doubt, default to the option that's hardest to recover from an "incorrect default." Defaulting to "private" is safer than "public" — public-by-mistake leaks; private-by-mistake just requires sharing later.
+
+### Use the recently-used choice
+
+If the user picked an option last time, default to it this time. "Recently used templates," "last upload directory," "previous report filter."
+
+### Use a "Recommended" badge
+
+Pair the default with an explicit signal that it's the recommended choice:
+
+```html
+<RadioGroup defaultValue="pro">
+  <Option value="starter">Starter</Option>
+  <Option value="pro">
+    Pro
+    <Badge>Recommended</Badge>
+  </Option>
+  <Option value="enterprise">Enterprise</Option>
+</RadioGroup>
+```
+
+This is honest — you're disclosing that you have a recommendation — and it tells users "if you don't have a strong opinion, this one's safe."
+
+## When *not* to default
+
+There are cases where forcing the user to choose is the right move:
+
+- **Account creation passwords.** Don't pre-fill or suggest; the user must compose.
+- **Payment amounts.** Don't pre-fill values for charity donations or tip amounts beyond a small set of explicit options.
+- **Permissions and visibility.** Don't default to "public" or "share with team" without an active selection.
+- **High-stakes irreversible actions.** Don't pre-select "Delete" in a confirmation dialog. (Actually invert: pre-select "Cancel" so the destructive path requires deliberate effort.)
+- **Where the system genuinely doesn't know.** Asking the user is more honest than guessing.
+
+For these cases, leave the choice unset and disable the proceed button until the user picks. The Hick's Law cost is real but justified.
+
+## Worked examples
+
+### Example 1: a sign-up plan picker
+
+Three plans, one is by far the most popular. Default to it; mark it as recommended.
+
+```html
+<form>
+  <fieldset class="plan-picker">
+    <legend class="sr-only">Pick a plan</legend>
+    <label class="plan">
+      <input type="radio" name="plan" value="starter" />
+      <strong>Starter</strong>
+      <p>Free for 14 days. Single user.</p>
+    </label>
+    <label class="plan plan--recommended">
+      <input type="radio" name="plan" value="pro" checked />
+      <strong>Pro</strong>
+      <span class="recommended-badge">Recommended</span>
+      <p>$29/mo. Up to 5 users.</p>
+    </label>
+    <label class="plan">
+      <input type="radio" name="plan" value="team" />
+      <strong>Team</strong>
+      <p>$99/mo. Up to 25 users.</p>
+    </label>
+  </fieldset>
+  <button class="primary">Continue with Pro</button>
+</form>
+```
+
+Note the button label *reflects* the default ("Continue with Pro"), so the user is reminded what they're committing to. If they change selection, the label updates.
+
+### Example 2: a notification settings panel
+
+Most users want notifications on, but not at maximum frequency. Default to a sane middle.
+
+```html
+<form>
+  <fieldset>
+    <legend>How often should we email you?</legend>
+    <label><input type="radio" name="freq" value="instant" /> Real-time (may be a lot)</label>
+    <label><input type="radio" name="freq" value="daily" checked /> Daily digest <span class="hint">(default)</span></label>
+    <label><input type="radio" name="freq" value="weekly" /> Weekly digest</label>
+    <label><input type="radio" name="freq" value="off" /> Off</label>
+  </fieldset>
+</form>
+```
+
+The explicit "(default)" annotation removes any guessing about why "Daily digest" is selected.
+
+### Example 3: a date range picker
+
+For a "Reports" page, default to a sensible range based on context.
+
+- On first visit: "Last 30 days" (covers most curiosity).
+- On return visit: the range the user last selected (recency bias).
+- After clicking a "Compare to" toggle: pre-fill the comparison range as "Previous 30 days."
+
+```js
+const lastUsedRange = localStorage.getItem('reports.range');
+const defaultRange = lastUsedRange ?? 'last_30_days';
+```
+
+### Example 4: a "Send to" picker in a messaging app
+
+The user is most likely to message the same people they recently messaged. Surface those as a "Recent" group at the top of the picker; the default is to type to filter.
+
+```
+[Search recipient________________]
+Recent
+  ● Maria Mendoza
+  ● Marketing team
+  ● Lin Chen
+All people
+  ● …
+```
+
+Recents collapse Hick's Law nearly to zero for repeat tasks.
+
+## Anti-patterns
+
+- **The pre-checked subscription.** "Subscribe to our newsletter" pre-checked at sign-up. Conversion goes up; trust goes down. Don't.
+- **The defaulted upsell.** A higher-priced plan pre-selected when the user's stated needs match a cheaper plan. The user finds out at checkout; ill will follows.
+- **The hidden default change.** Changing the default in a software update without telling users. Users feel the system "did something" without their consent.
+- **The opt-out for material consequences.** Pre-checked "auto-renew at full price" with the opt-out hidden three pages deep. Regulators are paying attention.
+- **The incoherent default set.** Defaults across a settings page that contradict each other (notifications ON, but email digest OFF, but in-app quiet hours ON 24/7). Means the system can't actually deliver the user's intent.
+
+## Heuristics
+
+1. **The acceptance-rate test.** Periodically measure: of users who land on this default, what percent accept it? If <50%, the default is wrong; pick a different one. If >85% across many users for many months, the default is doing its job.
+2. **The "who does this serve?" check.** For each default, ask: does this default primarily serve the user, or the business? If it's the business, examine whether the user would consent if asked clearly.
+3. **The "describe in one sentence" test.** Can you describe what the default *is* and *why* in one plain sentence? If yes, it's defensible. If you can't, it's probably opaque to users too.
+
+## Related sub-skills
+
+- **`hicks-law`** (parent).
+- **`hicks-law-menus`** — the complementary case where defaults aren't appropriate (the menu is a list of actions, not a choice with one obvious answer).
+- **`hicks-law-pricing`** — defaults are central to pricing tier selection.
+- **`satisficing`** — the cognitive principle that explains why defaults work: users accept the first acceptable option.
+- **`framing`** — how the default is *labeled* (e.g., "Recommended") affects acceptance rate.
+- **`nudge`** (interaction) — defaults are the canonical nudge; treat them as a design responsibility.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-defaults/references/defaults-research.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-defaults/references/defaults-research.md
@@ -1,0 +1,82 @@
+# Defaults: research and ethical guidance
+
+A reference complementing `hicks-law-defaults` with research on default acceptance rates and the ethics of choice architecture.
+
+## Research grounding
+
+- **Thaler, R. & Sunstein, C.** (2008). *Nudge: Improving Decisions About Health, Wealth, and Happiness*. The foundational text on choice architecture; coined "libertarian paternalism" — defaults that nudge users toward better choices while preserving the option to choose otherwise.
+- **Johnson, E. J. & Goldstein, D.** (2003). "Do defaults save lives?" *Science*. Showed organ-donation rates differ dramatically (~85% vs. ~15%) between countries with opt-in vs. opt-out defaults — same humans, same forms, different framing.
+- **Madrian, B. C. & Shea, D. F.** (2001). On 401(k) enrollment: changing from opt-in to opt-out raised participation from ~37% to ~86%. Defaults are powerful.
+- **Park, C. W. et al.** (2000). On consumer product defaults: pre-selected accessories or upgrades increase acceptance dramatically over equivalent opt-in offers.
+
+The pattern: defaults shape behavior more than persuasion does. A well-chosen default is among the highest-leverage design decisions available.
+
+## Acceptance rates
+
+Empirical observations across many products:
+
+- **Sensible defaults**: 60–85% acceptance.
+- **Well-defaulted (with explicit "Recommended" badge)**: 75–90%.
+- **Poorly-chosen defaults**: < 50% — and often *worse* than no default, because users don't trust the system afterward.
+
+Periodically test by flipping the default; if acceptance drops dramatically, the default was matching genuine preferences. If acceptance stays high, the default may have been driving behavior more than fitting it.
+
+## The ethics of defaults
+
+### Honest defaults
+
+A default is honest when:
+
+- It serves the user's interest, plausibly more than the average alternative.
+- The user is shown what they're accepting.
+- The user can change it without penalty.
+
+Examples: defaulting auto-save to ON, defaulting two-factor authentication to ON for new accounts.
+
+### Manipulative defaults
+
+A default is manipulative when:
+
+- It serves the business at the user's expense.
+- The user can't easily tell what's defaulted.
+- Changing it requires friction (deep menus, multiple confirmations).
+
+Examples: pre-checked email subscriptions; "remember me" defaulted on shared devices; auto-renew at full price defaulted.
+
+The legal landscape is shifting: GDPR, CCPA, and increasing FTC enforcement penalize manipulative defaults. The product safe move and the long-term trust move are the same: honest defaults only.
+
+### "Defaults" as legal default-rules
+
+Note that the "default" idea predates UX — in contract law, default rules are the terms that apply absent explicit agreement. Behavioral economics translates this: defaults are the "law" of a product's choice space.
+
+## Cross-domain examples
+
+### Government policy
+
+- **Organ donation** opt-out countries (Spain, Austria, France) vs. opt-in (US, UK historically): consistent ~5–10x higher donation rates with opt-out, no significant difference in survey-stated preferences.
+- **Retirement savings**: opt-out 401(k) enrollment raised US savings rates measurably; the US Pension Protection Act (2006) explicitly enabled this.
+- **Vaccination scheduling** by default appointment vs. opt-in: defaulting raises uptake.
+
+These are not gamification tricks; they are structural design choices with large welfare effects.
+
+### Industrial product design
+
+- **Cars**: seatbelts auto-tightened on engine start (some models) increase wearing rates.
+- **Appliances**: factory-default to energy-efficient modes; users override only when needed.
+- **Smart thermostats**: default to schedules learned from past behavior.
+
+### Consumer software
+
+- **macOS / iOS** ship with strong privacy defaults. Apps must request permissions; defaults are restrictive. This is a default-driven privacy posture.
+- **Chrome** historically defaulted permissive (cookies, notifications). Has shifted toward stricter defaults under regulatory pressure.
+
+## When *not* to use a strong default
+
+- Material commitments (purchases, account changes, data sharing) — require explicit choice.
+- High-stakes irreversible decisions — confirm explicitly.
+- When the system can't reasonably guess — ask.
+- When the user community has strongly varied preferences — ask, or offer a one-question setup wizard.
+
+## Closing
+
+Defaults are the most efficient Hick's Law mitigation — they collapse the decision for most users without removing it for anyone. Used honestly, they improve outcomes; used manipulatively, they erode trust and increasingly invite regulation. Pick your defaults as if you'd be willing to defend them in front of your users.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-menus/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-menus/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: hicks-law-menus
+description: 'Use this skill when designing menus, dropdowns, navigation, command palettes, or any interface where the user picks from a list. Trigger when the menu has more than ~7 items, when navigation feels overwhelming, when designing a cmd-K palette, when picking what goes in a "More" overflow, or when arguing about whether to add another menu item. Sub-aspect of `hicks-law`; read that first if you haven''t already.'
+---
+
+# Hick's Law in menus and navigation
+
+Menus are the canonical Hick's Law surface — every item adds decision cost, and the structure of the menu determines whether that cost compounds or stays bounded. This skill covers the practical patterns for menus, dropdowns, navigation, and command palettes.
+
+## The menu-size ladder
+
+Different menu sizes call for different interaction patterns:
+
+```
+1–4 items     →  inline buttons, tabs, or segmented control (all visible)
+5–8 items     →  dropdown menu, sidebar nav (scan-friendly)
+9–15 items    →  grouped dropdown with section headings
+16–50 items   →  searchable combobox / dropdown with type-to-filter
+50+ items     →  command palette (cmd-K) or full-page browser with filters
+```
+
+Picking the wrong rung is the most common Hick's Law failure: a `<select>` of 200 timezones, a sidebar of 30 flat items, a context menu with every conceivable action.
+
+## Top navigation
+
+Top-level navigation should land at 5–7 items in left-to-right scripts. Beyond that, the eye can't hold the structure in working memory while picking.
+
+If your IA naturally has more, group:
+
+```
+Sales | Marketing | Engineering | Finance | HR | Legal | Operations | IT | Facilities
+
+→ regroups as
+
+Departments | Projects | Reports | Settings
+```
+
+Where `Departments` opens a sub-menu with the 9 specifics.
+
+The trade-off: sub-menus add a click. Worth it when the alternative is a wall of top-level items.
+
+## Sidebar navigation
+
+Sidebar nav can hold more items than top nav (scrolling and grouping help), but the same rules apply within each group. Aim for groups of 3–7 items.
+
+```
+Workspace
+  Dashboard
+  Projects
+  Team
+
+Personal
+  Profile
+  Notifications
+
+Account
+  Billing
+  Security
+  Sign out
+```
+
+Three groups, each with 2–3 items. Total 8 items, but the user reads it as "3 things" then "the right thing within."
+
+## Dropdown menus (action menus)
+
+A `DropdownMenu` triggered by a "more" button on a row, header, or toolbar. Common Hick's Law mistake: dumping every action into one menu.
+
+Better:
+
+- **Surface common actions inline** (icon-buttons in the row); reserve the menu for the long tail.
+- **Group menu items** by purpose (Edit / Share / Move / Delete) with separators.
+- **Put destructive actions at the bottom**, after a separator (Serial Position Effect: visually distant from common items, also remembered better).
+
+```
+[Edit]
+[Duplicate]
+[Move to…]
+[Share]
+─────────
+[Archive]
+[Delete]    ← red, after separator
+```
+
+The user scans top-to-bottom; the structure aids the choice.
+
+## Command palettes (cmd-K)
+
+The command palette is the modern answer to "we have hundreds of commands and can't surface them all." The pattern:
+
+1. User presses `⌘K` (or types `/`).
+2. A search input appears.
+3. User types; results filter.
+4. User presses Enter on a result.
+
+This collapses Hick's Law — the user no longer scans a long list, they recall a name (or fragment) and the system shows matches. Combined with:
+
+- **Recents** at the top (no typing required for recently-used commands).
+- **Categorical groups** ("Actions / Navigation / Files / Help") so even un-typed exploration is structured.
+- **Fuzzy matching** so partial recall ("invoic" matches "Create invoice") works.
+
+Command palettes scale to hundreds of items because the interaction has changed.
+
+## Mobile menus
+
+Mobile bottom-nav: 3–5 items, no more. The thumb can't reach more than ~5 targets across the bar comfortably, and the screen has no room for labels at higher counts.
+
+If your app needs more entry points than 5, the bottom nav holds 4 primaries plus a "More" tab that opens a sheet with the rest.
+
+## Toolbars
+
+Application toolbars (think Word, Figma, Notion's slash-menu) have the same Hick's Law problem at extreme scale. Strategies:
+
+- **Tab the toolbar** (Office's ribbon: `Home / Insert / Layout / References / Mailings`). Each tab shows ~10 actions; total may be 80, but visible at any moment is one tab's worth.
+- **Contextual toolbars** that show actions relevant to the current selection. The user never sees the irrelevant 90%.
+- **Reserve the persistent toolbar for the 5–7 most-used actions across the entire app.**
+
+## Anti-patterns
+
+- **The "more is more" toolbar.** All actions visible all the time. Looks powerful, performs slow.
+- **The flat 50-item dropdown.** A `<select>` with no grouping, no search. Hick's Law tax compounded by the lack of within-list navigation.
+- **The context menu of doom.** Right-click reveals 25 actions, none separated, none grouped, including 3 destructive ones interspersed. Users learn to fear right-click.
+- **The "everything's a tab" pattern.** A page with 8 tabs across the top. The user has to commit to one to see what's there; restructure as nav or sections.
+
+## Heuristics
+
+1. **Count the visible options.** On a glance, how many distinct things can the user pick? More than 7? Group, default, or hide the long tail.
+2. **The fresh-user time-to-pick.** Watch a new user pick from your menu. Time it. >5 seconds suggests Hick's Law cost is too high.
+3. **The category test.** Can you label every group of items with a single noun? If yes, your grouping is conceptually clean. If you find yourself reaching for "Misc," you have ungrouped items that need a home.
+
+## Related sub-skills
+
+- **`hicks-law`** (parent).
+- **`hicks-law-defaults`** — for menus where one option dominates probability.
+- **`hicks-law-pricing`** — for the menu of plan tiers as a conversion event.
+- **`recognition-over-recall`** — the principle behind why command palettes work.
+- **`chunking`** — the perceptual basis for grouping menu items.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-menus/references/menu-pattern-library.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-menus/references/menu-pattern-library.md
@@ -1,0 +1,83 @@
+# Menu pattern library
+
+A reference complementing `hicks-law-menus` with a broader pattern catalog and platform notes.
+
+## Menu type by purpose
+
+| Pattern | Best for | Example apps |
+|---|---|---|
+| Top horizontal nav | 5–7 primary destinations | Most marketing sites, GitHub |
+| Sidebar nav (collapsible) | Complex IA, ≥ 8 destinations | Notion, Linear, Slack |
+| Bottom tab bar (mobile) | 3–5 primary destinations | Most native iOS/Android apps |
+| Hamburger drawer | Many low-frequency destinations | Mobile webs, Gmail mobile |
+| Dropdown menu | 4–10 actions/links from a single point | Account menus, file menus |
+| Mega menu | Wide content sites with many categories | Amazon, NYT |
+| Command palette | 100+ commands, expert users | VSCode, Linear, Notion |
+| Context menu (right-click) | Item-specific actions | File managers, IDEs |
+| Action sheet (mobile) | Item actions; takeover popup | iOS Files, sharing menus |
+| Toolbar | High-frequency formatting/actions | Word processors, design tools |
+
+Pick by user frequency × number of items × form factor.
+
+## Cross-domain examples
+
+### Restaurant menus
+
+Restaurant menus organize by course (appetizer, main, dessert) — a mix of Hick's Law mitigation (chunking) and convention. The fast-food drive-through menu (typically displayed above the order window) is constrained by readable distance; usually has 8–12 items grouped into 3–4 categories.
+
+Software menus can borrow: chunk by purpose, label groups clearly, show only what fits the user's reading distance (or attention span).
+
+### Library card catalogs
+
+Pre-digital library card catalogs offered three search routes: by author, title, and subject. Three top-level menu items, each leading to alphabetical scanning. The Dewey Decimal classification system is itself a hierarchical menu tree.
+
+The lesson: when content vastly exceeds menu capacity, route the user to a search/scan mechanism rather than enumerating all options.
+
+### TV channel guide
+
+Modern TV guides handle 200–500 channels by using grid layout (channel × time) rather than a list. Multi-dimensional categorization beats flat menus when categorization actually helps navigation.
+
+## Platform-specific menu conventions
+
+### macOS
+
+- **Menu bar** at top of screen: persistent, application-specific. App developers expected to expose all functionality here for keyboard-shortcut discoverability.
+- **Apple menu** (top-left): system-wide actions.
+- **Status menus** (top-right): always-visible OS/app indicators.
+
+### iOS
+
+- **Tab bar** at bottom: 2–5 primary destinations.
+- **Navigation bar** at top: title + back + actions (≤ 3 right actions).
+- **Toolbar** at bottom: contextual actions for the current screen.
+- **Action sheet**: modal popup for item-level actions.
+
+### Android (Material)
+
+- **Bottom navigation** (3–5 destinations) or **navigation drawer** (more, swipe to open).
+- **App bar** at top.
+- **Floating action button** (FAB) for the screen's primary action.
+- **Bottom sheet** for item actions.
+
+### Web
+
+- No platform convention; many patterns coexist. The norm has shifted over time:
+  - 2000s: top-nav with dropdowns.
+  - 2010s: hamburger everywhere (overcorrection).
+  - 2020s: persistent sidebar for app shells, sticky top for content sites, command palette as power-user backstop.
+
+## Searchable vs. scannable
+
+A menu becomes "searchable" when users type to filter; "scannable" when they read top-to-bottom.
+
+- **Scannable** is faster for ≤ 7 items (no typing overhead).
+- **Searchable** is faster for ≥ 20 items (collapses Hick's Law).
+- The transition zone (8–20 items) depends on user proficiency: experts know what to type; novices scan.
+
+The best modern menus support both: visible scannable items by default; type-to-filter when the user starts typing.
+
+## Resources
+
+- **WAI-ARIA Authoring Practices**, Menu and Menubar patterns.
+- **Apple HIG: Menus**, **Material Design: Menus**, both publicly documented.
+- **Refactoring UI** — chapter on menu and dropdown design.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-pricing/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-pricing/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: hicks-law-pricing
+description: 'Use this skill when designing pricing tables, plan pickers, tier selectors, or any conversion surface where the choice itself is the conversion event. Trigger when laying out 3-tier or 4-tier pricing, when arguing about whether to add a fourth plan, when designing the "Choose your plan" step of onboarding, or when fixing low conversion on a pricing page. Pricing pages are a special Hick''s Law case: the decision is the entire purpose of the page, and decision fatigue equals lost revenue. Sub-aspect of `hicks-law`; read that first if you haven''t already.'
+---
+
+# Hick's Law on pricing pages
+
+A pricing page is a Hick's Law surface where the decision *is the page*. Every option you add increases consideration time and abandonment risk; every option you remove may push some users toward the wrong tier. The right number of tiers is one of the most studied design decisions in conversion-rate-optimization research, and the answer is consistent: **fewer is usually better**.
+
+## The standard answer: 3 tiers
+
+The 3-tier pricing layout (often labeled Starter / Pro / Enterprise, or Free / Pro / Team) is the convention because it works. Three options:
+
+- Lets users compare meaningfully (anchoring effect: the middle option looks reasonable against both extremes).
+- Stays inside the easy-Hick's-Law range (log₂(4) ≈ 2 — minimal decision time).
+- Maps cleanly to user mental models (small / medium / large).
+
+Adding a fourth tier rarely helps. It increases consideration time, splits revenue across more buckets, and dilutes the framing of the middle tier as "the obvious choice." Companies that ship 5- or 6-tier pricing tables usually do so because internal consensus couldn't agree which features belonged where, not because users wanted more choice.
+
+## The role of the middle tier
+
+In 3-tier pricing, the middle tier typically captures the bulk of conversions. Designers exploit this with the **anchoring effect**:
+
+- The cheapest tier sets a low anchor (so the middle tier doesn't look expensive).
+- The most expensive tier sets a high anchor (so the middle tier looks reasonable, almost a deal).
+- The middle tier is highlighted as recommended.
+
+This is well-studied in pricing psychology (Ariely; Thaler & Sunstein on choice architecture). It's effective. It's also ethically defensible *when the middle tier is genuinely the right choice for most users* — and dishonest when the middle tier is engineered to drive revenue regardless of fit.
+
+## How to design the 3-tier table
+
+### Visual hierarchy
+
+Highlight the recommended (middle) tier with stacked emphasis cues:
+
+- Slightly larger card.
+- Brand-color top border or accent.
+- "Recommended" or "Most popular" badge.
+- Slightly heavier shadow.
+- The strongest CTA (filled button vs. outlined buttons on adjacent tiers).
+
+Do not over-do this. One tier highlighted; the other two visibly available but recessive. Three equally-emphasized tiers undo the recommendation effect.
+
+```html
+<div class="pricing-grid">
+  <article class="plan">
+    <h3>Starter</h3>
+    <p class="price">$9 / mo</p>
+    <ul>
+      <li>1 user</li>
+      <li>5 projects</li>
+      <li>Email support</li>
+    </ul>
+    <button class="outline">Start free trial</button>
+  </article>
+
+  <article class="plan plan--featured">
+    <span class="badge">Recommended</span>
+    <h3>Pro</h3>
+    <p class="price">$29 / mo</p>
+    <ul>
+      <li>5 users</li>
+      <li>Unlimited projects</li>
+      <li>Priority support</li>
+    </ul>
+    <button class="primary">Start free trial</button>
+  </article>
+
+  <article class="plan">
+    <h3>Team</h3>
+    <p class="price">$99 / mo</p>
+    <ul>
+      <li>25 users</li>
+      <li>Unlimited projects</li>
+      <li>SSO + audit log</li>
+    </ul>
+    <button class="outline">Talk to sales</button>
+  </article>
+</div>
+```
+
+### Feature comparison
+
+Don't list 30 features in each card. List the 3–6 differentiators that matter for the tier choice. A user comparing 3 tiers across 30 features each is doing a 90-cell evaluation; abandonment spikes.
+
+If you must list comprehensive features, put the comparison in a separate section *below* the cards (often a "Compare all features" toggle that reveals an exhaustive table). That defers Hick's Law cost to the small fraction of users who care to dig.
+
+### Pricing display
+
+Lead with the price for the most-likely billing cycle (usually monthly, though "per user / mo billed annually" is increasingly the default). Offer a billing-cycle toggle (Monthly / Annually) above the cards — annual is typically discounted to nudge that selection.
+
+```html
+<div class="billing-toggle" role="radiogroup" aria-label="Billing cycle">
+  <button aria-pressed="false">Monthly</button>
+  <button aria-pressed="true">Annual <span class="discount">-20%</span></button>
+</div>
+```
+
+Keep the toggle proximate to the cards so the relationship is obvious.
+
+### "Free" and "Enterprise"
+
+Two common edge cases:
+
+- **Free tier.** Useful as a low-friction entry point. Treat as a 4th tier visually demoted, *not* as the leftmost tier with full visual weight. Free dominates user attention disproportionately.
+- **Enterprise / Custom.** No published price, "Contact sales" CTA. Recede the visual weight here too — Enterprise is for the user who already knows they need it; don't compete with the published tiers.
+
+A workable layout: Starter / Pro / Team in three cards; Free as a small banner above; Enterprise as a small panel below. Three is still the visible decision space.
+
+### CTA copy on each tier
+
+The CTA should make the user's next step obvious and concrete:
+
+- Free trial: "Start free trial" (matches expectation).
+- Self-serve paid: "Choose Pro" or "Get Pro" (commits the user to the tier).
+- Enterprise: "Talk to sales" (signals sales process).
+
+Avoid identical "Sign up" CTAs across all tiers — Hick's Law cost is *higher* when nothing differentiates the action labels.
+
+## When to deviate from 3 tiers
+
+### 2 tiers
+
+When the product is genuinely simple and there are only two meaningful states (free vs. paid; basic vs. premium). 2 tiers is a strong "make the simpler choice" stance. Conversion-rate research suggests 2 tiers can outperform 3 when feature parity is tight.
+
+### 4 tiers
+
+Justified when:
+
+- A genuine usage-based segment exists (a "Studio" plan for individuals, "Team" for small companies, "Business" for mid-market, "Enterprise" for large).
+- Each tier captures meaningful market share — not internal-roadmap convenience.
+
+If you can't articulate the persona for each of 4 tiers in a sentence, you have 3 tiers and one of them is confused.
+
+### 5+ tiers
+
+Almost always wrong. Reasons companies end up here: (1) Sales tiering ("we want a plan for $499 and one for $2,999"); (2) feature-debt where every customer's special request became a tier; (3) failure to consolidate after a tier was added. Restructure.
+
+The pricing page that takes the user 3 minutes to scan is a pricing page that loses conversions.
+
+## Beyond the cards: progressive disclosure
+
+For products with genuinely complex pricing (consumption-based, hybrid SaaS-plus-usage, multiple add-ons), apply progressive disclosure:
+
+1. **Top of page:** the 3 simple tiers with a representative price.
+2. **Middle:** "Pricing details" section explaining usage, overages, add-ons.
+3. **Bottom:** comparison table for power-shoppers.
+4. **Calculator:** for usage-based, an interactive calculator the user can play with.
+
+The casual visitor sees three tiers and a price. The serious shopper finds the depth as they scroll.
+
+## Anti-patterns
+
+- **The "compare all" wall.** A pricing page that opens with a 30-row × 5-column comparison matrix. Cognitive load is enormous; conversion drops.
+- **The tier without a buyer.** A tier that exists "just in case" — usually the cheapest — that no actual segment wants. It splits attention without earning revenue.
+- **Identical visual weight across tiers.** No recommended highlight. Users default to the cheapest (Hick's Law + price-anchoring against $0).
+- **The decoy that's not a decoy.** Three tiers where the most expensive is *clearly* a worse value than the middle — the classic decoy structure — but priced so close to the middle that the middle no longer looks like a deal.
+- **Hidden pricing for self-serve plans.** "Contact sales for pricing" on a tier that should be self-serve. Users bounce; competitors with published prices win.
+- **The annual-default trick.** Showing annual prices by default but billed monthly (so the monthly cost feels lower than reality). Users discover at checkout; trust collapses.
+
+## Heuristics
+
+1. **The 30-second test.** Land a fresh user on the pricing page. After 30 seconds, can they articulate which tier is for them? If not, the page is too dense.
+2. **The middle-tier conversion check.** What percentage of paid signups land on the middle tier? Strong recommendation effect lands at 60–75%. Below that, the recommendation isn't reading; above 90%, the middle might be too dominant or other tiers misconfigured.
+3. **The competitor walk-through.** Open three competitors' pricing pages. Spend 30 seconds on each. Which felt easiest? Almost always the one with the cleanest hierarchy and clearest tier count. Match that experience or beat it.
+
+## Related sub-skills
+
+- **`hicks-law`** (parent).
+- **`hicks-law-defaults`** — the recommended-tier highlight is a defaulting pattern.
+- **`hicks-law-menus`** — pricing tables are a special case of menus.
+- **`comparison`** (cognition) — pricing is a comparison surface; align comparable features.
+- **`framing`** (cognition) — how each tier is labeled changes which one users pick.
+- **`anchoring`** (related; not in book) — the high-tier anchor makes the middle tier read as reasonable.
+- **`veblen-effect`** (aesthetics) — the very-high-priced enterprise tier earns desirability from its price.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-pricing/references/pricing-design-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law-pricing/references/pricing-design-cases.md
@@ -1,0 +1,73 @@
+# Pricing-page design: cases and conversion patterns
+
+A reference complementing `hicks-law-pricing` with case patterns from real pricing-page design and the conversion-rate-optimization literature.
+
+## The 3-tier convention's history
+
+The 3-tier (Bronze / Silver / Gold; Starter / Pro / Enterprise; Free / Plus / Premium) layout descends from earlier print-and-direct-mail pricing presentation. Magazines offered "1 year / 2 year / 3 year" subscriptions; phone companies offered "Basic / Standard / Premium" plans; insurance offered "Catastrophic / Standard / Comprehensive."
+
+The recurring three-options pattern works for the same reasons across centuries:
+
+- It maps to a natural mental model (small, medium, large).
+- It enables the **anchoring effect**: a high-priced option makes the middle look reasonable; a low-priced option makes the middle look like a real value.
+- It limits Hick's Law cost (log₂(4) ≈ 2 — minimal decision time).
+
+## The middle-tier dominance pattern
+
+Across many product categories, the middle tier captures 50–75% of conversions when:
+
+- It's labeled as "Recommended" or "Most Popular."
+- It's visually emphasized (border, badge, slight size increase).
+- The features list shows enough above the cheap tier to justify the upgrade and enough below the expensive tier to make the next jump feel discretionary.
+
+This is sometimes called "decoy pricing" or the **decoy effect** — an option whose primary purpose is to make another option look better. Done honestly (the middle tier is genuinely the right fit for most users), it's good design. Done manipulatively (the cheap tier is artificially crippled to push users up; the expensive tier is added solely to make the middle look reasonable), it's a dark pattern.
+
+## A/B testing findings
+
+Common pricing-page A/B test results from CRO literature (anonymized aggregations):
+
+- **Adding a "Recommended" badge to the middle tier**: +5 to +25% conversion lift toward that tier.
+- **Highlighting middle tier with brand color border**: +10 to +20% lift.
+- **Adding a 4th tier**: usually neutral to slight negative on total conversion; revenue may shift between tiers.
+- **Removing a tier (4 → 3)**: usually neutral to slight positive; reduces cognitive load.
+- **Annual-billing discount toggle defaulted to "Annual"**: +30 to +60% on annual-plan selection (with proportional revenue lift if your unit economics support it).
+- **Showing per-user pricing vs. flat pricing**: per-user often better for SMB segments; flat better for SOHO.
+
+These are illustrative; your product's audience and market will produce different numbers.
+
+## Cross-domain examples
+
+### Subscription magazines
+
+The "1 year / 2 year / Lifetime" pattern. Lifetime is rare; 1-year is typical; 2-year is the recommended-and-discounted middle.
+
+### SaaS canonical layouts
+
+Atlassian, Slack, Asana, Notion, Linear, and dozens more: same 3-tier (or 3+free) structure. Convergence isn't accidental; it's optimization across many A/B tests.
+
+### Mobile carriers
+
+US mobile pricing has historically been 3-tier ("Basic / Plus / Unlimited") with each tier carrying many bundled features, plus add-ons. The complexity pushed users into the most expensive tier as the "safe" choice — which is one read on why telco pricing has been disliked.
+
+### Charity giving
+
+Donation forms often show preset amounts ($10 / $25 / $50 / $100 / Custom). The middle preset typically captures plurality. Defaults work the same way as in product pricing.
+
+## Common pricing-page mistakes
+
+- **Hiding pricing.** "Contact sales" on a tier that should be self-serve. Conversion drops; competitors with published prices win.
+- **No "Recommended" highlight.** Three equally-weighted tiers; users gravitate to the cheapest by default.
+- **Feature wall.** A 30-row × 5-column comparison matrix at the top of the page. Most users bounce before scanning.
+- **Free tier given full visual weight.** Free is often loss-leader; over-emphasizing it pushes users into a tier that doesn't pay.
+- **Confusing per-user math.** "$8 per user per month, billed annually." Users do the wrong math at checkout. Show monthly-equivalent and annual-total on the page.
+- **Hidden enterprise.** Enterprise tier with no information at all. Sales-led customers want to qualify themselves before they talk.
+
+## Resources
+
+- **Price Intelligently** (Patrick Campbell) — pricing-research firm with extensive blog content on tier design.
+- **Reforge** — has materials on pricing strategy and UI.
+- **Demand Curve** and **Conversion Rate Experts** — agency blog content on pricing-page CRO.
+
+## Closing
+
+A pricing page is the most quantitatively-tested surface in many products — every change becomes measurable revenue. The Hick's Law principle stays constant: keep the visible decision space small, default the middle, anchor with the extremes, and let the user say yes without thinking.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: hicks-law
+description: 'Use this skill whenever a design has many options the user must choose among — menus, navigation, pickers, plan tiers, settings panels, action toolbars, lists of templates, anything that asks "which one?" Trigger when the user is laying out a navigation menu, designing a settings page, picking the structure of a wizard, building a country/timezone/currency picker, designing a pricing table, or reviewing a UI where users hesitate over which control to use. Trigger when there''s debate about "should we add another option?" — Hick''s Law is the principle that costs the option a price. Routes to sub-aspect skills for menus, defaults, and pricing.'
+---
+
+# Hick's Law
+
+Hick's Law (more precisely, the Hick-Hyman Law) is the empirical observation that the time required to make a decision among a set of options grows with the logarithm of the number of options. Stated as a formula:
+
+```
+T = b · log₂(n + 1)
+```
+
+Where T is decision time, n is the number of equally likely choices, and b is a constant determined by the cognitive context. The +1 accounts for the time to begin processing the choice set at all. The logarithmic growth is the design-relevant insight: doubling the number of options does not double decision time, but it does add a roughly constant increment each time.
+
+## Definition (in our own words)
+
+When a user must select one option from a set, the time and cognitive effort required to make that selection rise as the set grows — but not linearly. The user can scan and pick from a small set quickly; they need progressively more time as the set grows; and beyond a certain size (typically around 7–10 options for a flat list) they switch from scanning to searching, which is a different and slower mode.
+
+## Origins and research lineage
+
+- **Hick (1952)** measured reaction time as a function of the number of stimulus alternatives in a simple keypress task. He found a logarithmic relationship.
+- **Hyman (1953)** extended this with similar results across varied stimulus types, confirming the general law.
+- **Card, Moran & Newell (1983)** in *The Psychology of Human-Computer Interaction* incorporated Hick's Law into the early model human processor framework that grounded decades of HCI design.
+- **Modern critiques** (e.g., Seow 2005) note that Hick's Law strictly applies to highly practiced, equally-likely choices among visually distinguishable items. Real-world UI choices often violate these conditions — items aren't equally likely, users aren't fully practiced, items have semantic content the user must read. The law is a *guide*, not a measurement.
+
+The takeaway: more options is more decision cost, the cost grows sub-linearly, and beyond about 7 options the dominant cost shifts from "scan and pick" to "search the list."
+
+## Why Hick's Law matters
+
+In product design, every option you put in front of the user is paid for in two currencies: **decision time** (the user must consider it) and **decision fatigue** (the user has fewer mental resources for the next decision). On a single screen, the cost of one extra option is small. Across a workflow with many decision points, the costs compound.
+
+Designs that respect Hick's Law feel "easy" — users move through them without stalling. Designs that ignore it feel "complicated" — users hover, deliberate, and sometimes abandon.
+
+## When to apply
+
+- **Navigation IA.** Top-level navigation should typically be 5–7 items. Beyond that, the user can't hold the structure in working memory while scanning.
+- **Action toolbars.** A toolbar with 12 buttons asks a Hick's Law question on every glance. Cap visible actions; tuck the rest into menus or palettes.
+- **Pickers.** Country / timezone / currency / template pickers can have hundreds of items. Don't make the user choose from a flat list of 195 countries — switch to a different interaction (search, recents).
+- **Wizards.** Multi-step flows with many branches at each step compound the law: 4 choices × 4 choices × 4 choices = 64 paths to consider, even if the user only walks one.
+- **Settings.** A settings page with 30 toggles asks the user to evaluate 30 options. Group, default, and progressively disclose.
+
+## When NOT to apply (or when to misapply it)
+
+Hick's Law is sometimes invoked to justify removing options that users actually need. Beware of these failure modes:
+
+- **The "fewer-is-always-better" trap.** Some tasks have irreducible complexity — a tax form genuinely has 50 fields. Hick's Law doesn't say "remove fields"; it says "structure the choices so the user faces fewer at once."
+- **Assuming Hick's Law applies to text input.** Free-text input isn't choosing from a set; it's recall. Hick's Law doesn't apply directly. (Recognition over Recall does — see that principle.)
+- **Assuming all options are equally weighted.** When one option dominates probability (e.g., 80% of users want "Pro" plan), the cost is closer to "scan for the obvious one and click" than to a pure Hick's Law decision. Strong defaults change the equation.
+- **In expert contexts.** Practiced users on familiar tools can navigate large option sets quickly via spatial memory and shortcuts. A power-user IDE can have 200 menu items because experts don't *scan* them; they fly to known locations.
+
+## Strategies for reducing Hick's Law cost
+
+### 1. Reduce the count
+
+The most direct strategy. Audit the option set: which options are rarely used? Hide them behind "More" / "Advanced" / a command palette. The remaining set should be small enough to scan at a glance.
+
+The 80/20 rule pairs naturally with Hick's Law here: surface the 20% of options that handle 80% of cases; tuck the rest.
+
+### 2. Group the options
+
+A flat list of 30 items is hard. Three groups of 10 items, each with a heading, is much easier — the user makes a fast group choice (Hick's Law on 3), then a slower within-group choice (Hick's Law on 10).
+
+```
+Flat (Hick's cost: log₂(31) ≈ 4.95)
+  Item 1 … Item 30
+
+Grouped (Hick's cost: log₂(4) + log₂(11) ≈ 2 + 3.46 = 5.46)
+  Group A
+    Item 1 … Item 10
+  Group B
+    Item 11 … Item 20
+  Group C
+    Item 21 … Item 30
+```
+
+The arithmetic suggests grouping is *worse* by raw Hick's Law math. It isn't, in practice, because:
+
+- The user often only needs items in one group (cognitive load is on log₂(4) + log₂(11), not their sum).
+- Group headings make the structure recognizable and learnable — repeat visits are faster.
+- Visual chunking aids working memory.
+
+The math underestimates how badly humans handle long flat lists.
+
+### 3. Provide a strong default
+
+If you can pre-select the most likely option, you've cut the choice from N to "1 (the default) or N−1 (everything else)." Most users accept the default, so most users pay almost no decision cost.
+
+This is the single highest-leverage Hick's Law strategy: a good default eliminates the decision for most users.
+
+### 4. Switch interaction mode for very large sets
+
+Beyond ~10 options, scanning becomes search. The right interaction is no longer a `<select>` or radio group — it's a typeahead `combobox` or a `command palette` where the user types to filter. Filter-as-you-type collapses Hick's Law into the much faster Recognition-over-Recall.
+
+```
+≤ 5 options:  radio buttons or segmented control (all visible, instant pick)
+≤ 10 options: select dropdown
+≤ ~20 options: select with categories
+> 20 options: combobox / typeahead / command palette
+```
+
+### 5. Defer choices to the right moment
+
+A common Hick's Law mistake: presenting many options up-front when the user hasn't yet supplied the context that would narrow them. Defer.
+
+- A "Send a notification" form that asks "channel? (email/SMS/push/Slack/Teams) frequency? (instant/digest/weekly) audience? (everyone/admins/me)" before the user even has a draft — high Hick's cost. Better: let the user write the message first, then pick channel.
+
+### 6. Predict and rank
+
+If you can predict which options the user is likely to want (from their history, role, recency), put those at the top with a "Recent" or "Suggested" group. The user often finds their option without scanning the full list.
+
+## Worked examples
+
+### Example 1: country picker
+
+```html
+<!-- Anti-pattern: 195 countries in a flat select -->
+<select>
+  <option>Afghanistan</option>
+  <option>Albania</option>
+  …
+  <option>Zimbabwe</option>
+</select>
+```
+
+Decision cost is high (effectively a search, not a scan). Plus, the dropdown UI doesn't allow type-to-find effectively.
+
+```html
+<!-- Right: combobox with typeahead, plus recents -->
+<combobox>
+  <input placeholder="Search country" />
+  <listbox>
+    <group label="Recent">
+      <option>United States</option>
+      <option>Canada</option>
+    </group>
+    <group label="All countries">
+      <option>Afghanistan</option>
+      …
+    </group>
+  </listbox>
+</combobox>
+```
+
+The user types "ger," sees Germany, picks it. Hick's Law collapsed to recognition.
+
+### Example 2: navigation
+
+```html
+<!-- Anti-pattern: 14 top-nav items -->
+<nav>
+  <a>Home</a><a>Dashboard</a><a>Projects</a><a>Tasks</a><a>Reports</a>
+  <a>Calendar</a><a>Files</a><a>Inbox</a><a>Notifications</a><a>Team</a>
+  <a>Customers</a><a>Vendors</a><a>Settings</a><a>Help</a>
+</nav>
+```
+
+User can't decide where to start; eyes sweep, fatigue.
+
+```html
+<!-- Right: 5 top-level groups, with sub-nav under each -->
+<nav>
+  <a>Work</a>           <!-- Dashboard, Tasks, Calendar, Files -->
+  <a>Inbox</a>          <!-- Notifications, Messages -->
+  <a>People</a>         <!-- Team, Customers, Vendors -->
+  <a>Reports</a>
+  <a>Settings</a>
+</nav>
+```
+
+Five groups; user picks one in <1 second; sub-nav resolves the within-group choice.
+
+### Example 3: settings
+
+```html
+<!-- Anti-pattern: 30 toggles in a flat list -->
+<form>
+  <label><input type="checkbox" /> Send daily summary email</label>
+  <label><input type="checkbox" /> Send weekly summary email</label>
+  <label><input type="checkbox" /> Notify on mention in any channel</label>
+  …(27 more)
+</form>
+```
+
+The user is asked to evaluate 30 boolean choices, most of which they don't care about.
+
+```html
+<!-- Right: grouped, with strong defaults pre-selected -->
+<form>
+  <fieldset>
+    <legend>Email digest</legend>
+    <label><input type="radio" name="digest" value="off" /> Off</label>
+    <label><input type="radio" name="digest" value="daily" checked /> Daily (recommended)</label>
+    <label><input type="radio" name="digest" value="weekly" /> Weekly</label>
+  </fieldset>
+
+  <fieldset>
+    <legend>Push notifications</legend>
+    <label><input type="radio" name="push" value="off" /> Off</label>
+    <label><input type="radio" name="push" value="mentions" checked /> Mentions only (recommended)</label>
+    <label><input type="radio" name="push" value="all" /> All activity</label>
+  </fieldset>
+
+  <details>
+    <summary>Advanced (Slack, calendar, custom rules)</summary>
+    …(advanced settings, hidden by default)…
+  </details>
+</form>
+```
+
+Now the user faces 3 + 3 = 6 visible choices, both with sensible defaults. Most users accept the defaults. Power users open the disclosure.
+
+### Example 4: a wizard
+
+A 4-step wizard with 4 choices at each step has 256 logical paths. The user sees only 4 at a time, so per-step cost is manageable. But cumulative decision fatigue can be high.
+
+Mitigations:
+- Show progress (Stepper) so the user knows the end is in sight.
+- Default each step's choice based on prior steps when possible.
+- Allow "I'll come back to this" with a save-and-resume.
+
+## Anti-patterns
+
+- **The "kitchen-sink" toolbar.** All possible actions visible at once. Users freeze; the toolbar becomes wallpaper.
+- **The "expert mode by default" trap.** A new user is shown the same option-rich interface as a power user. They bounce.
+- **Hidden costs in disclosure.** Putting 20 options inside a "More" disclosure doesn't reduce Hick's Law cost; it just makes the user pay it after a click. Sometimes correct (advanced rarely-used settings), sometimes a procrastination of the real fix.
+- **Asking before you have to.** A configuration step at sign-up that asks 8 questions before the user has used the product. Defer until the user has context to answer.
+
+## Heuristics
+
+1. **The 7-second test.** Time how long it takes a fresh user to pick the right item from your list. >7 seconds suggests Hick's Law cost is too high; restructure.
+2. **The Pareto check.** Look at usage analytics. If 80% of usage is concentrated in 20% of options, surface that 20%; demote the rest.
+3. **The "default-acceptance" rate.** Pick a setting where you have a default. What percent of users keep the default? If high, the default is doing its Hick's Law work. If low, your default is wrong (or the question shouldn't have a default).
+
+## Related principles
+
+- **`80-20-rule`** — partner principle; identifies *which* options to surface and which to demote.
+- **`recognition-over-recall`** — the cognitive shift that lets typeahead collapse Hick's Law for very large sets.
+- **`progressive-disclosure`** — the structural strategy for hiding the long tail.
+- **`chunking`** — the perceptual basis for why grouped options outperform flat ones.
+- **`satisficing`** — users pick the first acceptable option; defaults exploit this.
+- **`flexibility-usability-tradeoff`** (interaction) — adding options gives flexibility *and* costs usability; Hick's Law quantifies the cost.
+
+## Sub-aspect skills
+
+- **`hicks-law-menus`** — applying the law to dropdowns, command palettes, navigation menus.
+- **`hicks-law-defaults`** — using defaults as the primary Hick's Law mitigation.
+- **`hicks-law-pricing`** — applying the law to plan/tier selection where the choice itself is the conversion event.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law/references/research-and-formulation.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/hicks-law/references/research-and-formulation.md
@@ -1,0 +1,69 @@
+# Hick's Law: research and formulation
+
+A reference complementing the `hicks-law` SKILL.md with the academic grounding and the limits of the law in practice.
+
+## The original studies
+
+- **Hick, W. E.** (1952). "On the rate of gain of information." *Quarterly Journal of Experimental Psychology*, 4(1), 11–26. Hick measured reaction time as a function of the number of equally-likely stimulus alternatives in a simple keypress task. He found a linear relationship between reaction time and `log₂(n)`, where n is the number of alternatives.
+- **Hyman, R.** (1953). "Stimulus information as a determinant of reaction time." *Journal of Experimental Psychology*, 45(3), 188–196. Replicated and extended Hick's findings with varied stimulus types, supporting the general law.
+
+The combined formulation is now usually called the Hick-Hyman Law. The Shannon-information formulation (T = a + b · log₂(n + 1)) became standard in HCI through Card, Moran & Newell's *The Psychology of Human-Computer Interaction* (1983).
+
+## What the law actually predicts
+
+Important: Hick's Law specifically predicts the time to *select* among options when:
+
+1. The options are equally likely.
+2. The user is highly practiced at the task.
+3. The options are visually distinguishable but semantically simple (a labeled key to press, an arrow direction).
+4. There's no additional cognitive processing beyond perceptual selection.
+
+In real UI:
+
+- Options are *not* equally likely (one is usually more popular).
+- Users are *not* fully practiced (most users encounter most UIs casually).
+- Options are *semantically rich* (the user has to read and understand each one).
+
+So the strict Hick's Law math underpredicts time in real UI. The general *shape* (logarithmic growth, decision cost compounds with option count) holds; the specific values don't.
+
+## Critiques and refinements
+
+- **Seow, S. C.** (2005). "Information theoretic models of HCI: A comparison of the Hick-Hyman Law and Fitts' Law." *Human-Computer Interaction*. Reviews the conditions under which Hick's Law applies, and argues for caution in casual application.
+- **Soegaard, M.** (Interaction Design Foundation summary). Notes that Hick's Law in UI design is best understood as a heuristic about cognitive load and option-set size, not a quantitative predictor.
+- **Modern eye-tracking** suggests that for visually-rich option sets (e.g., menu items with icons and descriptions), the relevant time is *scanning* time more than *deciding* time, and scan time scales differently — closer to linear than logarithmic for short lists.
+
+## When Hick's Law is the wrong model
+
+- **Search**, not select. When users type to filter, Hick's Law collapses. Recognition over Recall is the relevant principle.
+- **Dichotomous choice.** "Yes/No" / "Accept/Decline" — the law applies but the value is so small it doesn't matter.
+- **Highly-trained expert tasks.** Power users in IDEs, DAWs, photo editors operate by spatial memory; Hick's Law cost approaches zero for the option set they know cold.
+- **Cognitive evaluation tasks.** "Pick which essay is best." Hick's Law doesn't apply because the cost is in *evaluating* each option, not in *selecting* among recognized options.
+
+## Cross-domain examples
+
+### Restaurant menus
+
+A 200-item Cheesecake Factory menu vs. a 6-item In-N-Out menu. Both successful businesses; very different decision experiences. Studies (Iyengar's "jam jar" experiment, 2000) suggest that beyond a certain point, more options actually *reduce* purchase rates — choice overload, a cousin of Hick's Law.
+
+### Television channel lineup
+
+A linear cable lineup of 200 channels vs. a Netflix front page of curated rows. Netflix's design replaces Hick's Law (200 channels) with a different problem (10 rows of 20 items each, each chosen by algorithm). Different cognition load; arguably less.
+
+### Highway signs
+
+US Interstate signs limit destinations to 3–4 per sign for a reason. A sign with 10 destinations would force drivers to take their eyes off the road too long. The Hick's Law cost (in seconds of attention) translates directly to safety risk.
+
+### Phone IVR systems
+
+"Press 1 for billing, press 2 for technical support…" — the canonical Hick's Law surface where designers can't even rely on visual scanning. Most IVRs cap menu depth at 3 levels and breadth at 5 options per level for this reason. Going deeper or broader produces measurable abandonment.
+
+## Quantitative findings worth knowing
+
+- **Time to select from a 5-item flat dropdown**: ~1.5 seconds for typical desktop users.
+- **Time to select from a 20-item flat dropdown**: ~3.5 seconds (logarithmic scaling).
+- **Time to select from a 20-item searchable combobox** (after a 4-character type): ~1.2 seconds (search collapses the cost).
+- **Default-acceptance rate** for well-chosen defaults: 60–85% of users keep them — meaning most users pay near-zero Hick's Law cost.
+
+## Closing
+
+Hick's Law is the textbook principle most often invoked as a slogan ("more options = worse"). The reality is more nuanced: more options cost decision time, the cost grows sub-linearly, and good design (defaults, search, grouping) can shift the cost from "decide among N" to "recognize from N" or "evaluate the default."

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-arbitrary-and-symbolic/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-arbitrary-and-symbolic/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: iconic-arbitrary-and-symbolic
+description: 'Apply arbitrary and symbolic icon design — using forms with no inherent meaning that depend on convention to communicate (the hamburger menu, the kebab menu, the AI sparkle, app brand-mark icons). Use when a function has no clear visual referent, when working within a domain that has its own icon vocabulary, when establishing or following a convention, or when evaluating whether a convention is strong enough to support icon-only treatment. Arbitrary icons require prior learning to work; the skill is calibrating when to follow a convention vs. when to label.'
+---
+
+# Iconic Representation — arbitrary and symbolic
+
+Arbitrary icons have no inherent connection to what they represent. The hamburger menu (three horizontal lines) doesn't look like a menu in any physical sense. The kebab menu (three vertical dots) doesn't look like options. The "@" symbol for email doesn't depict email. These icons work only because users have learned the convention through repeated exposure.
+
+This is the most fragile form of iconic representation. New users don't recognize arbitrary icons. The icons depend entirely on convention strength, which varies by domain, by audience, and over time.
+
+But arbitrary icons also have an unmatched advantage: they can compress meaning into a single recognizable form for functions that have no good visual referent. "More options" has no physical analog; the kebab menu fills that gap. "AI assistance" has no physical analog; the sparkle is filling that gap.
+
+## How arbitrary icons gain meaning
+
+An arbitrary icon becomes recognizable only through accumulated exposure. The mechanism:
+
+1. A few influential products use a particular form for a particular function.
+2. Other products copy the convention.
+3. Users encounter the form in many places associated with the same function.
+4. Eventually, users recognize the form on sight, even in products they haven't seen before.
+
+This is convention-formation. It usually takes years. The hamburger menu, for example, was used in some interfaces in the late 2000s, became more common around 2010–2012, and was a near-universal mobile convention by 2015. The kebab menu followed a similar trajectory a few years later.
+
+Some conventions never make it. Many proposed icons are tried, fail to spread beyond the originating product, and remain opaque to users from other products. The convention-formation process is genuinely contingent — designers can't reliably predict which forms will become universal.
+
+## When arbitrary icons work
+
+Arbitrary icons work when:
+
+**The audience has been exposed to the convention.** A mobile-app user from 2025 recognizes the hamburger menu, the kebab menu, the sparkle for AI. A user from 2010 might not. A user who's never used software might not recognize any of them.
+
+**The function doesn't have a strong visual referent.** "More options," "menu," "AI features," "share" — none of these have obvious physical referents. Arbitrary icons fill the vocabulary gap.
+
+**The icon is reinforced by usage.** Users learn arbitrary icons through repetition. An arbitrary icon used in a single place in your product is harder to learn than one used in a consistent role across the product.
+
+**The icon is supported by context.** Even arbitrary icons gain interpretability from where they appear. A kebab in the corner of a list item is more clearly "actions for this item" than the same kebab in an unexpected location.
+
+## When arbitrary icons fail
+
+Arbitrary icons fail when:
+
+**The audience hasn't seen the convention before.** Domain-specific icons (a "diff" icon in developer tools) for a non-developer audience. Recent conventions (the AI sparkle, in 2024) for users who haven't used current AI tools.
+
+**Multiple competing conventions exist.** The "share" icon has different forms on Apple and Android platforms; users from one platform may not recognize the other's icon. Without label, the icon is ambiguous.
+
+**The icon is one of many similar arbitrary forms.** A toolbar with the hamburger menu, the kebab menu, the bento menu (3×3 dots), and the meatballs menu (three horizontal dots) — all variations on "menu" that users are expected to distinguish. Conventions have to be sharply different to coexist.
+
+**The convention is changing or fading.** Conventions stabilize over time but also drift. Users in transition periods may have trouble.
+
+**You invent your own arbitrary icon.** A custom icon designed for your product without external precedent. Users have no convention to draw on; recognition is essentially zero. Without significant onboarding, the icon doesn't communicate.
+
+## Working with established conventions
+
+When a convention exists for the function you need, the safe path is to use the established form even if you have a design opinion. The icon's recognizability comes from convention strength, not from intrinsic merit. A custom "share" icon, however well-designed, doesn't have the convention strength of the platform-native share icon.
+
+The exceptions:
+
+- **The convention is dying.** The floppy disk for save is increasingly anachronistic. Reaching for it because it's "the convention" may not serve users who don't recognize the source.
+- **The convention conflicts with a stronger one.** If your product's brand uses a specific iconographic language, forcing in an external convention may break the visual coherence. In these cases, label the icon to compensate.
+- **You're operating in a domain with a stronger convention.** Some domains have icon vocabularies more specific than the generic UI conventions.
+
+## When to invent vs. when to label
+
+When a function needs an icon and no established convention exists, the choice is between inventing a custom icon (risky for recognition) and using a text label (safe but less compact).
+
+**Use text:** for any infrequent function, any function where misclick is costly, any function where the audience varies in sophistication.
+
+**Use a custom icon (with paired label):** when space is tight and the function is used frequently enough for users to learn through repetition. Pairing with a label lets the icon develop convention strength gradually while supporting recognition immediately.
+
+**Use a custom icon alone:** essentially never, unless you're reproducing an existing convention from a related context. Inventing a new arbitrary icon for icon-only use is almost always a mistake.
+
+## Working with new conventions
+
+Some functions are too new to have established conventions yet. AI assistance is the current canonical example: dozens of products are introducing AI-powered features simultaneously, and a convention is still stabilizing. Currently:
+
+- The sparkle (often a four-pointed star or stylized starburst) is the most common.
+- Some products use a chat-bubble variant.
+- Some use a brain icon.
+- Some use a robot or "bot" icon.
+- Some use a wand or magic-wand icon.
+
+None of these has reached the convention strength of the hamburger menu. Users may or may not recognize each, and the recognition rates vary by audience.
+
+The pragmatic guidance: pick the most-common convention for your audience, pair with a label when first introducing it, and pay attention as the convention stabilizes. Be ready to update your icon if a different form wins.
+
+## Worked examples
+
+### The hamburger menu
+
+A canonical arbitrary icon. Three horizontal lines. No physical referent. Works because by 2020 it had become the dominant convention for "main menu" on mobile and was widely recognized. Now near-universal in mobile UIs.
+
+The icon's success is due to convention spread: many influential products (Facebook, Google, the major mobile platforms) used it consistently for years, training users to recognize it.
+
+### The kebab menu
+
+Three vertical dots. Even more arbitrary than the hamburger. Now the dominant convention for "more actions on this item." Spreads through modern mobile and web UIs.
+
+The kebab and the hamburger are both arbitrary, both used for menu-like functions, and now broadly distinguishable: the hamburger is "main menu" (often top-level navigation); the kebab is "more options for this thing" (often per-item actions).
+
+### The share icon (split convention)
+
+Apple and Android use different conventions for "share." Apple uses an upward-pointing arrow exiting a box. Android uses a graph of three dots connected by lines.
+
+Users familiar with one platform may not recognize the other's icon. Cross-platform products often use the platform-native version on each platform; web products typically pick one (often Apple's, given its visibility) and pair with a label.
+
+### The AI sparkle
+
+A four-pointed star or stylized burst. Currently coalescing as the convention for "AI feature" or "AI-generated content." Recognition rates are growing but vary by audience. Pairing with a label is still wise as of 2026.
+
+If the convention solidifies, the sparkle may become a recognized icon on its own. If something else (a different form, a text label) wins, the sparkle will fade. Convention formation is uncertain.
+
+### A custom-invented icon for a specialized function
+
+A productivity tool invents a custom icon for "rebuild dependency graph" — a unique geometric form combining a network diagram and a refresh symbol. Users have never seen the convention; recognition is essentially 0%. The icon communicates nothing.
+
+The fix: use a text label, or use a more conventional icon (a refresh arrow alone, with a label). Inventing arbitrary icons rarely works.
+
+## Anti-patterns
+
+**Using arbitrary icons icon-only without convention support.** Icons that depend on convention shouldn't be label-free unless the convention is strong in the audience.
+
+**Inventing new arbitrary icons.** Designers occasionally try to introduce a new form for a common function. Even well-designed custom icons rarely spread beyond the originating product.
+
+**Mixing many arbitrary icons that look similar.** Hamburger, kebab, bento, meatballs — all "menu" variants. Using more than one in a single product usually confuses users.
+
+**Convention-following that ignores audience.** Following a developer-tool convention in a non-developer product. The convention exists but not in your audience.
+
+**Convention-leading without authority.** Trying to introduce a new convention requires either market dominance (so other products will copy) or an industry standards body. Most products lack both.
+
+**Treating an established convention as if it weren't established.** Adding a label to the magnifying glass for "search" because "we don't want to assume." Sometimes the convention really is universal enough that the label is redundant. Audit your audience's actual recognition rates.
+
+## Heuristic checklist
+
+For each arbitrary icon, ask: **Is the convention established in my audience?** Test if uncertain. **Are there competing conventions?** If yes, pair with label or pick the one your audience knows. **Can users distinguish this icon from other arbitrary icons in my product?** If similar arbitrary icons coexist, the recognition cost rises sharply. **Is the convention stable, or in flux?** If in flux, label and revisit. **Am I tempted to invent a new arbitrary icon?** Almost always, the answer is "use text instead."
+
+## Related sub-skills
+
+- `iconic-representation` — parent principle on icon-based communication.
+- `iconic-resemblance` — sibling skill on similar icons.
+- `consistency-external` — convention strength comes from external consistency.
+- `mapping-cultural` — arbitrary icons are an extreme case of cultural mapping.
+- `recognition-over-recall` — once learned, arbitrary icons are recognized; before learning, they're invisible.
+
+## See also
+
+- `references/convention-strength.md` — how to evaluate convention strength and when to depend on it.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-arbitrary-and-symbolic/references/convention-strength.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-arbitrary-and-symbolic/references/convention-strength.md
@@ -1,0 +1,103 @@
+# Arbitrary icons — evaluating convention strength
+
+A working framework for evaluating whether a convention is strong enough to depend on as an icon-only treatment.
+
+## The strength spectrum
+
+Conventions exist on a spectrum from "essentially universal in your audience" to "specialized to a small subgroup."
+
+**Tier 1 — universal:** recognized by virtually all users in the audience. Icon-only treatment is safe. Examples: magnifying glass for search, gear for settings, trash for delete, hamburger menu (in mobile audiences). Recognition rate: 90%+.
+
+**Tier 2 — strong:** recognized by most users. Icon-only is usually safe but pairing with label improves accessibility and helps the long tail of unfamiliar users. Examples: kebab menu, share icon (within platform), bell for notifications. Recognition rate: 75–90%.
+
+**Tier 3 — emerging:** convention is forming but not yet dominant. Some competing conventions exist or recognition varies by audience. Pair with label until convention solidifies. Examples: AI sparkle (as of 2026), some emerging gesture conventions. Recognition rate: 40–75%.
+
+**Tier 4 — domain-specific:** strong within a domain, opaque outside. Use icon-only only if the audience is fully within the domain; otherwise label. Examples: developer-tool icons (diff, pull request, branch), design-tool icons (bezier curve, boolean operations), music-software icons. Recognition rate within domain: 80%+; outside domain: <30%.
+
+**Tier 5 — invented:** custom icon with no external precedent. Recognition is essentially zero on first encounter. Always label; don't expect the icon to communicate alone.
+
+## How to evaluate convention strength
+
+For an icon you're considering, evaluate convention strength by:
+
+**Survey usage in major products in your category.** If most products use a particular icon for the function, the convention is strong in your category. If usage is mixed, the convention is weaker.
+
+**Test recognition with users from your audience.** Show the icon (alone, no context) and ask what it means. The recognition rate is a direct measure of convention strength.
+
+**Check across audience subgroups.** New users vs. experienced users; younger vs. older; international vs. local. Convention strength often varies sharply across these dimensions.
+
+**Look for evidence in design system documentation.** When a convention is strong enough that platform design systems (Apple HIG, Material) document it, it has become near-universal in the platform's audience.
+
+**Watch the trajectory.** Conventions form over years and fade over years. An icon that was universal 10 years ago may be confusing now (the floppy disk); an icon that was niche 5 years ago may be becoming universal (the AI sparkle is on this trajectory).
+
+## Patterns of convention spread
+
+Conventions form when an icon is used:
+
+- **Across many products** (so users encounter it repeatedly).
+- **For the same function** (so the meaning is reinforced).
+- **In visible places** (toolbars, navigation, onboarding).
+- **By influential products** (Apple, Google, the leading product in a category).
+- **For long enough** (typically 3–5 years for a strong convention to form).
+
+The pattern is roughly: a couple of products use a form, others copy, the form becomes more common, eventually it's recognized as a convention. The reverse pattern is conventions fading: as fewer products use a form, recognition drops, and it eventually becomes opaque.
+
+You can sometimes contribute to convention spread by being early and visible, but you can't reliably create a convention by yourself. Convention spread is a network effect that requires multiple actors.
+
+## When a convention is conflicting
+
+Some functions have multiple competing conventions. Examples:
+
+- **Share:** Apple uses upward-arrow-from-box; Android uses graph-of-three-dots. Cross-platform products either use the platform-native version (most common) or pick one and label it.
+- **Save:** floppy disk (legacy convention) vs. cloud-with-checkmark (newer cloud-storage convention) vs. text label "Save". No clear winner; depends on audience and context.
+- **Filter vs. sort:** funnel for filter, up-down arrows for sort, but they're often confused. Pair both with text.
+- **Refresh vs. undo:** circular arrows can mean either, depending on the curve direction. Disambiguate visually or label.
+
+When conventions conflict, label the icon. Relying on icon-only with a conflicting convention is a recipe for misclick.
+
+## When to follow a convention you don't love
+
+Designers often want to use a convention they think isn't ideal. The principle: convention strength matters more than icon design merit. A "better" custom icon that nobody recognizes is worse than a "worse" conventional icon that everyone recognizes.
+
+The exceptions:
+
+- The convention is genuinely fading. If it no longer communicates to your audience, switching is justified.
+- The convention conflicts with your product's other patterns. If using it would create internal inconsistency, pair it with a label or pick a different approach.
+- You have a fundamentally better alternative *and* the resources to popularize it. (This is rare.)
+
+In most cases, follow the convention even if you don't love it. Recognition is what makes icons work.
+
+## When to break a convention deliberately
+
+Sometimes departing from a convention is the right call:
+
+- **The convention is dying** and your audience increasingly doesn't recognize it.
+- **The convention conflicts with accessibility** (color-only conventions, conventions that depend on visual detail at small sizes).
+- **The convention is misleading in your specific context** (the trash icon for "remove from network" rather than "delete").
+- **You're explicitly framing the departure** ("we're reimagining this category" with marketing that sets the expectation).
+
+In all these cases, the departure should be supported by a clear label and (if used in onboarding) explicit teaching. Sneaking in an unconventional icon without acknowledgment hurts users.
+
+## A simple decision tree
+
+For each icon decision:
+
+1. Is there a strong convention for this function in my audience? (Tier 1–2)
+   - **Yes:** use the convention, optionally label.
+   - **No:** continue to step 2.
+
+2. Is there an emerging convention? (Tier 3)
+   - **Yes:** use the most-common emerging convention, pair with label.
+   - **No:** continue to step 3.
+
+3. Is the function specific to a domain my audience knows? (Tier 4)
+   - **Yes:** use the domain convention, pair with label if mixed audience.
+   - **No:** continue to step 4.
+
+4. Is the function distinct enough to need its own icon?
+   - **No (or unclear):** use text label only.
+   - **Yes:** invent an icon and pair with label always; expect recognition to grow only with consistent use.
+
+## Cross-reference
+
+For the parent principle on iconic communication, see `iconic-representation`. For similar (resemblant) icons, see `iconic-resemblance`.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-representation/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-representation/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: iconic-representation
+description: 'Apply iconic representation — using simplified visual symbols to communicate function, status, or category at a glance. Use when designing icon sets, choosing between icon and text labels, evaluating whether to lean on existing iconography (resemblance to a known object) or invent symbolic icons (arbitrary forms with assigned meanings), or auditing whether your icons are actually communicating. Three kinds: similar (icons that look like what they represent), example (icons that depict an object associated with the function), and arbitrary/symbolic (forms with no inherent meaning, like the hamburger menu).'
+---
+
+# Iconic Representation
+
+> **Definition.** Iconic representation is the use of small visual symbols — pictograms, glyphs, signs — to convey meaning quickly and within limited space. Icons can communicate at a glance what would otherwise require text, support cross-language recognition, and create visual hierarchy by giving important elements a distinct visual identity. The skill is choosing icons that actually communicate to your audience, rather than icons that look meaningful but require explanation.
+
+The classic taxonomy distinguishes three kinds of iconic representation, in roughly decreasing order of inherent recognizability.
+
+**Similar icons.** The icon visually resembles what it represents. A camera icon for "take photo." A clock icon for "time." A magnifying glass for "search" (a bit of a stretch, but the metaphor is "looking closely"). Similar icons are easiest for new users because the visual reference does most of the work. They require minimal learning.
+
+**Example icons.** The icon depicts an object associated with the function rather than the function itself. A hamburger icon for "menu" (the visual is three horizontal lines that resemble stacked menu items, not the menu itself). A floppy disk for "save" (the visual is the storage medium, not the action of saving). A pencil for "edit" (the tool, not the editing). Example icons require some inference from object to function, and that inference is often cultural rather than universal.
+
+**Arbitrary or symbolic icons.** The icon has no inherent connection to its meaning; the meaning is assigned by convention. The kebab menu (three vertical dots) for "more options." The "@" symbol for email. Specific app-store icons. These work only because users have been trained to recognize them; without prior exposure, they communicate nothing.
+
+## Why iconic representation matters
+
+Icons earn their place in the interface for a few reasons.
+
+**They save space.** A search bar with just a magnifying glass icon is much smaller than one with the word "Search" plus a search bar. In dense interfaces, mobile especially, the space saved by iconic representation can be the difference between a usable layout and a crowded one.
+
+**They support cross-language recognition.** Icons don't need translation. A trash-can icon for delete works across English, Mandarin, Arabic, and Hindi audiences (with caveats about cultural references). For globally deployed products, this is a real advantage.
+
+**They create visual hierarchy.** A row of buttons with icons is more scannable than a row of all-text labels. The icons function as visual markers that the eye can quickly pick out.
+
+**They reinforce learning.** Users who learn the meaning of an icon associate it strongly with the function. Subsequent encounters require less cognitive effort to interpret.
+
+The flip side: icons that don't communicate are pure noise. They take up space, draw attention, and don't tell the user anything they need to know. An icon that requires the user to read a label to understand it has failed at being an icon.
+
+## When icons are the right choice
+
+Icons work when:
+
+**The function has a strong visual referent.** Photo (camera), search (magnifying glass), delete (trash can), settings (gear). The visual reference does most of the recognition work.
+
+**The audience knows the convention.** The hamburger menu is fine for users who've used mobile apps; it would be opaque to a complete novice. The kebab menu is similar. Domain-specific conventions (a "diff" icon in developer tools) work within the domain.
+
+**Space is constrained.** Mobile UIs, dense toolbars, status bars — places where every pixel counts. Icons can do more work per pixel than text.
+
+**The icon will be used frequently and consistently.** Icons reward learning; the more often users encounter them, the more efficient they become. For one-off or rarely-used controls, text labels are usually better.
+
+**Localization matters.** Icons can travel across languages and cultures more easily than text, though specific cultural references still need verification.
+
+## When icons are the wrong choice
+
+Icons fail when:
+
+**The function has no obvious visual referent.** "Reset password," "compare versions," "advanced filtering" — abstract operations with no physical analog. Inventing an icon for these usually produces a symbol the user doesn't recognize. Better to use text.
+
+**The audience doesn't share the convention.** Domain-specific icons in a general-audience product. Tech-industry icons in a non-tech audience. Generation-specific icons (the floppy disk for save) in cross-generational audiences.
+
+**The icon is one of many similar-looking ones.** When five icons in a toolbar are all thin-stroke outlined geometric shapes, they require careful inspection to distinguish. Text labels would be faster. A varied icon set helps but only to a point.
+
+**The cost of misidentification is high.** A "delete" icon that gets confused with a different action is dangerous. Either the icon should be unambiguous (a clear, conventional trash can) or it should be paired with text.
+
+**The icon is showing up infrequently.** A user who encounters an icon once a month doesn't have the repeated exposure to learn it. Label rarely-used icons.
+
+## Icon + text label
+
+When in doubt, pair the icon with a text label. The combination is more informative than either alone: the text tells novices what the icon means, while the icon helps experts scan quickly.
+
+The downsides of icon+text:
+
+- Takes more space than icon alone.
+- Adds visual complexity.
+- Can feel redundant in dense layouts.
+
+The upsides:
+
+- Universally interpretable.
+- Forgiving of unfamiliar icons.
+- Better for accessibility (screen readers can rely on the text; users who don't recognize the icon can still understand).
+
+For most UI elements that aren't space-constrained, icon+text is the safe default. Icon-alone should be reserved for cases where the icon is unambiguous in your audience and the space savings matter.
+
+## Sub-skills in this cluster
+
+- **iconic-resemblance** — Designing and choosing similar icons (icons that look like what they represent), and recognizing when resemblance is doing the work vs. when it's failing.
+- **iconic-arbitrary-and-symbolic** — Working with arbitrary symbols and developing cultural conventions, including how new conventions stabilize and old ones fade.
+
+## Worked examples
+
+### Toolbar in a writing app
+
+A writing app's formatting toolbar: bold (a "B"), italic (an "I"), underline (a "U"), bulleted list (lines with bullets), numbered list (lines with numbers), quote (a quotation mark), code (angle brackets or a monospace symbol), link (a chain link).
+
+Most of these icons are similar (the visual references the formatting itself). They're conventional across writing apps, so users transfer recognition. Icon-only is appropriate because the icons are unambiguous and the toolbar is space-constrained.
+
+### Dashboard with mixed icons and labels
+
+A SaaS dashboard's main navigation: Home (house icon + label), Inbox (envelope + label), Reports (chart + label), Team (people + label), Settings (gear + label).
+
+Each item has both icon and label. The icons help with scanning; the labels disambiguate (especially "Reports" which doesn't have a single dominant icon convention) and support accessibility. The combination is appropriate for a primary navigation that users encounter on every screen.
+
+### A custom icon that doesn't communicate
+
+A team designs a custom icon for "AI assistant": a stylized neural-network diagram with three nodes connected by lines. To the designers, it represents "AI." To users, it's a meaningless geometric shape. Without a label, users don't know what the button does.
+
+The fix: either pair the icon with a label ("AI Assistant"), use a more conventional icon (a sparkle or star is becoming the de-facto AI convention as of 2024–2026), or use just text.
+
+### Status icons with consistent vocabulary
+
+A monitoring dashboard uses consistent status icons: green check (healthy), yellow triangle (warning), red X (error), gray dash (unknown), blue clock (in progress). The icons are pictographically clear and the color provides reinforcement. Users can scan a long list of items and quickly identify which need attention.
+
+The combination of distinct shape + distinct color + consistent meaning creates a readable status system. Removing any element (color only, shape only) would weaken it for accessibility or scanning.
+
+### Icon overload in a dense interface
+
+A photo editor's tool palette has 24 icons in a 4×6 grid. All are thin outline strokes in monochrome. Users have to hover over each to find what they want. The icons are visually unified (good for branding) but functionally indistinguishable.
+
+The fix is varied weight, varied fill, or grouping into categories with visual breaks. The unified-stroke aesthetic was a designer-side choice that hurt usability.
+
+## Anti-patterns
+
+**Icons without meaning.** A row of decorative icons that doesn't communicate function. "We added some icons to make it look more visual." The icons aren't doing iconic work; they're decoration.
+
+**Icons that look meaningful but require explanation.** Custom icons designed for visual cohesion rather than for communication. They convey "we have a design system" but not "here's what this button does."
+
+**Icons relying on obsolete cultural references.** Floppy disks, brushed metal, rotary phones. The references no longer transfer to modern audiences.
+
+**Inconsistent icon style within a product.** Some icons outlined, some filled, some colored, some monochrome. The user can't tell which icons are related (the visual style doesn't carry meaning) and the overall product feels patched together.
+
+**Hover-only labels for unfamiliar icons.** An icon-only toolbar where the labels appear only on hover. Touch users (no hover) can't discover the labels at all. Mobile users especially are punished by this pattern.
+
+**The same icon for different functions across screens.** A magnifying glass that opens search on one screen and a filter panel on another. The user's expectation is violated, and the convention strength of the icon is eroded.
+
+**Two icons that look almost identical but mean different things.** Filter (funnel) and sort (up-down arrow) are notoriously confused. Pair both with text, or distinguish them more strongly visually.
+
+## Heuristic checklist
+
+Before relying on an icon, ask: **Does it look like what it represents (similar)?** That's strongest. **Or does it represent the function via an associated object (example)?** That requires the audience to know the association. **Or is it pure convention (arbitrary)?** That requires the audience to have prior exposure. **Will my audience actually recognize it?** Test with real users from the actual audience. **Is it consistently used across my product and (where applicable) the platform?** Inconsistent use destroys recognition. **Is it accessible?** Visual icons need text alternatives for screen readers and users with vision differences.
+
+## Related principles
+
+- **Mapping (cultural)** — icons are often the visual half of cultural mapping.
+- **Mimicry** — icons that resemble objects are surface mimicry at the symbolic level.
+- **Recognition Over Recall** — icons exploit recognition rather than recall.
+- **Consistency (external)** — convention strength is what makes arbitrary icons work.
+- **Affordance** — an icon's visual implies what kind of action it can trigger.
+- **Signal-to-Noise Ratio** — meaningless icons are pure noise; meaningful ones are signal.
+
+## See also
+
+- `references/lineage.md` — origins in semiotics, signage design, and HCI iconography research.
+- `iconic-resemblance/` — sub-skill on similar icons.
+- `iconic-arbitrary-and-symbolic/` — sub-skill on convention-based icons.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-representation/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-representation/references/lineage.md
@@ -1,0 +1,90 @@
+# Iconic Representation — origins and research lineage
+
+## Roots in semiotics
+
+The classification of signs into similar (iconic), example (indexical), and arbitrary (symbolic) comes from Charles Sanders Peirce's semiotics in the late 19th century. Peirce distinguished three kinds of relationships between a sign and what it signifies:
+
+- **Iconic:** the sign resembles the signified (a portrait resembles the person).
+- **Indexical:** the sign points to or is associated with the signified (smoke indexes fire; a footprint indexes a foot).
+- **Symbolic:** the relationship is arbitrary, established by convention (the word "tree" doesn't resemble or point to a tree; we just agreed it means tree).
+
+The Lidwell-Holden-Butler taxonomy of "similar / example / arbitrary or symbolic" maps loosely onto Peirce's categories: similar = iconic, example = indexical, arbitrary = symbolic. The terms differ but the underlying distinction is the same.
+
+The semiotic framework is useful because it tells you what each kind of icon needs to work. Iconic signs work without prior learning because the resemblance does the work. Indexical signs require knowing the association (smoke means fire because we know fire produces smoke). Symbolic signs require prior training in the convention.
+
+## In wayfinding and signage
+
+The use of iconic representation in signage long predates digital design. International airport pictograms — the silhouettes for restroom, baggage claim, customs, etc. — are the result of a 1974 American Institute of Graphic Arts (AIGA) and U.S. Department of Transportation collaboration that produced a standardized set of 50 pictograms intended to be universally interpretable across languages.
+
+The AIGA / DOT set was rigorously researched: candidate symbols were tested with diverse audiences for recognition rate, and only those that crossed a high threshold were adopted. The set is still widely used worldwide and has shaped subsequent pictogram standards (ISO, IEC).
+
+The lesson from this work: even ostensibly "universal" pictograms vary widely in actual recognition. Some symbols (the male/female restroom figures, the airplane for "departures") test very high; others (the symbol for "lost and found," the symbol for "currency exchange") test much lower and rely on context to be interpretable.
+
+## In early HCI: the Star icon set
+
+The Xerox Star (1981) is generally credited as introducing the modern icon-based desktop. The Star team designed icons for documents, folders, the trash can, the printer, and various other objects. Their research showed that iconic representations dramatically reduced the learning curve for new computer users compared to command-line systems.
+
+The Star team's approach was conservative: they preferred icons that depicted real-world objects (a folder that looked like a folder, a document that looked like a document with a folded corner) and tested icon designs with users to verify recognition. This emphasis on tested similarity carried forward into the Macintosh, Windows, and the broader convention of icon-based UI.
+
+## In modern UI: the convention era
+
+By the 2000s and 2010s, many digital icons had stabilized into conventions that no longer required (or could no longer afford) literal resemblance. The hamburger menu, the kebab menu, the share icon, the gear, the sparkle for AI — all became broadly recognized through repeated exposure rather than through visual similarity to anything in the physical world.
+
+This shift produced what some designers call "icon literacy": the ability to recognize and interpret a vocabulary of conventional symbols, much like reading. Users who've used many apps can read an icon-only toolbar with little difficulty; users new to digital interfaces struggle with the same toolbar.
+
+The implication: as the audience for digital products has matured, designers can lean more on convention and less on literal resemblance. But this doesn't extend to all audiences — children, older users, users in regions with less digital saturation, and accessibility audiences may still depend on literal resemblance or text labels.
+
+## Empirical findings on icon recognition
+
+Several studies, notably those by Rod Black and others on "icon comprehension," have produced stable findings:
+
+- **Recognition rates vary widely.** Even for ostensibly conventional icons, recognition rates in tested audiences typically range from 30% to 95%. Designers consistently overestimate how recognizable their icons are.
+- **Icon + label outperforms icon-only or label-only for first-time use.** The combination provides redundancy for the user to interpret.
+- **Icon-only outperforms icon + label for expert speed.** Once users have learned the icons, the label becomes redundant cognitive load.
+- **Color helps when the audience can perceive it.** Color-coded icon variants (a red trash for delete, a blue checkmark for confirm) improve recognition speed but fail for color-blind users without a non-color cue.
+- **Icon style consistency aids learning.** Mixed icon styles (some outlined, some filled, some skeuomorphic) are harder to learn than a coherent set.
+- **Domain-specific conventions are strong within the domain.** Code editors, design tools, music software, and other specialty applications have icon vocabularies that are nearly opaque to outsiders but immediately readable to insiders.
+
+## The accessibility dimension
+
+Icon-only interfaces present accessibility challenges:
+
+- **Screen readers** need text alternatives for icons (`aria-label`, alt text). An icon without text is invisible to non-sighted users.
+- **Low-vision users** may need larger icons or larger associated text.
+- **Cognitive accessibility** benefits from text labels because text disambiguates and slows down the requirement for fast pattern recognition.
+- **Cultural accessibility** can fail when icons reference objects unfamiliar to a user's culture.
+
+The accessibility considerations push toward icon+text for primary navigation and major actions, with icon-only reserved for compact contexts where space is genuinely scarce.
+
+## Modern conventions stabilizing in real time
+
+Some icon conventions are still actively stabilizing:
+
+- The "share" icon has multiple competing conventions (Apple's upward-arrow-from-box, Android's network-graph) that have not yet converged.
+- The "AI" icon is currently coalescing around a sparkle/star symbol, but variations exist.
+- The "voice input" icon has stabilized around a microphone but with various stylizations.
+- "Notifications" has converged on a bell across most platforms.
+
+When designing new icons, especially for new categories of function, you can sometimes contribute to which convention stabilizes. But more often, the safe path is to follow the dominant convention even if you have a design opinion.
+
+## Conventions that have faded
+
+Some conventions have actively faded over time:
+
+- The floppy disk for "save" — increasingly anachronistic for users who've never used floppies.
+- The mailing-envelope for "email" — recognized but losing strength as physical mail fades.
+- The CD/DVD icon for media — once standard, now mostly disappeared.
+- The wheel-knob for "tune" or "rotate" — depended on familiar physical knobs that have largely vanished.
+
+When a convention is fading, the safe path is to label the icon (or use a more current alternative) rather than relying on the dying convention.
+
+## Sources informing this principle
+
+- Peirce, C. S. (Late 19th century writings on semiotics; see *Collected Papers* vols. 2 & 4).
+- AIGA / U.S. DOT (1974). *Symbol Signs*.
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*.
+- Lodding, K. N. (1983). Iconic interfacing.
+- Norman, D. (1988). *The Design of Everyday Things*.
+- Horton, W. (1994). *The Icon Book: Visual Symbols for Computer Systems and Documentation*.
+- ISO 7001 and successor standards on public information symbols.
+- Modern platform icon guidelines (Apple SF Symbols, Material Symbols, Carbon Icons, etc.).

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-resemblance/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-resemblance/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: iconic-resemblance
+description: 'Apply iconic resemblance — designing or choosing icons that visually look like what they represent. Use when picking icons for actions or objects with strong visual referents (camera, clock, lock, calendar), evaluating whether a custom icon is communicating, or testing whether your icon set actually conveys meaning to your audience. Resemblance is the strongest form of icon recognition because it requires no prior learning; it fails when the function has no visual referent or when the audience doesn''t recognize the object being depicted.'
+---
+
+# Iconic Representation — resemblance
+
+Resemblant icons are those that visually look like what they represent. A camera icon for "take photo" — the shape literally depicts a camera. A clock icon for "time" — the shape depicts a clock. A folder icon for "folder" — the shape depicts a manila folder. The user understands what the icon means because it looks like the thing.
+
+This is the strongest form of icon recognition because it requires no prior learning. A user who has never seen the icon before but who has seen a camera in real life can interpret the camera icon. The work is done by the resemblance itself.
+
+## When resemblance works
+
+Resemblance works when:
+
+**The function or concept has a clear visual referent.** Camera (take photo), clock (time), envelope (email), magnifying glass (search/look closer), lock (security/private), trash can (delete), pencil (edit), calendar (date/schedule), star (favorite/rating), heart (like/love).
+
+**The referent object is universally familiar.** A camera is recognized worldwide. A clock is recognized worldwide. A trash can is recognized in most cultures (with regional variations in shape). A envelope is recognized in cultures that have postal systems.
+
+**The icon's level of abstraction matches the audience.** A photorealistic camera works for very literal contexts. A simple silhouetted camera works for general UI. A highly abstracted geometric "camera" may need to be tested to verify it still reads as a camera.
+
+**The space allows enough detail to be recognizable.** A camera icon needs enough detail (the body, the lens, perhaps a viewfinder or shutter) to be identifiable. At very small sizes, detail is lost and the icon becomes a generic blob.
+
+## When resemblance fails
+
+Resemblant icons fail when:
+
+**The function has no visual referent.** "Reset password," "compare versions," "advanced filters," "permissions." These abstract operations don't depict anything physical. Inventing an icon (a circular arrow for reset, two overlapping shapes for compare) becomes example-based or symbolic rather than truly resemblant, and recognition rates drop.
+
+**The referent isn't familiar to the audience.** A telegraph-machine icon for "send fast." A rotary-phone icon for "call." A typewriter for "writing." These references don't transfer to audiences who've never encountered the source.
+
+**The icon is too abstracted to read.** A "camera" rendered as just two concentric circles might still be a camera to the designer who knows the lineage, but to a fresh user it's just two circles. Test for the threshold of recognizability.
+
+**The icon is visually similar to other icons.** A camera and a video camera. A folder and a closed envelope. A pencil and a pen. When two functions have visually similar referents, the icons risk being confused.
+
+**The function is too specific for a general icon.** "Take HDR photo" doesn't have a distinct visual referent — both HDR and non-HDR photos use a camera. Resemblance bottoms out at the camera; further specificity requires text or a secondary symbol.
+
+## Designing resemblant icons
+
+When you're designing a new resemblant icon, a few practices help.
+
+**Pick the most identifying features of the referent.** A camera is identifiable by its body and lens — that's enough. Don't add a strap, a shutter button, an SD card slot. Each addition is detail that the user has to parse without adding recognition.
+
+**Stylize but stay readable.** The icon should be simplified enough to render clearly at icon sizes (16px–32px typical), but retain enough features to be unmistakable. Test at the actual rendering size, not just the design canvas.
+
+**Use silhouette over rendering.** A silhouette of a camera is more readable at icon sizes than a detailed perspective rendering. Silhouettes scale down better and read more quickly.
+
+**Consider the line weight of your icon set.** A camera icon outlined at 1.5px weight should match other icons in your set. Mismatched weights make icons look like they came from different libraries.
+
+**Test with users.** Show the icon at the rendering size, alongside other icons from your set, with no label. Ask users what they think it means. Anything below 80% recognition needs work or needs a label.
+
+## Worked examples
+
+### A camera icon
+
+A standard convention: a rounded rectangle (the camera body), a circle in the middle (the lens), a small square or dot at the top-left (the viewfinder or flash). Recognized worldwide. Works at sizes from 16px upward.
+
+Variants: a movie camera (with film reels on top, recognized as "video"), a film camera (with the film canister visible), a phone camera (with phone outline). Each conveys a more specific subtype.
+
+### A clock icon
+
+A standard convention: a circle with two hands (one short, one long) pointing at angles. Recognized worldwide. Works at very small sizes because the silhouette is distinctive.
+
+Variants: digital clock (rectangular with numeric digits), stopwatch (with crown and start button), alarm clock (with bells on top). Each conveys a more specific function.
+
+### A lock icon
+
+A standard convention: a stylized padlock with a U-shaped shackle on top. Recognized in cultures that use padlocks. Works at small sizes because the silhouette is distinctive.
+
+Variants: open padlock (unlocked), padlock with key (security/access), padlock with checkmark (confirmed lock).
+
+### A folder icon
+
+A standard convention: a manila-folder shape (a tab on top of a rectangle). Recognized in cultures with paper office filing systems — increasingly an acquired convention rather than a universal recognition. Works at small sizes.
+
+The folder convention is starting to weaken as paper folders fade from common workplaces. For some audiences (younger users, mobile-native users) the folder is now an acquired convention rather than a similar icon — they recognize it because they've seen it in software, not because it resembles an object they use.
+
+### A custom icon for "AI assistant"
+
+Initial design: a stylized neural-network diagram with three nodes connected by lines. Tested with users; recognition is 12%. Most users see "abstract geometric shape."
+
+Revised design: a sparkle or four-pointed star. Tested with users; recognition is now around 40%, and rising as the convention spreads.
+
+The lesson: there is no inherent visual referent for "AI assistant." The sparkle is becoming a symbolic convention (it works because users have started to associate it with AI features), not a similar icon. Similarity alone doesn't help here; the convention has to do the work.
+
+### A camera vs. video icon distinction
+
+Same product offers both photo and video capture. The icons are very similar (a camera body for photo; a camera body with film reels or a movie-camera form for video). The distinction is real but subtle, and users sometimes tap the wrong one.
+
+The fix is usually to make the difference more visually salient (a camera icon and a play-triangle for video, for instance) or to pair both with text labels.
+
+## Anti-patterns
+
+**Resemblance icons that don't actually resemble.** A custom icon designed to be "stylized" enough that it's no longer recognizable as the referent. The designer knows what it's meant to be; the user sees an abstract shape.
+
+**Decorative detail that obscures recognition.** A camera icon with a strap, lens cap, neck loop, brand logo, and shutter button — all the details add nothing and make the icon harder to read at small sizes.
+
+**Resemblance icons paired with similar resemblance icons that confuse.** A "camera" and a "video camera" icon that look nearly identical. Make the difference clear or pair with text.
+
+**Resemblance based on dying referents.** Icons resembling rotary phones, floppy disks, CRT TVs, mailing envelopes. The audience may not recognize the referent, in which case the resemblance does nothing.
+
+**Resemblance icons rendered inconsistently with the rest of the icon set.** A heavily-rendered photorealistic camera in a set of flat geometric icons. The visual mismatch suggests they came from different sources.
+
+## Heuristic checklist
+
+For each resemblant icon you're considering, ask: **Does my audience have a clear mental image of the referent?** If not, recognition will fail. **Does my icon depict the referent recognizably at the rendering size?** Test at actual size. **Is the icon visually distinct from other icons in my set?** Confused icons are worse than text labels. **Have I tested recognition with real users from my audience?** The designer's read is unreliable. **Does the icon's style match the rest of my set?** Coherence in style aids recognition.
+
+## Related sub-skills
+
+- `iconic-representation` — parent principle on iconic communication.
+- `iconic-arbitrary-and-symbolic` — sibling skill on convention-based icons.
+- `mimicry-surface` — resemblance icons are visual mimicry of the depicted object.
+- `mapping-cultural` — icon recognition is a form of cultural mapping.
+- `recognition-over-recall` — icons exploit recognition; this is the most direct form.
+
+## See also
+
+- `references/icon-design-process.md` — practical workflow for designing and testing resemblant icons.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-resemblance/references/icon-design-process.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/iconic-resemblance/references/icon-design-process.md
@@ -1,0 +1,137 @@
+# Resemblant icons — design and testing process
+
+A practical workflow for designing or selecting resemblant icons and verifying that they actually communicate.
+
+## Step 1: Identify the referent
+
+For the function the icon needs to communicate, identify the strongest visual referent. Some functions have an obvious referent:
+
+- Take photo → camera
+- View time → clock
+- Send email → envelope (or paper plane, depending on convention)
+- Search → magnifying glass
+- Lock / private → padlock
+- Edit → pencil
+- Calendar / scheduling → grid calendar
+- Delete → trash can
+
+Other functions have no strong referent:
+
+- Reset password
+- Compare versions
+- Refresh / reload
+- Sync
+- Share
+
+For the second group, you'll need to fall back on cultural conventions (a circular arrow for refresh, two arrows in a circle for sync) or on text labels. Don't try to invent a "similar" icon for these — invented similarity rarely transfers to users.
+
+## Step 2: Pick the most identifying features
+
+Real-world objects have many features; an icon needs to capture the few that make the object recognizable.
+
+For a camera:
+- Body (rectangular, often rounded corners): essential
+- Lens (circular, in the center or upper portion of the body): essential
+- Viewfinder, flash, or shutter button: optional decoration
+
+For a folder:
+- Tab on top: essential
+- Body of folder: essential
+- Closure mechanism, label area, papers inside: optional decoration
+
+For a clock:
+- Round face: essential
+- Two hands at angles: essential
+- Numbers, second hand, brand details: optional decoration
+
+The principle: include only what's needed for recognition. Strip everything else.
+
+## Step 3: Stylize for the icon system
+
+Match your set's visual language:
+
+- **Stroke weight:** all icons in a set should use the same stroke weight (typically 1.5px–2px for outlined icons at 24px size).
+- **Corner radius:** consistent across icons (sharp, slightly rounded, or fully rounded).
+- **Fill:** outlined or filled, but consistent within the set. Mixed fill styles look patched.
+- **Detail level:** all icons should have similar visual complexity. A highly detailed camera in a set of simple icons stands out as different.
+
+For most modern UI, the convention is:
+
+- 24px or 32px base size
+- Outlined or filled (pick one as primary)
+- 1.5px–2px stroke
+- Slight corner rounding (1px–2px)
+- Single color (uses currentColor in SVG, inheriting from the parent)
+
+## Step 4: Test at actual rendering size
+
+Designers often work at 100% zoom on a large monitor. Icons that look great at design size may be illegible at 24px or 16px in production.
+
+Render the icon at the actual sizes it will be used at. Look at it on the actual devices it will appear on. Verify that the recognizable features are still visible. If a camera icon at 16px just looks like a rounded rectangle (the lens has been lost), redesign with the smaller size in mind.
+
+## Step 5: Test with users
+
+Show the icon, alone or in context, to users from your actual audience. Ask: "What do you think this icon means?" Record the answers.
+
+A simple rubric:
+
+- 80%+ get it right with no label: icon is doing its job.
+- 60–80% get it right: probably needs a label, especially for first-time users.
+- Below 60%: the icon isn't communicating; needs redesign or label.
+
+Don't trust your own intuition about recognition — designers consistently overestimate.
+
+For specific testing, consider:
+
+- Showing the icon in isolation vs. in a row of similar icons (in-set recognition is harder than isolated).
+- Testing with users who haven't seen the product before (representative of new users).
+- Testing with users who've used the product (representative of expert users).
+- Testing across different audiences (older, younger, international).
+
+## Step 6: Pair with label when in doubt
+
+If recognition is borderline, or if the icon will be used infrequently, pair it with a text label. The pairing:
+
+- Costs space (more than icon alone).
+- Provides redundancy that catches users who don't recognize the icon.
+- Supports accessibility (screen readers and low-vision users).
+- Works well across audiences with different prior exposure.
+
+For primary navigation, major actions, and rarely-used functions, icon + label is usually the right default. Icon-only should be reserved for cases where space is genuinely scarce and the icon is unambiguous.
+
+## Step 7: Iterate based on production data
+
+Once shipped, monitor for signs that an icon isn't working:
+
+- Tooltip hover or long-press rates higher than expected.
+- Support questions about what the icon does.
+- Users clicking the wrong icon (visible in click data).
+- Users complaining in feedback channels.
+
+Any of these signals suggests the icon needs review. Either replace it with a more recognizable variant, add a label, or test alternatives.
+
+## Patterns that work well
+
+**Universal referents:** camera, clock, lock, envelope, magnifying glass. These work across most audiences with minimal stylization.
+
+**Domain-conventional referents:** specific icons within a domain (the diff icon in dev tools, the bezier-curve icon in design tools). Work well within the domain even if opaque outside it.
+
+**Stylized but distinctive silhouettes:** a icon doesn't have to look photorealistic to be recognizable; a clear silhouette of the referent is often enough.
+
+**Color reinforcing meaning:** a green checkmark, a red trash can, a blue calendar. Color adds a second layer of recognition (with accessibility caveats — color must not be the only cue).
+
+## Patterns that don't work
+
+**Overly stylized "modernized" icons** that abstract away the recognizable features.
+
+**Icons referring to objects outside the audience's experience** (typewriters, rotary phones, telegrams).
+
+**Icons designed for visual cohesion over communication** — a uniform-looking set where every icon is hard to tell apart.
+
+**Icons mixed with non-resemblant icons** in the same set without distinction. Users can't tell which icons they should recognize and which require prior learning.
+
+**Icons that rely on details too small to render** at production size.
+
+## Cross-reference
+
+For convention-based and arbitrary icons, see `iconic-arbitrary-and-symbolic`. For the parent principle, see `iconic-representation`.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model-mismatch-and-onboarding/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model-mismatch-and-onboarding/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: mental-model-mismatch-and-onboarding
+description: 'Use this skill when designing onboarding, when diagnosing why users keep getting confused, when migrating users from one product convention to another, or when the system genuinely differs from familiar comparable products. Trigger when the user mentions "users don''t get it," "we keep getting the same support tickets," or "this is a new pattern they need to learn." Sub-aspect of `mental-model`; read that first.'
+---
+
+# Mental-model mismatches and onboarding
+
+When the user's mental model and the system's actual behavior diverge, three things can be done: change the system to match the user's model; change the user's model through onboarding and teaching; or surface the divergence so the user knows when their model doesn't apply.
+
+## Diagnosing mismatches
+
+Common signals of mental-model mismatch:
+
+- **Repeated support tickets** about the same misunderstanding ("Why doesn't X work?" when X works fine — the user's expectation didn't match).
+- **Drop-off at the same flow step** (the user reached this step expecting one thing; got another; left).
+- **High undo / cancel rate** at a particular action.
+- **Forum / community questions** asking how to do things the system doesn't actually do.
+- **Negative reviews** mentioning unmet expectations.
+
+Each pattern points to a divergence between user model and system reality. The fix depends on which side to change.
+
+## Three fix strategies
+
+### 1. Change the system
+
+If the user's model is reasonable and many users share it, change the system to match. Often this is also the simpler design.
+
+Example: users expect "save" to commit immediately. If your system actually queues the save for later, either make save immediate or rename the action to reflect the actual behavior.
+
+### 2. Teach the model
+
+If the system's behavior is genuinely better and users can learn it, invest in onboarding.
+
+Examples:
+- Anti-lock brakes required teaching: "brake firmly, steer; don't pump." Manufacturer campaigns and driver-ed material taught the new model.
+- Spreadsheets taught a new computing model in the early 1980s; once learned, transferable.
+- Modal editors (vim) require learning that "modes" exist; users who learn become extremely productive.
+
+Onboarding that teaches a model:
+- **Walks the user through** the first task with explicit guidance.
+- **Provides explanation in context** — not a separate tutorial page.
+- **Shows the system's state** as actions happen, so the user observes the model.
+- **Uses progressive disclosure** of complexity over time.
+
+### 3. Surface the divergence
+
+When the system genuinely differs and you can't (or shouldn't) change the system, surface the difference at the moment it matters.
+
+Examples:
+- A "soft-deleted" item shows "Deleted (recoverable for 30 days)" — surfaces the system's actual model.
+- A subscription cancellation shows "Canceled — access continues until [date]" — surfaces what canceled actually means.
+- A search that ranks by relevance (not chronologically) shows "Sorted by relevance" — explains the unexpected order.
+
+The point is to expose the divergence at the moment of the action, not buried in documentation.
+
+## Onboarding patterns that teach mental models
+
+### Guided first task
+
+Walk the user through their first concrete task — not "here's a tour" but "let's create your first project."
+
+```html
+<aside class="onboarding-guide">
+  <h3>Let's create your first project</h3>
+  <p>1. Click the + button at the top right →</p>
+  <!-- The new-project button is highlighted; the user clicks; next step appears -->
+</aside>
+```
+
+Active practice teaches the interaction model better than passive watching.
+
+### Inline explanation at the moment of action
+
+When the user encounters a feature whose model differs from common expectations, explain in line:
+
+```html
+<div class="field">
+  <label for="visibility">Project visibility</label>
+  <select id="visibility">
+    <option value="private">Private (default)</option>
+    <option value="team">Team</option>
+    <option value="public">Public</option>
+  </select>
+  <p class="hint">
+    Private = only you. Team = everyone in your workspace. Public = anyone with the link.
+  </p>
+</div>
+```
+
+The explanation prevents knowledge mistakes by surfacing the actual model.
+
+### Progressive complexity
+
+Don't expose every feature on day one. Reveal them as the user encounters surfaces where they apply. The user's interaction model grows with their need.
+
+### "What's new" surfaces
+
+When you ship a feature whose model users wouldn't predict from prior versions, announce explicitly. A "what's new in v2" panel that explains how the new feature works, with brief examples, prevents widespread misunderstanding.
+
+## Anti-patterns
+
+- **Tour-only onboarding.** Walk the user through a passive demo. They forget within hours; their interaction model isn't reinforced.
+- **Documentation-as-onboarding.** "If you have questions, see the help center." Most users don't.
+- **Hidden divergences.** A system that differs from expectation but doesn't say so. Users assume; produce errors.
+- **Over-explanation in normal flows.** If you have to constantly explain how things work, the design isn't matching mental models well; redesign rather than over-tutorialize.
+
+## Heuristics
+
+1. **The "first surprise" diagnostic.** Watch a new user. Where do they say "huh, that's not what I expected"? Each surprise is a mental-model mismatch — fix the system or the surfaced model.
+2. **The support-ticket pattern audit.** Cluster recent support tickets by the misunderstanding behind them. Patterns reveal mismatches.
+3. **The cancel-rate signal.** Steps with high cancel rates often mean users reached them with the wrong expectation. Investigate.
+
+## Related sub-skills
+
+- **`mental-model`** (parent).
+- **`mental-model-system-vs-interaction`** — distinguishing the two model types.
+- **`expectation-effect`** — mental models *are* the user's expectations.
+- **`affordance`** — affordance teaches interaction models at the per-element level.
+- **`mimicry`** — borrowing familiar patterns leverages existing models.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model-mismatch-and-onboarding/references/onboarding-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model-mismatch-and-onboarding/references/onboarding-patterns.md
@@ -1,0 +1,35 @@
+# Onboarding patterns: reference
+
+A reference complementing `mental-model-mismatch-and-onboarding` with effective onboarding patterns.
+
+## Onboarding pattern catalog
+
+- **Guided first task**: walk the user through a concrete first task with explicit prompts. Active practice teaches better than passive watching.
+- **Empty-state guidance**: when the user lands on a blank surface, explain what it's for and offer one CTA.
+- **Coachmarks / tooltips**: contextual hints highlighting features as the user encounters them. Use sparingly to avoid tooltip fatigue.
+- **Checklist of first steps**: explicit "complete your setup" checklist that breaks initial onboarding into tractable chunks.
+- **Tour modes**: a guided tour through the interface. Useful for power tools; less useful for casual products.
+- **Sample data**: pre-populating with realistic example content lets the user explore before committing.
+- **Inline help**: persistent "?" or info icons next to ambiguous controls.
+- **What's new on first login**: brief callouts for new features users wouldn't predict from prior versions.
+
+## What works empirically
+
+NN/g and many other usability research orgs have studied onboarding. Recurring findings:
+
+- **Active beats passive.** Walking through a task beats watching a demo.
+- **In-context beats out-of-context.** Inline help beats a help center.
+- **Brief beats comprehensive.** Five steps the user can complete beats fifty steps they'll abandon.
+- **Skippable matters.** Returning users shouldn't re-encounter onboarding.
+
+## Anti-patterns
+
+- **Mandatory tutorial walls** that block product use until completed.
+- **Coachmark blizzards** that highlight every feature on first launch.
+- **Sample data the user can't delete** that clutters the workspace permanently.
+- **Onboarding that doesn't track completion** and re-shows steps the user already finished.
+
+## Resources
+
+- **NN/g articles on onboarding** — many practical findings.
+- **Samuel Hulick's UserOnboard.com** — case studies of real onboarding flows.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model-system-vs-interaction/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model-system-vs-interaction/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: mental-model-system-vs-interaction
+description: 'Use this skill when distinguishing the two mental-model types — system models (how the user thinks the system works) and interaction models (how the user thinks they should use it). Trigger when designing onboarding (which model to teach), reviewing user confusion (which model is wrong), or building documentation (which model to explain). Sub-aspect of `mental-model`; read that first.'
+---
+
+# System models vs. interaction models
+
+The book's distinction matters in practice because the two model types are formed differently and need different design responses.
+
+## System models
+
+How the user thinks the system works internally. Components, mechanisms, causal logic.
+
+Examples:
+
+- "The cloud" stores my files; they're somewhere on the internet.
+- "The recommendation algorithm" looks at what I clicked.
+- "Two-factor authentication" sends a code to verify it's me.
+
+System models are often inaccurate without consequence. Most users don't know how email actually routes (SMTP, MX records); their model — "I type address, click send, message arrives" — is sufficient. The system doesn't *need* an accurate user system model unless the user must reason about edge cases.
+
+When system models matter:
+
+- **Troubleshooting** — when something goes wrong, users with better system models recover faster.
+- **Privacy and security** — users with realistic models of how their data flows make better choices.
+- **Power use** — users with accurate models can use features beyond the basic.
+
+Designers tend to have rich system models (they built it); users tend to have simplified or wrong ones. The gap is acceptable up to a point.
+
+## Interaction models
+
+How the user thinks they should use the system. Actions, sequences, expected responses.
+
+Examples:
+
+- To save: Cmd-S or click File → Save.
+- To navigate: click links, use back button.
+- To delete: select item, press Delete or click trash icon.
+
+Interaction models are what designers must align to. A system whose interaction model the user can't form is unusable, regardless of how cleverly its system model is conceived.
+
+When interaction models matter:
+
+- **Always.** Every interaction is a moment when the user's interaction model is tested.
+- **Particularly** for first-use; subsequent use refines the model through experience.
+- **Critically** for destructive or irreversible actions.
+
+Users tend to have weak interaction models initially; with use, they accumulate accurate models through trial. Designers often have weak interaction models because they know "how it really works" rather than "how to use it." Bridging the gap requires user testing.
+
+## Asymmetry between designers and users
+
+The book makes this point compactly: designers tend to have complete system models but weak interaction models. Users have weak system models but, with use, develop accurate interaction models.
+
+The implication: designers can't infer the user's interaction model from their own. They must test with real users.
+
+## How to design for each
+
+### For system models
+
+- **Faithful system images** that surface the system's actual state.
+- **Conceptual onboarding** that teaches the model when accuracy matters.
+- **Documentation** that explains underlying mechanisms for users who care.
+- **Visualizations** of internal state when relevant (sync status, processing pipelines).
+
+### For interaction models
+
+- **Conventional patterns** so users transfer prior interaction models.
+- **Affordances** that signal what to do.
+- **Feedback** that confirms the action did what the user expected.
+- **Recovery** when the interaction didn't match expectation.
+
+## When to invest in which
+
+For most products, **interaction models** are the higher-priority investment. Most users don't need accurate system models; all users need accurate interaction models.
+
+Exceptions:
+
+- **Power-user tools** (developer tools, admin consoles) — power users benefit from system-model accuracy.
+- **Privacy-sensitive products** — users need to understand the system to consent meaningfully.
+- **Educational products** — teaching the system model is the point.
+
+## Worked examples
+
+### Example 1: a calendar app
+
+System model: events stored in a database; synced across devices via cloud.
+
+Interaction model: click date to create event; drag to move; click event to edit.
+
+Most users only need the interaction model. The system model can be opaque ("it just syncs"). Investment: interaction-model design and testing.
+
+### Example 2: a developer tool
+
+System model: code runs in a sandboxed environment; logs stream from server; deploys are versioned.
+
+Interaction model: type code in editor; click run; see output; click deploy.
+
+Power users (developers) benefit from the system model. Investment: both. The IDE's UI handles interaction; documentation, error messages, and visible state handle the system model.
+
+### Example 3: a privacy-affecting feature
+
+System model: data is shared with third parties for ad personalization.
+
+Interaction model: toggle in settings.
+
+Users *must* understand the system model to consent meaningfully. Investment: clear explanation of what the toggle actually does, in plain language, at the point of decision.
+
+## Anti-patterns
+
+- **Optimizing for system-model purity at the expense of interaction usability.** "Our metaphor is technically accurate but users can't find anything."
+- **Hiding the system model when users need it.** Privacy disclosures buried; sync status invisible; error messages that don't explain causes.
+- **Designer's interaction model substituted for user's.** Designers ship a clever flow that they themselves can navigate; users can't.
+
+## Heuristics
+
+1. **The "what model do users need?" check.** For each feature, ask: what does the user need to know about how this works (system) vs. how to use it (interaction)?
+2. **The user-test-vs-self-test.** Designers walking through their own design test the designer's model, not the user's. Watch real users.
+3. **The first-error analysis.** When a user encounters their first error, was it a system-model failure (they didn't know how it works) or interaction-model failure (they didn't know what to do)? Different fixes.
+
+## Related sub-skills
+
+- **`mental-model`** (parent).
+- **`mental-model-mismatch-and-onboarding`** — bridging the gaps when models diverge.
+- **`affordance`** — interaction models at the per-element level.
+- **`mimicry`** — borrowing models from familiar systems.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model-system-vs-interaction/references/two-models-research.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model-system-vs-interaction/references/two-models-research.md
@@ -1,0 +1,25 @@
+# System vs. interaction models: research reference
+
+A reference complementing `mental-model-system-vs-interaction` with research context.
+
+## The asymmetry between designers and users
+
+The book's central insight: designers tend to have rich system models (they built it; they know how it works internally) but weak interaction models (they don't experience the product as a first-time user does). Users tend to have weak system models (they don't know how the internals work) but, with use, develop accurate interaction models (they learn how to use it through practice).
+
+This asymmetry has implications:
+
+- **Designers can't infer user interaction models from their own.** Self-testing reveals the designer's interaction model, not the user's.
+- **User testing is essential** — the gap is invisible without it.
+- **Documentation written by designers** often emphasizes system-model accuracy; users would benefit more from interaction-model walkthroughs.
+
+## Research sources
+
+- **Norman, D.** "Some observations on mental models" in Gentner & Stevens (1983). The system-model / interaction-model distinction.
+- **Young, R. M.** "Surrogates and Mappings: Two Kinds of Conceptual Models for Interactive Devices" in Gentner & Stevens (1983). Distinguishes models of "what the device does" from models of "how to use it."
+- **Carroll, J. M.** Many works on minimalist instruction and how users develop interaction models through use.
+
+## Resources
+
+- Gentner, D. & Stevens, A. (eds.) *Mental Models* (1983).
+- Norman, D. *The Design of Everyday Things* (2013).
+- Carroll, J. M. *The Nurnberg Funnel* (1990).

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: mental-model
+description: 'Use this skill whenever the design will be used by people who bring prior expectations — which is essentially every design. Trigger when designing onboarding, when picking metaphors (folders, channels, projects), when reviewing why users keep getting confused, when migrating from one product convention to another, or when the user mentions "users don''t understand," "they keep doing X wrong," or "we''re inventing something new." Mental Model is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) and grounds most modern user-experience design.'
+---
+
+# Mental Model
+
+A mental model is the user's internal representation of how a system works. When the user's mental model matches the system's actual behavior, interaction is smooth — the user predicts correctly, takes the right actions, and recovers from problems easily. When the mental model diverges from reality, errors and confusion follow. The designer's job is to either build a system that matches the user's existing mental model, or build the system in a way that teaches an accurate model quickly.
+
+## Definition (in our own words)
+
+Every user comes to a design with assumptions about how it will work, drawn from prior experience: how computers behave, how websites navigate, how forms validate, how billing is structured. These assumptions form a mental model — a simplified representation that lets the user predict what will happen if they take a particular action. When the prediction matches reality, the design feels intuitive. When it doesn't, the design feels confusing — or worse, the user proceeds confidently and produces unintended results.
+
+The book distinguishes two complementary mental-model types: **system models** (how the user thinks the system works internally) and **interaction models** (how the user thinks they should interact with the system). Designers tend to have rich system models and weak interaction models; users tend to have weak system models and (with use) increasingly accurate interaction models.
+
+## Origins and research lineage
+
+- **Kenneth Craik**, *The Nature of Explanation* (Cambridge University Press, 1943). The foundational text — Craik proposed that humans build internal models of external reality and run those models to predict consequences. The basis for cognitive psychology's model-based reasoning.
+- **Philip Johnson-Laird**, *Mental Models* (Cambridge, 1983). Mental models as the unit of human reasoning.
+- **Donald Norman**, *The Design of Everyday Things* (1988, 2013). Brought mental models into mainstream design vocabulary. Norman distinguished the **designer's model** (what the designer intended), the **system image** (what the design actually presents), and the **user's model** (what the user infers from the system image). The designer's job is to make the system image clearly communicate the intended model.
+- **Lidwell, Holden & Butler** (2003) compactly distinguish system models from interaction models. The book's central case: anti-lock brakes whose interaction model differed from conventional brakes (don't pump; brake firmly and steer). Drivers using the wrong interaction model didn't get the safety benefit.
+- **D. Gentner & A. Stevens (eds.)**, *Mental Models* (Erlbaum, 1983). Collected research on how people form and use mental models.
+
+## The two model types
+
+### System models
+
+How the user thinks the system works — its components, its rules, its causal mechanisms. Examples:
+
+- "The cloud" stores my files; they're available from any device.
+- "Email" sends messages from my account to another account; once sent, gone.
+- "A folder" contains files; moving a file out of one folder puts it in another.
+
+System models can be wildly inaccurate without affecting the user. Most users don't know how email actually works (SMTP, MX records, queues); their model is "type address, click send, message arrives." That's enough.
+
+### Interaction models
+
+How the user thinks they should interact with the system. Examples:
+
+- To save: click File → Save (or press Cmd-S).
+- To unsubscribe from a mailing list: scroll to the bottom of the email and click "unsubscribe."
+- To recover a deleted file: open the trash and drag it out.
+
+Interaction models are what designers must align to. A perfectly-conceived system whose interaction model the user can't form is unusable.
+
+## When mental models matter
+
+- **Always**, but especially when:
+  - The product is new in its category (no established conventions).
+  - The product borrows from a familiar category but does something subtly different.
+  - The product's underlying mechanism differs from how the user imagines it ("soft delete" looks like "delete").
+  - Users come from a different product (migration: their model is from competitor X).
+
+## Strategies for working with mental models
+
+### Match the user's existing model
+
+If a familiar mental model exists, design to match it. Don't reinvent. Examples:
+
+- **Folder metaphor** for file systems — users from desktop computing transfer their model directly.
+- **Email metaphor** for messaging products — users from email transfer expectations about senders, recipients, threads.
+- **Shopping-cart metaphor** for e-commerce — users from physical retail transfer expectations.
+
+The trade-off: matching limits you to the existing model's shape. Sometimes the right design needs to break it.
+
+### Teach a new model when needed
+
+If your system genuinely differs, teach the model — through onboarding, through naming, through the system image:
+
+- **Antilock brakes** required teaching: "brake firmly and steer; don't pump." Posters, training, and visceral feel during practice all helped.
+- **Spreadsheets** taught a new computing model in the early 1980s; once learned, transferable across applications.
+- **Touch interfaces** taught new gestures (pinch-to-zoom, swipe) that users didn't have from prior interfaces.
+
+The investment in teaching pays off if the new model is genuinely better; it fails if the new model is just different.
+
+### Make the system image faithful
+
+Norman's three models (designer / system image / user) align only if the system image — what the user actually sees — clearly communicates the designer's intent. A system image that obscures the model produces user-model drift.
+
+Examples of faithful system images:
+
+- A "soft delete" that explicitly says "Moved to trash. Will be deleted in 30 days." User's model now matches reality.
+- An auto-save indicator that says "Saved 2 minutes ago" rather than vanishing once save completes. User knows the state.
+- A loading spinner with status text ("Authenticating..." → "Connecting to server..." → "Loading your data..."). User's model of the process is faithful to what's happening.
+
+## When mental models break
+
+The classic break case: a feature whose interaction model differs from a similar-looking feature.
+
+- **Anti-lock brakes** — the book's example. Drivers had the conventional-brakes model (pump on slick surfaces); ABS requires the opposite (brake firmly, steer). Drivers using the wrong model didn't get the safety benefit; sometimes worse, drivers were misled by ABS into believing they could drive faster on slick surfaces.
+- **Find-and-replace dialogs** that match across or within documents inconsistently — users expect one behavior, get another.
+- **Trash-emptying schedules** — users believe deleted is gone; some systems retain for 30 days; some indefinitely; users don't know.
+
+When the system's behavior departs from the user's model, surface the difference explicitly.
+
+## Worked examples
+
+### Example 1: building on a familiar model
+
+A new project-management tool uses Kanban boards (familiar from Trello, physical sticky-note boards). Users transfer their model: columns are statuses, cards are tasks, dragging changes status. Onboarding is light because the model is mostly already there.
+
+### Example 2: teaching a new model
+
+A code-collaboration tool (Git) introduces concepts (commits, branches, merges, conflicts) that don't exist in the prior file-editing model. Onboarding explicitly teaches:
+- "A commit is a snapshot of your code at a point in time."
+- "A branch is a parallel line of work."
+- "Merging combines two branches; conflicts arise when they touch the same lines."
+
+Without this teaching, users from a Word-document model misunderstand and produce unintended states.
+
+### Example 3: revealing the system model when it diverges
+
+A SaaS product uses soft-delete: users delete an item; it goes to a trash that's purged after 30 days. The user's model from desktop computing is "deleted = gone immediately." The product surfaces the difference:
+
+```
+"Project archived. It will be permanently deleted in 30 days. [Restore] [Delete now]"
+```
+
+Now the user's model includes the recovery window. They can trust their actions.
+
+### Example 4: aligning the interaction model with the user's stated goal
+
+A user wants to "share a document with my team." The interaction model in many products is: change permissions on the document, then send a link. A simpler interaction model: "Share with team" button that does both at once.
+
+The simpler model maps closer to the user's goal-level thinking; the user doesn't have to think about permissions and links separately.
+
+### Example 5: when the system surprises
+
+A user clicks "Cancel subscription." The system says "subscription canceled — you'll be downgraded at the end of the billing period." The user's model was "canceled = no longer charged." The system's model was "canceled = no future renewals; current period continues."
+
+Either model is defensible; the divergence is the issue. Surface the actual behavior at the moment of action.
+
+## Cross-domain examples
+
+### Technology adoption: ATMs
+
+Early ATMs (1960s–80s) had to teach a new mental model — a bank machine that dispensed cash without a teller. Banks invested heavily in education; users initially distrusted; gradually the model became standard. Now it's invisible.
+
+Modern parallel: contactless payment (NFC). The mental model "tap to pay, no signature, no physical card insertion" took years to spread; now it's standard.
+
+### Anti-lock brakes (the book's case)
+
+ABS provided a measurable safety improvement in controlled tests. In real-world driving, the improvement was much smaller — because drivers used the wrong interaction model (pumping the brakes). Manufacturer campaigns to teach the new model ("brake firmly and steer") closed the gap partly.
+
+The lesson: technical superiority doesn't translate to real-world benefit if the interaction model doesn't transfer.
+
+### Cooking: induction stovetops
+
+Induction cooktops behave differently from gas or resistive electric. They heat the pan, not the air; they don't glow red; turning off "stops" the heat almost instantly. Users from gas/electric models often misjudge — leaving pans on a "hot" surface that's already cooled, or turning up heat further because the pan isn't visibly responding.
+
+Induction-cooktop manufacturers add visible cues (glowing rings, residual-heat indicators) to bridge the model gap.
+
+## Anti-patterns
+
+- **Inventing metaphors no user has ever encountered.** "Wisdom Pods" or "Synergy Spaces" sound clever; they don't transfer.
+- **Borrowing a familiar metaphor for behavior that doesn't match it.** A "trash" that empties silently; a "save" that auto-syncs in real-time without the user seeing.
+- **System images that obscure system behavior.** Loading screens that don't say what's happening; "Save" buttons that may or may not commit; opaque pricing.
+- **Onboarding that's just a tour.** Watching a feature demo doesn't teach a model as well as guided practice.
+- **Inconsistency that breaks the learned model.** "Save" works one way in one section; differently elsewhere.
+
+## Heuristics
+
+1. **The "what model are users bringing?" check.** Before designing, name the prior product/category your users are likely coming from. Their model from there transfers — partially.
+2. **The mental-model-mismatch audit.** When users report confusion, ask: what model do they have? What model does the system actually have? The gap is the design opportunity.
+3. **The first-use walkthrough.** Watch a new user. Where they're confused or surprised is where their model diverged from the system.
+4. **The system-image check.** What does the system actually show the user? Does it accurately reflect the underlying behavior? If yes, models stay aligned. If no, mistakes follow.
+
+## Related principles
+
+- **`affordance`** — affordance signals interaction models at a per-element level.
+- **`mapping`** — control-effect relationships are part of the interaction model.
+- **`expectation-effect`** — expectations come from mental models.
+- **`mimicry`** — borrowing recognizable patterns leverages existing models.
+- **`consistency`** — consistency lets users transfer one part of the model to another.
+- **`recognition-over-recall`** — recognition is faster when it matches a learned model.
+- **`errors`** — mistake-type errors flow from wrong models.
+
+## Sub-aspect skills
+
+- **`mental-model-system-vs-interaction`** — distinguishing the two model types and choosing which to optimize for.
+- **`mental-model-mismatch-and-onboarding`** — diagnosing model mismatches and designing onboarding that teaches the right model.
+
+## Closing
+
+Mental models are the substrate of intuitive design. Users don't experience the system you built; they experience the model they have of the system. When the two align, your work becomes invisible — users just *use* it. When they diverge, every other design move is fighting an undertow. Building the system image so that users can form a faithful model is the deepest design discipline.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model/references/research-and-norman.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mental-model/references/research-and-norman.md
@@ -1,0 +1,50 @@
+# Mental models: research and design history
+
+A reference complementing the `mental-model` SKILL.md with deeper grounding.
+
+## Foundational research
+
+- **Kenneth Craik**, *The Nature of Explanation* (Cambridge, 1943). Proposed that humans build internal models of external reality and reason by running simulations on those models.
+- **Philip Johnson-Laird**, *Mental Models* (Cambridge, 1983). Mental models as the unit of human reasoning; demonstrated through deductive-reasoning experiments.
+- **D. Gentner & A. Stevens (eds.)**, *Mental Models* (Erlbaum, 1983). Collected research on how mental models form, change, and influence behavior.
+- **Donald Norman**, "Some Observations on Mental Models" in Gentner & Stevens (1983); *The Design of Everyday Things* (1988, 2013). Translated mental-model research into design vocabulary.
+
+## Norman's three-model framework
+
+Norman distinguishes:
+
+- **The designer's model**: what the designer intended the product to be.
+- **The system image**: what the product actually presents to the user (UI, documentation, packaging, marketing).
+- **The user's model**: what the user infers from the system image.
+
+The designer can't communicate the designer's model directly — only through the system image. The user can't perceive the designer's model directly — only through the system image. The system image is the entire bandwidth between designer and user.
+
+If the system image is faithful, the user's model approaches the designer's model and use is smooth. If the system image is ambiguous or misleading, the user's model diverges and confusion follows.
+
+The implication: design *the system image* deliberately. Every visible element communicates something about the designer's model; if it's not the right thing, it's the wrong thing.
+
+## Cross-domain examples
+
+### Anti-lock brakes (the book's case)
+
+ABS interaction model differs from conventional brakes. In controlled tests with trained drivers, ABS reduces accidents measurably. In real-world driving, the gain has been smaller — because many drivers use the conventional-brakes interaction model (pumping). Some drivers also adjust by driving more aggressively in poor weather, partly canceling the safety benefit (a positive feedback loop).
+
+The system image (the brake pedal) doesn't communicate the difference. Drivers' mental models don't update from prior driving experience without explicit teaching.
+
+### Cars: the steering-by-leaning Segway
+
+The Segway's interaction model — lean forward to go forward — differs from any prior personal-transportation interaction. Riders need explicit teaching ("don't think; lean") and practice. The system image (a vertical column with handlebars) doesn't communicate the model; teaching does.
+
+### Software: the desktop metaphor
+
+The desktop metaphor (folders, files, trash) borrows from physical office-worker experience. Users from that background transferred their interaction model directly. Younger users without that background (smartphone-first) sometimes struggle with the metaphor — folders are foreign.
+
+The lesson: model-borrowing works best when the borrowed-from population includes the user. New populations may need different models.
+
+## Resources
+
+- **Craik, K.** *The Nature of Explanation* (1943).
+- **Johnson-Laird, P.** *Mental Models* (1983).
+- **Norman, D.** *The Design of Everyday Things* (1988, 2013).
+- **Gentner, D. & Stevens, A. (eds.)** *Mental Models* (1983).
+- **Tognazzini, B.** "First Principles of Interaction Design" — discusses mental models in HCI design.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry-behavioral/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry-behavioral/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: mimicry-behavioral
+description: 'Apply behavioral mimicry — making an interface element behave like a familiar physical object so the user''s physical-world intuitions transfer to the digital interaction. Use when designing gestures, animations, transitions, drag-and-drop, scroll behaviors, or any interaction where physical-world analogies could clarify the experience. Behavioral mimicry is more durable than visual skeuomorphism — physics-mimicking behaviors age well — but it requires deliberate calibration: too much physical fidelity slows the interaction down without communicating anything new.'
+---
+
+# Mimicry — behavioral
+
+Behavioral mimicry is making an interface element act like its physical analog. The springy bounce when a list reaches its end (Apple's "rubber band" scrolling). The page-turn animation in an e-reader. The drag gesture that follows your finger with apparent weight. The sliding panel that comes in from the right side of the screen. Each borrows physical-world physics or motion to make the digital interaction feel grounded.
+
+Behavioral mimicry is often subtler than surface mimicry but more durable. The page-turn animation doesn't depend on the e-reader looking like a book; it just needs to feel like turning. The rubber-band scroll doesn't need a leather binding to work; the physical metaphor (an elastic that resists past its limit) carries on its own.
+
+## Why behavioral mimicry matters
+
+The user's physical intuitions are a vast, free knowledge resource. They know that when you push something it moves; when you pull, it comes toward you; when you let go, gravity affects it; when something is heavy, it accelerates slowly; when it's light, it's easy to flick away. An interface that exploits these intuitions feels natural without requiring instruction.
+
+A list that scrolls smoothly with momentum (continues moving briefly after the finger lifts, gradually slowing as if to friction) is doing physical-mimicry work: it behaves like a sheet of paper would if you flicked it. Users have no trouble understanding the behavior because they've been flicking paper for years.
+
+Without the physics, the same scroll would feel mechanical and computer-like. With the physics, it feels organic. The work the user's brain does to predict the next position of the list is almost zero.
+
+## Where behavioral mimicry is most useful
+
+Behavioral mimicry pays off most clearly in:
+
+**Gesture design.** Gestures are inherently invisible (you can't see what gestures are available the way you can see buttons), so users rely heavily on physical analogies to predict what gestures will do. Pinch-to-zoom mimics stretching fabric; swipe-to-dismiss mimics flicking a card aside; drag-to-rearrange mimics moving objects on a desk.
+
+**Scroll and panning behavior.** Smooth momentum scrolling, edge-of-list bounce, pinch-to-zoom on a canvas — all behavioral mimicry of physical sheets and surfaces.
+
+**Drag and drop.** The visual element follows the cursor with apparent weight; it can be dropped onto valid targets; it returns to its origin if dropped on an invalid target. All physical mimicry.
+
+**Modal entry and exit.** Modals that slide in from the bottom (mimicking a card being placed on top), drawers that slide in from the side (mimicking a panel sliding open), dialogs that fade in (a softer, less physical metaphor) all set different expectations through their entry behavior.
+
+**Animations between states.** When the UI changes state — an item gets selected, a panel expands, a chart updates — the in-between motion should follow physical intuitions. Things should accelerate from rest, decelerate as they approach their target, and arrive smoothly.
+
+## Calibrating physical fidelity
+
+The temptation with behavioral mimicry is to maximize physical fidelity. Real-world physics, after all, is universally understood. But maximum fidelity is rarely the right answer.
+
+**Too much fidelity slows down the interaction.** A list that scrolls with realistic friction takes seconds to come to a stop. A page-turn animation that mimics actual paper takes hundreds of milliseconds. For frequent interactions, the physical fidelity becomes a tax that frequent users pay over and over.
+
+**Too much fidelity reveals the artifice.** A "heavy" object that doesn't actually have inertia, or a fake-3D button that doesn't depress correctly, draws attention to the imperfection. Maximum fidelity is judged against an impossibly high standard.
+
+**Too little fidelity feels mechanical.** A list that snaps to position when the finger lifts. A modal that appears instantly with no transition. A drag-and-drop where the dragged item teleports to the cursor. Each lacks the organic feel that even minimal physical mimicry would provide.
+
+The sweet spot is usually somewhere in the middle: enough physical mimicry to feel natural, not so much that the interaction is slowed by it. Industry standard timings — 150ms for micro-interactions, 250–300ms for transitions, 400–500ms for major state changes — are calibrated to this sweet spot.
+
+## Worked examples
+
+### Apple's rubber-band scroll
+
+When a list is scrolled past its end on iOS, the content "stretches" past the boundary and then snaps back. This is behavioral mimicry of an elastic surface: the user pulled past where the content ends, and the content's elasticity returns it to position.
+
+The mimicry serves a function beyond aesthetics: it clearly communicates "you've reached the end" by allowing the user to feel the boundary rather than just hitting a hard stop. The user knows immediately that there's no more content because they felt the resistance.
+
+This is one of the most-imitated behaviors in modern UI — copied across platforms — because the physical intuition transfers so cleanly.
+
+### A page-turn animation in an e-reader
+
+Many e-readers offer a page-turn animation that mimics flipping a paper page: the leading edge curls, the page rotates around an invisible spine, the next page is revealed underneath. The mimicry is rich.
+
+For new users, the mimicry is welcoming and reassuring — the experience feels like reading a book. For frequent users, the mimicry becomes a small tax: each page turn takes 200ms or more that a snap transition would not. Most modern e-readers offer the page-turn as an option but default to snappier transitions; the mimicry is appreciated occasionally and skipped during active reading.
+
+### Drag-to-rearrange behavior
+
+In a list with reorderable items, when the user picks up an item and moves it, the item follows the finger with a slight scale and shadow (suggesting physical lifting). Other items in the list shift to make space as the dragged item passes over them. When dropped, the item settles into its new position with a brief animation.
+
+All of this is behavioral mimicry: lift, weight, displacement, settle. The user's physical intuitions about moving objects in space transfer directly. The result feels natural.
+
+The failure mode would be a drag interaction where the item teleports between positions, or the other items don't move, or the drop happens with no transition. Each violation makes the interaction feel mechanical.
+
+### Modal entry from the bottom
+
+A bottom-sheet modal slides up from the bottom edge of the screen, decelerating as it approaches its target position. The user perceives it as a card being lifted into view from below. They understand intuitively that the gesture to dismiss is to slide it back down.
+
+Compare to a modal that appears instantly in the middle of the screen with no transition. The user can't predict how to dismiss it (where does it go when dismissed?) and the appearance is jarring.
+
+### Skip-button that doesn't mimic anything physical
+
+Some UIs use animations that don't correspond to any physical behavior — a button that pulses, a card that wobbles, a notification that flips in three dimensions. These can be charming but they're not mimicry; they're just animation. The user's understanding of the interaction doesn't transfer from physical experience because the behavior doesn't match anything physical.
+
+This isn't necessarily wrong — non-mimicking animation can be useful for attention or delight — but it's not behavioral mimicry. Be honest about which one you're doing.
+
+## Anti-patterns
+
+**Behavioral mimicry that conflicts with surface mimicry.** A button that looks like a flat shape but bounces around when clicked like a physical object. The visual treatment doesn't predict the behavior.
+
+**Fidelity that costs speed.** Page-turn animations that take half a second on every page; modal transitions that take a full second to complete; scroll friction that lasts after the finger lifts for too long. Frequent interactions need to be quick; reserve high-fidelity behavior for occasional interactions.
+
+**Inconsistent behavioral physics.** Some animations follow ease-out curves, others ease-in-out, others linear. Some interactions have momentum; others snap. Without consistency, the user can't form expectations about how the interface will behave.
+
+**Behaviors that mimic obsolete physics.** A skeuomorphic phone-dial-pad that requires you to "rotate" each digit. The behavioral mimicry is a perfect simulation of an interaction nobody under fifty has ever performed. The mimicry doesn't transfer because the source isn't familiar.
+
+**Overdone physical effects.** Particle bursts, shimmer effects, exaggerated bounces that have no physical analog but are decorative. These can be charming in moderation; in excess they make the interface feel toy-like and slow down frequent interactions.
+
+**Mimicry of impossible physics.** Gestures that require movements people can't easily perform, animations that violate basic physical intuitions (objects accelerating to a stop in zero distance, things teleporting through other things). Users sense the wrongness even when they can't articulate it.
+
+## Heuristic checklist
+
+Before designing a behavior, ask: **Is there a physical analog the user already knows?** If yes, mimicking it gives you free understanding. **What level of fidelity is appropriate for how often this interaction will happen?** Frequent: low fidelity, fast. Occasional: more fidelity is acceptable. **Does my physical mimicry follow physics consistently?** Inconsistent physics breaks the mimicry. **Is my physical mimicry predicting the affordance correctly?** A bounce should suggest something elastic; a slide should suggest sliding; a fade should suggest appearing/disappearing — not random animation choices. **Will the mimicry feel slow on the hundredth use?** If yes, calibrate it down or make it skippable.
+
+## Related sub-skills
+
+- `mimicry` — parent principle on the strategy of borrowing from the familiar.
+- `mimicry-surface` — sibling skill on visual mimicry.
+- `feedback-loop-states-and-latency` — animation timing as feedback design.
+- `affordance` — physical mimicry sets affordances by inheriting them from the source.
+- `mapping-natural` — physical mimicry is one form of natural mapping.
+
+## See also
+
+- `references/animation-timing.md` — practical guidance on calibrating physical fidelity through animation timing.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry-behavioral/references/animation-timing.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry-behavioral/references/animation-timing.md
@@ -1,0 +1,103 @@
+# Behavioral mimicry — animation timing
+
+Practical guidance on calibrating the timing and physics of animations so they mimic physical behavior helpfully without slowing the interaction down.
+
+## Standard timings
+
+A useful starting set, drawn from years of platform design guidelines (Apple, Google, etc.):
+
+- **Micro-interactions: 100–200ms.** Button hover, focus state, small color shifts. Fast enough that users don't perceive a delay.
+- **State transitions: 200–300ms.** Panel expansion, tab switch, modal appearance. Long enough to communicate the transition; short enough to not slow frequent interactions.
+- **Major state changes: 400–500ms.** Full-screen transitions, navigation between sections. Long enough for the user to track what changed.
+- **Page-level transitions: 500–800ms.** Loading states, route changes. Reserved for less-frequent interactions where the user benefits from clear acknowledgment.
+
+These are starting points, not absolutes. Specific products may need different timing based on the audience, the frequency of interaction, and the device class.
+
+## Easing curves
+
+The shape of the animation matters as much as its duration.
+
+- **Linear:** moves at constant speed. Feels mechanical; rarely the right choice for physical mimicry.
+- **Ease-in:** starts slow, accelerates. Mimics objects starting from rest.
+- **Ease-out:** starts fast, decelerates. Mimics objects coming to a stop. Often the most "natural" feeling for UI transitions.
+- **Ease-in-out:** slow at both ends, fast in the middle. Mimics objects in transit between stable positions. Standard for many UI transitions.
+- **Spring/bounce:** overshoots the target slightly and settles back. Mimics elastic or playful behavior. Used for emphasis or for explicitly-physical metaphors (rubber-band scroll).
+
+Pick a small set of curves and apply them consistently. Inconsistent easing is one of the easiest signs of an under-designed motion system.
+
+## Physical metaphors and their timing
+
+Different physical metaphors call for different timings.
+
+**Falling/dropping:** ease-in (gravity accelerates). Brief — physical objects fall quickly. 200–300ms.
+
+**Sliding (low friction):** ease-out (object slides and decelerates). 250–400ms depending on distance.
+
+**Sliding (high friction):** linear or ease-in (object resists motion). Slower, 400–600ms. Use for "heavy" interactions where the user should feel the weight.
+
+**Bouncing/elastic:** spring with some overshoot. 300–500ms total, with the overshoot being a small fraction.
+
+**Rotating:** linear or ease-in-out depending on the metaphor. Wheels and dials usually have momentum (ease-out); fixed rotations (page-turn) usually use ease-in-out.
+
+**Fading:** linear or ease-out. Fades are often ambient and shouldn't draw attention to themselves; linear is fine.
+
+## Pacing for repeated interactions
+
+The most important calibration question: how often will this interaction happen?
+
+For interactions a user will perform many times per session (sending a message, scrolling a list, switching tabs), the animation should be short — under 200ms ideally, and certainly under 300ms. Even tiny delays accumulate over hundreds of interactions per session.
+
+For interactions performed occasionally (opening a settings panel, switching pages, completing a checkout), the animation can afford to be longer — up to 500ms or more — because the cost is paid once and the additional clarity may be worth it.
+
+For interactions performed rarely (onboarding, completing a major milestone), the animation can be much longer (500ms to 2s) and can include richer choreography because the moment deserves emphasis.
+
+## When animation is too slow
+
+Signs that animations are slowing the interaction down:
+
+- Users complain about the product "feeling slow" even when measured task times are fast.
+- Users develop habits like clicking the same button twice (because the first click's animation made them think nothing happened).
+- Power users ask for an option to disable animations.
+- Heavy users start using keyboard shortcuts to bypass UI animations.
+
+If you see these signs, audit your animation timing. Cutting all animations by 30% often produces dramatic perceived-speed improvements with no loss of clarity.
+
+## When animation is too fast
+
+Signs that animations are too snappy:
+
+- Users miss state changes (didn't notice the panel opened).
+- Users think the system did the wrong thing because they didn't see the transition.
+- Users have trouble tracking what changed during major state shifts.
+
+If you see these signs, the animations need to slow down enough to be perceived. The fix is usually adding 100–200ms to specific transitions, not all of them.
+
+## Reduced motion
+
+Many users have accessibility settings for reduced motion (avoiding triggering vestibular issues or simply preferring less animation). Honor these settings: when reduced motion is requested, replace bounce/spring/elaborate transitions with simple fades or instant changes.
+
+The reduced-motion path should still be considered designed, not just "no animation." A clean fade conveys state change clearly; an instant snap with no transition can be jarring.
+
+## Anti-patterns
+
+**Same timing for everything.** Picking 500ms as the global animation timing and applying it to micro-interactions, transitions, and major state changes alike. Frequent interactions feel slow; rare ones feel rushed.
+
+**Inconsistent easing.** Some animations are ease-out, others spring, others linear, with no apparent pattern. The motion system feels patched together.
+
+**Overlapping animations that compound.** Multiple animations triggered in close succession that all run on top of each other, creating visual chaos. Sequence them or simplify.
+
+**Animations that aren't interruptible.** A 500ms transition that locks user input until it completes. Frequent users get frustrated by being unable to act during the animation. Animations should generally be interruptible — if the user clicks something else mid-animation, the previous animation should snap to its end and the new one should begin.
+
+**Bouncing things that don't need to bounce.** Spring/bounce animations are fun in moderation but visually noisy in excess. Reserve them for moments that warrant emphasis.
+
+**Ignoring reduced-motion preferences.** Users who've set accessibility preferences shouldn't be forced through your animations. Honor the settings and provide a designed experience for the reduced-motion path.
+
+## Test pattern
+
+Record your interface during normal use. Watch the recording at 0.5x speed. Are there animations that are unnecessarily long? At 2x speed, do you miss transitions? The right calibration is somewhere in between.
+
+Then have someone use the product who hasn't seen it. Watch their face. If they're squinting or pausing during transitions, things may be too slow. If they're clicking the same button twice or asking what happened, things may be too fast.
+
+## Cross-reference
+
+For the parent principle on mimicking physical behavior, see `mimicry-behavioral`. For animation as feedback design, see `feedback-loop-states-and-latency`.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry-surface/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry-surface/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: mimicry-surface
+description: 'Apply surface mimicry — making an interface element look like a familiar physical object to communicate its purpose at a glance. Use when introducing a control or container that has no native UI vocabulary, designing a niche product that benefits from a recognizable visual reference (a journal that looks like a journal, a wallet that looks like a wallet), or evaluating whether visual skeuomorphism is communicating or just decorating. Surface mimicry is most useful for novice users in unfamiliar mediums; it becomes anachronistic as the source fades or as users learn the abstract conventions.'
+---
+
+# Mimicry — surface
+
+Surface mimicry is the visual layer of mimicry: an interface element rendered to look like a physical object. The fake-leather Calendar app of iOS 6, the legal-pad Notes app, the brushed-aluminum desktop widget — all are surface mimicry. The element behaves like a digital control, but the visual treatment communicates "this is the digital version of [thing]."
+
+The strength of surface mimicry is recognition. A user looking at a fake-leather journal app immediately understands they're meant to write personal entries in it. They don't need a label; the visual reference does the work.
+
+The weakness is that visual references age quickly. The leather-bound journal looked premium in 2010 and looks dated in 2026. The brushed-aluminum panel signaled "professional audio gear" in 2008 and signals "outdated software" today. Surface mimicry has a shelf life that depends on the source's continued relevance.
+
+## When surface mimicry is the right tool
+
+Surface mimicry is most valuable when:
+
+**The user has no other reference for what the thing is.** A novel category of tool, an experimental interaction model, a unique form factor. Surface mimicry of a familiar physical object can be the fastest way to establish a mental model.
+
+**The audience genuinely knows the source.** A journal app for adults who write in paper journals: leather-bound visual references work. A journal app for teenagers who've never owned a paper journal: the same references read as "Grandma's app."
+
+**The visual reference adds emotional or aesthetic value.** A meditation app that looks like a Zen garden. A reading app whose pages have a subtle paper texture. The mimicry isn't strictly functional but contributes to the desired emotional register.
+
+**The product is targeting a niche where the source is part of the identity.** A music-production app for vintage-synth enthusiasts can lean into hardware-mimicking knobs and faders because the audience values that aesthetic. The same mimicry in a general-audience tool would alienate users.
+
+## When surface mimicry is the wrong tool
+
+Surface mimicry becomes a liability when:
+
+**The audience doesn't know the source.** Mimicking analog audio gear for users who've never used analog audio gear teaches nothing. The visual reference is just decorative.
+
+**The mimicry suggests limitations the digital version doesn't have.** A fake-paper interface that doesn't support search, formatting, or sharing. Users primed by the visual to expect paper-like limitations may not discover the digital affordances.
+
+**The source has faded from common experience.** Floppy disks, CRT televisions, tape cassettes, rotary phones. References that were universal in one decade may be unfamiliar a decade later.
+
+**The mimicry creates accessibility problems.** Heavy textures, decorative typography, low-contrast skeuomorphic styling — all can hurt readability, screen-reader compatibility, and accessibility for users with vision differences. Decorative mimicry that compromises function is the wrong tradeoff.
+
+**The mimicry conflicts with brand or platform conventions.** A skeuomorphic app on a flat-design platform feels foreign. Heavy visual decoration may conflict with the brand's broader aesthetic.
+
+## Layers of surface mimicry
+
+Surface mimicry runs from very literal to very abstract. The layers carry different costs and benefits.
+
+**Photorealistic.** Detailed rendering of textures, lighting, materials — the calendar that looks like real torn paper, the journal with stitched leather. Highest recognition impact, highest aesthetic risk, shortest shelf life.
+
+**Stylized.** A simplified visual reference — the calendar that has paper-edge serration but isn't trying to be photorealistic. Moderate recognition, more durable visually.
+
+**Iconic.** A schematic reference — a simple folder icon that just suggests a folder. Low decoration cost, often the right level for ongoing UI elements.
+
+**Symbolic only.** A label or word with no visual reference at all. No mimicry, just naming. Often the right choice for established conventions where the reference no longer needs visual reinforcement.
+
+The flat-design movement of the 2010s pushed most UI to "iconic" or "symbolic only" — mimicry became simpler and more abstract while preserving the underlying metaphors. This is where most interfaces sit today.
+
+## Worked examples
+
+### A reading app
+
+An e-reader app uses subtle surface mimicry: a slight off-white "paper" background, a serif typeface in a comfortable line length, the page-turn animation when navigating. The mimicry is restrained — no fake leather binding, no torn-paper edges, no shadow effects suggesting depth. Just enough to evoke the reading experience.
+
+The mimicry helps users settle into a reading mindset. It doesn't try to be a paper book — it's recognizably a digital reading experience, with search, lookup, and adjustable text. The mimicry contributes to the emotional register without locking the experience into paper limitations.
+
+### A music app that over-mimics
+
+A music app for casual listeners is rendered to look like a vintage tape deck: cassette graphics, fake LCD displays, simulated spinning reels. The audience — people in their 20s and 30s — has rarely used cassettes. The visual references don't communicate; they're decorative kitsch. Users are mildly amused on first launch and indifferent thereafter.
+
+Worse, the cassette metaphor implies limitations: linear playback, fast-forward and rewind, side A and side B. Users wonder if the app supports modern features (playlists, shuffle, smart queues) because the visual tells them not to expect those.
+
+The fix would be to abandon the cassette mimicry in favor of modern abstract conventions (a play button, a queue, a visual representation of audio waveforms or album art) that don't carry obsolete affordance limitations.
+
+### A journal app that gets it right
+
+A journal app for adults who keep written journals uses moderate surface mimicry: an off-white paper background, a generous serif typeface, a single elegant cursor. No fake leather, no stitching, no shadow rendering. Just enough to evoke the feeling of writing in a personal journal.
+
+The mimicry is age-appropriate (adults who keep journals know what paper journals look and feel like) and tasteful (the visual reference doesn't shout). And the app extends paper's affordances: encrypted storage, cross-device sync, search across entries.
+
+This is surface mimicry done well: it sets the emotional register without being decorative kitsch and without limiting the digital affordances.
+
+### A productivity tool with no surface mimicry
+
+A modern productivity tool uses no surface mimicry at all. Buttons are flat rectangles with brand color. Cards are plain containers with shadow only when elevated. The interface looks "computer-native" — no attempt to mimic physical objects.
+
+This works because the underlying metaphors (folders, files, shared workspaces) are now widely understood without visual reinforcement. Users don't need a literal folder icon to understand what a folder is. The abstract treatment is faster, lighter, more performant, and more accessible than heavier surface mimicry.
+
+For most modern productivity tools, this is the right baseline. Surface mimicry is reserved for the moments where it adds genuine value (an empty-state illustration, a one-off welcome screen).
+
+### A specialty audio tool that uses surface mimicry well
+
+A guitar amplifier simulator app is styled to look like an actual guitar amplifier: knobs for gain, treble, mid, bass; toggle switches for channels; an LED indicator. The audience — guitarists — knows what these controls look like and what they do because they're modeled on real hardware they own. The mimicry communicates instantly to the actual user.
+
+This is surface mimicry in a niche: the audience genuinely knows the source, the source is current (people still buy guitar amps), and the references are functional rather than decorative.
+
+## Anti-patterns
+
+**Surface mimicry without behavioral or functional mimicry.** A button that looks like a physical button but doesn't depress on click; a "page" that looks like paper but scrolls like a webpage. The visual promise isn't kept.
+
+**Surface mimicry of obsolete sources.** Floppy disks, brushed metal panels, leather-bound journals for audiences that don't recognize the references.
+
+**Surface mimicry that hurts accessibility.** Decorative typography, low-contrast skeuomorphic styling, heavy textures that interfere with screen readers or low-vision users.
+
+**Surface mimicry as a substitute for thought.** Reaching for skeuomorphic styling to "make the interface feel friendly" without thinking about what specifically the mimicry is communicating. Often a sign that the underlying design hasn't been fully figured out.
+
+**Surface mimicry inconsistently applied.** Some screens are heavily skeuomorphic, others are flat. The user can't form a coherent expectation of what the product is. Either commit to a register or commit to flat — don't drift between them within a single product.
+
+**Mimicry of competitor products' surface styling.** "Make it look like X" without understanding why X looks the way it does. Often imports surface decisions that were appropriate for X's audience but not yours.
+
+## Heuristic checklist
+
+Before reaching for surface mimicry, ask: **Does my audience know the source I'm referencing?** If not, the mimicry communicates nothing. **Is the mimicry communicating something specific about function or emotional register, or is it decorative?** Decoration is fine, but be honest about it. **Does the mimicry suggest limitations the digital medium doesn't have?** If so, find a way to signal the additional capabilities. **Will the source still be familiar in 5 years?** If not, the mimicry has a short shelf life. **Does the mimicry conflict with platform or accessibility conventions?** If so, the cost may exceed the recognition benefit.
+
+## Related sub-skills
+
+- `mimicry` — parent principle on the strategy of borrowing from the familiar.
+- `mimicry-behavioral` — sibling skill on behavioral mimicry.
+- `aesthetic-usability-effect` — surface treatment shapes perceived usability; mimicry is one form.
+- `iconic-representation` — icons are surface mimicry at the symbolic level.
+- `archetypes` — brand archetypes and surface mimicry both shape emotional register.
+
+## See also
+
+- `references/skeuomorphic-vs-flat.md` — practical guidance on the spectrum from photorealistic to abstract surface treatment.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry-surface/references/skeuomorphic-vs-flat.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry-surface/references/skeuomorphic-vs-flat.md
@@ -1,0 +1,77 @@
+# Surface mimicry — skeuomorphic to flat spectrum
+
+Practical guidance on positioning surface mimicry across the spectrum from photorealistic skeuomorphism to fully abstract flat design.
+
+## The spectrum
+
+**Photorealistic skeuomorphism.** Detailed rendering of materials and lighting. Used historically (iOS 6-era Apple, Microsoft Bob, early consumer software) to introduce new mediums by referencing physical objects users already knew.
+
+**Tactile skeuomorphism.** Subtle suggestion of physicality — bevels, shadows, gradients — without literal material rendering. Common in transitional eras (late 2000s).
+
+**Neumorphism.** A specific recent style featuring soft shadows that suggest controls extruding from or sinking into the surface. Visually distinctive but often criticized for accessibility (low contrast on extruded elements).
+
+**Material design / depth-aware flat.** Flat colors and shapes, but with controlled use of shadow and elevation to suggest layered surfaces. Google's Material Design is the canonical example.
+
+**Pure flat.** No shadows, no gradients, no skeuomorphic references at all. Solid colors, sharp lines, abstract shapes. The most performant and lightweight; can be hard to distinguish interactive from non-interactive elements.
+
+**Outline / minimal.** Even less than flat — outlines instead of fills, minimal color, maximum restraint. Used for highly information-dense interfaces (data dashboards, professional tools).
+
+Most contemporary products sit between Material Design and Pure Flat, with selective skeuomorphic touches for specific moments (illustrations, empty states, onboarding).
+
+## Choosing a position on the spectrum
+
+**Audience expectations.** Users coming from older operating systems may expect more skeuomorphic styling; users from modern web apps expect flatter. Match the audience.
+
+**Brand register.** Premium / traditional brands often benefit from subtle skeuomorphic touches (satinated surfaces, refined shadows). Modern / tech-forward brands often favor flat. Friendly / casual brands often use playful illustration that references physical objects without trying to be photorealistic.
+
+**Information density.** High-density interfaces (data tables, dashboards, professional tools) benefit from flat or minimal styling — every visual flourish costs scanning time. Low-density interfaces (consumer apps, marketing pages) can afford more visual richness.
+
+**Accessibility requirements.** Pure-flat designs can be ambiguous about what's interactive (a flat rectangle can be a card, a button, a section divider). Some skeuomorphic cues (shadow under interactive elements, hover states with depth) can improve clarity for users who can't rely on color alone.
+
+**Performance.** Heavy skeuomorphism — many shadows, gradients, photorealistic textures — costs render time and battery. Flat designs are dramatically more performant. For mobile and embedded contexts, flat is usually the right tradeoff.
+
+## Practical guidance
+
+**Use skeuomorphic touches sparingly and deliberately.** A subtle shadow on cards. A gentle gradient on a hero. A textured background on a sign-in page. Each should serve a specific purpose; don't add them by default.
+
+**Match the level of mimicry to the cost of misreading.** A button that doesn't clearly look like a button costs the user time to find. Adding subtle depth (a small shadow, a slight bevel) helps. A decorative illustration with no function can be flatter or more abstract.
+
+**Test for affordance clarity.** Show your interface to someone who hasn't seen it. Ask them to point to everything that's clickable. If they miss things, your styling isn't communicating clearly enough; consider adding more cues.
+
+**Don't fake what's not there.** A photorealistic 3D button that doesn't actually depress when clicked sets up a false promise. Either render with full physical metaphor (depress, shadow shifts, button color changes) or stay abstract.
+
+**Avoid mid-spectrum confusion.** The interfaces that age worst are the ones that committed half-heartedly to skeuomorphism — some elements skeuomorphic, others flat, with no clear logic. Pick a point on the spectrum and apply it consistently.
+
+## Examples by category
+
+**Productivity software.** Mostly Material Design / depth-aware flat. Skeuomorphic touches reserved for specific moments (signature pads, color pickers).
+
+**Reading apps.** Often subtle paper-mimicking treatment for the reading surface itself, with flat chrome around it.
+
+**Music apps.** General-audience apps are flat or material; pro-audience apps (DAWs, synth simulators) often use heavier skeuomorphism because the audience knows the hardware references.
+
+**Banking apps.** Almost universally flat or material now. Earlier eras featured heavy skeuomorphism (ATM-styled interfaces, embossed card graphics) that has been stripped away.
+
+**Game UI.** Wide range, from highly stylized fantasy interfaces (heavy skeuomorphism) to minimal indie game UI (extreme flat). Often the most decorative point on the spectrum because games value emotional and aesthetic register over efficiency.
+
+**Children's apps.** Often more illustrative and skeuomorphic; children may benefit from concrete visual references and respond to richness.
+
+**Professional tools.** Generally flat or minimal to maximize information density and minimize distraction.
+
+## Anti-patterns
+
+**Mid-2010s neumorphism gone wrong.** Soft-shadow extruded buttons that look beautiful in the design comp but fail accessibility (low contrast against the background) and confuse users about what's interactive.
+
+**Half-flat designs with random skeuomorphic survivals.** A flat-design product where one button is still rendered as a 3D pill from an earlier era. Reads as bug, not as design.
+
+**Fake depth that doesn't follow physics.** Shadows that fall in different directions on different elements; "elevated" cards that overlap in ways physical cards couldn't. The visual promise isn't kept by the visual logic.
+
+**Outdated mimicry treated as timeless.** Brushed-aluminum panels, leather textures, faux-wood — all signaled "premium" in particular eras and signal "outdated" outside those eras. Verify that your visual references still read as intended.
+
+## A simple test
+
+Take screenshots of your interface from a year ago. Do they still look current, or do they look noticeably dated? If they look dated, the skeuomorphic level may be too high — they're aging with their visual references. If they still look current, the design is positioned to age more gracefully.
+
+## Cross-reference
+
+For the parent principle on visual mimicry, see `mimicry-surface`. For behavioral mimicry, see `mimicry-behavioral`.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: mimicry
+description: 'Apply the principle of Mimicry — borrowing the form, behavior, or visual language of something familiar to make a new design recognizable. Use when introducing a novel feature whose function would be opaque without an analogy, choosing between metaphor and convention, designing for a category your users already know, or evaluating whether a "skeuomorphic" element helps or hurts. Mimicry comes in surface (visual resemblance), behavioral (acts like the source), and functional (does what the source does) forms. Used well, it accelerates learning; used badly, it carries forward limitations the new medium doesn''t share.'
+---
+
+# Mimicry
+
+> **Definition.** Mimicry is the design strategy of borrowing the appearance, behavior, or function of something the user already knows in order to make a new design recognizable and learnable. The desktop metaphor (folders, files, trash can) is mimicry of office tools. The "card" pattern in mobile UIs is mimicry of physical cards. The page-turn animation in early e-readers is mimicry of physical books. Each borrows from a familiar source to give users an instant mental model for an unfamiliar medium.
+
+The principle is the same one that early software pioneers used to onboard users into a fundamentally new medium: borrow visual and behavioral language from the physical world so users had something to ground their understanding. The desktop metaphor of the original Macintosh mimicked the world of paper documents and folders that office workers already understood. Hypertext mimicked the cross-references in a book. The mouse pointer mimicked the index finger pointing.
+
+Mimicry works because it short-circuits learning. The user doesn't have to be told what a "trash can" does because they already know what a trash can does. The interface borrows the user's existing knowledge.
+
+## The three layers of mimicry
+
+Mimicry can happen at one or several layers. The distinction matters because the layers come with different costs and benefits.
+
+**Surface mimicry.** The new design *looks like* the source. A button styled to look like a physical button (with a 3D bevel, shadow, and pressed state). A note app styled to look like a yellow legal pad. A music player styled to look like an analog mixer. Surface mimicry is the strongest form for first-encounter recognition — users can see at a glance what the thing references — but it can feel dated or kitschy if the visual reference becomes anachronistic.
+
+**Behavioral mimicry.** The new design *behaves like* the source. The page-turn animation in an e-reader. The drag-to-rearrange gesture that follows physical-world manipulation. The springy bounce when a list reaches its end (Apple's "rubber band" scrolling). Behavioral mimicry is often subtler than surface mimicry but more durable — the behavior carries the recognition without depending on visual style.
+
+**Functional mimicry.** The new design *does what* the source does. A "shopping cart" in an e-commerce site mimics the function of a supermarket cart: collect items, decide what to buy, check out. A "notebook" in a journaling app mimics the function of a paper notebook: record thoughts, organize by date or topic. The mimicry is conceptual — the user understands the new tool because they understand the source's function.
+
+A successful mimicry usually combines layers: a shopping cart is functionally a cart, looks at least vaguely like a cart (icon), and behaves like one (you add items, then check out). The layers reinforce each other.
+
+## When mimicry works
+
+Mimicry pays off most clearly when the source is universally understood and the new medium genuinely benefits from the analogy.
+
+**The source is universally understood.** The trash can, the folder, the cart, the book, the pencil. When the source is something nearly every user has encountered, mimicry is essentially free. When the source is specialized (a knob mimicking an analog audio-mixer fader, in an interface for non-audio-engineers), mimicry teaches less than it might seem to.
+
+**The new medium genuinely benefits from the analogy.** Hypertext genuinely benefits from "page" and "link" metaphors borrowed from books. The desktop metaphor genuinely benefited from "folder" and "document" metaphors borrowed from paper offices. The analogy isn't just decorative — it gives users a useful mental model for navigating the new medium.
+
+**The analogy doesn't carry forward limitations.** A digital folder doesn't have to be limited to one location (a file can have multiple "tags," unlike a physical document). A digital trash can doesn't have to be emptied physically. Successful mimicry often borrows the recognizable parts of the source while shedding limitations the new medium doesn't have.
+
+## When mimicry fails
+
+Mimicry fails in a few characteristic ways.
+
+**The analogy is forced.** A music app where the mixer view is styled like a 1980s analog mixer board — knobs, faders, panels, all rendered in 3D. New users don't recognize the references (they've never used an analog mixer). Old users find it kitschy. The mimicry was designed for an audience that no longer exists.
+
+**The analogy carries limitations the new medium doesn't have.** An e-reader that mimics page-turning so faithfully that you can't search across pages, or scroll through content, or jump to a chapter. The visual analogy locks the interface into the limitations of the physical book, sacrificing the digital advantages.
+
+**The analogy obscures the actual functionality.** A note-taking app styled to look like a physical legal pad but with rich-text formatting, embedded images, and AI auto-summaries. Users see the legal-pad surface and assume the functionality is also paper-like; they don't discover the AI features because the visual mimicry tells them not to expect them.
+
+**The analogy is misleading.** A "trash can" icon for an action that doesn't actually delete (it removes from view but keeps the data). The user, primed by the mimicry, thinks the data is gone and is then surprised to find it. The mimicry created false expectations.
+
+**Mimicry of mimicry.** A new design that mimics an established software design that itself mimicked something physical. Eventually the chain of references is so abstracted that no one remembers the original source, and the design is just inheriting forms without understanding why. Question whether the original mimicry is still serving its purpose.
+
+## The skeuomorphism debate
+
+Skeuomorphism — visual mimicry of physical objects, often very literal — was the dominant interface aesthetic in the late 2000s and early 2010s. iOS 6 had felt-textured Game Center, leather-bound Calendar, and a Notes app styled like a yellow legal pad. iOS 7 (2013) deliberately stripped much of this away in favor of "flat" design.
+
+The shift wasn't a rejection of mimicry as a principle; it was a rejection of *literal surface mimicry* in favor of behavioral and functional mimicry. The flat-design era kept the underlying metaphors (folders are still folders, the trash can is still the trash can) but stopped rendering them with leather, paper, and shadow. The reasoning: by 2013, users no longer needed the literal visual reference to understand the metaphor — they had years of accumulated experience with the abstract version.
+
+This is a useful lesson about mimicry's lifecycle. Strong literal mimicry helps when the source is the user's primary reference; it becomes optional once users have internalized the metaphor; it becomes anachronistic when the source has faded from common use.
+
+## Sub-skills in this cluster
+
+- **mimicry-surface** — Visual mimicry: when to render an interface element to look like a physical object, and when literal mimicry helps vs. when it's decorative kitsch.
+- **mimicry-behavioral** — Behavioral mimicry: when to make an interface behave like a physical object, and how to choose which physical behaviors to preserve and which to leave behind.
+
+## Worked examples
+
+### A digital notebook that gets the metaphor right
+
+A note-taking app uses functional mimicry of the paper notebook (you write notes; notes are organized by topic or date) and behavioral mimicry of the paper experience (typing feels responsive, the cursor advances as you type, the page scrolls naturally). It does *not* visually mimic paper (no fake paper texture, no lined background by default) — modern users don't need the visual reference. And it adds digital affordances that paper doesn't have (search across all notes, tags, automatic backup, sharing).
+
+This is mimicry done well: borrowing what helps users understand the tool, shedding limitations that don't apply, adding capabilities the source didn't have.
+
+### A music app that over-mimics
+
+A digital audio workstation styled to look like a physical hardware mixer: 3D knobs, fader strips, LED meters, wood-paneled bezels. Old audio engineers find it nostalgic; new users find it bewildering — they have no idea what the knobs do because they've never used a hardware mixer. The mimicry is teaching nothing.
+
+The fix is to abandon the surface mimicry and use modern UI conventions for the controls (sliders, value displays, clear labels) while preserving the underlying functional model (channels, buses, sends) that the source genuinely contributes.
+
+### A calendar with strong category mimicry
+
+A calendar app uses the standard month-grid, week-column, and day-detail views that every calendar app has used for decades. The mimicry isn't of physical calendars (no fake leather binding); it's of the category-conventional digital calendar. Users from any other calendar app are immediately at home.
+
+This is mimicry of an established software pattern rather than a physical object — and it's just as valuable. The user's accumulated learning across other calendar apps transfers directly.
+
+### A "smart folder" that breaks the metaphor productively
+
+In macOS, "smart folders" are saved searches that look and behave like folders but contain results of a query rather than a fixed set of files. The interface mimics the folder enough that users understand the affordance (you can browse it, drag from it) but extends the metaphor to do something paper folders can't (auto-update with new matching files).
+
+The mimicry is partial: enough to get the user started, with explicit framing ("smart folder") to signal the difference. The user gets the recognition benefit and the new capability.
+
+### A "card" pattern in mobile UI
+
+The card pattern (a rectangular container with content, often with a slight shadow) mimics physical cards (index cards, business cards, playing cards) at the visual level. The behavioral mimicry is partial: cards in a feed can be swiped (like flicking a physical card aside) or tapped to expand. The mimicry is loose enough not to constrain the digital affordances (cards can have video, animations, interactive elements) but tight enough to give users an instant mental model.
+
+This has become one of the dominant UI patterns of the mobile era. The mimicry of a familiar physical object proved durable.
+
+## Anti-patterns
+
+**Mimicry that prevents discovery of new affordances.** A digital book that looks so much like a paper book that users don't try to search, scroll, or jump. The visual mimicry tells them to expect paper-book limitations.
+
+**Mimicry of obsolete sources.** The floppy disk for save in 2026. The mailing-envelope icon for email when most users have never sent physical mail. These references are increasingly mysterious to users who've never encountered the source.
+
+**Visual mimicry without behavioral mimicry.** A button that looks like a physical button (3D bevel, shadow) but doesn't actually depress when you click it, or clicks with an unconvincing animation. The visual promise isn't kept by the behavior.
+
+**Behavioral mimicry without visual mimicry.** A slider that physically follows your finger (good behavioral mimicry) but is rendered as an abstract line with no clear indication that it's draggable. The visual doesn't suggest the behavior.
+
+**Mimicry of an analogy that doesn't fit.** A "wallet" metaphor for a tool that doesn't actually hold cards — perhaps it shows balances or transactions but doesn't store payment methods. The analogy creates expectations the tool doesn't meet.
+
+**Pure decoration disguised as mimicry.** Adding fake paper textures or leather backgrounds because they "look classy," with no functional justification. Decoration is fine, but don't claim it's mimicry; mimicry has a job to do.
+
+## Heuristic checklist
+
+Before reaching for a mimicry, ask: **What is the source, and is it universally understood by my audience?** If not, the mimicry teaches less than it seems to. **What does the mimicry actually communicate — function, behavior, or just visual style?** Be deliberate about which layer you're using. **Does the source's limitations apply to the new medium?** If not, shed them. **Is the mimicry necessary?** If users would understand the new design just as well with modern abstract conventions, the mimicry may be decoration rather than communication. **Has the source faded from common experience?** If so, the mimicry may be becoming a barrier rather than an aid.
+
+## Related principles
+
+- **Mental Model** — mimicry borrows from a known mental model to construct a new one.
+- **Affordance** — mimicked objects often inherit their affordances from the source.
+- **Mapping** — mimicry of physical objects tends to bring strong natural mapping with it.
+- **Iconic Representation** — icons are often mimicry at the symbolic level.
+- **Consistency (external)** — convention-following is mimicry of established software patterns.
+- **Form Follows Function** — successful mimicry occurs when form genuinely reflects function; bad mimicry imposes form regardless of function.
+
+## See also
+
+- `references/lineage.md` — origins in skeuomorphic design and metaphor theory.
+- `mimicry-surface/` — sub-skill on visual mimicry.
+- `mimicry-behavioral/` — sub-skill on behavioral mimicry.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/mimicry/references/lineage.md
@@ -1,0 +1,69 @@
+# Mimicry — origins and research lineage
+
+## Pre-digital roots: skeuomorphism in physical design
+
+The term "skeuomorph" predates digital design by more than a century. In archaeology and design history, a skeuomorph is an object that retains visual features from a previous version even after those features no longer serve a function. The handle on a ceramic pitcher echoes an earlier metal pitcher's handle. The decorative columns on a Greek revival building mimic structural columns from an era when columns held up roofs.
+
+Skeuomorphism in this older sense was sometimes purely decorative (carrying forward a visual style) and sometimes functional in a different way (signaling continuity with a tradition, providing recognition). The judgment about whether it serves a purpose has always been contested.
+
+## In early HCI: the desktop metaphor
+
+The Xerox Alto and PARC research in the early 1970s, popularized by the Apple Lisa (1983) and the Macintosh (1984), introduced what came to be called the "desktop metaphor." The screen represented a physical desk; folders organized documents; files lived in folders; a trash can held things to be deleted; a clipboard held things being moved.
+
+The metaphor was a deliberate teaching device. Office workers in the early 1980s knew what a folder was, what a document was, what a trash can was. The interface borrowed this knowledge to teach users what computers were for. It worked: the desktop metaphor enabled a generation of non-technical users to learn computers, and many of its conventions (folders, files, the trash) became invisible parts of computing.
+
+Alan Kay, one of the architects of the desktop metaphor, has said in retrospect that the metaphor was both more successful and more limiting than its designers anticipated. More successful because it onboarded millions of users. More limiting because it locked subsequent designs into a single physical-office reference, even as computing moved beyond the office.
+
+## Skeuomorphic design in the smartphone era
+
+Apple's iOS (2007) doubled down on visual mimicry. The original iPhone's apps used heavy skeuomorphic styling: leather textures, paper, felt, brushed metal, photorealistic icons. The Calendar app looked like a paper calendar. Notes had a yellow legal-pad background with red margin lines. Game Center had felt with poker-table styling.
+
+The reasoning, articulated by Apple's design leadership at the time (especially Steve Jobs and Scott Forstall), was that the iPhone introduced a fundamentally new interaction medium (multi-touch) and users needed familiar visual references to anchor their understanding. Skeuomorphism was scaffolding for the new medium.
+
+By 2013, iOS 7 stripped most of this away in favor of a "flat" aesthetic. Jonathan Ive's team argued that users had internalized the underlying metaphors and no longer needed the literal visual representation. Calendar still represented dates, but didn't have to look like paper. Notes still represented written text, but didn't have to look like a legal pad. The metaphor was carried by the structure, not the surface.
+
+The shift was contested at the time but has since been widely accepted: literal surface mimicry was a useful onboarding device for the first generation of smartphone users; once those users had learned the new conventions, the literal mimicry became unnecessary decoration. The deeper metaphors — folders, calendars, documents — persisted because they were doing genuine work; the leather and felt did not.
+
+## Theoretical framings: metaphor and analogy
+
+The HCI literature has framed mimicry under several theoretical banners.
+
+**Conceptual metaphor theory** (Lakoff and Johnson, 1980) argues that human cognition is fundamentally metaphorical — we understand abstract concepts through bodily and physical experiences. Mimicry in interface design exploits this: a "shopping cart" lets users reason about an abstract checkout flow using physical-cart intuitions; a "trash can" lets users reason about deletion using physical-disposal intuitions.
+
+**Cognitive walkthroughs** in HCI evaluation (Lewis, Polson, Wharton, Rieman, 1990) used metaphor as a key element: users approaching an unfamiliar interface look for familiar elements to ground their understanding. Strong mimicry produces strong walkthrough success; weak or misleading mimicry produces walkthrough failure.
+
+**The principle of least astonishment** in interaction design holds that a new design should behave the way users expect, given their prior experience. Mimicry is the principal mechanism for setting these expectations: the user's "expectations" are largely the behaviors of similar things they've encountered before.
+
+## When mimicry helps and when it hurts
+
+The empirical literature on metaphor in software, especially studies in the 1990s and 2000s, suggests a few patterns.
+
+**Strong mimicry helps for novices.** New users with no prior software experience benefit dramatically from mimicry of physical objects they know. The desktop metaphor's success was largely with this audience.
+
+**Mimicry helps less for experts.** Experts have already internalized the abstract patterns of software. Heavy literal mimicry can feel patronizing or noisy to them.
+
+**Mimicry that carries forward limitations hurts everyone.** A digital book that mimics a physical book so faithfully that you can't search across pages is worse than either a digital book that abandons the physical model or a physical book.
+
+**Mimicry that preserves the metaphor while adding capabilities works for everyone.** A digital folder that you can also tag, share, and search is the best of both worlds.
+
+**Mimicry of obsolete sources confuses new users.** The floppy disk for save is increasingly mysterious to users who've never used a floppy. The mimicry teaches nothing because the source is unknown.
+
+The successful mimicry through the era is the kind that picks the right source, preserves what helps, sheds what doesn't, and adds what the new medium can.
+
+## Mimicry in modern AI and conversational interfaces
+
+The current generation of AI tools has revived old mimicry questions. A conversational AI can mimic the patterns of human conversation (turn-taking, casual language, expressed uncertainty), the patterns of a search engine (a single query, a list of results), or the patterns of an expert assistant (questions, clarifications, deliverables).
+
+Each mimicry brings expectations. Conversational mimicry primes users to expect human-like memory, judgment, and accountability — expectations that current AI sometimes meets and sometimes spectacularly fails. Search-engine mimicry primes users to expect that the answer is somewhere in the corpus and the AI is finding it, missing the AI's generative capability. Assistant mimicry primes users to expect a kind of professional reliability that current AI may not have.
+
+These mimicry choices are not just stylistic; they shape how users will interpret outputs and react to errors. The choice deserves design-level attention rather than being made implicitly.
+
+## Sources informing this principle
+
+- Apple Human Interface Guidelines (multiple editions, particularly the 1984 Macintosh and 2013 iOS 7 guidelines).
+- Lakoff, G., & Johnson, M. (1980). *Metaphors We Live By*.
+- Lewis, C., Polson, P., Wharton, C., & Rieman, J. (1990). Testing a walkthrough methodology for theory-based design of walk-up-and-use interfaces.
+- Norman, D. (1988). *The Design of Everyday Things*.
+- Carroll, J. M., Mack, R. L., & Kellogg, W. A. (1988). Interface metaphors and user interface design.
+- Erickson, T. D. (1990). Working with interface metaphors.
+- The skeuomorphism debates around iOS 6 and iOS 7 (2012–2013) in design publications.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure-defaults-and-tucking/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure-defaults-and-tucking/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: progressive-disclosure-defaults-and-tucking
+description: 'Use this skill when deciding *what to surface* and *what to tuck* — the editorial choices behind progressive disclosure. Trigger when laying out a settings page, picking which form fields to show by default, deciding whether a section starts collapsed or open, or arguing about whether a feature deserves primary chrome or belongs in "Advanced." Sub-aspect of `progressive-disclosure`; read that first.'
+---
+
+# Progressive disclosure: defaults and tucking decisions
+
+Progressive disclosure is mostly an *editorial* discipline. The technical patterns (accordions, tabs, "More" buttons) are easy; the hard work is deciding which content earns primary placement and which gets tucked. This skill is about that decision.
+
+## The framework: who, when, how often
+
+For each candidate piece of content or control, ask three questions:
+
+### 1. Who is it for?
+
+- **Everyone (every user, every visit)** → primary layer, always visible.
+- **Most users (the typical case)** → primary layer, visible by default.
+- **Some users (specific roles or contexts)** → secondary layer, disclosed by user action.
+- **Few users (power users, edge cases)** → secondary or tertiary layer, disclosed and possibly behind labels like "Advanced."
+
+### 2. When is it needed?
+
+- **Always** → primary.
+- **Per visit, but only sometimes per session** → secondary, easy to reach.
+- **Once during setup, never again** → primary during setup, then move to settings.
+- **Only on error / exception** → don't show by default; surface on the relevant condition.
+
+### 3. How often is it used?
+
+This is the most concrete question — answerable from analytics.
+
+- **Used by ≥ 50% of users on most visits** → primary.
+- **Used by 20–50% of users, or by everyone occasionally** → primary, possibly with tighter visual treatment.
+- **Used by 5–20% of users, or by power users routinely** → secondary, behind one explicit affordance.
+- **Used by < 5% of users** → secondary or tertiary, possibly worth removing entirely.
+
+These thresholds are rules of thumb; tune to your product. The bigger point: usage data is the strongest signal for tucking decisions, and most teams don't look at it before laying out chrome.
+
+## Defaulting disclosure state
+
+When a section *can* start open or closed, choose deliberately:
+
+### Default open
+
+- The section the user is most likely to read or modify.
+- The section required to complete the task (if disclosure is in a form).
+- The first section in a sequence (so the user has somewhere to land).
+- A single-section accordion (if there's only one, it's not really collapsed by purpose).
+
+### Default closed
+
+- Sections that supplement the primary task.
+- "Advanced" or "Optional" sections.
+- Sections so long they'd dwarf the rest of the page if open.
+- Sections used by < 20% of users on a given visit.
+
+### Remember user state
+
+For settings pages and frequent surfaces, remember which sections each user opened previously and restore on next visit:
+
+```js
+// On open, persist
+sectionToggle.addEventListener('toggle', () => {
+  localStorage.setItem(`section-${sectionId}`, sectionToggle.open ? '1' : '0');
+});
+
+// On load, restore
+const saved = localStorage.getItem(`section-${sectionId}`);
+if (saved !== null) sectionToggle.open = saved === '1';
+```
+
+Power users who always reopen the same section will appreciate it; novices who never expand it pay no cost.
+
+## What earns primary placement
+
+The primary layer is finite real estate. Be ruthless. A useful triage:
+
+### Always primary
+
+- The page's purpose-defining content. (A user lands on a Reports page; the report is primary.)
+- The required actions to complete the typical task. (A checkout flow; "Place order" is primary.)
+- Wayfinding chrome that orients the user.
+
+### Usually primary
+
+- Frequently-used controls.
+- Status indicators that change meaningfully (notification counts, error states).
+- Recently-used items (recents accelerate frequent tasks).
+
+### Sometimes primary
+
+- Customization options that vary by user role.
+- Onboarding hints for new users (but not for veterans).
+- Contextual help that depends on user state.
+
+### Rarely primary
+
+- Advanced configuration.
+- Account management (move to a separate page).
+- Marketing, upsells, "what's new."
+
+## What earns tucking
+
+Conversely, candidates for the secondary or tertiary layer:
+
+- **Optional fields** in forms.
+- **Power-user filters** in search/list UIs.
+- **Customization** of layouts, themes, keyboard shortcuts.
+- **Account / billing / security** controls (their own page, not a sidebar accordion).
+- **Help and documentation links** (footer or help menu).
+- **Legal / compliance links** (footer).
+- **Settings the user changes once and forgets** (push to a "Preferences" page).
+
+## A worked example: a settings page audit
+
+Imagine the current Settings page exposes 34 fields across 5 sections in a single scroll-y view. A progressive-disclosure pass might restructure as:
+
+```
+Profile (always visible at top)
+  Display name
+  Email
+  Time zone
+
+Notifications (accordion, default closed for users who haven't changed it)
+  Email digest
+  Mention notifications
+  Quiet hours
+
+Workspace (accordion, default closed)
+  Workspace name
+  Members [link to separate page]
+  Default project
+
+Security (separate page; link in nav)
+  Password
+  2FA
+  Sessions
+  API tokens
+
+Advanced (accordion, default closed; appears only for users with the appropriate role)
+  Webhooks
+  Custom CSS
+  Feature flags
+
+Danger zone (separate panel at bottom; visually demoted)
+  Transfer ownership
+  Delete workspace
+```
+
+Profile (3 fields) is primary because every user changes their email or name occasionally. Security goes to its own page because it's high-stakes and benefits from its own focused surface. Advanced is conditional. Danger zone is at the bottom and visually distinct — out of the way of accidental engagement.
+
+## Tucking dynamic content
+
+Some content can't be tucked because it changes — notifications, real-time updates, error states. Patterns:
+
+- **Badge on the disclosure trigger.** A "Notifications (3)" trigger tells the user there's something behind it; they can choose to expand.
+- **Toast / banner for transient changes.** Auto-dismissing surface that doesn't require user action.
+- **Modal for blocking changes.** Forces the user to acknowledge.
+
+Don't bury error states inside collapsed accordions. If a form section has an error, the section must be open (or auto-open on submit failure).
+
+## The "Advanced" label question
+
+When a section is labeled "Advanced," users self-select. Power users open it; novices don't. This is mostly good — it manages expectations. But beware:
+
+- **"Advanced" can be condescending.** If a setting is just a bit unusual, calling it advanced may make users feel othered.
+- **"Advanced" can be a dumping ground.** If everything ungrouped goes under Advanced, the label loses meaning. Keep Advanced focused on power-user tools.
+- **"Advanced" should be findable for power users.** Don't bury Advanced inside Account inside Settings.
+
+Alternative labels: "Optional," "More options," "Power tools," "For developers." Pick what fits the audience.
+
+## Anti-patterns
+
+- **Hiding the required.** Required form fields tucked behind disclosure. Submit fails; user is confused.
+- **Disclosure for the sake of less.** Hiding genuinely-needed controls "to make it cleaner." The user can't do their job.
+- **All accordions closed.** A page where every section is collapsed feels empty. Open the first one (or two) so the user lands.
+- **Disclosure with no signal.** "More options" with no hint of what's behind. Pair labels with semantic clues ("Advanced filters," "Additional fields").
+- **Changing what's primary without telling users.** A long-time user comes back to find a setting they relied on tucked into Advanced. Migration UX matters: announce the change.
+
+## Heuristics
+
+1. **The "what would the typical user need?" test.** For each visible element, ask: typical-user-typical-visit? If no, candidate for tucking.
+2. **The analytics audit.** Look at click data per control. <5% of users engage → strong tuck candidate. <1% → strong removal candidate.
+3. **The new-user test.** Walk a new user through the surface. Watch for which elements draw their attention vs. confuse them. Tuck the confusers.
+4. **The expert-user test.** Walk a power user through the surface. Watch what they reach for that's hidden. Surface those, or improve the disclosure affordance.
+
+## Related sub-skills
+
+- **`progressive-disclosure`** (parent).
+- **`progressive-disclosure-disclosure-affordances`** — the specific UI patterns for revealing tucked content.
+- **`80-20-rule`** — the analytical method for identifying what's primary.
+- **`hicks-law-defaults`** — defaulting disclosure state is itself a Hick's Law mitigation.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure-defaults-and-tucking/references/editorial-method.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure-defaults-and-tucking/references/editorial-method.md
@@ -1,0 +1,113 @@
+# Tucking decisions: editorial method
+
+A reference complementing `progressive-disclosure-defaults-and-tucking` with a more detailed method and worked case studies.
+
+## A repeatable audit method
+
+For an existing surface that needs a progressive-disclosure pass, work through these steps:
+
+### 1. Inventory every visible element
+
+List every control, field, link, and content block on the surface. Don't skip "small" elements — small noisy elements add up.
+
+### 2. Tag each element with usage data
+
+For each, find or estimate:
+
+- **% of users who interact with it per visit.** From analytics if available; from intuition if not.
+- **% of users who interact with it ever.** A control used by 30% of users some time but only 2% per visit is different from one used by 30% of users every visit.
+- **Role / segment that uses it.** Power users, admins, novices, billing-payers — different roles have different needs.
+
+### 3. Categorize each element by tier
+
+Using the rough thresholds from the parent skill:
+
+- **≥ 50% per-visit usage** → primary tier.
+- **20–50% per-visit, or routine for a clear segment** → secondary tier (visible but de-emphasized).
+- **5–20% per-visit, or power-user routine** → disclosed (behind one click).
+- **< 5% per-visit** → disclosed deeper, or candidate for removal.
+
+### 4. Group disclosed items into coherent sections
+
+The disclosed long tail isn't one bucket; it's several. Group by purpose so the user can predict what's behind which disclosure.
+
+Bad: "More options" → 30 unrelated controls.
+Good: "Advanced filters" → 8 filtering controls. "Webhooks" → webhook configuration. "Display preferences" → layout/theme controls.
+
+### 5. Pick affordances per group
+
+Different groups call for different affordances:
+- Long settings groups → separate page or accordion.
+- Optional fields → inline accordion.
+- Filters → inline expand or side panel.
+- Help / explanation → tooltip or popover.
+
+### 6. Audit the new layout against tasks
+
+For each major user task, walk through the redesigned surface. Are the controls the user needs accessible without too many clicks? Is anything required hidden? Does the new chrome enable or hinder common workflows?
+
+### 7. Migrate carefully
+
+For existing users, moving controls is disruptive. When possible:
+
+- Announce the change (banner, changelog, in-app notification).
+- For at least one release, make the relocated control findable from its old position (a tooltip or short-lived link).
+- Make sure search includes the relocated controls so users can find them by name.
+
+## Case study: a settings page redesign
+
+Imagine a Settings page with 38 controls across one long scroll.
+
+**Audit data:**
+
+- 7 controls used by ≥ 50% of users per visit (display name, email, time zone, password, 2FA, notification frequency, default view).
+- 14 controls used by 5–20% (workspace name, member list, integrations, etc.).
+- 17 controls used by < 5% (webhooks, custom CSS, beta flags, audit log, etc.).
+
+**Redesigned structure:**
+
+```
+Settings (entry page; primary tier)
+├── Profile (3 controls; primary)
+├── Security (2 controls; primary; same page or split for high-stakes)
+├── Notifications (1 control + accordion to expand granular controls)
+└── Display preferences (1 control + accordion)
+
+Settings → Workspace (separate page)
+├── Workspace name, members, billing (primary on this page)
+└── Integrations (accordion; secondary)
+
+Settings → Advanced (separate page; secondary tier overall)
+├── Webhooks
+├── API tokens
+├── Custom CSS
+└── Feature flags
+
+Settings → Audit log (separate page; rarely used but high-stakes)
+
+Settings → Danger zone (separate panel; visually distinct)
+└── Transfer ownership, Delete account
+```
+
+The 7 most-used controls are visible on the entry page. The next tier is one click away. The long tail is on its own page, named for what it contains.
+
+## Defaults: open vs. closed
+
+For each accordion or disclosed section, decide its default state:
+
+- **Default open** if more than half the users likely engage with it on most visits.
+- **Default closed** if engagement is occasional.
+- **Default to user's previous state** if you persist preferences.
+- **Default open if it's the only section** — a single closed accordion looks like a bug.
+
+## Anti-patterns specific to tucking
+
+- **The "let's hide the controversial one"** trap. If a control is controversial because it has poor UX, fix the UX. Don't hide it; users still need it.
+- **The Marie Kondo trap.** "Does this spark joy?" applied to UI. Some controls don't spark joy — billing, password reset, account deletion — but users need them. Joy isn't the metric; *fitness for purpose* is.
+- **The "small team likes it" defense.** A control loved by your design team but used by 0.5% of users is still a tucking candidate. Internal preference doesn't translate to user need.
+
+## Resources
+
+- **Heath, C. & Heath, D.** *Decisive* (2013) — on how to make multi-option decisions deliberately.
+- **Tidwell, J.** *Designing Interfaces* — pattern catalog with disclosure patterns.
+- **NN/g** — practical articles on settings-page redesign and progressive disclosure analytics.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure-disclosure-affordances/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure-disclosure-affordances/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: progressive-disclosure-disclosure-affordances
+description: 'Use this skill when picking the *mechanism* for revealing tucked content — accordion vs. modal vs. tab vs. separate page vs. tooltip. Trigger when designing the UI for "More options," picking between an inline accordion and a side sheet, deciding whether a wizard step should be a modal or a separate page, or reviewing whether existing disclosure affordances are doing their job. Sub-aspect of `progressive-disclosure`; read that first.'
+---
+
+# Progressive disclosure: choosing the affordance
+
+Once you've decided what to tuck, the next decision is how to surface it on demand. Different disclosure affordances suit different relationships between the primary and secondary content. Picking the wrong one is a common subtle UX error.
+
+## The affordance ladder
+
+Ordered roughly from lightest to heaviest:
+
+```
+Tooltip / popover         — supplementary info; doesn't disturb flow
+Inline expand (accordion) — additional fields/sections within the page
+Tab                       — parallel views in the same region
+Side sheet / drawer       — detail beside primary content
+Modal / dialog            — focused interaction, blocks primary
+Separate page             — full context shift, deep-linkable
+```
+
+Each level adds friction; pick the lightest affordance that does the job.
+
+## Tooltip / popover
+
+For supplementary information that the user might want but doesn't need to act on.
+
+```html
+<button>
+  Free trial
+  <span tabindex="0" aria-describedby="trial-info">ⓘ</span>
+</button>
+<div id="trial-info" role="tooltip" hidden>
+  14 days, no credit card required. Cancel anytime.
+</div>
+```
+
+**Use for:**
+- Definitions of jargon.
+- Format hints for inputs.
+- Explanations of UI labels.
+- Status / metadata that isn't worth a separate field.
+
+**Don't use for:**
+- Required interaction (clicking inside a tooltip is fragile).
+- Long-form content (tooltips are for small bits).
+- Mobile-primary surfaces (no hover; touch tooltips are awkward).
+
+## Inline expand (accordion)
+
+The classic disclosure pattern: a section header that expands to reveal its content.
+
+```html
+<details>
+  <summary>Advanced filters</summary>
+  <fieldset>
+    <label>Created after <input type="date" /></label>
+    <label>Tags <input /></label>
+  </fieldset>
+</details>
+```
+
+**Use for:**
+- Optional form fields.
+- Settings sections that are sometimes relevant.
+- FAQ-style content (question = trigger, answer = content).
+- Any case where the deeper content makes sense in line with the primary.
+
+**Don't use for:**
+- Content that needs more space than the page can give.
+- Content the user must engage with for primary task completion.
+- Sequenced content (steps in a workflow — use a separate page or modal).
+
+## Tab
+
+Parallel views within the same page region. Switching tabs preserves context (the user is still on the same page; they're just seeing a different facet).
+
+```html
+<nav role="tablist">
+  <button role="tab" aria-selected="true">Overview</button>
+  <button role="tab">Activity</button>
+  <button role="tab">Members</button>
+  <button role="tab">Settings</button>
+</nav>
+<div role="tabpanel">...current tab content...</div>
+```
+
+**Use for:**
+- Parallel views of the same object (overview, activity, members for a project).
+- Different cuts of the same data (filter by status: All / Open / Closed).
+- Configuration sections grouped by purpose.
+
+**Don't use for:**
+- Sequential workflows (tabs imply parallel; use a stepper for sequence).
+- Tabs where one is far more important than the others (just show the primary; tuck the rest behind a different affordance).
+- Mobile primary nav (mobile bottom-nav is a tab pattern at the global level, but mid-page tabs on mobile are often awkward).
+
+## Side sheet / drawer
+
+A panel that slides in beside the primary content, leaving primary visible. Useful for detail-of-an-item interactions where the user wants to see context while they work.
+
+```html
+<aside class="sheet" role="complementary">
+  <header>
+    <h2>Edit invoice #1284</h2>
+    <button aria-label="Close">×</button>
+  </header>
+  <form>...invoice fields...</form>
+  <footer>
+    <button>Cancel</button>
+    <button class="primary">Save</button>
+  </footer>
+</aside>
+```
+
+**Use for:**
+- Editing a row from a table (the table stays visible; the sheet is the editor).
+- Detail views in inboxes (Gmail's preview pane).
+- Filters or properties for a selected object (Figma's right panel).
+
+**Don't use for:**
+- Standalone detail views the user might bookmark (use a separate page).
+- Long forms that benefit from full-page focus.
+- Modal-required interactions (use a true modal).
+
+## Modal / dialog
+
+A focused surface that blocks the primary. The user can't continue with primary tasks until they close the modal.
+
+```html
+<dialog role="dialog" aria-labelledby="dialog-title">
+  <h2 id="dialog-title">Confirm deletion</h2>
+  <p>Permanently delete "Q4 plan"? This can't be undone.</p>
+  <button>Cancel</button>
+  <button class="destructive">Delete</button>
+</dialog>
+```
+
+**Use for:**
+- Destructive confirmations.
+- Decisions that genuinely block the primary task (you can't continue until you choose).
+- Brief, focused interactions (signing in, reviewing a single short form).
+
+**Don't use for:**
+- Long flows that would feel claustrophobic in a modal (use a separate page).
+- Information the user might want to reference while continuing work (use a side sheet).
+- Trivial confirmations the user will dismiss on autopilot (lean on undo instead).
+
+## Separate page
+
+A full URL change. Used when the disclosed content is large enough or important enough to warrant its own context.
+
+**Use for:**
+- Deep settings (Account / Security / Billing).
+- Configuration UIs that fill the screen.
+- Documentation that benefits from its own URL (shareable, bookmarkable).
+- Anything the user might link to or return to directly.
+
+**Don't use for:**
+- Quick edits that should preserve context.
+- Optional fields in an existing form.
+- Brief decisions / confirmations.
+
+## Picking the right affordance
+
+A few diagnostic questions:
+
+### Does the user need to keep seeing the primary?
+
+- Yes → tooltip, inline expand, tab, or side sheet.
+- No → modal or separate page.
+
+### Will the user return to this disclosed content?
+
+- Yes, frequently → separate page (so they can bookmark / link).
+- No, just this once → modal or sheet.
+
+### Does the disclosed content have its own structure (multiple subsections)?
+
+- Yes → separate page or full sheet.
+- No → modal, accordion, or tooltip.
+
+### Is the disclosed content a parallel view (vs. a deeper level)?
+
+- Parallel → tab.
+- Deeper → accordion or modal.
+
+### Does the disclosed content involve a decision the user must make before continuing?
+
+- Yes → modal.
+- No → any other affordance.
+
+## Common mismatches
+
+- **Modal where a tab would do.** A "Filter" modal that pops up to set filters, then closes. Filters belong inline or in a side panel; they're parallel to the main view, not a blocking decision.
+- **Accordion where a separate page would do.** Account / billing / security crammed into accordions on a single Settings page. Each is its own context; they deserve their own pages.
+- **Tooltip where an inline note would do.** Important explanation hidden in a tooltip the user must hover. Inline help text under the field is more accessible and discoverable.
+- **Separate page where a side sheet would do.** Editing a row by navigating to its detail page, then back to the list. Loses scroll position and context. A side sheet preserves both.
+- **Tab where progressive disclosure isn't needed.** Two tabs where one has 95% of the relevant content. Just show the primary; the second "tab" can be a link or a smaller affordance.
+
+## Mobile considerations
+
+Mobile compresses the affordance choices:
+
+- **Tooltips** become awkward (no hover); use inline help or a dedicated info screen.
+- **Side sheets** typically become full-screen sheets (left or right slide-in).
+- **Modals** typically become full-screen presentations.
+- **Tabs** stay viable but with smaller labels.
+- **Inline accordions** still work well; arguably better on mobile (less screen real estate for everything visible).
+
+When in doubt on mobile, default to inline disclosure (accordion) or full-screen takeover. The middle ground (small popovers, partial overlays) often feels cramped.
+
+## Accessibility notes
+
+- **`<details>` / `<summary>`** is the most accessible inline-expand pattern; native keyboard, semantics, and screen-reader support.
+- **`<dialog>`** is the modern modal element with proper focus management when used with `.showModal()`.
+- **Tabs** require ARIA: `role="tablist"`, `role="tab"`, `role="tabpanel"`, `aria-selected`, arrow-key navigation.
+- **Tooltips** need keyboard activation (focus, not just hover) and proper `aria-describedby` references.
+- **Sheets / drawers** need focus trap, Esc to close, focus restoration on close.
+
+Most modern UI libraries (Radix, React Aria, headless component sets) implement these correctly. Custom implementations frequently get focus management wrong; lean on libraries.
+
+## Heuristics
+
+1. **The "lightest viable" rule.** Pick the lightest affordance on the ladder that meets the need. Promoting unnecessarily adds friction.
+2. **The deep-link test.** Can users link directly to the disclosed content? If yes, you probably want a separate page (or modal whose state is in the URL). If no, lighter affordance is fine.
+3. **The frequency check.** How often does the user open this disclosure? Frequent → light affordance (low friction). Rare → heavier affordance is fine.
+4. **The dismiss test.** Can the user always dismiss / close? Esc, click outside, close button — at least two of these should work.
+
+## Related sub-skills
+
+- **`progressive-disclosure`** (parent).
+- **`progressive-disclosure-defaults-and-tucking`** — the editorial decisions that produce the choices this skill helps execute.
+- **`affordance`** (interaction) — disclosure triggers must look like triggers.
+- **`feedback-loop`** (interaction) — opening a disclosure should give immediate visual feedback.
+- **`accessibility-operable`** (process) — disclosure affordances must work with keyboard.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure-disclosure-affordances/references/affordance-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure-disclosure-affordances/references/affordance-patterns.md
@@ -1,0 +1,262 @@
+# Disclosure affordances: pattern reference
+
+A reference complementing `progressive-disclosure-disclosure-affordances` with deeper detail on each pattern's accessibility, motion design, and history.
+
+## Native vs. custom
+
+Modern HTML provides native primitives for several disclosure patterns:
+
+- **`<details>` / `<summary>`** — inline expand. Native keyboard, semantics, ARIA-correct.
+- **`<dialog>`** — modal. Native focus management when invoked via `.showModal()`.
+- **`<select>`** — dropdown. Native scaffolding for popover-style choosers.
+
+Native primitives come with accessibility for free. Custom implementations frequently get focus management, ARIA, and keyboard handling wrong. Reach for native first.
+
+When native won't do (you need rich content inside the disclosure, you need styling unavailable on native), use a well-maintained accessible component library (Radix UI, React Aria, headless component sets, shadcn) rather than rolling your own.
+
+## Pattern: inline expand (the `<details>` pattern)
+
+```html
+<details>
+  <summary>Advanced filters</summary>
+  <fieldset>
+    <label>Created after <input type="date" /></label>
+    <label>Tags <input /></label>
+  </fieldset>
+</details>
+```
+
+**Native behaviors for free:**
+- Click summary or press Enter/Space to toggle.
+- Toggle state in DOM (`open` attribute).
+- Screen readers announce expanded/collapsed state.
+- Keyboard focus on the summary by default.
+
+**Styling considerations:**
+- Default browser triangle marker can be hidden with `details > summary { list-style: none; }` and `summary::-webkit-details-marker { display: none; }`.
+- Use `[open]` selector to style the expanded state differently.
+- Animate the disclosure with care — `<details>` doesn't animate height by default; libraries like Motion or `interpolate-size: allow-keywords` (CSS) help.
+
+## Pattern: accordion (multiple `<details>` or ARIA-driven)
+
+A vertical stack of disclosure sections. The accessibility pattern is documented in WAI-ARIA Authoring Practices.
+
+```html
+<div class="accordion">
+  <h3>
+    <button aria-expanded="true" aria-controls="panel-1">
+      Profile
+    </button>
+  </h3>
+  <div id="panel-1">...profile fields...</div>
+
+  <h3>
+    <button aria-expanded="false" aria-controls="panel-2">
+      Notifications
+    </button>
+  </h3>
+  <div id="panel-2" hidden>...notification fields...</div>
+</div>
+```
+
+Or simpler with `<details>`:
+
+```html
+<details open>
+  <summary><h3>Profile</h3></summary>
+  <div>...profile fields...</div>
+</details>
+<details>
+  <summary><h3>Notifications</h3></summary>
+  <div>...notification fields...</div>
+</details>
+```
+
+**Single-open vs. multi-open:**
+
+- **Single-open accordion** (only one section open at a time; opening another closes the previous) reduces visual mass but adds friction when comparing sections.
+- **Multi-open accordion** (any combination open) is more flexible; common in settings pages. Lacks native scaffolding (since `<details>` siblings are independently open), but ARIA pattern handles it.
+
+Pick single-open when sections are mutually exclusive in use. Pick multi-open when users may want to keep multiple sections open at once.
+
+## Pattern: tabs
+
+WAI-ARIA tablist pattern is well-documented. Brief structure:
+
+```html
+<div class="tabs">
+  <div role="tablist" aria-label="Project sections">
+    <button role="tab" aria-selected="true" aria-controls="overview-panel" id="overview-tab">
+      Overview
+    </button>
+    <button role="tab" aria-selected="false" aria-controls="activity-panel" id="activity-tab">
+      Activity
+    </button>
+  </div>
+  <div role="tabpanel" id="overview-panel" aria-labelledby="overview-tab">
+    ...overview content...
+  </div>
+  <div role="tabpanel" id="activity-panel" aria-labelledby="activity-tab" hidden>
+    ...activity content...
+  </div>
+</div>
+```
+
+**Keyboard interactions** (per ARIA):
+- `Tab` moves into the tablist; once focused, arrow keys move between tabs.
+- `Enter` / `Space` activates the focused tab.
+- `Home` / `End` go to first / last tab.
+
+**Activation modes:**
+- **Automatic** — focusing a tab activates it immediately. Good for short-load tabs; bad for tabs that fetch data on activation.
+- **Manual** — focusing a tab moves focus but doesn't activate; user presses Enter to activate. Good for slow-load tabs.
+
+## Pattern: side sheet / drawer
+
+A panel that slides in from a screen edge. Implementation typically uses `<dialog>` with custom positioning, or a custom `<aside>` with focus management.
+
+```html
+<dialog id="invoice-edit" class="sheet">
+  <header>
+    <h2>Edit invoice</h2>
+    <button aria-label="Close">×</button>
+  </header>
+  <form>...</form>
+  <footer>
+    <button>Cancel</button>
+    <button class="primary">Save</button>
+  </footer>
+</dialog>
+
+<style>
+  dialog.sheet[open] {
+    position: fixed;
+    top: 0; right: 0; bottom: 0;
+    width: min(480px, 100vw);
+    margin: 0;
+    border: 0;
+    border-left: 1px solid hsl(0 0% 88%);
+    transition: transform 200ms ease-out;
+  }
+</style>
+```
+
+**Behaviors required:**
+- Focus moves into the sheet on open.
+- Focus is trapped inside while open.
+- Focus returns to the trigger when closed.
+- `Esc` closes.
+- Click outside (on the backdrop) closes (typically).
+
+`<dialog>` with `.showModal()` provides focus trap and Esc handling natively. Use it.
+
+## Pattern: modal (true modal blocking interaction)
+
+```html
+<dialog id="confirm">
+  <h2>Discard changes?</h2>
+  <p>Your unsaved edits will be lost.</p>
+  <form method="dialog">
+    <button value="cancel">Cancel</button>
+    <button value="confirm" class="destructive">Discard</button>
+  </form>
+</dialog>
+
+<script>
+  const dialog = document.getElementById('confirm');
+  document.querySelector('[data-trigger="confirm"]').addEventListener('click', () => {
+    dialog.showModal();
+  });
+  dialog.addEventListener('close', () => {
+    if (dialog.returnValue === 'confirm') {
+      // do destructive thing
+    }
+  });
+</script>
+```
+
+The `<dialog>` element with `showModal()` provides:
+- Modal blocking (background is inert).
+- Focus trap.
+- Esc to close.
+- Backdrop styling via `::backdrop`.
+
+Older browsers may need a polyfill; modern evergreen browsers support it directly.
+
+## Pattern: tooltip
+
+Tooltips reveal supplementary information on hover/focus. Several pitfalls:
+
+- **Hover-only fails for touch and keyboard.** Always include focus trigger.
+- **`title` attribute** is the most accessible but limited (no styling, slow show timing on most browsers).
+- **Custom tooltips** require `aria-describedby` referencing the tooltip element.
+
+```html
+<button aria-describedby="trial-tooltip">
+  Start free trial
+</button>
+<div id="trial-tooltip" role="tooltip" hidden>
+  14 days, no credit card required.
+</div>
+
+<script>
+  // Show tooltip on hover or focus; hide on blur or mouseleave.
+</script>
+```
+
+**WAI-ARIA tooltip pattern requirements:**
+- Tooltip appears on hover or focus.
+- Tooltip dismisses on blur, mouseleave, or Esc.
+- Tooltip content is referenced via `aria-describedby` on the trigger.
+- Tooltip cannot contain interactive content (use a popover for that).
+
+## Pattern: popover
+
+Like a tooltip but can contain interactive content (buttons, links, form fields). Used for menus, comboboxes, contextual actions.
+
+The browser-native `popover` attribute (released in 2023+) handles this:
+
+```html
+<button popovertarget="my-popover">Open menu</button>
+<div id="my-popover" popover>
+  <ul>
+    <li><button>Option 1</button></li>
+    <li><button>Option 2</button></li>
+  </ul>
+</div>
+```
+
+Native popover handles open/close, light-dismiss (click outside or Esc), and focus.
+
+For older browsers or richer behavior, libraries like Floating UI handle positioning math.
+
+## Motion design
+
+Disclosure motion should:
+
+- **Be brief.** 150–250ms is typical; longer feels slow.
+- **Use ease-out timing** for opening (decelerates as it lands).
+- **Respect `prefers-reduced-motion`.** Disable or shorten motion when the user has set this preference.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  details, dialog, .accordion-content {
+    transition: none;
+  }
+}
+```
+
+Motion serves comprehension: it shows the user *where* the new content came from. Slamming open with no transition feels jarring; long animations test patience.
+
+## Heuristics
+
+1. **The lightest-viable rule.** Pick the lightest disclosure affordance that does the job.
+2. **The library check.** Are you using a well-tested component library, or did someone hand-roll this? Hand-rolled disclosures are nearly always missing some accessibility detail.
+3. **The keyboard-only walk.** Open every disclosure on the page using only the keyboard. Anything you can't reach is broken.
+4. **The screen-reader audit.** With NVDA / VoiceOver / TalkBack, walk through. Are expand/collapse states announced? Are tabs announced as "tab, X of Y"?
+
+## Resources
+
+- **WAI-ARIA Authoring Practices Guide** — w3.org/WAI/ARIA/apg. Canonical patterns for accordion, dialog, tablist, tooltip.
+- **MDN: `<details>`, `<dialog>`, popover** — current browser support.
+- **Inclusive Components** by Heydon Pickering — accessible patterns for disclosures, accordions, modals.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: progressive-disclosure
+description: 'Use this skill whenever a design has *more* available than the user needs to see at this moment — settings panels with advanced options, forms with optional fields, dashboards with drill-down detail, navigation with deep IA, dialogs with "More options" affordances, marketing pages with FAQ accordions. Trigger when designing or fixing surfaces that feel "overwhelming," when stakeholders argue about whether to expose every option up front, when novice and expert users have different tolerance for the same surface, or when reviewing a UI cluttered with rarely-used controls. Progressive disclosure is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003), originally formalized through the Xerox Star user-interface work in the 1970s.'
+---
+
+# Progressive Disclosure
+
+Progressive disclosure is the discipline of revealing information and controls in layers — showing only what's needed for the current decision and tucking the rest behind explicit affordances the user can invoke when they need more. It's one of the most decisive cognition principles in software UI: it reduces visible complexity for the 80% case while preserving access to the long tail.
+
+## Definition (in our own words)
+
+Instead of presenting every option, control, and piece of information at once, divide the surface into layers based on usage frequency or relevance. Show the "primary layer" — what the typical user needs in the typical case — and conceal the rest behind disclosure affordances (a "More" button, an accordion, an "Advanced" tab, a menu). Users who need the deeper layers can reach them with one explicit action; users who don't are spared the cognitive cost of looking past them.
+
+## Origins and research lineage
+
+- **The Xerox Star user interface** (Xerox PARC, 1981) is widely credited as the first commercial system to explicitly apply progressive disclosure as a design strategy. Properties dialogs in Star showed common settings by default and offered more-detailed controls behind a "More" button — a pattern adopted by Mac OS, Windows, and most modern UI conventions afterward.
+- **Lidwell, Holden & Butler**, *Universal Principles of Design* (2003) articulated the principle as "a strategy for managing information complexity in which only necessary or requested information is displayed at any given time" and noted its application both in software and physical environments (theme park lines that don't expose their full length).
+- **Jakob Nielsen** has written extensively on progressive disclosure as a usability technique: it reduces error rates by hiding controls users aren't ready to use, and it eases novice onboarding without penalizing expert use.
+- **Cognitive load theory** (Sweller, 1988 and later) explains the underlying mechanism: every visible element imposes some intrinsic and extraneous cognitive load. Hiding the long tail of options removes the extraneous load they impose, freeing working memory for the task at hand.
+
+## Why progressive disclosure matters
+
+Every visible option costs the user something. They must:
+
+1. **Notice** it — perceptual cost.
+2. **Read** it — comprehension cost.
+3. **Evaluate** whether it's relevant to their task — decision cost.
+4. **Decide** whether to use it — Hick's Law cost.
+5. **Live with** the consequence if they engaged with it incorrectly — error cost.
+
+For options that are rarely used, the user pays this cost on every visit and almost never gets value from it. The math is brutal: a user visiting a settings page 50 times pays the cost on each of the 47 fields they don't need to see, every time, in service of changing the 3 fields that matter.
+
+Progressive disclosure inverts the math: the 3 frequent fields are visible, the 47 are tucked away with one explicit affordance. Cost-per-visit collapses; access is preserved.
+
+## When to apply
+
+- **Long forms** where some fields are required and others optional.
+- **Settings pages** with both common and advanced options.
+- **Toolbars** where a few actions cover most use and the rest live in overflow menus or palettes.
+- **Filter UIs** with basic and advanced filtering.
+- **Pricing pages** with feature lists too long to display in tier cards.
+- **Dialogs** with "Show more" / "Advanced" patterns.
+- **Documentation** with summary up top and details on demand.
+- **Onboarding** that introduces features gradually rather than all at once.
+
+## When NOT to apply
+
+- **When all the disclosed information is essential.** A safety checklist, a legal disclosure, a price breakdown the user must see before buying — hiding these is malpractice.
+- **When discovery matters more than density.** A new product surface where users don't yet know what's possible needs to *show* features, not hide them. Progressive disclosure assumes users know what they're looking for or can find it via search.
+- **When the disclosure adds confusion.** A "More" button leading to two more buttons leading to a panel — disclosure depth without payoff. If the deeper layers are themselves overwhelming, the principle isn't being applied; it's being deferred.
+- **In compliance / accessibility contexts.** Information required by law, by accessibility standards, or by user-trust commitments (privacy disclosures, billing terms) cannot be hidden behind disclosure. They can be *summarized* with a "Read full terms" link, but not concealed.
+
+## The two layers (and sometimes three)
+
+A useful model: think of every surface as having a primary layer and a deeper layer (or two).
+
+### Primary layer
+
+What's visible by default. Should answer:
+
+- The 80% case: what most users need, most of the time.
+- The required path: fields, controls, or information without which the task can't be completed.
+- The wayfinding chrome: nav, breadcrumb, page title.
+
+### Secondary layer
+
+Visible after one explicit user action. Should answer:
+
+- The 20% case: options used by power users or in unusual situations.
+- Optional refinements: filters, settings, customizations.
+- Detail / explanation that the primary layer summarizes.
+
+### Tertiary layer (sparingly)
+
+Visible only after deeper navigation. Should be:
+
+- The very-long tail: feature flags, debug tools, edge-case settings.
+- "Expert mode" / advanced / "I really want to do something unusual."
+
+Going deeper than 3 layers is rare and usually a sign the IA itself is too dense.
+
+## Disclosure affordances
+
+The mechanism by which the user reveals deeper layers. Patterns:
+
+### "Show more" / "More choices" buttons
+
+The Xerox Star pattern. A button at the edge of the visible content reveals additional fields or options inline.
+
+```html
+<form>
+  <label>Find: <input name="q" /></label>
+  <button type="button" onclick="toggle('advanced')">More choices ▾</button>
+
+  <fieldset id="advanced" hidden>
+    <label>Search in: <select>...</select></label>
+    <label>Match: <select>...</select></label>
+  </fieldset>
+
+  <button type="submit">Find</button>
+</form>
+```
+
+The toggle is reversible; "More choices" becomes "Fewer choices" when expanded. Users can close back to the simpler view.
+
+### Accordions
+
+Multiple disclosure affordances stacked vertically, each revealing its own deeper content.
+
+```html
+<details>
+  <summary>Account</summary>
+  <div>...account fields...</div>
+</details>
+
+<details>
+  <summary>Notifications</summary>
+  <div>...notification settings...</div>
+</details>
+
+<details>
+  <summary>Advanced</summary>
+  <div>...advanced settings...</div>
+</details>
+```
+
+Native `<details>` / `<summary>` provides the accessibility scaffolding for free; reach for it before custom accordions.
+
+### Tabs
+
+Different views within the same region, only one visible at a time. Useful when the secondary content is *parallel* to the primary, not deeper.
+
+```html
+<nav role="tablist">
+  <button role="tab" aria-selected="true">Overview</button>
+  <button role="tab">Activity</button>
+  <button role="tab">Members</button>
+  <button role="tab">Settings</button>
+</nav>
+```
+
+### Pages and routes
+
+The strongest form of disclosure: a separate page reached by navigation. Use when the deeper content is large enough to warrant its own URL, breadcrumb, and orientation chrome.
+
+### Modals and sheets
+
+A primary surface remains in context while a deeper surface overlays. Useful for editing a single object's detail, configuring something, or reviewing.
+
+### Hover / focus reveals
+
+The lightest disclosure: a tooltip or popover on hover/focus. Reserved for supplementary information that doesn't disrupt the main flow.
+
+```html
+<button>
+  Free trial
+  <span class="info" tabindex="0" aria-describedby="trial-info">ⓘ</span>
+</button>
+<div id="trial-info" role="tooltip" hidden>
+  14 days, no credit card required.
+</div>
+```
+
+Caveat: hover-only disclosures fail on touch and for keyboard users. Always pair with focus or click.
+
+## Worked examples
+
+### Example 1: a search form with simple and advanced modes
+
+The canonical Xerox Star pattern, still the right answer for most search UIs.
+
+```html
+<form action="/search">
+  <input name="q" placeholder="Search" autofocus />
+  <button type="submit">Search</button>
+
+  <details>
+    <summary>Advanced</summary>
+    <fieldset>
+      <label>In: <select name="in">
+        <option>All</option>
+        <option>Title</option>
+        <option>Body</option>
+      </select></label>
+      <label>Posted after: <input type="date" name="after" /></label>
+      <label>Author: <input name="author" /></label>
+    </fieldset>
+  </details>
+</form>
+```
+
+99% of users hit Enter on the search field. The 1% who need scoped search expand Advanced and refine.
+
+### Example 2: a settings page with chunked sections
+
+Long settings pages benefit from accordion-style disclosure: each section is collapsed by default; the user opens the one they want.
+
+```html
+<form class="settings">
+  <details open>
+    <summary><h2>Profile</h2></summary>
+    <div>
+      <label>Display name <input /></label>
+      <label>Bio <textarea></textarea></label>
+    </div>
+  </details>
+
+  <details>
+    <summary><h2>Notifications</h2></summary>
+    <div>...notification controls...</div>
+  </details>
+
+  <details>
+    <summary><h2>Security</h2></summary>
+    <div>...security controls...</div>
+  </details>
+
+  <details>
+    <summary><h2>Advanced</h2></summary>
+    <div>...power-user options...</div>
+  </details>
+</form>
+```
+
+The first section is open by default (`open` attribute) so the user lands somewhere; the rest expand on demand.
+
+### Example 3: a filter bar with primary and advanced filters
+
+```html
+<form class="filters">
+  <input type="search" placeholder="Search" />
+  <select><option>Status: Active</option>...</select>
+  <select><option>Owner: Anyone</option>...</select>
+
+  <details>
+    <summary>+ More filters</summary>
+    <fieldset>
+      <label>Created after <input type="date" /></label>
+      <label>Tag <input /></label>
+      <label>Custom field 1 <input /></label>
+      <label>Custom field 2 <input /></label>
+    </fieldset>
+  </details>
+</form>
+```
+
+Three filters cover most use; the rest are an explicit gesture away.
+
+### Example 4: a marketing FAQ
+
+A marketing page with 25 questions and answers is overwhelming. Show the questions; expand answers on click.
+
+```html
+<section class="faq">
+  <h2>Common questions</h2>
+
+  <details>
+    <summary>How long is the free trial?</summary>
+    <p>14 days. No credit card required.</p>
+  </details>
+
+  <details>
+    <summary>What happens after the trial?</summary>
+    <p>You can choose a paid plan or downgrade to our free tier...</p>
+  </details>
+
+  <details>
+    <summary>Do you support SSO?</summary>
+    <p>Yes, on Pro and Enterprise plans...</p>
+  </details>
+</section>
+```
+
+The page reads as 25 questions, not as 25 paragraphs of answers. Users open only the ones they care about.
+
+### Example 5: progressive disclosure in onboarding
+
+A user signs up for a complex product. Showing every feature on day one would overwhelm. Instead:
+
+- **Day 1:** the product introduces itself with one simple flow (create your first object).
+- **Days 2–7:** contextual tooltips reveal features as the user encounters surfaces where they apply.
+- **Week 2+:** "What's new" or "Tips" surfaces introduce advanced features once the user has the basics.
+
+The complexity is *temporally* disclosed rather than spatially.
+
+## Cross-domain examples
+
+### Theme park lines
+
+A theme park line stretching to the horizon discourages joining. Modern parks use serpentine queues, walls, and visual breaks to disclose only a small segment of the line at a time. Visitors at the front can't see the back; visitors at the back can't see the front; the apparent line length is much shorter than the actual length.
+
+The same logic underlies "infinite scroll" in software (the user only sees the current view; the apparent content depth is limited) and "lazy loading" (only what's needed now is loaded; the rest waits).
+
+### Restaurant menus
+
+A multi-page menu with categories on tabs is progressive disclosure. The user picks a category (Appetizers / Mains / Desserts) and sees only those items. Without the categorization, all 80 items would compete for attention.
+
+A single-page menu by contrast — common at fast-food counters — exposes everything because the order decision happens in seconds and Hick's Law cost is small enough to absorb.
+
+### Print form folding
+
+Government and legal forms often fold the long instructions out of the way until the user reaches a relevant section. Tax forms, insurance applications, and the IRS-style worksheet model all use spatial disclosure to manage a 30-page form's visible complexity.
+
+### Chapter-by-chapter book reading
+
+A book is progressive disclosure of content. The reader doesn't see Chapter 12 while reading Chapter 1; they reach it sequentially. Books that violate this (showing all spoilers up front) frustrate readers; books that respect it (gradual reveal) succeed.
+
+## Anti-patterns
+
+- **Disclosure to nowhere.** A "More options" button that reveals one additional checkbox. The disclosure overhead exceeds the disclosed value.
+- **Disclosure stacking.** "More" → "More" → "More" → the actual control. Each click is friction; aggregate clicks compound.
+- **Hiding the required.** Required fields tucked behind disclosure. The user submits with the visible fields filled, gets an error, expands the hidden section to find more required fields.
+- **Hiding the primary action.** The "Save" or "Buy" button is somehow inside an accordion. Users miss it; conversion drops.
+- **Defaults closed when most users need them open.** A FAQ where the most-asked question is collapsed at the same level as a 50-times-rarer question.
+- **No memory of disclosure state.** Every page load resets disclosed sections. A power user who reopens "Advanced" every visit will resent it.
+- **Using disclosure to bury bad news.** "Total" prominent; "Including taxes and fees" tucked behind disclosure. Users feel cheated when they expand.
+
+## Heuristics
+
+1. **The "what does the typical user need?" test.** For each visible element on the surface, ask: is this in the typical user's path? If no, ask: should it be tucked behind disclosure? Most "yes."
+2. **The "click count" audit.** For the most common task on this surface, how many clicks does it take? Disclosure that increases the click count for common tasks is wrong.
+3. **The "did they find it?" test.** Watch users perform an uncommon task. Do they find the disclosed control? If they search, miss, and give up, your disclosure affordance isn't visible enough.
+4. **The Pareto check.** Look at usage analytics. What percentage of users engage with a given control? <20% is a strong candidate for disclosure. <5% is a strong candidate for *removal* (or moving to a separate "advanced" page).
+
+## Related principles
+
+- **`hicks-law`** — partner principle; progressive disclosure shrinks the visible decision space, reducing Hick's Law cost.
+- **`80-20-rule`** — partner principle; tells you which 20% to surface and which 80% to disclose.
+- **`chunking`** — disclosure groups items into chunks (sections, accordions); chunking organizes within them.
+- **`recognition-over-recall`** — disclosed items must be recognizable; "More options" needs to suggest what's behind it.
+- **`mental-model`** — disclosure depth must match the user's mental model; surprise depth confuses.
+- **`performance-load`** — progressive disclosure reduces both cognitive load (less to read) and kinesthetic load (less to scroll).
+- **`wayfinding`** — disclosure interacts with wayfinding; users must be able to *find* the disclosed content when they need it.
+- **`signal-to-noise-ratio`** (perception) — disclosure is the procedural form of SNR discipline applied to time-of-display.
+
+## Sub-aspect skills
+
+- **`progressive-disclosure-defaults-and-tucking`** — how to decide what's primary vs. tucked, and how to default disclosure states.
+- **`progressive-disclosure-disclosure-affordances`** — the specific UI patterns (buttons, accordions, tabs, modals) and when each fits.
+
+## Closing
+
+Progressive disclosure is one of the highest-leverage cognition moves in modern UI design. Done well, it creates an experience that feels simple to novices and powerful to experts — the same surface serving both. Done poorly, it hides what users need and surfaces what they don't. The discipline is in the editorial choice: who is this *for*, and what do they need *now*?

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure/references/research-and-cross-domain.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/progressive-disclosure/references/research-and-cross-domain.md
@@ -1,0 +1,113 @@
+# Progressive Disclosure: research and cross-domain reference
+
+A reference complementing the `progressive-disclosure` SKILL.md with deeper grounding from HCI research and cross-domain application.
+
+## Research lineage
+
+- **The Xerox Star user interface** (Xerox PARC, 1981). The first commercial system to apply progressive disclosure as a deliberate design strategy. The Star's properties dialogs showed common settings by default and offered detailed controls behind a "More" button — a pattern adopted by Apple's Lisa (1983), Macintosh (1984), Microsoft Windows, and most subsequent UI conventions. The Star's design philosophy is documented in: Johnson, J. et al., "The Xerox Star: A Retrospective," in *Human-Computer Interaction: Toward the Year 2000* (1995).
+- **Carroll, J. M. & Carrithers, C.** (1984). "Training Wheels in a User Interface." *Communications of the ACM* 27(8). The "training wheels" concept: progressively introduce features so novices aren't overwhelmed. Closely related to progressive disclosure as a learnability strategy.
+- **Carroll, J. M.** *The Nurnberg Funnel* (MIT Press, 1990). Argued for "minimalist instruction" — showing learners only what they need now, in a context where they need it. Anticipates much modern onboarding-as-progressive-disclosure thinking.
+- **Sweller, J.** (1988) and the cognitive-load theory tradition. Provides the theoretical mechanism: working memory has limits; visible elements impose load even when ignored; reducing visible elements reduces extraneous load.
+- **Lidwell, Holden & Butler**, *Universal Principles of Design* (2003) compactly articulated progressive disclosure as a unified design strategy spanning software UIs, instructional materials, and physical environments.
+- **Nielsen, J.** has written multiple NN/g articles on progressive disclosure as a UX technique, particularly for forms, settings, and learnability.
+
+## The Xerox Star pattern in detail
+
+The Star's "More" button pattern works because of several design choices:
+
+- The default view shows the most-frequent options. New users see only what they need.
+- The "More" button is consistently labeled and consistently placed (right edge of the dialog).
+- Expanding "More" doesn't lose state — fields the user filled in stay filled.
+- The expansion is reversible — "More" becomes "Fewer" and the user can collapse.
+- The same dialog shape works for every property type, so users learn the pattern once.
+
+These properties make the affordance learnable by exposure. After encountering "More" in a few dialogs, users predict what's behind it elsewhere.
+
+## When progressive disclosure outperforms its alternatives
+
+Common alternatives to progressive disclosure include:
+
+- **Show everything by default.** Pro: maximally discoverable. Con: cognitive load on every visit; novices overwhelmed.
+- **Wizard / multi-step flow.** Pro: imposes structure, no decision overload at any step. Con: feels patronizing for power users; loses ability to skip-around.
+- **Search-only ("just search for what you need").** Pro: scales to any IA depth. Con: requires user to know what to search; bad for discovery.
+
+Progressive disclosure occupies a useful middle ground: it shows the typical case, surfaces the rest on demand, supports both novice and expert with the same surface. Its trade-offs:
+
+- **Power users pay a click** to reach disclosed content. Mitigations: keyboard shortcuts, remembered disclosure state.
+- **Novices may not discover** the deeper content exists. Mitigations: clear disclosure labels, contextual prompts ("More options").
+
+## Cross-domain examples
+
+### Theme park line design
+
+Theme parks engineer queues to disclose only a small portion of the line at any time. Visitors at the entrance see a manageable wait; visitors deep in the line don't see how much remains. Patterns:
+
+- **Serpentine layouts** that fold long lines into compact spaces.
+- **Walls and partitions** that block sightlines.
+- **Status signs** that give the user some information ("Are you ready for...") without exposing the full line.
+- **Distractions** (videos, themed environments) that occupy time without adding wait stress.
+
+The progressive-disclosure principle: visitors agree to a long wait one segment at a time, never seeing the whole length. If they saw the whole line, more would balk.
+
+### Restaurant menus
+
+Many restaurants use progressive disclosure in menus. The main menu shows entrées; the wine list is a separate document; specials are announced verbally; the dessert menu arrives after dinner. Each layer is delivered at the moment it's relevant.
+
+A "single big menu" approach (everything on one page, including beverages, desserts, mods) overwhelms diners. The staged approach respects when each decision is made.
+
+### Application installation
+
+Modern installers often hide most options behind an "Advanced" or "Custom" button. Default installation accepts sensible defaults; advanced installation lets the user pick install location, components, etc. The disclosure mirrors usage: most users want the default; few want to customize.
+
+### Tutorials and education
+
+Good educational design uses progressive disclosure: introduce a concept simply, let the learner practice, then introduce nuance and edge cases. Programming tutorials especially benefit — "Here's a function" before "Here's how function scope and closure interact."
+
+The ill-fit is the textbook that introduces all the formalism on page 1 before showing what it's for. Few learners survive the first chapter.
+
+### Maps and zoom
+
+Digital maps progressively disclose detail by zoom level. At country zoom, only major cities and freeways are labeled. Zooming in reveals streets, then building names, then individual addresses. Showing all detail at all zooms would be unreadable.
+
+The same logic applies to dashboards: high-level KPIs at the page top; click into each to drill down to the contributing details.
+
+## Common patterns across domains
+
+| Domain | Primary layer | Secondary layer | Affordance |
+|---|---|---|---|
+| Software dialog | Common settings | Advanced settings | "More" button |
+| Settings page | Frequently-changed | Power-user / rare | Accordion or tab |
+| Theme park queue | Current segment | Full line | Walls / serpentine layout |
+| Restaurant | Entrée menu | Wine, dessert, specials | Separate documents / staff timing |
+| Map app | High-level | Detail | Zoom |
+| Tutorial | Core concept | Edge cases / advanced | Subsequent chapters |
+| Help center | Top issues | Long-tail issues | Search / category drill-down |
+| Tax form | Common income types | Unusual situations | Schedules / supplemental forms |
+
+The same principle, instantiated differently per medium.
+
+## Failure modes
+
+- **All-collapsed default.** A page where every section starts collapsed reads as empty. Open the first section so the user has somewhere to land.
+- **Disclosure stacking.** Collapsed → "More" → "Even More" → "Advanced." Each click adds friction; the deeper content is effectively hidden.
+- **Hiding the required.** Required fields tucked behind disclosure. Users submit and fail.
+- **No memory.** Every page load resets disclosed state. Users who frequently expand the same section grow frustrated.
+- **Unlabeled disclosure.** "More options" with no hint of what's behind. Users won't expand unless desperate.
+- **Disclosure as dark pattern.** Burying important information (fees, terms, opt-outs) behind disclosure. Users feel cheated when they expand.
+
+## Heuristics
+
+1. **The Pareto check.** What fraction of users engage with each control? If <20%, candidate for tucking. If >80%, must be primary. The middle is judgment.
+2. **The expert-vs-novice test.** Walk a novice through the surface; then a power user. Ideally both succeed without friction, the novice via primary chrome and the power user via disclosure.
+3. **The "did they find it?" check.** For tucked content, can users locate it when they need it? If they search instead of finding the disclosure, the affordance is too quiet.
+4. **The "wait, where did that go?" check.** Long-time users are sensitive to controls being moved into disclosure. Migration UX matters.
+
+## Resources
+
+- **NN/g articles on progressive disclosure** — many publicly available.
+- **Tidwell, J.** *Designing Interfaces* (2010). Pattern catalog including disclosure patterns.
+- **Cooper, A. et al.** *About Face* — chapter on disclosure and density.
+
+## Closing
+
+Progressive disclosure is among the best-understood and most-applied principles in modern UI design — and yet still routinely violated by surfaces that show everything, by accordions hiding the required, by "Advanced" tabs holding what should be primary. The discipline is not in knowing the pattern; it's in applying the editorial judgment of *what belongs where* on every surface.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-over-recall/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-over-recall/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: recognition-over-recall
+description: 'Use this skill whenever the user must locate or choose something from many possibilities — pickers, command palettes, navigation menus, autocompletes, recents lists, search results, settings panels. Trigger when designing inputs that ask the user to "type the right thing," when picking between dropdowns and search-first interfaces, when reviewing why users keep typing wrong values into autocomplete fields. Recognition Over Recall is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) and one of Nielsen''s 10 heuristics — recognizing options is far easier than recalling them from memory.'
+---
+
+# Recognition Over Recall
+
+People are dramatically better at recognizing things they've previously seen than at recalling them from memory. A multiple-choice question is easier than a fill-in-the-blank because the options are visible — the user only has to recognize the right one rather than retrieve it. The same principle holds across UI design: showing options beats asking the user to type from memory; using familiar conventions beats requiring the user to recall arbitrary commands.
+
+## Definition (in our own words)
+
+Recognition memory and recall memory work differently in human cognition. Recognition is fast, relatively effortless, and survives long after the original exposure. Recall requires active retrieval — searching through memory for the right item — and is slower, more error-prone, and degrades faster over time. Designs that show options for the user to recognize from outperform designs that ask the user to recall and type. The classic case in UI design: the shift from command-line interfaces (recall: "what was that command?") to graphical menus (recognition: "I see what I want; click it") dramatically expanded who could use computers.
+
+## Origins and research lineage
+
+- **Cognitive psychology** has demonstrated the recognition-over-recall asymmetry across decades of memory research. Recognition tasks (multiple choice) consistently outperform recall tasks (fill-in-the-blank) for the same content.
+- **The Xerox Star user interface** (1981) is the seminal applied work. The Star's designers leveraged recognition over recall throughout: menus showed available options instead of requiring command memorization. Documented in Johnson, Roberts, et al. (1995), "The Xerox 'Star': A Retrospective," in *Human Computer Interaction: Toward the Year 2000*.
+- **Lidwell, Holden & Butler** (2003) compactly stated the principle and noted recognition-driven decision-making — users often select familiar options over potentially-better unfamiliar ones (the "consumer brand familiarity" effect).
+- **Jakob Nielsen** included "Recognition rather than recall" as one of his 10 usability heuristics (1994 onward).
+- **Hoyer & Brown (1990)**, "Effects of Brand Awareness on Choice for a Common, Repeat-Purchase Product." *Journal of Consumer Research*. Showed that brand familiarity influences purchase choices independent of objective product quality — a recognition effect in the marketplace.
+
+## Why recognition matters
+
+Working memory is small (~4 items). Long-term memory is vast but accessed primarily through cues. Recognition tasks provide the cue (the option is visible); recall tasks ask the brain to generate the cue from scratch.
+
+For UI design:
+- **A flat list of 30 timezones** asks users to recognize the right one. Fast.
+- **A blank field "type your timezone"** asks users to recall. Slow, error-prone, requires precise spelling.
+- **A combobox** combines: type a few characters; the system shows matches; user recognizes and selects. Fast and tolerant of incomplete recall.
+
+The discipline: prefer surfaces that show what's available over surfaces that ask the user to remember.
+
+## When to apply
+
+- **Always**, when the user must select from a known set of options.
+- **Especially** when the option set is large or the user is occasional (less practiced; weaker recall).
+- **Critically** when the user might not know what's available — discoverability problem solved by recognition.
+
+## When recall *is* appropriate
+
+A few cases where recall outperforms recognition:
+
+- **Power-user shortcuts.** Frequent users develop muscle memory for keyboard shortcuts. Forcing them to recognize from a menu every time slows them.
+- **Free-text input** for genuinely open-ended content (writing prose, naming new objects). Recognition can't show what doesn't exist yet.
+- **Authentication.** Passwords are deliberately recall-based for security; recognition would weaken them.
+- **Creative input.** Brainstorming, artistic creation, problem-solving where the answer isn't a selection from a known set.
+
+## Patterns that leverage recognition
+
+### Combobox / typeahead
+
+The user types a few characters; the system filters from a known set; the user recognizes and selects.
+
+```html
+<combobox label="Country">
+  <input placeholder="Search country..." />
+  <listbox>
+    <option value="us">United States</option>
+    <option value="uk">United Kingdom</option>
+    <option value="de">Germany</option>
+    <!-- 192 more -->
+  </listbox>
+</combobox>
+```
+
+Better than:
+- Long select dropdown (visible options but no filtering for large sets).
+- Free-text field (recall required; typos cause errors).
+
+### Recents and frequently-used lists
+
+The most-recent or most-used items are surfaced first. Repeat actions become recognition tasks ("there it is again").
+
+```
+Recently used:
+  • Projects > Acme Q4
+  • Reports > Monthly summary
+  • Inbox
+
+Other workspaces:
+  • Projects > ...
+```
+
+### Command palettes (cmd-K)
+
+The palette shows available commands; the user filters by typing partial recall and recognizes the rest. Combines fast keyboard access (for power users) with recognition (for occasional users).
+
+### Visible navigation
+
+A sidebar showing available sections is recognition-based. The user sees what's there. Compare to command-line where the user must recall the command name.
+
+### Picker UIs over free-text
+
+A date picker shows a calendar; the user clicks the date. Compare to a free-text "MM/DD/YYYY" field that requires the user to recall the format.
+
+```html
+<input type="date" />  <!-- shows calendar picker; recognition -->
+<!-- vs. -->
+<input type="text" placeholder="MM/DD/YYYY" />  <!-- recall required -->
+```
+
+### Auto-complete in form fields
+
+```html
+<input name="email" type="email" autocomplete="email" />
+```
+
+The browser offers previously-used values; the user recognizes and selects.
+
+## Recognition in decision-making
+
+The book makes a related point: recognition often dominates decision-making. People choose the familiar option even when an unfamiliar option is objectively better. Examples:
+
+- **Brand-name products** in stores chosen over generic equivalents at lower price.
+- **Returning to the same restaurant** instead of trying new ones.
+- **Sticking with familiar tools** even when newer ones are demonstrably better.
+
+For product design, this means familiarity is a competitive moat. Users who know your product's interaction patterns will choose your product over alternatives requiring re-learning.
+
+## Worked examples
+
+### Example 1: timezone selector
+
+Bad (recall):
+```html
+<input name="timezone" placeholder="Type your timezone" />
+```
+
+Good (recognition):
+```html
+<select name="timezone">
+  <option>America/Los_Angeles (PST/PDT)</option>
+  <option>America/New_York (EST/EDT)</option>
+  <option>Europe/London (GMT/BST)</option>
+  <!-- 200+ more -->
+</select>
+```
+
+Better (recognition + filtering):
+```html
+<combobox name="timezone">
+  <input placeholder="Search..." />
+  <listbox>
+    <group label="Recent">
+      <option>America/Los_Angeles</option>
+    </group>
+    <group label="All">
+      <option>...</option>
+    </group>
+  </listbox>
+</combobox>
+```
+
+The combobox version: recents at top (recognition), filterable for the rest.
+
+### Example 2: command-line CLI vs. command palette
+
+CLI (recall):
+```
+$ git checkout -b feature/new-thing
+```
+
+Command palette (recognition):
+```
+[ Cmd-K opens palette ]
+Search: "create branch"
+> Create branch
+> Switch to branch
+> Delete branch
+```
+
+Both reach the same outcome. The CLI is faster for users who recall; the palette is faster for users who don't. Modern dev tools offer both.
+
+### Example 3: navigation menu over command memory
+
+Early word processors (WordStar, vi) required users to recall command sequences. Modern word processors show menus; the user recognizes the option.
+
+The recognition-based approach made word processors mass-market; the recall-based approach kept them tools for the technical.
+
+### Example 4: recents in a file picker
+
+```
+Open file...
+
+Recent files:
+  - resume-2026.docx
+  - project-notes.md
+  - budget.xlsx
+
+Browse:
+  Documents/
+  Downloads/
+  Desktop/
+```
+
+Recents collapse the recall task (where did I put it?) to recognition (there it is).
+
+## Cross-domain examples
+
+### Multiple choice exams
+
+The classic recognition-over-recall demonstration. Multiple choice exams are easier than essay or fill-in-the-blank because they provide cues. Test designers calibrate by limiting how cue-rich the choices are.
+
+### Restaurants: visible menus
+
+A printed menu at a restaurant lets diners recognize options. Asking diners to "tell us what you want" without a menu would dramatically slow ordering and limit choice variety.
+
+### Retail: shelf displays
+
+Stocked shelves where products are visible enable recognition-based shopping. Compare to bartender ordering ("what cocktails do you have?"), where customers must recall.
+
+### Library card catalogs (historical)
+
+Pre-digital libraries provided card catalogs (recognition: browse cards) and shelf browsing (recognition: see books). Modern search engines combine both: type partial recall, recognize from results.
+
+## Anti-patterns
+
+- **Empty fields requiring exact recall.** A field labeled "country" with no autocomplete; users must remember exact spelling.
+- **Hidden features requiring command knowledge.** "There's a feature for that, but you have to know to look for it." Discoverability problem.
+- **Over-reliance on muscle memory.** Designs assuming all users will memorize keyboard shortcuts; new users left out.
+- **No recents.** Frequent destinations not surfaced; users repeatedly retype.
+- **Generic placeholders that don't aid recognition.** "Enter value" instead of showing examples.
+
+## Heuristics
+
+1. **The "show options" check.** For each input, ask: are the valid options shown to the user, or must they recall? Showing usually wins.
+2. **The recents-coverage audit.** For pickers and navigation, are recents surfaced? If not, frequent users pay a recall tax.
+3. **The autocomplete check.** Are inputs hooked to autocomplete (browser, password manager, custom)? Each unaided input is a recall task.
+4. **The discoverability test.** Can a user find a feature without prior knowledge of its name? If not, recall is required to know about it.
+
+## Related principles
+
+- **`exposure-effect`** — exposure builds recognition; familiar items become preferred.
+- **`serial-position-effects`** — first and last items in a list are recognized fastest.
+- **`visibility`** — visible options enable recognition; hidden options don't.
+- **`hicks-law`** — recognition collapses Hick's Law for typeahead-filtered options.
+- **`mental-model`** — recognition leverages prior models; recall asks for explicit retrieval.
+- **`mimicry`** — borrowing familiar patterns leverages recognition.
+
+## Sub-aspect skills
+
+- **`recognition-pickers-and-palettes`** — pickers, dropdowns, comboboxes, command palettes; recognition-based selection patterns.
+- **`recognition-recents-and-suggestions`** — using recents, frequently-used, and contextual suggestions to accelerate repeat tasks.
+
+## Closing
+
+Recognition Over Recall is one of the cheapest cognition wins in design. Showing options where the user would otherwise have to remember reduces error rates, speeds tasks, and dramatically widens the user base. The discipline is recognizing each input as a recall-vs-recognition choice and defaulting to recognition unless there's a specific reason not to.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-over-recall/references/research-and-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-over-recall/references/research-and-cases.md
@@ -1,0 +1,37 @@
+# Recognition over recall: research and cases
+
+A reference complementing `recognition-over-recall` with research grounding.
+
+## Cognitive-psychology basis
+
+Recognition memory and recall memory engage different processes:
+
+- **Recognition** matches a current stimulus against memory traces. Fast (<500ms), high accuracy, durable.
+- **Recall** generates information from memory without prompts. Slower (1–3s), lower accuracy, more prone to "tip-of-tongue" failures.
+
+The asymmetry is well-documented across decades of memory research (Tulving, Mandler, others). It holds across age, language, and clinical conditions.
+
+## The Xerox Star (1981)
+
+The seminal applied work. The Star's designers replaced command-line memorization with menus, icons, and visible options — a dramatic recognition-over-recall shift. The interface paradigm spread to Apple's Lisa (1983), Macintosh (1984), Microsoft Windows, and most subsequent personal computing.
+
+Documented in Johnson, J. et al., "The Xerox 'Star': A Retrospective" (in *Human Computer Interaction: Toward the Year 2000*, 1995).
+
+## Brand recognition in marketplace
+
+Hoyer & Brown (1990), "Effects of Brand Awareness on Choice for a Common, Repeat-Purchase Product," *Journal of Consumer Research*. Showed that brand familiarity influences purchase choices independent of product quality. People bought familiar brands even when blind taste tests favored alternatives.
+
+Implication for product design: familiar brands and patterns are competitive moats — users recognize and choose them over equivalent or superior unfamiliar alternatives.
+
+## Modern applications
+
+- **Search engines** combine recognition (results) with partial recall (query). The user types a few words and recognizes matches.
+- **Command palettes** (cmd-K) collapse recall (knowing the command name) into recognition (filtered list).
+- **Autocomplete** in browsers, IDEs, and forms reduces recall to recognition.
+- **Recommendation systems** surface predicted-relevant items so the user recognizes rather than searches.
+
+## Resources
+
+- Tulving, E. *Elements of Episodic Memory* (1983).
+- Norman, D. *The Design of Everyday Things* (2013).
+- Nielsen, J. "10 Usability Heuristics" (1994 onward) — recognition rather than recall is heuristic #6.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-pickers-and-palettes/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-pickers-and-palettes/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: recognition-pickers-and-palettes
+description: 'Use this skill when designing pickers, dropdowns, comboboxes, autocompletes, command palettes, or any UI that lets the user select from a known set. Trigger when picking between a free-text field and a select; when designing a command palette; when reviewing why users keep typing wrong values into autocomplete inputs. Sub-aspect of `recognition-over-recall`; read that first.'
+---
+
+# Pickers, palettes, and recognition-based selection
+
+Selection UI is the most direct application of recognition-over-recall. Showing the user a list of valid options — visually scannable or filterable — beats requiring them to type from memory.
+
+## The picker ladder by set size
+
+Different selection patterns suit different option counts:
+
+| Option count | Pattern | Notes |
+|---|---|---|
+| 2 | Toggle / switch | Visual either-or |
+| 3–5 | Radio group / segmented | All options visible |
+| 5–8 | Select dropdown | Visible on click |
+| 8–20 | Grouped select | Categorical chunking helps |
+| 20+ | Combobox / typeahead | Filter-as-you-type |
+| 100+ | Search-first picker | Search-driven; recents augment |
+
+Going lighter than the count permits forces unnecessary recall. Going heavier adds complexity without benefit.
+
+## Patterns
+
+### Combobox / typeahead
+
+```html
+<combobox label="Country">
+  <input placeholder="Search countries..." />
+  <listbox>
+    <option>United States</option>
+    <option>United Kingdom</option>
+    <!-- filtered as user types -->
+  </listbox>
+</combobox>
+```
+
+The user types partial recall; the system filters; the user recognizes the right option. Tolerates typos with fuzzy matching.
+
+### Command palette (cmd-K)
+
+A palette that lists actions, navigation destinations, and search:
+
+```
+[ ⌘K opens palette ]
+
+Search:
+> Recents
+  Create invoice
+  Open settings
+> Actions
+  Search projects
+  Invite teammate
+> Navigation
+  Go to Dashboard
+  Go to Projects
+```
+
+Categorical groups + search + recents = recognition for nearly any command.
+
+### Recents at the top of pickers
+
+```html
+<combobox label="Assignee">
+  <listbox>
+    <group label="Recent">
+      <option>Maria Mendoza</option>
+      <option>Lin Chen</option>
+    </group>
+    <group label="All members">
+      <!-- alphabetical -->
+    </group>
+  </listbox>
+</combobox>
+```
+
+Repeat-task speed via recents.
+
+### Suggestions and predictions
+
+For inputs where the system can predict likely values:
+
+```html
+<input
+  name="email"
+  type="email"
+  autocomplete="email"
+  list="email-suggestions"
+/>
+<datalist id="email-suggestions">
+  <option value="user@example.com" />
+  <option value="user@gmail.com" />
+</datalist>
+```
+
+The browser surfaces matching options; the user recognizes and selects.
+
+### Visual pickers for inherently-visual content
+
+For colors, dates, locations, etc., visual pickers are more recognition-friendly than coded inputs:
+
+- Color picker (visual swatch grid) beats hex code input.
+- Date picker (calendar) beats text date input.
+- Map picker (visual location) beats lat/long input.
+
+## Combobox accessibility
+
+The WAI-ARIA Combobox pattern documents the keyboard interaction:
+
+- `Tab` enters the input.
+- Arrow keys navigate the listbox.
+- Enter selects the highlighted option.
+- Esc closes the listbox without selection.
+
+Reach for an accessible combobox library (Radix, React Aria, Headless UI) rather than rolling your own — focus management and ARIA are easy to get wrong.
+
+## Anti-patterns
+
+- **Free-text where a picker would do.** Asking users to type "United States" exactly when a dropdown could show options.
+- **Empty pickers** that require typing to see anything (vs. showing options on focus).
+- **Picker without filter** for sets larger than ~10 items. Scrolling 200 items is slow.
+- **No recents.** Users repeatedly retype the same destinations.
+- **Picker labels that don't match user vocabulary.** Showing internal names instead of friendly names.
+
+## Heuristics
+
+1. **The "what's available?" test.** For each input, ask: how does the user know what valid options are? If they don't, you're requiring recall.
+2. **The set-size match.** Match the picker pattern to the option count.
+3. **The recents-presence audit.** For pickers used repeatedly, are recents surfaced? If not, every selection is a fresh recognition task.
+
+## Related sub-skills
+
+- **`recognition-over-recall`** (parent).
+- **`recognition-recents-and-suggestions`** — accelerating repeat tasks.
+- **`hicks-law-menus`** — picker design under decision-time constraints.
+- **`accessibility-operable`** — comboboxes are notorious accessibility-test surfaces.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-pickers-and-palettes/references/picker-pattern-catalog.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-pickers-and-palettes/references/picker-pattern-catalog.md
@@ -1,0 +1,31 @@
+# Picker patterns: catalog reference
+
+A reference complementing `recognition-pickers-and-palettes` with picker-pattern detail.
+
+## Modern command-palette implementations
+
+Command palettes proliferated in the 2010s and 2020s. Notable implementations:
+
+- **Sublime Text** (2008) — among the first widely-adopted; popularized cmd-shift-P.
+- **VSCode** — same convention; expanded to "Quick Open" (cmd-P) for files.
+- **Linear** — extended to nearly all navigation and actions.
+- **Notion, GitHub, Slack, Stripe Dashboard** — all converged on cmd-K or similar.
+
+The pattern is now an expected feature of modern productivity tools.
+
+## Combobox accessibility
+
+The WAI-ARIA Combobox pattern (w3.org/WAI/ARIA/apg) documents the canonical implementation:
+
+- `role="combobox"` on the input.
+- `role="listbox"` on the dropdown.
+- `aria-expanded`, `aria-controls`, `aria-activedescendant` for state.
+- Keyboard: arrow keys navigate, Enter selects, Esc closes.
+
+Reach for `cmdk`, `Downshift`, `Headless UI Combobox`, `Radix Combobox` — accessible, well-tested implementations beat hand-rolled.
+
+## Resources
+
+- WAI-ARIA Authoring Practices: Combobox pattern.
+- `cmdk` library — popular React command-palette implementation.
+- NN/g articles on autocomplete and search-first interfaces.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-recents-and-suggestions/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-recents-and-suggestions/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: recognition-recents-and-suggestions
+description: 'Use this skill when designing surfaces that accelerate repeat tasks through recents, frequently-used items, and contextual suggestions. Trigger when designing pickers used repeatedly, command palettes, navigation that should adapt to user behavior, or any surface where a returning user shouldn''t have to retype their frequent destinations. Sub-aspect of `recognition-over-recall`; read that first.'
+---
+
+# Recents, frequents, and contextual suggestions
+
+Recognition is fastest when the user doesn't even have to scan a long list — when the system anticipates and surfaces the likely options first. Recents, frequents, and predictive suggestions all leverage this: the user's likely target is at the top, often without typing anything.
+
+## Patterns
+
+### Recents
+
+A list of items the user has recently interacted with. Surfaced at the top of pickers, navigation, or empty search inputs.
+
+```html
+<combobox label="Recipient">
+  <input placeholder="Search recipients..." />
+  <listbox>
+    <group label="Recent">
+      <option>Maria Mendoza (last sent: yesterday)</option>
+      <option>Marketing Team (last sent: 3 days ago)</option>
+    </group>
+    <group label="All">...</group>
+  </listbox>
+</combobox>
+```
+
+Most users compose for a small set of recipients repeatedly; recents collapse the recall task.
+
+### Frequents
+
+Items used most often (regardless of recency). Useful when usage is clustered around a small set but not necessarily recent.
+
+```
+Frequently used apps:
+  • Email
+  • Slack
+  • Code editor
+  • Browser
+```
+
+A common laptop dock pattern.
+
+### Recommended / suggested
+
+System-predicted likely options based on context. Examples:
+
+- A "for you" feed.
+- "People you may know."
+- "Suggested replies" in messaging.
+- "Suggested tags" when categorizing.
+
+Recommendations work when the prediction is good. Bad recommendations (irrelevant, wrong) are worse than none — they distract and erode trust.
+
+### Pinned / favorites
+
+User-curated frequently-accessed items. Less algorithmic than recents/suggestions; user-explicit.
+
+```
+Pinned:
+  ★ Q4 Planning Doc
+  ★ Team OKRs
+  ★ Customer feedback dashboard
+```
+
+Combine with recents and suggestions for a complete fast-access surface.
+
+### Smart defaults
+
+Pre-fill fields with predicted values based on context (signed-in user, recent inputs, time of day, location).
+
+```html
+<form>
+  <label>Country
+    <select name="country">
+      <option value="US" selected>United States</option>
+      <!-- selected because of user's IP location -->
+    </select>
+  </label>
+</form>
+```
+
+The user can change but rarely needs to.
+
+## When recents/suggestions hurt
+
+- **When the prediction is bad.** Wrong recents distract; the user has to filter past them.
+- **When privacy matters.** Recents reveal user history; in shared-device contexts this can leak information.
+- **When the option set is critical to the task.** A "recent" suggestion in a destructive action might bias the user toward the wrong choice.
+
+For high-stakes actions, present the full set without privileging recents.
+
+## Privacy and recents
+
+Recents reveal user activity to anyone with screen access. Considerations:
+
+- **Don't surface recents on shared/public devices** unless explicitly opted in.
+- **Provide a "clear recents" option.**
+- **Don't leak across tenants** (a recent in workspace A shouldn't appear when the user switches to workspace B).
+- **Be cautious with sensitive contexts** (health apps, finance apps, dating apps).
+
+## Anti-patterns
+
+- **Stale recents** that include items the user no longer cares about, never expiring.
+- **Recents that span privacy boundaries** (work email recents in personal context).
+- **Suggestions that don't update** as the user's behavior changes.
+- **Surfacing recents in wrong contexts** (showing "recent files" on a different user's account).
+
+## Heuristics
+
+1. **The "would the user pick this without typing?" check.** For each picker, ask: in the median case, can the user get to their target without typing? If yes, recents are doing their job.
+2. **The recents-quality audit.** Sample your recents lists. Are they actually relevant to current intent?
+3. **The privacy review.** What do recents reveal? Should they be hidden by default in some contexts?
+
+## Related sub-skills
+
+- **`recognition-over-recall`** (parent).
+- **`recognition-pickers-and-palettes`** — picker patterns recents augment.
+- **`satisficing`** — recents enable satisficing by surfacing acceptable options first.
+- **`hicks-law-defaults`** — defaults and recents both reduce decision cost.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-recents-and-suggestions/references/recents-and-prediction-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/recognition-recents-and-suggestions/references/recents-and-prediction-cases.md
@@ -1,0 +1,52 @@
+# Recents, frequents, and predictive UI: reference
+
+A reference complementing `recognition-recents-and-suggestions` with implementation patterns.
+
+## Recents data sources
+
+Where to compute recents from:
+
+- **User activity logs** — server-side history of user actions.
+- **Local storage** — client-side recents for fast access.
+- **Browser history** — for navigation recents.
+- **Frecency** (a Mozilla coinage) — combined recency + frequency score.
+
+## Frecency algorithms
+
+A frecency score combines recency and frequency. Items used recently *and* often score highest. Used by Firefox URL bar, VSCode quick-open, and similar.
+
+A simple frecency formula:
+
+```js
+function frecency(item) {
+  const recencyScore = 1 / (1 + daysSince(item.lastAccess));
+  const frequencyScore = Math.log(1 + item.accessCount);
+  return recencyScore * 10 + frequencyScore;
+}
+```
+
+Tunable weights let you favor recency or frequency depending on context.
+
+## Predictive suggestion sources
+
+Where suggestions come from:
+
+- **Recently used** — simple, fast, often accurate.
+- **Frequency-weighted** — favors items used many times.
+- **Time-of-day patterns** — morning vs. evening usage.
+- **Context** — the page, the role, the workspace.
+- **Similar-user behavior** — collaborative filtering.
+- **Content-based** — items similar to what the user just acted on.
+
+## Privacy considerations
+
+- **Per-context recents** — work recents shouldn't leak to personal context.
+- **Clearable** — let users clear recents.
+- **Opt-out** — let users disable recents tracking entirely.
+- **Encryption / scoping** — recents stored in user-controlled stores.
+
+## Resources
+
+- Mozilla "frecency" definition — Firefox URL-bar algorithm.
+- Search-bar UX research from NN/g.
+- Privacy by design literature (Cavoukian, others).

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-breadcrumbs-and-context/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-breadcrumbs-and-context/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: wayfinding-breadcrumbs-and-context
+description: 'Use this skill when designing the orientation chrome that tells users where they are — breadcrumbs, current-page indicators, page titles, header context, "you are here" markers, parent-link affordances. Trigger when designing a multi-level IA, when users complain "I lost track of where I was," when reviewing whether to add or remove a breadcrumb, or when picking between navigation patterns for hierarchical content. Sub-aspect of `wayfinding`; read that first.'
+---
+
+# Wayfinding: breadcrumbs and "you are here" context
+
+The orientation stage of wayfinding is largely served by the chrome a user sees on every page: the breadcrumb at the top, the highlighted item in the nav, the page title, the URL pattern. Done well, this chrome is invisible (the user just knows where they are). Done poorly, it forces the user to actively reconstruct their location every time they look up.
+
+## What "you are here" chrome must do
+
+Three jobs, on every page:
+
+1. **Confirm location.** Where am I in the IA right now?
+2. **Show parents.** What contains this page? How did I get here?
+3. **Offer escape.** How do I go back up the tree?
+
+Each job has standard patterns; combining them produces a complete orientation system.
+
+## Breadcrumbs
+
+Breadcrumbs are the most-cited orientation pattern: a horizontal path from the root to the current page.
+
+```html
+<nav aria-label="Breadcrumb">
+  <ol>
+    <li><a href="/">Home</a></li>
+    <li><a href="/projects">Projects</a></li>
+    <li><a href="/projects/acme">Acme</a></li>
+    <li aria-current="page">Settings</li>
+  </ol>
+</nav>
+```
+
+### When breadcrumbs help
+
+- **Hierarchical IA** with ≥ 3 levels of depth (e.g., e-commerce: Home › Electronics › Cameras › DSLR).
+- **Documentation sites** with sectioned content.
+- **Settings pages** that nest into sub-sections.
+- **Deep app shells** where the user might forget how they got somewhere.
+
+### When breadcrumbs are noise
+
+- **Flat IA** (≤ 2 levels). A breadcrumb saying "Home › Profile" doesn't add information; the page title does the work.
+- **Single-page apps with no hierarchical structure.** A breadcrumb on a Trello board is awkward — Trello's "spatial" model is the wayfinding chrome.
+- **Mobile contexts** where horizontal space is precious. Often replaced by a "Back to ..." button that names the parent.
+
+### Breadcrumb anti-patterns
+
+- **Breadcrumb that doesn't match the URL.** "Home › Settings › Notifications" but the URL is `/u/3829/p/abc/n` — confusion.
+- **Breadcrumb whose intermediate items aren't real pages.** Clicking "Projects" in the breadcrumb above should take you to a Projects index, not 404.
+- **Breadcrumb showing the user's *path*, not the IA *hierarchy*.** "Home › Search Results › Project Acme › Settings" mixes navigation history with structure. Pick one.
+- **Breadcrumb instead of a current-page indicator.** Breadcrumbs supplement nav highlighting; they don't replace it.
+
+## Current-page indicator in primary nav
+
+The user looks at the primary nav and sees one item highlighted: the current page (or current section).
+
+```html
+<nav>
+  <a href="/dashboard">Dashboard</a>
+  <a href="/projects" aria-current="page">Projects</a>
+  <a href="/team">Team</a>
+  <a href="/settings">Settings</a>
+</nav>
+
+<style>
+  nav a[aria-current="page"] {
+    background: var(--bg-active);
+    color: var(--fg-active);
+    font-weight: 500;
+  }
+</style>
+```
+
+`aria-current="page"` makes the indicator accessible to screen readers; CSS makes it visible.
+
+For sidebar navs with sections and sub-items, both the section header and the current sub-item should have indicators — the user sees the section context as well as the specific page.
+
+## Page titles
+
+The page's `<h1>` and the browser tab's `<title>` are wayfinding chrome.
+
+- **`<h1>`** confirms what page you're on. It should match the nav item that brought you here.
+- **`<title>`** appears in the browser tab and in browser history. It should be descriptive enough to identify the page without context.
+
+```html
+<title>Q4 plan — Notes — Acme — MyProduct</title>
+<h1>Q4 plan</h1>
+```
+
+The tab title shows the path from specific to general (current page → context → product); the H1 shows just the current page (since context is visible elsewhere on the page).
+
+## URL patterns
+
+The URL is wayfinding for power users and for shared/bookmarked links.
+
+- **Hierarchical paths** (`/projects/acme/notes/q4-plan`) reflect IA depth. Each segment is a real, navigable level.
+- **Flat slugs with no hierarchy** (`/p/8f3c7a`) are opaque. Useful for stable IDs; bad for orientation.
+- **Search-state URLs** (`/search?q=q4+plan&filter=notes`) carry orientation about *what the user did*, not where they are in the IA.
+
+The pragmatic rule: hierarchical URLs for content that has a hierarchy; opaque URLs for objects that don't (a chat message, a notification). Don't mix.
+
+## Header context
+
+The persistent app header carries orientation information beyond the nav:
+
+- **The current workspace / organization name.** Important for users with access to multiple.
+- **The current user's avatar / account menu.** Confirms which account they're signed in as.
+- **The current environment** (production vs. staging) — critical for power-user safety.
+
+```html
+<header class="app-header">
+  <a href="/" class="logo">MyProduct</a>
+  <button class="org-switcher">Acme Inc ▾</button>
+  <nav>...</nav>
+  <button class="user-menu">
+    <img alt="Maria Mendoza" src="/avatar/maria.jpg" />
+  </button>
+</header>
+```
+
+In settings or developer tools, an environment indicator ("PROD", "STAGING", "DEV") in a strong color belongs in the header — it's safety-critical orientation.
+
+## "Back to ..." patterns
+
+For pages that exist *below* a parent (a detail view of an item in a list), a "Back to ..." link at the top is more compact and sometimes more useful than a full breadcrumb:
+
+```html
+<a class="back-link" href="/projects/acme">
+  ← Back to Acme
+</a>
+<h1>Q4 plan</h1>
+```
+
+This works well when the user came *from* the parent. It's less appropriate when the user landed on the detail directly (e.g., from a notification or shared link), because they may not have a clear "back" in mind.
+
+## Mobile constraints
+
+Mobile screens compress orientation chrome. Patterns:
+
+- **Replace breadcrumbs with a single "Back" arrow** in the top nav, naming the parent ("← Acme").
+- **Use the page title as the entire orientation.** Don't try to fit a multi-level breadcrumb on a 375px screen.
+- **Bottom nav highlights the current section** rather than a sidebar showing all of them.
+
+## Testing orientation chrome
+
+The single most useful test: **the deep-link test.**
+
+1. Open your app to a page deep in the IA — say, three levels down.
+2. Note the URL.
+3. Open it in a new browser window with no history.
+4. Look at the page for 5 seconds.
+5. Without scrolling, can you tell:
+   - What page this is?
+   - What section it belongs to?
+   - How to get to the home page?
+   - What the parent of this page is?
+
+If yes to all four, your orientation chrome is working. If no, the chrome is too thin.
+
+## Anti-patterns
+
+- **The mystery URL.** Page at `/p/8f3c7a` with no breadcrumb, no nav highlight, no clear title. The user can't form a cognitive map even if they want to.
+- **Two indicators in conflict.** The breadcrumb says "Settings" but the active nav item is "Profile." The user trusts neither.
+- **Page titles that don't match nav labels.** Nav says "Documents," page title is "File Repository." Each rename is a mental-map cost.
+- **Breadcrumbs to nowhere.** Clicking an intermediate level 404s because that intermediate page doesn't exist.
+- **Headers without environment indication on multi-environment products.** A user runs a destructive script in prod thinking they're in staging.
+- **No orientation on overlays.** A modal floats with no indication of what page is behind it; the user closes it and isn't sure where they are.
+
+## Heuristics
+
+1. **Glance test.** Land on a page; in 1 second, can you say its name? In 3 seconds, can you say its parent's name? In 5 seconds, can you say its grandparent? If the chain breaks somewhere, that level's chrome is missing or weak.
+2. **Highlight audit.** Click through every nav item. For each destination, is the active state correctly highlighted? Stale or missing highlight is a common bug.
+3. **Title parity.** Does every page's H1 match the nav label that points to it? Mismatches degrade trust.
+
+## Related sub-skills
+
+- **`wayfinding`** (parent).
+- **`wayfinding-physical-spatial-metaphors`** — spatial metaphors set the high-level wayfinding model; breadcrumbs handle the per-page orientation.
+- **`wayfinding-search-and-recovery`** — when orientation fails, search recovers.
+- **`hierarchy`** (perception) — visual hierarchy on a page is page-internal wayfinding.
+- **`recognition-over-recall`** — orientation chrome lets users recognize where they are; without it, they recall (slower, error-prone).
+- **`visibility`** — chrome must be visible to do its job.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-breadcrumbs-and-context/references/orientation-chrome-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-breadcrumbs-and-context/references/orientation-chrome-patterns.md
@@ -1,0 +1,172 @@
+# Orientation chrome: pattern reference
+
+A reference complementing `wayfinding-breadcrumbs-and-context` with a pattern catalog and history.
+
+## Breadcrumb taxonomy
+
+Three distinct breadcrumb types, often confused:
+
+### Location breadcrumbs (most common)
+
+Show the user's position in the IA hierarchy:
+
+```
+Home › Projects › Acme › Settings
+```
+
+Each segment is a real page; clicking goes "up" the tree. This is what most users mean by "breadcrumbs."
+
+### Path breadcrumbs
+
+Show the user's actual navigation history:
+
+```
+Dashboard › Search › Results › Project Acme › Settings
+```
+
+Mirrors browser history. Less common; can be useful for complex flows where users want to retrace their steps. Confusing if mixed with location breadcrumbs.
+
+### Attribute breadcrumbs
+
+Show the *filters* applied rather than the IA path:
+
+```
+All projects › Active › Owned by me › Q4 deadline
+```
+
+Common in faceted-search UIs (e-commerce category pages). Each segment is a filter the user can remove.
+
+The three types serve different jobs; mixing them creates confusion. Pick one per surface.
+
+## "You are here" indicators in nav
+
+Every nav item that points to the user's current page should have a visible active state. Common patterns:
+
+```css
+/* Subtle background tint */
+nav a[aria-current="page"] {
+  background: var(--color-active-bg);
+  color: var(--color-active-fg);
+}
+
+/* Left border (for sidebar nav) */
+nav a[aria-current="page"] {
+  border-left: 3px solid var(--color-brand);
+  padding-left: calc(1rem - 3px);
+}
+
+/* Bold weight + underline (for top nav) */
+nav a[aria-current="page"] {
+  font-weight: 600;
+  border-bottom: 2px solid var(--color-brand);
+}
+```
+
+For sub-section pages, *both* the section and the sub-item should be marked: section has a section-level highlight; sub-item has a stronger highlight. This shows the user where they are at every level of the IA.
+
+## URL design as wayfinding
+
+URLs are wayfinding chrome that lives outside the rendered page. Patterns:
+
+| URL style | Wayfinding signal | When it fits |
+|---|---|---|
+| `/projects/acme/notes/q4-plan` | Hierarchical; reflects IA depth | Content with a clear hierarchy |
+| `/p/8f3c7a` | Opaque; ID-only | Stable IDs for objects, deep-linking |
+| `/projects?team=acme&status=active` | State-bearing | Filtered views, search results |
+| `/u/maria/timeline` | User-scoped | Per-user content (profiles, dashboards) |
+| `/?modal=settings` | Modal-state in URL | Allows shareable links to modal-open states |
+
+Hierarchical URLs are the strongest wayfinding signal but require URL changes when IA shifts. Opaque URLs are stable but uninformative. Most apps use a mix.
+
+## Page title patterns
+
+The `<title>` element appears in browser tabs, browser history, and search-engine results. It's wayfinding chrome that follows the page out into the user's environment.
+
+A useful pattern:
+
+```
+[Specific Page] — [Section] — [Product]
+```
+
+Examples:
+
+```
+Q4 plan — Notes — Acme — MyProduct
+Settings: Notifications — Acme — MyProduct
+Dashboard — Acme — MyProduct
+```
+
+This puts specific information first (visible when tabs are narrow) and product name last (consistent across all tabs).
+
+## Header chrome elements
+
+The persistent app header carries wayfinding signals beyond navigation:
+
+- **Workspace / org switcher.** For multi-tenant products, which workspace you're in is critical context.
+- **Account / user indicator.** Confirms the signed-in user (avoids "I changed something on the wrong account").
+- **Environment indicator.** "PROD" / "STAGING" / "DEV" — mission-critical for power tools.
+- **Notification indicator.** Count of unread items as a soft "you have business elsewhere" signal.
+- **Search input.** Always available; supports recovery from any wayfinding failure.
+
+For products with multiple workspaces, the workspace indicator should be visually distinct enough that users can tell at a glance — color, name, or both.
+
+## Mobile orientation patterns
+
+Mobile compresses orientation chrome. Patterns:
+
+### Stacked back-stack
+
+iOS pattern: a "back" button at top-left names the parent ("← Acme"). Tapping returns to the parent. Builds a stack the user can unwind one level at a time.
+
+### Bottom-tab persistent context
+
+The currently-active tab is always indicated in the bottom nav, even when the user is deep in a sub-screen. Returns to root by tapping the active tab again.
+
+### Pull-down navigation
+
+Some apps (Twitter / X, Threads) use pull-down gestures to surface global navigation. Costs discoverability; suits power users.
+
+## Wayfinding for keyboard users
+
+Keyboard users navigate by tab order, focus, and shortcuts — not by clicking visible chrome. Wayfinding for them needs:
+
+- **Visible focus indicators** (`:focus-visible` outlines) so they can see where they are.
+- **Skip links** ("Skip to main content") that jump past nav chrome.
+- **Predictable focus order** that matches the visual reading order.
+- **Keyboard shortcuts for common navigation** (`g h` to go home, `g s` to go to settings — the GitHub pattern).
+- **Focus restoration after modal close** so the user returns to where they were.
+
+## Accessibility intersection
+
+Orientation chrome that helps sighted users also helps screen-reader users — but only if marked correctly:
+
+- `aria-current="page"` on the active nav item is announced.
+- `<nav aria-label="Breadcrumb">` and `<nav aria-label="Main">` distinguish navigation regions.
+- `<main>` and `<aside>` landmark elements let screen-reader users jump between regions.
+- Page `<title>` is the first thing announced on page load.
+
+A common bug: visual nav highlighting via class (`.active`) without the corresponding `aria-current`. The visual chrome works for sighted users; screen reader users get no signal.
+
+## Cross-domain examples
+
+### Wayfinding signs in airports
+
+Airport signs often include the equivalent of a breadcrumb: "Concourse C → Gates C20–C40 → Gate C26." Each segment narrows the location. The same logic underlies software breadcrumbs.
+
+### Address bars in browsers
+
+The browser's URL address bar is the most-used wayfinding chrome ever built. It tells users where they are (URL), where they've been (history), and lets them go elsewhere (typing). Apps that hide or obscure URL information forfeit a major orientation tool.
+
+### Mile markers on highways
+
+Mile markers serve route-monitoring (you've traveled X distance) and orientation (you're at mile 247 in California). The "page X of Y" indicator in long flows or paginated docs is the same idea.
+
+## Resources
+
+- **Krug, S.** *Don't Make Me Think* — chapter on navigation and the trunk test.
+- **NN/g** — many publicly available articles on breadcrumbs, page titles, and navigation indicators.
+- **GOV.UK Design System** — example of orientation chrome at high quality.
+
+## Closing
+
+Orientation chrome is one of those design layers that's invisible when correct and brutal when missing. The user doesn't notice the breadcrumb that helps them; they notice the missing breadcrumb that doesn't. Building it well is mostly about consistency: same patterns, same locations, every page.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-physical-spatial-metaphors/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-physical-spatial-metaphors/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: wayfinding-physical-spatial-metaphors
+description: 'Use this skill when deciding whether (and how) to borrow physical-world wayfinding metaphors for software — rooms, doors, paths, maps, landmarks. Trigger when designing app shells with multiple "spaces," when picking metaphors for navigation (workspace, channel, board, project), when reviewing skeuomorphic vs. flat navigation choices, or when the user mentions "feels like a maze" or "where''s the front door of this app." Sub-aspect of `wayfinding`; read that first.'
+---
+
+# Wayfinding through physical-spatial metaphors
+
+Software navigation borrows from physical-world wayfinding all the time — sometimes deliberately, often by accident. "Folders" mimic filing cabinets; "rooms" and "channels" mimic conference rooms; "boards" and "lists" mimic whiteboards; "drilling down" and "zooming out" are spatial verbs. Used well, these metaphors give users an instant cognitive map. Used carelessly, they create expectations the software can't meet.
+
+## When physical metaphors help
+
+The metaphor must satisfy three conditions to be net-positive:
+
+1. **The user already knows the source.** A "folder" works because filing cabinets are universal. A "Kanban board" works for users who know Kanban; less for those who don't.
+2. **The mapping is consistent.** If your "rooms" can be entered, exited, and have walls, then they should *behave* like rooms — opening one closes the other (or layers it visibly), entering signals a context shift, leaving returns to the previous space.
+3. **The user gains something the metaphor uniquely provides.** Spatial metaphors usually provide spatial intuitions: where things are relative to each other, what's nearby, what's deeper.
+
+When all three hold, the metaphor offloads cognitive work to the user's existing model.
+
+## When metaphors backfire
+
+- **Mismatch between metaphor and behavior.** A "Trash" that empties itself silently every 30 days is not a trash — physical trash sits there until you take it out. The metaphor implies one behavior, the system does another, and trust degrades.
+- **Forced metaphors that don't fit.** Apple's mid-2000s reach for skeuomorphism (leather-bound calendars, felt-textured Game Center) borrowed metaphors that added no informational value and aged poorly.
+- **Cross-cultural assumptions.** A "front porch" or "lobby" metaphor presumes architectural conventions that don't translate universally.
+- **Mixing incompatible metaphors.** "Drag this folder into the room you want to share it with" combines a filing-cabinet verb with a building-room metaphor; it works only if the user squints.
+
+## Useful spatial metaphors in modern software
+
+### Rooms / Channels / Spaces
+
+Slack channels, Discord servers, Notion workspaces, Microsoft Teams. The metaphor: a named container with members and a context. Each room has its own conversations and norms.
+
+Wayfinding implications:
+- Switching rooms feels like changing context (visual transition; current-room highlighted).
+- Entering a room you've never visited shouldn't feel arbitrary — recent activity, who's there, what's pinned should orient you.
+- A "lobby" or "general" channel acts as the entry-room equivalent.
+
+### Boards / Lanes / Cards
+
+Trello, Linear, Asana boards. The metaphor: a flat surface (board) with regions (lanes/columns) and movable items (cards). Maps to whiteboards, post-it walls, kanban systems.
+
+Wayfinding implications:
+- The whole board is visible at once — no drilling down required for the primary view.
+- Cards have positions; moving them carries meaning.
+- Zooming out to see "all boards" requires a different metaphor (a folder of boards, a workspace).
+
+### Folders / Trees / Hierarchies
+
+The original spatial metaphor: file systems. Folders within folders within folders.
+
+Wayfinding implications:
+- Depth reads as "deeper into" — backwards/up is the universal escape.
+- Tree views show siblings and parents simultaneously; flat folder views show only contents (the file manager pattern).
+- Breadcrumbs make hierarchy navigable without committing to a tree view.
+
+The trap: deep hierarchies are easier to *create* than to *navigate*. Wayfinding research consistently finds that 4+ levels of depth become frustrating; users prefer broader, shallower structures.
+
+### Maps and Canvases
+
+Figma, Miro, FigJam. The metaphor: an infinite 2D plane that the user pans and zooms across.
+
+Wayfinding implications:
+- Position carries meaning; spatial proximity is grouping.
+- Mini-maps and zoom-to-fit are wayfinding tools borrowed directly from physical maps.
+- Without these tools, users get lost on infinite canvases ("where's the design I made yesterday?").
+
+### Stacks / Decks / Stories
+
+Card-stack metaphors (Stories on Instagram, swipeable decks). The metaphor: a stack of cards consumed sequentially.
+
+Wayfinding implications:
+- Position-in-sequence is the orientation (3 of 7).
+- Forward/back are the only navigation verbs; usually no "jump to" without breaking the metaphor.
+- Works well for short sequences; fails for long ones (no random access).
+
+## Cross-domain examples
+
+### Museum and gallery wayfinding
+
+Museums have used spatial metaphors for centuries: rooms grouped by period, by region, by artist. Visitors orient by which "room" they're in. Modern museum apps mirror this — the audio tour app shows you which room corresponds to your current location, and tapping a room reveals its contents.
+
+The lesson: when the physical space is well-organized, the digital equivalent inherits that organization for free.
+
+### City vs. suburban wayfinding
+
+Cities organized on grids (Manhattan, parts of Tokyo) are easier to wayfind than organic-grown cities (Boston, Lisbon, much of London). Grid metaphors translate to software well: a settings page laid out as a grid of categories (Profile, Notifications, Security, Billing) is easier to navigate than one organized by some idiosyncratic logic.
+
+When your IA naturally has a grid-like structure, expose it. When it has an organic structure, lean into landmarks.
+
+### "Skeuomorphism revisited"
+
+The flat-design movement (post-2013) rejected literal skeuomorphism (leather-bound calendars, felt poker tables). What survived: *spatial intuitions* without literal visual mimicry. Sliding panels still feel like opening drawers; cards still feel like tangible objects. The visual style went flat; the spatial metaphors stayed.
+
+The current trend (post-2020) is "neo-skeuomorphism" — subtle depth cues, careful shadows, motion that respects spatial logic. The principle: borrow the *physics*, not the *textures*.
+
+## Anti-patterns
+
+- **Inventing metaphors no user has ever encountered.** "Rendezvous Spaces" or "Wisdom Pods" sound clever in design reviews and confuse everyone in production.
+- **Treating containers as both folders and tags.** A folder is exclusive (a file lives in one folder); a tag is inclusive (a file can have many tags). Hybrid systems where a "folder" can also be applied as a tag confuse users.
+- **The infinite map without a home.** Infinite-canvas tools without a "go to my home" or "fit to content" are wayfinding deserts.
+- **Animation that contradicts the spatial metaphor.** Closing a sheet and having it shrink to a corner unrelated to where it opened from breaks the spatial intuition.
+
+## Heuristics
+
+1. **Name the metaphor explicitly.** "We're treating these as rooms — that means entering signals a context shift, exiting returns to where you were." Once named, the team can audit consistency.
+2. **The "what would the physical version do?" check.** When in doubt about a behavior, ask: what would the physical-world equivalent do? Does the software match?
+3. **The new-user metaphor test.** Onboard a new user without explaining your metaphors. If they intuit "channel," "board," "folder" correctly, the metaphor is doing its work. If they ask "what's a Space?", the metaphor is too clever.
+
+## Related sub-skills
+
+- **`wayfinding`** (parent) — the principle and four-stage framework.
+- **`wayfinding-search-and-recovery`** — when spatial metaphors fail, search recovers.
+- **`wayfinding-breadcrumbs-and-context`** — making the "where am I" answer load-bearing.
+- **`mental-model`** — physical metaphors work because they leverage existing mental models.
+- **`mimicry`** — the broader principle of borrowing successful patterns.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-physical-spatial-metaphors/references/metaphor-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-physical-spatial-metaphors/references/metaphor-cases.md
@@ -1,0 +1,92 @@
+# Spatial metaphor cases and history
+
+A reference complementing `wayfinding-physical-spatial-metaphors` with longer historical context and case studies.
+
+## A short history of digital spatial metaphors
+
+### The desktop metaphor (1970s–present)
+
+Xerox PARC's Alto (1973) introduced the desktop, files, folders, and trash can — borrowing the office worker's physical environment and translating it to a 2D screen. Apple commercialized it (Lisa, Macintosh) and Microsoft followed (Windows). Forty-plus years later, "files" and "folders" are universal vocabulary; users who never sat at a typewriter still navigate hierarchical file systems.
+
+The desktop metaphor's success: the source domain (an office) was familiar to the target users (white-collar workers), the mapping was consistent (drag a file into a folder = put a file into a folder), and the metaphor solved a real problem (organizing many files).
+
+### The web as a place (1990s)
+
+Early web design borrowed heavily from physical metaphors: "homepage," "site map," "back" and "forward," "bookmarks," "visiting" a site. The browser itself is a *navigator*. The metaphor was strong enough to outlast the technologies that birthed it.
+
+### The skeuomorphic moment (mid-2000s–early 2010s)
+
+Apple's iOS (2007–2013) leaned hard into literal skeuomorphism: leather-bound calendars, felt-textured Game Center, the wood-and-tape Voice Memos icon, the linen background. The metaphors weren't just *spatial*; they were *visual* mimicry of physical objects.
+
+Skeuomorphism worked when the metaphor added affordance (the iBooks bookshelf taught users they could browse books). It failed when the metaphor was decoration only (the Notes app's yellow legal pad added nothing). Apple's flat-design pivot (iOS 7, 2013) rejected literal skeuomorphism while keeping spatial metaphors.
+
+### Modern minimal-spatial design (2013–present)
+
+Current convention: keep spatial metaphors at the *behavior* level (sliding panels, modals "above" content, drawers that pull from edges) without literal physical visual mimicry. The Material Design system formalized this with elevations, shadows, and motion that obey spatial physics.
+
+## Case studies
+
+### Slack's "channels" metaphor
+
+Slack's channels are digital rooms: each has members, a name, a context, a history. Joining a channel feels like entering a room; leaving feels like leaving. The metaphor works because:
+
+- The source (a chatroom or office breakout space) is familiar.
+- Behavior matches expectation: messages in #general are visible to everyone in #general, like conversations in a public room.
+- The visual treatment (channel switcher in sidebar, channel name as page header) reinforces the spatial intuition.
+
+What Slack adds: cross-channel search and DMs that don't fit the room metaphor cleanly. Slack handles these by treating them as *separate* metaphors (search has its own UI; DMs have their own list) rather than forcing them into the channels framework.
+
+### Notion's "pages" and "workspaces"
+
+Notion's metaphor is more book-like: a workspace contains pages, pages contain pages, with a tree structure on the left. The metaphor is "outline" or "hierarchical document," familiar from years of Microsoft Word and OneNote.
+
+Notion's wayfinding strength: the tree on the left always shows you where you are. Notion's wayfinding weakness: deep hierarchies become hard to navigate, and the lack of strong landmarks makes deeply-nested pages feel anonymous.
+
+### Figma's "infinite canvas"
+
+Figma uses a 2D plane metaphor. You pan, zoom, and create objects in space. The wayfinding tools borrowed directly from physical maps:
+
+- Mini-map (in some configurations).
+- "Zoom to fit" and "zoom to selection" — zoom controls.
+- Frames and pages (organize the canvas into named regions).
+
+The metaphor scales because zoom collapses the cost of distance — far is the same as close, just at different magnification.
+
+### Trello's "boards / lists / cards"
+
+Trello's metaphor is the kanban board. Cards move horizontally through lists; lists organize a board; boards live in a workspace. The metaphor is almost too good — Trello users sometimes apply kanban thinking to non-kanban problems because the metaphor is so persuasive.
+
+Trello's wayfinding within a board is excellent (the whole board is visible at once); across boards is weaker (boards are listed but lack distinguishing landmarks).
+
+### macOS Finder vs. Windows Explorer
+
+Both file managers expose a file-system hierarchy with similar primitives, but they made different metaphor choices:
+
+- **Finder** emphasizes spatial layout — windows remember their position, files have fixed positions in icon view, the column view exposes the hierarchy as a horizontal tree.
+- **Explorer** emphasizes browsing — the address bar with breadcrumbs, the navigation pane with shortcuts, less spatial memory.
+
+Power users in each ecosystem develop different wayfinding habits. Neither is universally better; each fits a slightly different mental model.
+
+## Failed metaphors
+
+### Microsoft Bob (1995)
+
+Microsoft Bob attempted a literal "house" metaphor for the desktop: rooms with furniture, where each piece of furniture was an application launcher. The metaphor was over-extended (every behavior had to fit "things in rooms"), the visual mimicry was heavy, and the productivity cost was substantial. Bob is now a footnote in design history.
+
+The lesson: a metaphor that the user can't predict is worse than no metaphor.
+
+### Second Life (2003) as a productivity environment
+
+Second Life and similar virtual worlds attempted to bring 3D spatial metaphors to general-purpose computing. The promise: a "world" you could navigate, with offices, conference rooms, shopping districts. The reality: navigation in 3D space is harder than navigation in 2D, the visual processing cost is higher, and the spatial metaphor didn't add productivity over flat 2D web equivalents.
+
+Subsequent VR/AR efforts (Workrooms, Horizon Workrooms, Apple Vision Pro productivity apps) have learned: 3D spatial metaphors work for specific tasks (collaborative whiteboarding, 3D modeling) and rarely improve general 2D-friendly tasks.
+
+## Resources
+
+- **Norman, D.** *The Design of Everyday Things* (1988, 2013) — chapter on conceptual models.
+- **Cooper, A. et al.** *About Face* — chapter on metaphors in interaction design.
+- **Tognazzini, B.** "First Principles of Interaction Design" — discusses metaphor selection.
+
+## Closing
+
+Spatial metaphors are powerful when they fit and damaging when they don't. The discipline is in choosing them deliberately, mapping them consistently, and abandoning them when the source-domain expectations stop helping. A literal mimicry adds visual cost; a behavioral mimicry adds intuitive comprehension. Aim for the latter.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-search-and-recovery/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-search-and-recovery/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: wayfinding-search-and-recovery
+description: 'Use this skill when designing search as the universal wayfinding recovery, or when designing for users who got lost — 404 pages, "results not found," "you''ve reached an unexpected page," empty states that should orient, and any moment where the user''s mental map has failed and the system must repair it. Trigger when designing global search, command palette, error pages, or recovery flows. Sub-aspect of `wayfinding`; read that first.'
+---
+
+# Wayfinding: search and recovery
+
+Wayfinding fails. Users mistype URLs, follow stale links, click on a section that doesn't have what they thought it would, get teleported by a notification into a context they don't recognize. When wayfinding fails, the system has two jobs: (1) help the user find what they were after, (2) rebuild their orientation so they can navigate again on their own.
+
+## Search as universal recovery
+
+For complex apps, **search is the most reliable wayfinding repair tool the user has**. When the cognitive map breaks, the user types what they want and the system locates it. This works because:
+
+- It collapses the user's failure to find through navigation into a single recall task.
+- It surfaces results from across the entire IA, regardless of where the user currently is.
+- Modern fuzzy matching handles typos and partial recall.
+- It scales to IAs of any size without restructuring.
+
+A robust search experience for wayfinding recovery has these properties:
+
+### 1. Always reachable
+
+Global search must be one keystroke or one click away from anywhere in the app. Common patterns:
+
+- **`/` to focus search.** A long-standing convention from GitHub, Twitter, Slack.
+- **`⌘K` / `Ctrl+K` to open command palette.** Newer; faster for power users; widespread in modern dev tools.
+- **Persistent search input in the header.** Always visible; lower friction than keyboard shortcut.
+
+```html
+<header class="app-header">
+  <input type="search"
+         placeholder="Search anything (or press /)"
+         id="global-search"
+         aria-label="Search" />
+</header>
+```
+
+### 2. Searches across the whole IA, not just one domain
+
+A search that only finds documents (and not also settings, people, projects) is incomplete recovery. The user often doesn't know the *category* of what they want; they just know the name.
+
+```
+Results
+  Documents
+    "Q4 plan"
+    "Q4 review notes"
+  Settings
+    "Quarterly notification frequency"
+  People
+    "Quentin Ramirez"
+```
+
+Categorical grouping in results restores the user's cognitive map even as it answers their query.
+
+### 3. Shows location for each result
+
+Each result should display where it lives in the IA — its breadcrumb. This serves two purposes:
+
+- The user picks the right result (some have similar names).
+- After clicking, the user knows where they're being taken — orientation begins before they arrive.
+
+```html
+<ul class="search-results">
+  <li>
+    <a href="/projects/acme/notes/q4-plan">
+      <h3>Q4 plan</h3>
+      <p class="path">Projects › Acme › Notes</p>
+      <p class="snippet">Our Q4 plan focuses on three priorities...</p>
+    </a>
+  </li>
+</ul>
+```
+
+### 4. Recents and suggestions
+
+Empty search inputs should show recents (the user's frequent destinations) and suggestions (likely searches based on context). This makes search useful even before the user has typed anything.
+
+### 5. Recovers gracefully from no-results
+
+A "No results for 'qrt plnan'" page is the most common search-recovery moment. Patterns:
+
+- **Suggest spelling corrections** ("Did you mean *q4 plan*?").
+- **Show partial matches** ("Showing results for 'plan' instead").
+- **Offer common starting points** ("Or browse: Recent / Pinned / Templates").
+
+Never just say "no results" with no path forward.
+
+## Lost-state pages: 404 and friends
+
+A 404 (Not Found) page is the most common explicit wayfinding failure. The user followed a link or typed a URL and arrived nowhere.
+
+A wayfinding-aware 404 does five things:
+
+1. **States plainly what happened.** "This page doesn't exist." Not "Error 404" — the user doesn't care about the HTTP code.
+2. **Explains likely causes.** "The page may have moved, the URL may be mistyped, or the content may have been removed."
+3. **Offers recovery options.** "Search for what you were looking for: [search input]."
+4. **Provides escape paths to known territory.** "Go to home" / "Go to your dashboard."
+5. **Acknowledges the user's situation, not just the system's.** Skip the "Oops!" mascots; treat the user as someone trying to do something legitimate.
+
+```html
+<main class="error-page">
+  <h1>This page doesn't exist</h1>
+  <p>
+    The link you followed may be broken, the URL may be mistyped,
+    or the page may have been moved. Try searching for what you need:
+  </p>
+  <form action="/search">
+    <input type="search" name="q" placeholder="Search..." autofocus />
+    <button>Search</button>
+  </form>
+  <p>
+    Or go to <a href="/">your dashboard</a>.
+  </p>
+</main>
+```
+
+For *internal* errors (500, service unavailable, timeout), the same wayfinding-recovery principles apply, but the apology and reassurance content shift slightly: it's the system's fault, not the user's URL. Still: state plainly, offer recovery, provide escape.
+
+## Recovery from "I'm in the wrong context"
+
+Sometimes the user isn't lost in URL space — they're lost in mental-model space. They opened a settings panel and don't recognize where they are; they navigated into a deep flow and forgot where it started.
+
+Patterns that help:
+
+- **Persistent breadcrumbs** showing the user's current depth and offering up-tree links.
+- **"Back to ..." buttons** at the top of detail pages, naming the parent (not just an arrow).
+- **Cancel / Close affordances on every modal/sheet/drawer** that return the user to a known state.
+- **Esc key escape** from any overlay, popover, modal — keyboard recovery without thinking.
+
+## Recovery from accidental destination
+
+The user clicked a link they didn't mean to and arrived somewhere unintended. They need:
+
+- **Browser back to work** (don't break it with single-page-app history mismanagement).
+- **Visible "go back" affordance** in case they don't know browser back exists.
+- **Stable URL** so they can copy it / bookmark it / share it / understand it.
+
+If you've ever shipped an SPA where the back button leads to a confused state, you've created a wayfinding trap.
+
+## The empty state as wayfinding
+
+Empty states are wayfinding moments: the user arrived at a page expecting content, found none, and now needs orientation about what to do.
+
+A wayfinding-aware empty state:
+
+- Confirms they're in the right place ("This is your inbox. It's currently empty.").
+- Suggests an action that makes the page useful ("Send your first invoice to see it here.").
+- Doesn't punish the user for being early ("Welcome! Nothing here yet, and that's fine.").
+
+## Anti-patterns
+
+- **Search that only searches one domain.** If the user has to know which specific search to use, search has failed as wayfinding recovery.
+- **404 pages with no escape.** A "404 Not Found" with a logo and nothing else is a dead end.
+- **Mascots over function on error pages.** A cute illustration above unclear copy and no recovery path is decoration replacing function.
+- **No recents in search.** Forcing the user to type their frequent destinations every time.
+- **Broken back button.** SPAs that mismanage history; users lose their place and trust.
+- **Modal traps.** Overlays that don't close on Esc, don't close on backdrop click, don't have a visible close button.
+- **"You may also like" instead of recovery.** Recommendations on a 404 don't replace a search box and a home link.
+
+## Heuristics
+
+1. **The teleport test.** Drop yourself onto a random URL with no nav memory. Can you orient and recover within 10 seconds? If no, your recovery affordances are too thin.
+2. **The broken-link test.** Type a deliberately-broken URL (`/nope-this-doesnt-exist`). What does the page do? Does it help you, or just say no?
+3. **The "I forgot where I was" test.** Open a deep page, then a modal, then another modal. Close everything. Can you tell what page you're back on? If not, route monitoring failed.
+4. **Search reach test.** Try to search for a setting from inside the search input. Does it find it? If not, search isn't a complete recovery tool.
+
+## Related sub-skills
+
+- **`wayfinding`** (parent).
+- **`wayfinding-physical-spatial-metaphors`** — when spatial metaphors fail, search compensates.
+- **`wayfinding-breadcrumbs-and-context`** — the orientation chrome that prevents recovery from being needed.
+- **`recognition-over-recall`** — search results work because recognizing the right one is easy; recalling its path was hard.
+- **`forgiveness`** (interaction) — recovery from wayfinding errors is part of forgiveness.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-search-and-recovery/references/search-as-ia.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding-search-and-recovery/references/search-as-ia.md
@@ -1,0 +1,129 @@
+# Search as IA: deeper reference
+
+A reference complementing `wayfinding-search-and-recovery` with deeper context on search as a wayfinding tool.
+
+## When search becomes the IA
+
+For sufficiently complex products, **search is more important than navigation.** Notion, Linear, GitHub, and modern dev tools have shifted the primary navigation experience from sidebar drilling to command palette searching. The reasoning:
+
+- IAs at scale (thousands of pages, hundreds of objects) outgrow what hierarchical navigation can expose.
+- Power users navigate by recall (typing what they want) faster than by recognition (clicking through menus).
+- Fuzzy matching handles typos and partial recall, making search forgiving in ways navigation isn't.
+
+The downside: search doesn't help users *discover* what's there. Users only search for things they already know exist. Discovery still requires browsable navigation.
+
+The synthesis: a complete wayfinding system has *both*. Sidebar / breadcrumb / nav for discovery and orientation; search / palette for direct retrieval and recovery.
+
+## Search-as-recovery patterns
+
+### Always-available global search
+
+The user must be able to invoke search from anywhere with one keystroke or click. Conventional bindings:
+
+- **`/`** focuses search. Twitter / X, GitHub, Vim — long-standing convention.
+- **`⌘K` / `Ctrl+K`** opens command palette. Sublime Text, VSCode, Slack, Linear, Notion, GitHub.
+- **`⌘⇧P` / `Ctrl+Shift+P`** opens command palette in some VSCode-derived tools.
+
+Picking one (preferably both — `/` for content search, `⌘K` for actions/navigation) gives users a reliable escape from any wayfinding failure.
+
+### Categorical results
+
+Search results from a single, undifferentiated list are harder to scan than results grouped by category:
+
+```
+Documents (3)
+  Q4 plan
+  Q4 meeting notes
+  Q4 retrospective
+
+Settings (1)
+  Quarterly reports
+
+People (1)
+  Quentin Ramirez
+```
+
+Categorical grouping serves wayfinding directly: it reminds the user of the IA structure ("oh right, settings are a thing").
+
+### Recents and pinned
+
+Empty search input shouldn't be empty. Show:
+
+- **Recents** — the user's recently-visited pages or recently-run commands.
+- **Pinned** — items the user has marked for fast access.
+- **Suggestions** — likely searches based on context (the user is on a billing page; suggest billing-related searches).
+
+This makes search useful even before the user types.
+
+### Source-path display on every result
+
+Every result should show its source path:
+
+```
+Q4 plan
+  Projects › Acme › Notes
+```
+
+This serves two purposes: disambiguation (multiple "Q4 plan" pages might exist) and orientation (the user learns where things live).
+
+## Algorithmic considerations
+
+Modern search uses fuzzy matching, typo tolerance, and ranking heuristics. A few that matter for wayfinding:
+
+- **Recency boost.** Recently-accessed items rank higher; users often want to return to where they just were.
+- **Personalization.** Items the user has accessed before rank higher than items they haven't.
+- **Title vs. content matching.** Title matches typically rank higher than full-text body matches.
+- **Levenshtein distance / fuzzy match.** Tolerates 1–2 typos; helps when users misremember names.
+
+Without these, naive search frustrates users by failing on small mistakes.
+
+## Recovery from no-results
+
+The most common search failure: the user types something, nothing matches. Patterns:
+
+- **Spelling correction** ("Did you mean 'invoice'?").
+- **Partial match fallback** ("Showing results for 'invoice' instead of 'invoise'").
+- **Category-only suggestions** ("No exact matches. Browse: Recent / Pinned / Templates").
+- **"Search the web"** as a last resort for content sites.
+
+Never just say "no results" with no path forward.
+
+## 404 design
+
+The 404 page is the canonical wayfinding-failure surface. A wayfinding-aware 404 has:
+
+1. Plain statement of what happened (not "Error 404").
+2. Likely causes (mistyped URL, removed page, broken link).
+3. Search input, autofocused.
+4. Escape paths to known territory (home, dashboard, sitemap).
+5. Reporting affordance for genuinely-broken links ("Report this link as broken").
+
+Avoid: cute mascots that take up half the page; jokes; "Lost in cyberspace" phrasing that doesn't help.
+
+## Cross-domain reference
+
+### Library catalogs
+
+Library catalogs are the original search-as-recovery system: a card catalog (or its digital descendant) lets users find books they couldn't navigate to via shelf browsing. The dual system (browsing the stacks for serendipity, searching the catalog for retrieval) is exactly the navigation+search synthesis modern apps use.
+
+### Email search vs. folders
+
+Email is the case study of search outcompeting navigation. Gmail's design bet (2004) was that users could *search* for any email rather than file it into folders. Folder-based email systems (Outlook, Apple Mail) coexist; the trend has been toward search dominance.
+
+The lesson for app design: when the corpus is too large to file meaningfully, search wins.
+
+### Google as wayfinding for the web
+
+The whole web is the most extreme search-as-IA case. Without a search engine, the early web was navigated by directories (Yahoo's hierarchical taxonomy in 1994). Google's PageRank made search faster than directory browsing, and directories withered.
+
+The web's IA *is* search now. Most users don't navigate by URL or directory; they search.
+
+## Resources
+
+- **Morville, P. & Rosenfeld, L.** *Information Architecture for the World Wide Web* (2006). Comprehensive IA reference, including search as IA.
+- **Rubin, J. & Chisnell, D.** *Handbook of Usability Testing* (2008). Search-task usability methods.
+- **NN/g articles on search UX** — many practical findings.
+
+## Closing
+
+Search isn't a backup for nav; in modern apps, it's a peer. The wayfinding-aware designer treats search as a first-class navigation surface and invests in it accordingly.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: wayfinding
+description: 'Use this skill whenever a user must navigate within a non-trivial space — a multi-page web app, a documentation site, a hierarchical settings panel, a conference site, a multi-step flow, a campus, a building, an app with deep IA. Trigger when the user asks how navigation should be structured, when users get lost, when "I can''t find X" complaints recur, when designing breadcrumbs, sitemaps, search, or recovery flows. Wayfinding is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003); it''s also the only principle from that source not previously covered by these plugins. Routes to sub-aspect skills for spatial metaphors, search-and-recovery, and breadcrumbs.'
+---
+
+# Wayfinding
+
+Wayfinding is the process by which people use spatial and environmental information to orient themselves, choose a path, monitor their progress along it, and recognize when they've arrived. It originated as an architectural and urban-design concept — how people find their way through buildings, campuses, cities — and translates almost directly to information architecture and navigation design in software.
+
+## Definition (in our own words)
+
+Whenever a user must move from where they are now to where they want to be — across rooms in a building, across pages in a web app, across screens in a multi-step flow — they perform a sequence of cognitive operations: figuring out where they are, deciding which way to go, checking that they're still on the right path, and recognizing the destination when it appears. Designs that make any of these four operations harder than necessary produce the universal symptom: users get lost, double back, give up, or call support.
+
+## Origins and research lineage
+
+- **Kevin Lynch**, *The Image of the City* (MIT Press, 1960). The foundational text. Lynch interviewed residents of Boston, Jersey City, and Los Angeles about how they navigated their cities, and identified five elements of the cognitive map: **paths, edges, districts, nodes, and landmarks**. These five categories still organize the field.
+- **Romedi Passini**, *Wayfinding in Architecture* (1984) and *Wayfinding: People, Signs, and Architecture* (with Paul Arthur, 1992). Translated Lynch's urban concepts into architectural design, particularly for hospitals, airports, and other complex public buildings where wayfinding failure is consequential.
+- **Roger Downs and David Stea**, *Cognitive Maps and Spatial Behavior* (1973), and the broader cognitive-mapping research tradition in environmental psychology.
+- **Lidwell, Holden & Butler**, *Universal Principles of Design* (2003), articulated the four-stage model (orientation, route decision, route monitoring, destination recognition) that is the most-cited contemporary summary in design education.
+- **Web wayfinding** translates the same framework. Steve Krug's *Don't Make Me Think* (2000) is the most-cited application to web design; the "where am I, where can I go, what's here" trio of questions is wayfinding restated for screens.
+
+## The four stages
+
+A useful structure adapted from the design-research literature:
+
+### 1. Orientation
+
+Where am I right now? What's around me? Where is my destination relative to here?
+
+In a building: signs, landmarks (the central atrium, the colored carpet, the unique sculpture), maps at decision points.
+
+In an app: the page title, the breadcrumb, the highlighted nav item, the URL, the visible chrome that anchors the user in the system's structure.
+
+A user with poor orientation feels "lost in the app" — even if they could reach their destination by clicking forward, they don't know where they currently are or how the current page relates to the rest.
+
+### 2. Route decision
+
+Given where I am and where I'm going, which path do I take?
+
+In a building: signage at each junction, with the destination clearly named and an unambiguous direction.
+
+In an app: navigation that lists destinations clearly, with link text matching the destination's name. Search as the universal "I don't know which path; just take me there" recovery.
+
+A user with poor route-decision support faces too many choices, ambiguous labels, or paths that look equivalent. They guess; they're often wrong.
+
+### 3. Route monitoring
+
+Am I still on the right path? Is the destination getting closer or farther?
+
+In a building: continued signage along the path, intermediate landmarks, paths that have clear "this leads somewhere" character (a long hallway with the destination at the end, not a series of identical turns).
+
+In an app: visible progress indicators (steppers, breadcrumbs that fill in as you go), a stable URL pattern that reflects depth, transitions that show the user moving "into" rather than "across."
+
+A user with poor route monitoring takes a step, looks up, doesn't recognize where they are anymore, and either retreats or guesses again.
+
+### 4. Destination recognition
+
+Have I arrived?
+
+In a building: the destination has a clear identity — a marked door, a desk, a sign. Dead-ends or terminals reinforce arrival ("you have reached the end of the path; this must be it").
+
+In an app: a clear page title, a layout that matches the user's mental image of the destination, no ambiguity about whether this is the right page or a stop-along-the-way.
+
+A user with poor destination recognition arrives at the right page and doesn't realize it. They scroll, check again, click somewhere else.
+
+## When to apply
+
+- **Designing or auditing IA.** Wayfinding is the IA discipline applied at the user's eye level.
+- **Designing onboarding flows or wizards.** Multi-step flows are explicit wayfinding exercises.
+- **Documentation sites.** Doc users routinely report "I know it's in here somewhere" — a wayfinding failure.
+- **Settings panels with depth.** Whenever users must drill into a sub-section to change a value, all four stages apply.
+- **Help / support surfaces.** Users land here in a degraded wayfinding state already; design must repair their orientation before doing anything else.
+
+## When NOT to apply (or when to be careful)
+
+- **Single-page tools.** A calculator, a simple form, a one-screen dashboard doesn't have wayfinding to design.
+- **When the IA itself is wrong.** Wayfinding is about helping users navigate the IA you have. If the underlying IA is incoherent (the user expects "Settings → Notifications" and you've put notifications under "Account → Preferences → Communications"), no amount of wayfinding cosmetics will fix it. Restructure first.
+- **In voice-only or text-only conversational interfaces.** Wayfinding intuitions about visual landmarks don't transfer; replaced by narrative ordering, prompts, and confirmation.
+
+## Worked examples
+
+The examples are framework-agnostic — written in plain HTML, conceptual mockup, or general structure — to make the wayfinding decisions visible. Apply them to your stack of choice.
+
+### Example 1: a documentation site
+
+A docs site with 200 pages of content is a wayfinding nightmare unless designed deliberately.
+
+**Orientation:** every page has a sidebar showing the user's current section expanded and the current page highlighted. The breadcrumb at the top shows the path from root. The URL pattern (`/docs/section/subsection/page`) reinforces depth.
+
+**Route decision:** the sidebar lists sibling pages and parent sections. A search box (with type-to-filter) handles "I don't know where this is, take me there."
+
+**Route monitoring:** as the user clicks deeper, the URL extends and the breadcrumb grows. The sidebar's currently-active item visibly shifts. Internal links use a slightly different style than external links so the user can predict outcomes before clicking.
+
+**Destination recognition:** every page has a single H1 matching its title in the nav. The sidebar's current-item highlight confirms "you are here." The page's own structure — code samples, examples, conclusion — matches the user's expectation of what a docs page contains.
+
+```html
+<aside class="sidebar">
+  <nav>
+    <h2>Getting Started</h2>
+    <ul>
+      <li><a href="/docs/install">Installation</a></li>
+      <li><a href="/docs/quickstart" aria-current="page">Quickstart</a></li>
+      <li><a href="/docs/configuration">Configuration</a></li>
+    </ul>
+    <h2>Guides</h2>
+    <ul>...</ul>
+  </nav>
+</aside>
+
+<main>
+  <nav aria-label="Breadcrumb">
+    <ol>
+      <li><a href="/docs">Docs</a></li>
+      <li><a href="/docs/getting-started">Getting Started</a></li>
+      <li aria-current="page">Quickstart</li>
+    </ol>
+  </nav>
+  <h1>Quickstart</h1>
+  <article>...</article>
+</main>
+```
+
+### Example 2: a hierarchical settings panel
+
+A settings page with three sections, each with sub-sections, easily becomes "I changed something here last week and now I can't find it again."
+
+**Orientation:** persistent settings nav (sidebar or stepped tabs) shows all top-level sections; current section highlighted; current sub-section nested visible.
+
+**Route decision:** the section names map to user vocabulary, not internal team vocabulary. "Notifications" not "Push Subscriptions Service Configuration."
+
+**Route monitoring:** clicking into a sub-section preserves the parent context; the settings nav still shows the user is inside "Notifications → Email."
+
+**Destination recognition:** each settings page has a clear title, the controls relevant to that page only, and an obvious save affordance (or auto-save with confirmation toast). No ambiguity about whether a setting belongs to this page or another.
+
+### Example 3: a multi-step wizard
+
+A 5-step checkout flow asks the user to navigate forward through known territory.
+
+**Orientation:** stepper at top shows all 5 steps with current step highlighted and completed steps marked.
+
+**Route decision:** the user typically only goes forward (Continue button) but should be able to go back to fix earlier steps without losing data.
+
+**Route monitoring:** between steps, transitions are forward-feeling (slide-in from right, page builds); the stepper updates immediately to confirm the move.
+
+**Destination recognition:** the final step is visually distinct ("Review your order" with a summary, a single "Place order" CTA); the post-purchase screen ("Thanks! Your order #12345 is confirmed") makes arrival unambiguous.
+
+### Example 4: search as wayfinding recovery
+
+For complex apps, search is the universal escape hatch: when wayfinding fails, the user types what they want and the system locates it.
+
+```html
+<header>
+  <input type="search" placeholder="Search docs, settings, projects..."
+         aria-label="Search" id="global-search" />
+</header>
+
+<!-- Results show source/location for each match: -->
+<ul class="search-results">
+  <li>
+    <a href="/docs/api/auth">
+      <h3>Authentication</h3>
+      <p class="path">Docs › API Reference › Authentication</p>
+      <p class="snippet">Authentication uses bearer tokens...</p>
+    </a>
+  </li>
+  <li>
+    <a href="/settings/notifications">
+      <h3>Email digest frequency</h3>
+      <p class="path">Settings › Notifications</p>
+    </a>
+  </li>
+</ul>
+```
+
+The breadcrumb-style path on each result is wayfinding for the search itself: it tells the user not just *what* matched but *where it lives*, building their cognitive map of the system.
+
+## Cross-domain examples
+
+### Hospital wayfinding
+
+Hospitals are notorious wayfinding cases — anxious or unwell visitors with low cognitive bandwidth navigating large, often confusingly-labeled buildings. The best hospital wayfinding systems use:
+
+- **Color-coded zones** (Cardiology = blue, Oncology = green) so users orient by hue.
+- **Floor-by-floor maps** at every elevator landing.
+- **"You are here" markers** on every map — orientation made explicit.
+- **Distinct landmarks** at decision points (a sculpture, a fountain, a colored wall) that work even when signs are missed.
+- **Greeters** as a redundant human wayfinding system for users who fail the visual one.
+
+Software equivalent: clear section identity (color, icon), maps (sitemap, breadcrumb), explicit current-location markers, distinct visual landmarks per section, and search as the human-greeter analog.
+
+### Airport wayfinding
+
+Airports succeed where hospitals struggle because they:
+
+- Use a small vocabulary of unmistakable signs (Departures, Arrivals, Baggage Claim, Gates A/B/C).
+- Repeat key signs at frequent intervals (no decision point lacks a sign).
+- Use universal pictograms (planes, suitcases, restrooms) that survive language barriers.
+- Position signs at multiple heights so they're visible above crowds.
+
+Software lessons: limit the IA vocabulary; repeat orientation cues frequently; use universal iconic representations; position chrome where users look.
+
+### Theme parks
+
+Disney's parks deliberately use sightlines and "weenies" (a Walt Disney term for visual landmarks at the end of paths — Cinderella's Castle being the canonical one) to draw guests through the park without instruction. The wayfinding is invisible because the architecture itself does it.
+
+Software equivalent: a well-designed app's home screen shows users where they can go without explicit nav — the visual hierarchy *is* the wayfinding.
+
+## Anti-patterns
+
+- **The mystery URL.** A page at `/p/8f3c7a` with no breadcrumb, no nav highlight, no obvious source. The user can't form a cognitive map.
+- **"You are here" missing.** A nav that doesn't highlight the current item. Users can't orient.
+- **Ambiguous link labels.** "Click here," "Read more," "Settings" (which settings?). Route decision degraded.
+- **Inconsistent labels.** A link called "Profile" leads to a page titled "Account Information" leads to a sub-section called "Personal Details." Each rename costs the user's mental map.
+- **Hidden current page.** No breadcrumb, no page title, no nav highlight. The user has only the URL — and even URLs are often opaque (`/u/3829/?t=2`).
+- **Dead-end pages.** A page the user lands on with no way out except the browser back button. Even error pages should offer a path forward.
+- **Search-only IA.** "If you need it, just search." Useful as a recovery; abdicating navigation in favor of search forces the user to type instead of recognize.
+
+## Heuristics
+
+1. **The "where am I?" test.** Drop a fresh user onto a random deep page in your app. Within 5 seconds, can they identify (a) what page they're on, (b) what section it belongs to, (c) how to get to the home page? If not, orientation is broken.
+2. **The "find X" test.** Give a user a goal ("change your notification frequency to weekly digest"). Time them. >60 seconds suggests route decision is broken.
+3. **The "did I arrive?" test.** After clicking, can the user tell whether they got to the right page or a transitional one? Ambiguity here means destination recognition is broken.
+4. **The "trace your steps" test.** Ask the user to retrace the path they took to get here. If they can't, route monitoring was inadequate.
+5. **The 404 audit.** Look at your top broken-link / 404 URLs. Each is a wayfinding failure (or a missing page that should exist).
+
+## Related principles
+
+- **`mental-model`** — wayfinding works through the user's mental map; mental models are the substrate.
+- **`recognition-over-recall`** — recognizing a destination is easier than recalling its path.
+- **`progressive-disclosure`** — wayfinding's natural ally: don't show all of the IA at once; reveal as the user descends.
+- **`hierarchy`** (perception) — visual hierarchy is the orientation cue inside any single page.
+- **`consistency`** — wayfinding only works if the rules don't change between pages.
+- **`errors`** (interaction) — wayfinding errors (taking a wrong path) need recovery paths.
+- **`visibility`** — invisible nav makes wayfinding impossible; nav must be perceivable.
+- **`affordance`** (interaction) — links must look like links; navigation chrome must look navigable.
+
+## Sub-aspect skills (read these for specific applications)
+
+- **`wayfinding-physical-spatial-metaphors`** — when and how to borrow physical wayfinding metaphors (rooms, doors, paths) for software navigation; when to discard them.
+- **`wayfinding-search-and-recovery`** — designing search as the universal wayfinding recovery; lost-state pages, 404s, error recovery.
+- **`wayfinding-breadcrumbs-and-context`** — breadcrumbs, current-page indicators, "you are here" patterns; deciding when to use them and how to make them load-bearing rather than decorative.
+
+## Closing
+
+Wayfinding is one of the cleanest cross-domain transfers in design — the same four stages apply to a hospital corridor and a settings page. The user looking lost in your dashboard and the visitor lost in a hospital basement are running the same cognitive process and failing it for the same reasons. Build for the four stages, and the user's experience of "moving through" your product becomes effortless in a way they never have to articulate.

--- a/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding/references/research-and-cross-domain.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/cognition-and-learnability-principles/skills/wayfinding/references/research-and-cross-domain.md
@@ -1,0 +1,117 @@
+# Wayfinding: research and cross-domain reference
+
+A reference complementing the `wayfinding` SKILL.md with the academic grounding from environmental psychology and architecture, and a wider range of cross-domain examples.
+
+## Research lineage
+
+- **Kevin Lynch**, *The Image of the City* (MIT Press, 1960). The foundational text — Lynch interviewed residents of Boston, Jersey City, and Los Angeles to understand how they navigated their cities, and identified five elements of the cognitive map: **paths** (channels of movement: streets, walkways, transit lines), **edges** (boundaries that aren't paths: shorelines, walls, railroad cuts), **districts** (sections with shared character: a neighborhood, a downtown), **nodes** (focal points: junctions, plazas, transit stops), and **landmarks** (singular reference points: a tower, a statue, a distinctive building). These five categories still organize wayfinding research, and they map to software almost without translation: paths = navigation flows; edges = section boundaries; districts = sub-sections of an app; nodes = pages with many incoming and outgoing links; landmarks = distinctive pages or features users remember.
+- **Romedi Passini**, *Wayfinding in Architecture* (Van Nostrand Reinhold, 1984). Translated Lynch's urban concepts into architectural design. Passini's framework explicitly covers indoor wayfinding — hospitals, airports, large public buildings — and is more directly applicable to software than Lynch's outdoor focus.
+- **Paul Arthur and Romedi Passini**, *Wayfinding: People, Signs, and Architecture* (McGraw-Hill, 1992). The standard reference work; covers signs, maps, environmental cues, and the cognitive processes of wayfinding.
+- **Roger Downs and David Stea**, *Cognitive Maps and Spatial Behavior* (Aldine, 1973). The cognitive-mapping research tradition: how people internally represent the spaces they navigate.
+- **Steve Krug**, *Don't Make Me Think* (New Riders, 2000, 2014). The most-cited application of wayfinding to web design. Krug's "trunk test" — can a user landing on any page identify what site they're on, what page they're on, and what their main options are — is wayfinding distilled to a usability heuristic.
+- **Lidwell, Holden & Butler**, *Universal Principles of Design* (Rockport, 2003), articulated the four-stage model (orientation, route decision, route monitoring, destination recognition) that compactly summarizes the wayfinding literature for designers.
+
+## Lynch's five elements applied to software
+
+| Lynch's element | Physical example | Software equivalent |
+|---|---|---|
+| **Paths** | Streets, sidewalks, transit lines | Primary navigation routes; the most-traveled flows through your IA |
+| **Edges** | Shorelines, walls, railroads | Section boundaries; the line between marketing site and app, between free and paid, between domains |
+| **Districts** | Neighborhoods, downtowns | Major sections of the app: Dashboard, Settings, Reports |
+| **Nodes** | Plazas, transit hubs, intersections | Highly-connected pages: home, dashboard, search results |
+| **Landmarks** | Distinctive buildings, statues | Memorable pages or features: the dashboard's primary KPI, the empty-state mascot, the unique feature page |
+
+A productive design exercise: list each of these five for your app. If any category is empty (no clear landmarks, no nodes, no district boundaries), wayfinding is likely weak.
+
+## Cross-domain examples
+
+### Hospital wayfinding — high stakes, high-stress users
+
+Hospitals are the canonical wayfinding-failure context. Visitors are anxious or unwell, often arriving for appointments at unfamiliar departments. Bad hospital wayfinding has measurable costs: late appointments, no-shows, confused emergency arrivals.
+
+What works:
+
+- **Color-coded zones.** Cardiology = blue, Oncology = green, etc. Color carries categorical information for users in low-bandwidth states.
+- **"You are here" maps at every elevator landing.** Orientation made explicit at the most disorienting transitions.
+- **Distinct landmarks at decision points.** A sculpture, a glass wall, a colored floor — perceptual cues that survive missed signs.
+- **Greeters and information desks** as a redundant human wayfinding system.
+
+Software lessons: clear section identity (color, icon), maps available at transitions (sitemap, breadcrumb on every page), distinct visual landmarks per section, and search/help as the human-greeter analog.
+
+### Airport wayfinding — universal vocabulary
+
+Airports succeed where hospitals struggle, partly because:
+
+- **Small, repeated vocabulary.** Departures, Arrivals, Baggage Claim, Gates A/B/C. Users learn the vocabulary in one airport and apply it everywhere.
+- **Frequent sign repetition.** No decision point lacks a sign.
+- **Universal pictograms** that survive language barriers.
+- **Multi-height signage** so signs are visible above crowds.
+
+Software lessons: limit IA vocabulary; repeat orientation cues frequently; use universal iconic representations; place chrome where users look (typically top edge of viewport).
+
+### Theme parks — wayfinding through architecture
+
+Disney parks deliberately use sightlines and "weenies" — a Walt Disney term for distinctive structures placed at the end of paths to draw guests forward. Cinderella's Castle is the canonical weenie at Disneyland; the Tree of Life at Animal Kingdom does the same job.
+
+The wayfinding is invisible because the architecture *is* the wayfinding. Visitors don't read signs to find the castle; the castle is visible from many vantage points and visually pulls them.
+
+Software equivalent: a well-designed home page or landing screen shows users where they can go without explicit instruction. The visual hierarchy *is* the wayfinding.
+
+### Universities — established district / landmark wayfinding
+
+University campuses combine all of Lynch's elements: paths (walkways), edges (campus boundary, the bridge between the two halves), districts (the science quad, the humanities quad), nodes (the student union, the library), landmarks (the bell tower, the chapel, the unusual statue). Veteran students navigate by spatial memory; new students by signs and maps; both can succeed.
+
+Software equivalent: experienced users navigate by muscle memory and keyboard shortcuts; new users by visible nav and search; both should succeed.
+
+### Conference centers — temporary wayfinding
+
+Conference signage solves a temporary version of the wayfinding problem: attendees who don't know the venue, navigating by session names that change room hourly. What works:
+
+- **Master schedule maps** posted at central nodes.
+- **"Now playing" indicators** outside each room.
+- **Wayfinding apps** that show your personal schedule with directions.
+
+Software equivalent: dynamic "what's happening here" indicators (notifications, in-app tutorials), personalized navigation based on user state.
+
+## Quantitative findings worth knowing
+
+- **Visitor surveys at large hospitals** consistently find ~30% of first-time visitors get lost on their way to appointments without staff intervention. Investments in wayfinding signage measurably reduce this.
+- **Web wayfinding studies** (NN/g and others) show that users abandon sites within 10–20 seconds when they can't orient. Strong wayfinding chrome correlates with lower bounce rates.
+- **Krug's "trunk test"** — open a random page; can you identify the site, page, section, primary actions in <5 seconds — fails on a substantial percentage of B2B SaaS apps that haven't invested in wayfinding chrome.
+
+## Edge cases
+
+### Wayfinding without a hierarchy
+
+Some apps have *flat* IA — a single workspace, a single timeline, an inbox. Wayfinding still applies: orientation (where in the timeline?), route decision (filter, search, scroll), route monitoring (scroll position, "you're at the top"), destination recognition (you found the message you wanted).
+
+The four-stage framework adapts; the navigation chrome is different.
+
+### Wayfinding in agent-driven and AI interfaces
+
+When an LLM or agent acts on the user's behalf and surfaces results, the user has *no path memory* for how they got there. Wayfinding implications:
+
+- Agents should narrate ("I navigated to Settings → Notifications and changed the frequency").
+- Results should include source paths so the user can verify.
+- Recovery (undo, "show me what you did") is critical because the user didn't construct the path themselves.
+
+### Wayfinding in voice interfaces
+
+Voice has no visual chrome; orientation is purely auditory. Patterns:
+
+- **Confirm location at the start of every interaction** ("You're in Settings.").
+- **Echo state changes** ("I've changed your notification frequency to weekly.").
+- **Always provide an exit** ("You can say 'main menu' to go back.").
+
+## Resources
+
+- **Lynch, K.** *The Image of the City* (1960). Short, readable, foundational. Worth a weekend read.
+- **Arthur, P. & Passini, R.** *Wayfinding: People, Signs, and Architecture* (1992).
+- **Krug, S.** *Don't Make Me Think* (2014, 3rd ed.). Web-applied wayfinding.
+- **Garrett, J. J.** *The Elements of User Experience* (2010). The IA layer that wayfinding sits on top of.
+- **NN/g articles on navigation** — many publicly available studies and writings.
+- **Calori, C. & Vanden-Eynden, D.** *Signage and Wayfinding Design* (2015). Practical wayfinding-design reference for physical environments.
+
+## Closing
+
+Wayfinding is one of the cleanest cross-domain transfers in design. The same four stages apply to a hospital corridor, a museum, a university campus, an airport, a Trello board, a Notion workspace, a settings panel. The discipline is *not* in inventing new patterns — most patterns are well-established. It's in *using* them: putting orientation chrome on every page, naming things consistently, providing search as recovery, and noticing when a user gets lost (which is the bug, not the feature).

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/.claude-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/.claude-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json.schemastore.org/claude-plugin.json",
+  "name": "interaction-and-control-principles",
+  "displayName": "Interaction & Control Principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for interaction, affordance, feedback, errors, and user control. Covers Fitts's Law, Affordance, Forgiveness, Feedback Loop, Errors, Constraint, Mapping, Expectation Effect, and Control. Drawn from the interaction-related entries of 'Universal Principles of Design' (Lidwell, Holden, Butler, 2003) and the broader HCI literature (Fitts, Norman, Nielsen heuristics, Cooper).",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HDeibler/universal-design-principles.git",
+    "directory": "plugins/interaction-and-control-principles"
+  },
+  "category": "design",
+  "keywords": [
+    "design",
+    "ux",
+    "interaction",
+    "affordance",
+    "feedback",
+    "errors",
+    "controls",
+    "fitts",
+    "forgiveness",
+    "constraint",
+    "mapping",
+    "universal-design-principles"
+  ]
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/.codex-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "interaction-and-control-principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for interaction, affordance, feedback, errors, and user control. Covers Fitts's Law, Affordance, Forgiveness, Feedback Loop, Errors, Constraint, Mapping, Expectation Effect, and Control.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": [
+    "design",
+    "ux",
+    "interaction",
+    "affordance",
+    "feedback",
+    "errors",
+    "controls",
+    "fitts"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Interaction & Control Principles",
+    "shortDescription": "Affordance, feedback, errors, controls, and user agency.",
+    "developerName": "Hunter D",
+    "category": "Design",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "longDescription": "Framework-agnostic design principles for interaction, affordance, feedback, errors, and user control. Covers Fitts's Law, Affordance, Forgiveness, Feedback Loop, Errors, Constraint, Mapping, Expectation Effect, and Control.",
+    "websiteURL": "https://github.com/HDeibler/universal-design-principles"
+  }
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/.codexignore
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/.codexignore
@@ -1,0 +1,7 @@
+.git/
+.DS_Store
+**/.DS_Store
+tmp/
+temp/
+.cache/
+scratch/

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/.cursor-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/.cursor-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "interaction-and-control-principles",
+  "displayName": "Interaction & Control Principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for interaction, affordance, feedback, errors, and user control. Covers Fitts's Law, Affordance, Forgiveness, Feedback Loop, Errors, Constraint, Mapping, Expectation Effect, and Control.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": ["design", "ux", "interaction", "affordance", "feedback", "errors", "controls", "fitts"],
+  "category": "design",
+  "tags": ["interaction", "affordance", "feedback", "errors", "controls", "fitts"],
+  "skills": "./skills/"
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/LICENSE
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/LICENSE
@@ -1,0 +1,39 @@
+MIT License
+
+Copyright (c) 2026 Hunter D
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+# Notes on attribution
+
+This software is a derivative *working library* inspired by the principle
+taxonomy popularized in *Universal Principles of Design* (Lidwell, Holden, &
+Butler, Rockport Publishers, 2003). The principle names and high-level
+taxonomy are drawn from that source, used here as a research reference under
+fair use. All prose, examples, code, anti-patterns, and analyses in this
+repository are written in the authors' own words, drawing on the broader
+publicly available design and HCI research literature (Wertheimer, Hick,
+Fitts, Norman, Nielsen, Tufte, Lynch, WCAG, Lavie & Tractinsky, Csikszentmihalyi,
+Zajonc, and many others).
+
+This software is not affiliated with, endorsed by, or sponsored by Rockport
+Publishers, the Lidwell-Holden-Butler authors, or any other rightsholder of
+the original book. See `ATTRIBUTION.md` for a fuller breakdown of sources.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/README.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/README.md
@@ -1,0 +1,24 @@
+# interaction-and-control-principles
+
+Framework-agnostic design principles for interaction, affordance, feedback, errors, and user control.
+
+## Status
+
+| Skill cluster | State |
+|---|---|
+| `interaction-router` | ✅ Complete |
+| **Fitts's Law** + `touch-targets` + `screen-edges` + `pointer-acceleration` | ✅ Complete (reference-grade) |
+| **Affordance** + `signifiers` + `false-and-anti` | ✅ Complete |
+| **Forgiveness** + `undo-and-soft-delete` + `confirmation-and-prevention` | ✅ Complete |
+| **Feedback Loop** + `states-and-latency` + `positive-vs-negative` | ✅ Complete |
+| **Errors** + `slips` + `mistakes` | ✅ Complete |
+| **Constraint** + `physical` + `psychological` | ✅ Complete |
+| **Mapping** + `mapping-natural` + `mapping-cultural` | ✅ Complete |
+| **Expectation Effect** + `expectation-effect-priming` + `expectation-effect-design-cues` | ✅ Complete |
+| **Control** + `control-locus` + `control-power-vs-simplicity` | ✅ Complete |
+
+29 skills, each with a `references/` deep-dive file.
+
+## Planned
+
+After this batch, priority next builds: `convergence`, `defensible-space`, `entry-point`, `flexibility-usability-tradeoff`, `nudge`, `operant-conditioning`, `propositional-density`, `recognition-over-recall`.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/SECURITY.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Report security issues by opening a private security advisory on GitHub or by
+emailing hunterd107@gmail.com.
+
+This marketplace packages prompt-only agent skills. It does not bundle MCP
+servers, hooks, scripts, executable dependencies, credentials, or networked
+services.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance-false-and-anti/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance-false-and-anti/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: affordance-false-and-anti
+description: 'Use this skill when designing or fixing controls that mislead users — elements that look interactive but aren''t (false affordance), or controls that need to clearly communicate "you can''t do that here" (anti-affordance, like disabled states). Trigger when reviewing UIs where users tap inert elements expecting response, when designing disabled states, when picking treatments for read-only fields, or when a "decorative" element is being mistaken for a button. Sub-aspect of `affordance`; read that first.'
+---
+
+# False affordance and anti-affordance
+
+The mirror images of standard affordance: the elements that *look* interactive but aren't, and the elements that *are* interactive but should signal "not right now." Both deserve as much design attention as standard affordance — and both are routinely neglected.
+
+## False affordance: looks interactive, isn't
+
+A false affordance is an element whose visual treatment suggests interactivity it doesn't have. The user is led to expect an action; the action doesn't happen; trust drops.
+
+Common sources:
+
+- **Cards and panels styled like buttons.** A bordered, rounded, slightly-elevated container holds static content. Users tap; nothing happens.
+- **Hover states on non-interactive elements.** A box that highlights on hover but isn't clickable. Users learn to mistrust hover signals.
+- **Hyperlink-blue text that isn't a link.** Some design systems use blue for emphasis without realizing users read it as link affordance.
+- **Underlined non-link text.** Underline is a strong link signifier; using it for emphasis or definition collides with that convention.
+- **Icon-buttons next to non-interactive content.** A trash icon shown next to an item the user actually can't delete.
+
+### Fixes
+
+- Strip interactive-looking treatments from inert content. Use neutral backgrounds, no borders, no hover changes.
+- Reserve underlines for actual links. Use bold or italics for emphasis instead.
+- If a box must look distinct, use *uniform connectedness* (a tinted region) rather than *button-like elevation* (drop shadow, border).
+
+## Anti-affordance: signaling "you can't"
+
+Anti-affordance is the deliberate design of cues that tell the user "this is interactive in principle but unavailable to you right now." The most common case: disabled controls.
+
+A disabled control needs to:
+
+1. **Look different** from enabled (lower opacity, neutral color, no fill).
+2. **Not respond** to hover or click as it would when enabled.
+3. **Show a "no" cursor** (`cursor: not-allowed`).
+4. **Optionally explain** why it's disabled — via tooltip or adjacent text.
+
+```html
+<button class="btn" disabled
+        aria-disabled="true"
+        title="Add at least one item to checkout">
+  Continue to checkout
+</button>
+```
+
+```css
+.btn[disabled] {
+  background: hsl(0 0% 92%);
+  color: hsl(0 0% 50%);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+.btn[disabled]:hover {
+  /* no change — this is the anti-affordance */
+  background: hsl(0 0% 92%);
+}
+```
+
+### When *not* to disable
+
+A common UX mistake: disabling a button silently when the user "isn't ready" (form has unfilled required field; cart is empty). The user sees a non-responsive button and doesn't know why.
+
+Better:
+
+- **Keep the button enabled** and surface the validation error on click. The user gets a clear explanation rather than a silent block.
+- Or, if the button must be disabled, **explain why** alongside it (a small note, a tooltip on hover/focus, or a visible reason).
+
+```html
+<button class="btn">Continue to checkout</button>
+<p class="hint">Add at least one item to your cart to continue.</p>
+```
+
+The user can read the hint and act; the button isn't a dead end.
+
+### Read-only fields
+
+A field that's input-shaped but not editable is a special anti-affordance case.
+
+```html
+<label>Account ID
+  <input type="text" value="acct_8f3c7a" readonly />
+</label>
+```
+
+```css
+input[readonly] {
+  background: hsl(0 0% 96%);
+  color: hsl(0 0% 30%);
+  cursor: text;       /* still selectable for copy */
+  border: 1px solid hsl(0 0% 90%);
+}
+```
+
+The treatment says "this is data, not a control" — neutral background, no focus outline activation, but still selectable so users can copy.
+
+For fields that aren't *currently* editable but *could* be (e.g., locked behind a permission), the visual treatment should hint that editability exists in principle.
+
+## False affordance from animation
+
+A subtle modern source: animating a non-interactive element. A heading that wiggles, an icon that pulses, a card that slowly tilts. These attract attention; users assume attention means interactivity.
+
+If the animation is decoration only, audit whether it's drawing attention away from real interactive controls. If it's a callout for new content, ensure clicking does *something* — even if just to dismiss the callout.
+
+## Worked examples
+
+### Example 1: a card that *should* be clickable vs. one that shouldn't
+
+```html
+<!-- Clickable: card-link wraps, hover responds -->
+<a href="/projects/acme" class="card-link">
+  <article class="card">...</article>
+</a>
+
+<!-- Inert: no link wrap, no hover response -->
+<article class="card card--inert">
+  <h3>System status</h3>
+  <p>All services operational.</p>
+</article>
+```
+
+```css
+.card { padding: 16px; border: 1px solid hsl(0 0% 88%); border-radius: 8px; }
+.card-link { display: block; text-decoration: none; color: inherit; }
+.card-link:hover .card { border-color: hsl(220 90% 60%); box-shadow: 0 4px 12px rgba(0,0,0,0.08); }
+
+.card--inert {
+  background: hsl(0 0% 98%);  /* slightly different bg signals "informational" */
+  border-color: hsl(0 0% 92%);
+}
+.card--inert:hover {
+  /* no change — anti-affordance */
+}
+```
+
+The clickable card shifts on hover; the inert one stays still. Users learn quickly that hover-responsive cards are clickable and others aren't.
+
+### Example 2: read-only vs. disabled vs. unavailable
+
+Three subtly different states, each with its own anti-affordance:
+
+```html
+<!-- Read-only: data, never editable here -->
+<label>Workspace ID
+  <input value="ws_abc123" readonly />
+</label>
+
+<!-- Disabled because of state: editable when condition is met -->
+<label>Email
+  <input value="user@example.com" disabled aria-describedby="email-locked" />
+</label>
+<p id="email-locked" class="hint">Verify your email to enable changes.</p>
+
+<!-- Unavailable due to permission: visible but not actionable -->
+<label class="field-locked">
+  <span>Workspace name <LockIcon aria-hidden /></span>
+  <input value="Acme Inc" readonly />
+  <p class="hint">Only workspace admins can change this.</p>
+</label>
+```
+
+The user gets specific anti-affordance signals for each: read-only data is visually demoted; conditionally-disabled is enabled-looking-but-with-explanation; permission-locked has a lock icon and explanation.
+
+## Anti-patterns
+
+- **Decorative elevation on content cards.** Drop shadows that suggest "object you can interact with" on cards that are pure content. Strip the shadow.
+- **Disabled-button silent dead ends.** A submit button that's just disabled with no explanation. Users hunt for what's wrong.
+- **Read-only fields styled identically to editable.** Users tab into them, type, get confused.
+- **Inert hover responses.** A non-clickable element with a hover style applied "for visual interest." Users tap it, nothing happens, trust drops.
+
+## Heuristics
+
+1. **The "I tapped, nothing happened" audit.** Watch users. Each unproductive tap is a false-affordance failure or an anti-affordance failure (disabled with no explanation).
+2. **The hover-style audit.** Every element with a hover state should be interactive. If you have hover styles on non-interactive elements, strip them.
+3. **The disabled-with-context check.** Every disabled control on every page should answer "why?" — via tooltip, adjacent text, or context.
+
+## Related sub-skills
+
+- **`affordance`** (parent).
+- **`affordance-signifiers`** — the standard case of making affordance visible.
+- **`feedback-loop`** — disabled controls should still give *some* feedback (cursor change at minimum).
+- **`accessibility-understandable`** (process) — disabled states must be programmatically conveyed (`disabled` attribute, `aria-disabled`).

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance-false-and-anti/references/disabled-state-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance-false-and-anti/references/disabled-state-patterns.md
@@ -1,0 +1,93 @@
+# Disabled state and false affordance: pattern reference
+
+A reference complementing `affordance-false-and-anti` with deeper detail on disabled-state patterns and false-affordance audits.
+
+## Disabled state patterns
+
+The "disabled button" is one of the most contentious UX patterns. Three schools of thought:
+
+### School 1: always disable invalid actions
+
+Default in many UI libraries. The button is grayed out and inert until preconditions are met (e.g., form complete and valid).
+
+**Pros:** unambiguous; user can't trigger an action that would fail.
+
+**Cons:** silent unless paired with explanation. Users hunt for what's wrong. Particularly bad on long forms — the user can't tell which field is incomplete without scrolling and looking.
+
+### School 2: keep enabled, validate on submit
+
+The button stays enabled. Clicking triggers validation; errors appear inline with explanations.
+
+**Pros:** explicit feedback. The user sees specifically what's wrong.
+
+**Cons:** user expectation of "click works" is briefly violated. Some users assume the click failed silently; mitigations (loading state, scroll-to-error, focus-on-error) help.
+
+### School 3: enable + inline status
+
+Button stays enabled, but a status message nearby ("3 fields need attention") tells the user what's stopping them. Clicking still triggers full validation.
+
+**Pros:** best of both worlds — no silent block, clear status, no hunting.
+
+**Cons:** more design surface to maintain.
+
+The right choice depends on form complexity and stakes. For short forms, School 1 with inline hints is fine. For long forms, School 2 or 3 wins because the user shouldn't have to memorize what's wrong while scrolling.
+
+## Disabled state must be perceivable
+
+Whichever school you pick, disabled controls need:
+
+- **Visual demotion** — lower opacity, neutral background, reduced contrast.
+- **`cursor: not-allowed`** — the universal "no" signal on hover.
+- **`disabled` attribute** in HTML — semantically correct, prevents click events.
+- **`aria-disabled="true"`** — for assistive tech, especially in custom components where native `disabled` doesn't apply.
+- **No hover state response** — the button shouldn't shift on hover when disabled (that's a false signifier).
+
+```css
+.btn[disabled],
+.btn[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none; /* prevent click; or handle via JS */
+}
+```
+
+## Read-only field treatment
+
+A read-only field is anti-affordance for editability with retained affordance for selection (the user can still copy the value).
+
+```css
+input[readonly],
+textarea[readonly] {
+  background: hsl(0 0% 96%);
+  border-color: hsl(0 0% 90%);
+  color: hsl(0 0% 30%);
+  cursor: text; /* still selectable */
+}
+input[readonly]:focus { outline: 0; box-shadow: none; }
+```
+
+Notes:
+
+- Unlike `disabled`, `readonly` fields *are* in the form submission and *are* focusable.
+- `cursor: text` (not `not-allowed`) because users can select and copy.
+- Removing the focus outline avoids the false signifier of "you can edit this now."
+
+## False-affordance audit checklist
+
+```
+[ ] Are any non-interactive elements styled as buttons (filled, bordered, raised)?
+[ ] Are any non-interactive elements styled with hover responses?
+[ ] Is any non-link text underlined?
+[ ] Are any "decorative" icons sitting in positions where users expect buttons?
+[ ] Are any animated elements drawing attention to non-interactive content?
+[ ] Are any cards styled to look clickable but actually inert?
+[ ] Are any read-only fields styled identically to editable?
+```
+
+Each "yes" is a candidate for false-affordance fix.
+
+## Resources
+
+- **Norman, D.** *Design of Everyday Things* — chapter on visibility and affordance.
+- **NN/g** — articles on form field disabled states and validation patterns.
+- **WCAG 4.1.2 Name, Role, Value** — disabled state must be programmatically conveyed.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance-signifiers/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance-signifiers/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: affordance-signifiers
+description: 'Use this skill when the design has interactive capability but users aren''t *seeing* it — when the affordance is technically present but the signifier (the visible cue that tells users "you can do this") is missing or weak. Trigger when reviewing flat-design UIs where everything looks the same, when designing custom controls, when stakeholders ask "should this be more obvious?", or when picking signifier strength for primary vs. secondary actions. Sub-aspect of `affordance`; read that first.'
+---
+
+# Signifiers: making affordance perceivable
+
+In Norman's later refinement (2008), he distinguished *affordance* (the underlying possibility — a button can be pressed) from *signifier* (the visible cue that tells the user about the affordance — the button looks pressable). The distinction matters because designers control signifiers; affordances often exist regardless. A button that's missing a signifier still affords pressing — but no one knows.
+
+## The signifier inventory
+
+Every interactive element should carry one or more signifiers. The strongest are perceivable preattentively (within the first 200ms of viewing) without conscious thought.
+
+### Strong signifiers
+
+- **Filled background** with a brand or neutral color, distinct from the page background. Reads as "object."
+- **Visible border** outlining the interactive region. Reads as "discrete element you can act on."
+- **Drop shadow / elevation** suggesting the element floats above content.
+- **Distinctive shape** (rounded rectangle for buttons, pill shape for chips, circle for FABs).
+- **Underline** for links.
+
+### Medium signifiers
+
+- **Color difference from surrounding text** (the classic blue link).
+- **Cursor change** on hover (`cursor: pointer`). Desktop only.
+- **Hover state** (color shift, shadow change). Desktop only.
+- **Focus ring** when keyboard-focused. Critical for keyboard users.
+- **Iconography** (a pencil for edit, a trash for delete) for users who recognize the convention.
+
+### Weak signifiers
+
+- **Subtle color tint** (5% darker than background). Easy to miss.
+- **Tiny chevron or arrow** at the edge. Easy to miss.
+- **Implicit position** (e.g., "the bottom right of every card has the row actions"). Requires learning.
+
+For new-user surfaces, lean on strong signifiers. For dense expert tools, medium signifiers are acceptable because users develop spatial memory.
+
+## Signifier strength must match action stakes
+
+A useful rule: signifier strength should match the action's importance and consequence.
+
+```
+Primary action (Submit, Buy, Continue)
+  → Strongest signifier: filled background + brand color + cursor + hover
+
+Secondary action (Cancel, Save Draft)
+  → Medium signifier: outlined border + cursor + hover
+
+Tertiary action (Help, More info)
+  → Lighter signifier: text-only + color + underline on hover
+
+Destructive action (Delete, Remove)
+  → Different signifier: distinct color (red) + cursor + hover, often after a confirmation step
+```
+
+When the primary action has the same signifier as the tertiary, the user doesn't know which is most important. Signifier strength is a hierarchy decision.
+
+## Hover, focus, and active state signifiers
+
+Static signifiers tell the user "this is interactive." Response signifiers tell them "you've engaged it."
+
+- **Hover** (mouse over): color shift, shadow lift, slight scale change.
+- **Focus** (keyboard tab to): visible focus ring (`outline: 2px solid var(--ring); outline-offset: 2px`).
+- **Active** (pressing/holding): darker color, slight inset shadow, no scale change.
+- **Disabled**: lighter color, no hover/active response, `cursor: not-allowed`.
+
+These should *layer*. A button with a strong static signifier should still respond to hover and focus.
+
+```css
+.btn {
+  /* static signifier */
+  background: hsl(220 90% 50%);
+  color: white;
+  padding: 8px 16px;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 100ms;
+}
+.btn:hover { background: hsl(220 90% 45%); }
+.btn:focus-visible {
+  outline: 2px solid hsl(220 90% 50%);
+  outline-offset: 2px;
+}
+.btn:active { background: hsl(220 90% 40%); }
+.btn[disabled] {
+  background: hsl(0 0% 92%);
+  color: hsl(0 0% 50%);
+  cursor: not-allowed;
+}
+```
+
+Five distinct states; each communicates something different. Stripping any of them weakens the signifier system.
+
+## Signifier patterns by component type
+
+### Button
+
+- Filled or outlined background.
+- Distinct shape (typically rounded rectangle).
+- Cursor pointer.
+- Hover/focus/active states.
+- Always pair with a verb label.
+
+### Link
+
+- Color (typically brand).
+- Underline (always or on hover, depending on context).
+- Cursor pointer.
+- Distinct from surrounding body text.
+
+### Input field
+
+- Distinct background (usually different from surrounding page).
+- Border (visible or visible on focus).
+- Cursor text on hover.
+- Focus ring or border-color change on focus.
+
+### Toggle / switch
+
+- Distinctive shape (pill with circular slider).
+- Animated transition between states.
+- Strong color difference between on and off.
+
+### Drag handle
+
+- Iconographic signifier (six dots, two-line "grip").
+- `cursor: grab` on hover, `cursor: grabbing` on active.
+- Often dimmed in still state, brighter on hover.
+
+### Disclosure trigger (accordion, "More")
+
+- Chevron or plus/minus icon.
+- Animation on toggle.
+- Cursor pointer.
+- Often whole row is hover-responsive, not just the icon.
+
+## Anti-patterns
+
+- **Signifier-stripped flat design.** A "minimalist" button with no border, no background, no shadow. Identical to surrounding text except for slight color. Users miss it.
+- **Hover-only signifier.** Element looks like content; only on hover does it reveal it's a button. Touch users see no signifier; keyboard users may not focus it; even mouse users may not hover.
+- **Signifier mismatch with role.** A "tertiary" action (like a help link) given the strongest signifier — users press it expecting the primary action.
+- **Inconsistent signifiers for the same role.** "Submit" buttons vary in style across pages. Each page is a re-learning.
+- **Disabled controls without anti-affordance.** A disabled button that looks identical to enabled. Users tap; nothing happens; confusion.
+
+## Heuristics
+
+1. **The signifier audit.** For each interactive element on the page, list its signifiers. If the count is 0–1, signifier is too weak. 2+ stacked signifiers (background + cursor + hover) is the safer baseline.
+2. **The role-vs-signifier check.** Does the visual emphasis of each element match its role importance? Primary action should have the strongest signifier; tertiary the weakest.
+3. **The state coverage check.** For each interactive element, do you have static, hover, focus, active, and disabled signifiers? Missing focus = inaccessible to keyboard. Missing active = no press feedback.
+
+## Related sub-skills
+
+- **`affordance`** (parent).
+- **`affordance-false-and-anti`** — the inverse problem: when signifiers suggest interactivity that isn't there.
+- **`hierarchy`** (perception) — signifier strength is a hierarchy decision.
+- **`accessibility-perceivable`** (process) — signifiers must be perceivable across abilities.
+- **`feedback-loop`** — response signifiers (hover, focus, active) are micro-feedback.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance-signifiers/references/signifier-design-decisions.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance-signifiers/references/signifier-design-decisions.md
@@ -1,0 +1,63 @@
+# Signifier design decisions: deeper reference
+
+A reference complementing `affordance-signifiers` with patterns and trade-offs around picking signifier strength.
+
+## Norman's signifier framework
+
+Norman's 2008 essay "Signifiers, not affordances" argued that designers should focus on signifiers because:
+
+- Affordances often exist regardless of design (a `<button>` is clickable whether styled or not).
+- The design decision is *what to make perceivable* about that affordance.
+- Designers don't add or remove the underlying possibility; they add or remove the cues users see.
+
+This shifts the design question from "is this affordable?" to "does the user know it's affordable?" — which is much more answerable from observation.
+
+## The signifier budget
+
+Like emphasis, signifiers spend attention. A page where every element is highly signifier-rich (every "card" has hover, every section has a chevron, every label has a help-icon) reads as noisy.
+
+A useful budget: 3–5 distinct signifier styles per surface, each consistent in role.
+
+```
+Primary action      → filled background, brand color, strong hover
+Secondary action    → outlined, neutral, medium hover
+Tertiary action     → text-only, brand color, light hover
+Destructive action  → distinct color (typically red), strong hover, often after confirm
+Inert content       → no signifier
+```
+
+Five distinct styles, each used for one role consistently across the entire product.
+
+## Signifier consistency across components
+
+The signifier system should hold across all interactive elements, not just buttons:
+
+- A "More" disclosure trigger should use the same chevron icon site-wide.
+- Drag handles should use the same six-dot icon site-wide.
+- Sortable column headers should use the same arrow indicator.
+- Editable fields (when not always editable) should use the same affordance hint.
+
+Inconsistency degrades the system: each variation forces the user to re-learn what the cue means.
+
+## When subtle signifiers are appropriate
+
+Dense expert tools (IDEs, DAWs, trading terminals) sometimes use subtler signifiers because users develop muscle memory and spatial knowledge. They don't *scan* for the signifier; they fly to where they remember the control was.
+
+The trade-off: new users have a much steeper learning curve. Tools intended for daily use by professionals can absorb that curve; tools intended for casual or occasional users can't.
+
+## Mobile-specific signifier challenges
+
+Mobile lacks hover, which is a major signifier channel on desktop. Mitigations:
+
+- **Stronger static signifiers** — bordered, filled, or both.
+- **Press-state animations** that confirm taps.
+- **Long-press** as a discoverable secondary affordance (often communicated through onboarding or empty-state hints).
+- **Iconographic conventions** (hamburger menu, plus FAB) that users recognize across apps.
+
+Mobile bottom-nav and FAB patterns work because they exploit consistent iconography and position — the user learns once across many apps.
+
+## Resources
+
+- **Norman, D.** "Signifiers, not affordances" — jnd.org, 2008.
+- **Material Design**, **Apple HIG** — both publicly document signifier patterns for their platforms.
+- **NN/g** — many articles on signifier design and the flat-design regression.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: affordance
+description: 'Use this skill whenever the question is whether the user can tell what an element does — whether it looks clickable, draggable, expandable, editable, or interactive at all. Trigger when designing buttons, links, custom controls, drag handles, draggable cards, editable inline fields, or any interactive element. Trigger on reviews when users hesitate, miss controls, or click on things that aren''t interactive. Affordance is one of the most decisive principles in interaction design — Norman placed it at the center of *The Design of Everyday Things* — and it''s one of the most violated by modern flat-design conventions that strip the visual cues users rely on.'
+---
+
+# Affordance
+
+Affordance is the relationship between an object's properties and the actions it makes possible. A door handle affords pulling; a flat plate affords pushing; a button affords pressing; a slider affords sliding. When the affordance matches the intended use, the design works without instruction. When the affordance contradicts the intended use, even a sign saying "PUSH" cannot fully repair it — users still try to pull the handle first.
+
+## Definition (in our own words)
+
+Affordance is what an object's appearance, shape, weight, and material tell the user about what they can do with it. The affordance lives partly in the object itself (a button has a graspable shape) and partly in the user's perception of it (a child seeing a button for the first time has a different model than an adult who's seen ten thousand). Designers control the visual and behavioral signals; users bring prior experience. Where the two align, the design "just works"; where they diverge, the user must read, ask, or guess.
+
+## Origins and research lineage
+
+- **James J. Gibson**, *The Ecological Approach to Visual Perception* (Houghton Mifflin, 1979). Gibson coined "affordance" in ecological psychology to describe what an environment offers an animal: a horizontal surface affords standing; a graspable object affords carrying. The concept predates HCI but maps naturally to it.
+- **Donald Norman**, *The Design of Everyday Things* (1988, revised 2013). Translated affordance from Gibson's perceptual psychology into design vocabulary. Norman's iconic example — doors that look like they pull but actually push — became shorthand for affordance failure.
+- **Norman's later refinement** — "Signifiers, not affordances" (2008). Norman clarified that what designers actually control are *signifiers* (visible cues that suggest an action). The affordance is the underlying possibility; the signifier is what tells the user about it. The book's principle covers both, but the distinction matters in fine-grained design discussion.
+- **Lidwell, Holden & Butler** (2003) compactly stated the principle as "a property in which the physical characteristics of an object or environment influence its function" and gave the door-handle-vs-flat-plate example as the canonical illustration.
+- **Web/UI affordance research** — Bagrow, Tognazzini, and many others have studied how affordance translates to flat 2D screens. The shift from skeuomorphic to flat design (around 2013) reduced traditional affordance signals; subsequent recovery (subtle shadows, hover states, motion) has rebuilt them in less literal forms.
+
+## Why affordance matters
+
+Affordance is the fastest comprehension channel a UI has. A user looking at a screen for half a second can tell — preattentively, before reading a single label — which elements are interactive and which are content. Strong affordance lets the user form a working theory of the page in seconds; weak affordance forces them to point at things and watch what happens.
+
+The cost of weak affordance compounds:
+
+- **Time wasted hovering** over non-interactive elements to check.
+- **Time wasted scanning** for the interactive element among the inert ones.
+- **Misclicks** on things that look interactive but aren't (or vice versa).
+- **Anxiety** about what happens when something is clicked.
+- **Eventual learned helplessness** — users stop exploring and stick to the obvious paths.
+
+## When to apply
+
+- **Every interactive element** must have an affordance signal. This is non-negotiable.
+- **Every non-interactive element** must *not* look interactive. False affordance is as damaging as missing affordance.
+- **Custom controls** — when reaching past native HTML elements, you take on responsibility for the affordances those native elements provided for free.
+- **Empty states and onboarding** — affordance carries the "what can I do here?" answer before any text does.
+- **Touch surfaces** — touch has no hover, so affordance must work in the still state.
+
+## When NOT to apply (or when to be careful)
+
+- **Decorative elements** that aren't interactive should not have affordance signals. A "Welcome" banner shouldn't look like a button just because it's prominent.
+- **Disabled controls** need *anti-affordance* — visibly different (lower opacity, different cursor) so users don't try to interact.
+- **Power-user-only controls in dense UIs** can have subtler affordance because experts use spatial memory; new-user surfaces need stronger cues.
+
+## What the user reads as affordance
+
+Affordance signals fall into a small set of categories:
+
+### Shape and outline
+
+A bordered, rectangular shape with text inside reads as a button — across cultures, across years. The convention is so strong that it survives flat design: even a single-line border is enough to communicate "pressable."
+
+### Color contrast against context
+
+An element that's a different color than its surroundings reads as set apart, often as interactive. The brand-color CTA is the canonical case.
+
+### Depth and elevation
+
+Drop shadows, gradients, raised edges all suggest "pressable object floating above the page." Even subtle elevation (`box-shadow: 0 1px 2px rgba(0,0,0,0.05)`) is enough to communicate "this is a button, not flat content."
+
+### Cursor change
+
+Hover changes the cursor (`cursor: pointer`) — a strong "this is clickable" signal on desktop. For touch users this doesn't help; pair with visual signals.
+
+### Hover and focus state
+
+Color change, shadow shift, slight scale on hover signals "this responds to you." Focus ring on keyboard focus signals "this is interactive and currently selected."
+
+### Underline (for links)
+
+Underlined text reads as a link. The convention is so old it predates the web (footnotes in print). Stripping link underlines for aesthetic reasons damages affordance — color alone is weaker, especially for color-blind users.
+
+### Iconography
+
+A trash-can icon affords delete; a pencil icon affords edit; a magnifying glass icon affords search. These are *learned* affordances — they require prior exposure — but conventional icons have become as universal as physical-object affordances were before screens.
+
+### Position and grouping
+
+Buttons clustered at the bottom of a card or modal afford "primary actions." A control isolated in the corner of a row affords "this row's options." Position carries affordance through learned UI conventions.
+
+## Worked examples
+
+### Example 1: button vs. text vs. plain content
+
+```html
+<!-- Plain content: no affordance, none expected -->
+<p>Your account expires in 14 days.</p>
+
+<!-- Link: text-link affordance (color + underline on hover) -->
+<p>Your account expires in 14 days. <a href="/billing">Update billing</a></p>
+
+<!-- Button: button affordance (shape + background) -->
+<p>Your account expires in 14 days.</p>
+<button class="btn-primary">Update billing</button>
+```
+
+```css
+.btn-primary {
+  background: hsl(220 90% 50%);
+  color: white;
+  padding: 8px 16px;
+  border: 0;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.btn-primary:hover { background: hsl(220 90% 45%); }
+.btn-primary:focus-visible {
+  outline: 2px solid hsl(220 90% 50%);
+  outline-offset: 2px;
+}
+
+a { color: hsl(220 90% 40%); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
+a:hover { text-decoration-thickness: 2px; }
+```
+
+The plain `<p>` reads as content. The `<a>` reads as a link via color + underline. The `<button>` reads as a button via shape + color + cursor + hover.
+
+### Example 2: clickable card
+
+A common modern pattern: a card that's entirely clickable. The challenge: a card looks like content by default; making it clickable requires explicit signals.
+
+```html
+<a href="/projects/acme" class="card-link">
+  <article class="project-card">
+    <h3>Acme Project</h3>
+    <p>Q4 marketing site refresh</p>
+    <p class="meta">3 open tasks · Due May 15</p>
+  </article>
+</a>
+```
+
+```css
+.card-link { text-decoration: none; color: inherit; display: block; }
+.project-card {
+  border: 1px solid hsl(0 0% 88%);
+  border-radius: 8px;
+  padding: 16px;
+  background: white;
+  transition: border-color 150ms, box-shadow 150ms, transform 150ms;
+}
+.card-link:hover .project-card {
+  border-color: hsl(220 90% 60%);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  transform: translateY(-1px);
+}
+.card-link:focus-visible .project-card {
+  outline: 2px solid hsl(220 90% 50%);
+  outline-offset: 2px;
+}
+```
+
+The card's affordance: subtle border in the still state (suggesting "object, not flat content"), strong response on hover (border color, shadow lift, slight upward translate). Without those state changes, the card looks identical to a non-clickable info panel.
+
+### Example 3: drag handle
+
+A drag handle is a deliberately-novel control; its affordance must teach the user.
+
+```html
+<li class="sortable-row">
+  <button class="drag-handle" aria-label="Drag to reorder">
+    <svg viewBox="0 0 24 24" width="16" height="16">
+      <circle cx="9" cy="6" r="1.5" /><circle cx="9" cy="12" r="1.5" /><circle cx="9" cy="18" r="1.5" />
+      <circle cx="15" cy="6" r="1.5" /><circle cx="15" cy="12" r="1.5" /><circle cx="15" cy="18" r="1.5" />
+    </svg>
+  </button>
+  Task name
+</li>
+```
+
+```css
+.drag-handle {
+  cursor: grab;
+  background: transparent;
+  border: 0;
+  padding: 8px;
+  color: hsl(0 0% 60%);
+}
+.drag-handle:hover { color: hsl(0 0% 30%); }
+.drag-handle:active { cursor: grabbing; }
+```
+
+The signals: the six-dot icon (an established convention), `cursor: grab` (signals "you can pick this up"), and a hover state to confirm the control responds.
+
+### Example 4: editable inline text
+
+A field that becomes editable on click — useful but affordance-fragile because the field looks like static text by default.
+
+```html
+<h2 class="editable" contenteditable="true">Project name</h2>
+```
+
+```css
+.editable {
+  cursor: text;
+  border-bottom: 1px dashed transparent;
+  padding-bottom: 2px;
+  transition: border-color 150ms;
+}
+.editable:hover { border-bottom-color: hsl(0 0% 70%); }
+.editable:focus {
+  border-bottom-color: hsl(220 90% 50%);
+  outline: 0;
+}
+```
+
+Hover signals "you can interact" via the dashed underline. Focus locks in via solid color. Without these, users don't realize the heading is editable until they accidentally click and panic.
+
+### Example 5: anti-affordance for disabled controls
+
+```html
+<button class="btn-primary" disabled>Save (no changes)</button>
+```
+
+```css
+.btn-primary[disabled] {
+  background: hsl(0 0% 92%);
+  color: hsl(0 0% 50%);
+  cursor: not-allowed;
+}
+.btn-primary[disabled]:hover { background: hsl(0 0% 92%); /* no change */ }
+```
+
+The disabled state visibly removes affordance: lighter color (recedes), `cursor: not-allowed` (signals impossibility), no hover response. Pair with a label or tooltip explaining *why* it's disabled — disabled affordance tells the user they can't, but not why.
+
+## Cross-domain examples
+
+### Door handles vs. push plates
+
+Norman's canonical example. A vertical handle says "grab and pull." A horizontal flat plate says "push here." A door that requires pushing but has a handle is a *false affordance* — even with a "PUSH" sign, users will instinctively pull first. Better: replace the handle with a plate or bar shape.
+
+### Industrial control design
+
+Knobs afford turning. Switches afford flipping. Sliders afford sliding. Buttons afford pressing. Industrial designers select control types based on the action's semantics; mismatches create slips even with experienced operators.
+
+### Lego bricks
+
+Lego bricks afford stacking. The studs on top mate with the cavities on the bottom of the next brick. The shape *teaches* the assembly system — children figure out plugging without instruction because the shapes are unambiguous.
+
+### Children's toys
+
+A shape-sorter teaches affordance: square hole takes square block; round hole takes round block. The mismatched attempts fail visibly; the matched attempts succeed satisfyingly. This is affordance pedagogy in physical form.
+
+### Software desktop metaphors
+
+The original desktop metaphor (Xerox Star, Mac) borrowed affordance from physical desktops. Folders look like folders; trash looks like trash. The metaphor *teaches* the affordance via familiarity. Modern flat design has stripped the literal mimicry while retaining the structural affordances (folders are still containers; trash is still a destination).
+
+## Anti-patterns
+
+- **The flat-design no-affordance trap.** A "minimalist" UI where buttons have no border, no background, no cursor change. Users can't tell what's interactive without trial-and-error.
+- **The mystery card.** Cards on a dashboard that are sometimes clickable and sometimes not, with no visual difference between the two states. Users learn to suspect everything.
+- **Style-only links.** Links that have only a slight color difference from body text — no underline, no hover affordance change. Color-blind users see no difference.
+- **Hover-only affordance on touch.** Affordance signals that only appear on hover fail entirely on touch devices. Build affordance into the still state.
+- **Fake affordance.** A page header that looks like a button (bordered, raised) but isn't clickable. Users tap; nothing happens; trust erodes.
+- **Inconsistent affordance.** Buttons that look like buttons in one place and like links in another, for the same action role. Each place is a re-learning.
+- **Custom controls without inherited affordance.** Building a `<div onclick>` instead of `<button>` strips the native affordance signals (cursor, focus, keyboard activation). You must rebuild them all manually.
+
+## Heuristics
+
+1. **The squint test.** Squint at the screen until detail blurs. Can you still identify which elements are interactive? If everything blurs into the same shapes, affordance is too weak.
+2. **The fresh-user click test.** Hand the design to someone who hasn't seen it. Watch what they hover and tap. Misses are affordance failures.
+3. **The grayscale test.** Convert to grayscale. Affordance that depended on color (a blue link) collapses; you'll see what affordance remains. Robust affordance survives grayscale.
+4. **The hover-off test.** Disable all hover states. Does the still state still communicate which elements are interactive? If no, you were leaning on hover too much.
+5. **The keyboard-only test.** With Tab, can you reach every interactive element? Are the focus rings visible? Affordance for keyboard users is the focus ring; missing rings = missing affordance for them.
+
+## Related principles
+
+- **`constraint`** — affordance and constraint are complementary: affordance suggests what *can* be done; constraint blocks what *can't*. Both work together.
+- **`mapping`** — affordance signals what an element does; mapping signals what it affects.
+- **`mimicry`** — borrowing affordance from familiar physical or digital objects.
+- **`wayfinding`** — interactive elements with affordance are wayfinding cues.
+- **`feedback-loop`** — once acted on, the element gives feedback confirming the action.
+- **`consistency`** — affordance only works when the same shape always means the same action.
+- **`accessibility-perceivable`** — affordance must be perceivable across abilities; color-only affordance fails colorblind users.
+- **`hierarchy`** — primary actions need stronger affordance than secondary; emphasis economy applies.
+
+## Sub-aspect skills
+
+- **`affordance-signifiers`** — Norman's later refinement: the visual cues designers control to make affordances perceivable. When the underlying affordance exists but the signifier is missing, the user doesn't know.
+- **`affordance-false-and-anti`** — false affordance (looks interactive but isn't) and anti-affordance (deliberately signals "you can't do this here"). Both are crucial counterparts to standard affordance design.
+
+## Closing
+
+Affordance is the principle that decides whether your UI is intuitive or has to be taught. Strong affordance is invisible — users just *know* what to click — and weak affordance is the silent reason support tickets ask "how do I X?" when X is right there on the screen. Build affordance into the still state, layer on the response states, and audit every interactive element for whether someone seeing it for the first time would recognize it as interactive.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance/references/gibson-norman-and-flat-design.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/affordance/references/gibson-norman-and-flat-design.md
@@ -1,0 +1,102 @@
+# Affordance: Gibson, Norman, and the flat-design history
+
+A reference complementing the `affordance` SKILL.md with deeper grounding in the perceptual-psychology origins and the recent design-history shifts.
+
+## Gibson's ecological theory
+
+James J. Gibson coined "affordance" in *The Senses Considered as Perceptual Systems* (1966) and developed it fully in *The Ecological Approach to Visual Perception* (1979). His radical claim: perception isn't a matter of taking sensory data and inferring what's there; it's a direct pickup of *affordances* — what the environment offers an animal.
+
+A horizontal surface affords standing for a creature of the right size and weight. Water affords drinking, washing, and swimming. A graspable object affords carrying. The affordance exists in the relationship between the object and the perceiver — it's not purely "in" the object, and not purely "in" the perceiver.
+
+Gibson's framing was disruptive in psychology because it shifted explanation from internal mental representations to environmental properties. Whether his strong claim is right is still debated; but for design, the concept is enormously useful: design objects to *afford* their intended uses, and the intended uses become perceptually obvious.
+
+## Norman's translation
+
+Donald Norman introduced affordance to the design world in *The Psychology of Everyday Things* (1988, retitled *The Design of Everyday Things*). His door-handle examples became canonical:
+
+- A door with a handle affords pulling.
+- A door with a flat plate affords pushing.
+- A door that requires pushing but has a handle is *misdesigned* — the affordance contradicts the intended use.
+
+The book's wider message: the world is full of well-meaning designs that violate affordance, forcing users to read signs, ask for help, or learn the hard way. The book made "affordance" common vocabulary in design, software UX, and product engineering.
+
+## Norman's later refinement: signifiers
+
+In a 2008 essay ("Signifiers, not affordances") and the 2013 revised edition of *Design of Everyday Things*, Norman clarified an important distinction:
+
+- An **affordance** is a relationship — an action the object/environment makes possible for some user.
+- A **signifier** is a perceivable cue that tells the user about the affordance.
+
+In screen design, the affordance often exists regardless of the visual treatment (a `<button>` is clickable whether or not you style it). What designers control is the *signifier* — the visual treatment that tells users "this is clickable."
+
+Norman's clarification matters for screens because:
+
+- A bare `<button>` element has the affordance of clickability but may have weak signifiers (no styling).
+- Adding a background color, border, hover state — these are all signifiers.
+- A `<div onclick>` has the affordance of clickability (because of the onclick) but no native signifiers; you must add them all manually, plus accessibility scaffolding.
+
+The book's principle (and most casual usage in the design field) collapses the two terms; the distinction matters when you're auditing why an interactive element isn't working.
+
+## The flat-design recession of signifiers (2013–2018)
+
+The shift from skeuomorphic to flat design, kicked off by iOS 7 (2013) and Microsoft's Metro/Modern style earlier, stripped many traditional signifiers:
+
+- Drop shadows reduced to subtle or eliminated.
+- Bezels and gradients on buttons flattened.
+- Fewer iconographic-style 3D illustrations.
+- Borders thinner or removed.
+
+For aesthetic reasons, the result was cleaner, more modern-feeling UIs. For affordance, the result was widespread regression: users couldn't tell what was clickable. NN/g and other usability research bodies documented this regression in articles like "Flat UI Elements Attract Less Attention and Cause Uncertainty" (2017).
+
+The course-correction since ~2018 has been "almost flat" or "soft flat" or "neumorphism" — keeping the visual lightness while restoring just enough signifier (subtle shadow, hover response, more bordered chrome) to keep affordance perceivable.
+
+The lesson: aesthetic style trends can erode usability when they remove signifiers. Affordance discipline must be re-asserted on every project, against every style fad.
+
+## Cross-domain examples
+
+### Tools and instruments
+
+A hammer affords striking; a screwdriver affords turning; a saw affords cutting. The shapes evolved over centuries to make their uses obvious. Modern industrial designers can short-circuit this evolution by deliberately matching shape to action.
+
+### Children's toys (Lego, shape sorters)
+
+Lego studs and cavities are pure affordance: the bricks teach themselves. Shape sorters teach affordance through fail-fast: wrong shapes don't fit, right ones do.
+
+### Apple's product design
+
+Jonathan Ive's industrial designs at Apple (iPod, iPhone, MacBook) are exercises in affordance discipline: the physical buttons and surfaces signal their use without labels. The unibody MacBook's hinge is shaped to invite opening. The iPhone's home button (in versions that had one) is shaped to invite pressing.
+
+### Architecture: doors, paths, stairs
+
+The doors-vs-handles example generalizes:
+
+- Stairs afford climbing only when the riser height is in a comfortable range.
+- A path afford walking only when its width and surface are appropriate.
+- A handrail affords gripping at the right height.
+
+Architects work with affordance constantly; software designers can borrow the discipline.
+
+## Anti-pattern history: skeuomorphism's overreach
+
+The pendulum swung the other way before the flat-design recession. iOS 1–6 (2007–2013) leaned hard into literal skeuomorphism:
+
+- iCal looked like a leather-bound calendar.
+- Game Center had felt-textured backgrounds.
+- Notes looked like a yellow legal pad.
+- iBooks had a wooden bookshelf.
+
+Critics argued this was decoration without affordance benefit (the leather doesn't help you use the calendar). Defenders argued the metaphors *did* help with affordance — the bookshelf taught users that books had spines they could pull.
+
+The middle ground: borrow *behavioral* affordances from physical objects (sliding, pressing, sticking) without literal *visual* mimicry.
+
+## Resources
+
+- **Gibson, J. J.** *The Ecological Approach to Visual Perception* (1979).
+- **Norman, D.** *The Design of Everyday Things* (1988, revised 2013).
+- **Norman, D.** "Signifiers, not affordances" (jnd.org, 2008).
+- **NN/g** — multiple articles on flat design and affordance regression.
+- **Apple HIG** and **Material Design** — both extensively document signifier conventions for their platforms.
+
+## Closing
+
+Affordance is one of those principles that sits beneath nearly every interaction-design decision. The discipline isn't in knowing the principle; it's in noticing every interactive element on every screen and asking: does it look interactive in the still state? Does it respond when engaged? Does it stay consistent across the product? Three small audits, repeated, that catch most affordance failures.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint-physical/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint-physical/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: constraint-physical
+description: 'Use this skill when designing structural constraints that prevent invalid actions through the shape, layout, or behavior of the design itself — paths (channels of motion), axes (rotary controls), barriers (blocks). Trigger when designing input controls, drag-and-drop affordances, modal dialogs, or hardware-style structural prevention. Sub-aspect of `constraint`; read that first.'
+---
+
+# Physical constraints
+
+Physical constraints prevent invalid actions through the structure of the design — the shape of a connector, the boundary of a screen, the channel of a slider. The user *can't* take the wrong action because the structure rejects it. Stronger than psychological constraints; not always available.
+
+## The three subtypes (from the book)
+
+### Paths
+
+Channels that direct motion. The user can move along the path; off-path movement is impossible or rejected.
+
+Software examples:
+
+- **Sliders** constrain motion to one dimension.
+- **Range inputs** constrain values to a defined min/max.
+- **Scroll bars** constrain scrolling direction.
+- **Dropdown lists** constrain selection to provided options.
+
+```html
+<!-- Path constraint: value must be 0-100 -->
+<input type="range" min="0" max="100" value="50" />
+
+<!-- Path constraint: choice from fixed set -->
+<select>
+  <option>Small</option>
+  <option>Medium</option>
+  <option>Large</option>
+</select>
+```
+
+### Axes
+
+Rotary controls. Convert applied force into rotation; effectively infinite range in a small space.
+
+Software examples:
+
+- **Rotation gestures** in canvas tools.
+- **Color-wheel pickers** that constrain hue selection to a circular path.
+- **Dial-style controls** for continuous values.
+
+### Barriers
+
+Block, slow, or redirect motion.
+
+Software examples:
+
+- **Modal dialogs** block interaction with content beneath.
+- **Disabled buttons** block their action.
+- **Permission gates** block access to features.
+- **Screen edges** stop cursor motion (Fitts's edge advantage).
+- **Form-validation blocks** prevent submission when invalid.
+
+## Patterns
+
+### Input-type constraints (paths)
+
+```html
+<input type="email" />     <!-- only accepts email format -->
+<input type="number" min="0" />   <!-- only non-negative numbers -->
+<input type="date" />      <!-- only valid dates -->
+<input type="color" />     <!-- only valid hex colors -->
+```
+
+The browser enforces the constraint; the user can't submit invalid data.
+
+### Drop-zone constraints (barriers)
+
+A drag-and-drop interaction can constrain valid drops at the API level:
+
+```js
+dropZone.addEventListener('dragover', e => {
+  if (isValidTarget(draggedItem, dropZone)) {
+    e.preventDefault();  // allow drop
+  }
+  // not preventing default = drop won't fire
+});
+```
+
+The browser's drag-and-drop API itself uses constraint: `preventDefault` opens the channel; absence keeps it blocked.
+
+### Modal as barrier
+
+```html
+<dialog open>
+  <h2>Required action</h2>
+  <p>You must complete this step before continuing.</p>
+  <button onclick="proceed()">Continue</button>
+</dialog>
+```
+
+The dialog blocks interaction with the page beneath. Use sparingly; barriers irritate when they don't serve a clear purpose.
+
+### Disabled state (block)
+
+```html
+<button id="submit" disabled>Submit</button>
+```
+
+The button can't trigger its action until enabled. Pair with explanation of what would enable it.
+
+## When to use physical over psychological
+
+- **When the consequence of the wrong action is severe** (data loss, security breach, irreversible operation). Physical constraints are stronger.
+- **When the user is novice** or the system is unfamiliar — psychological constraints rely on prior knowledge that may not exist.
+- **When there's no acceptable failure mode** — make the wrong action impossible.
+
+## When physical constraints over-restrict
+
+- **Format constraints stricter than necessary** — phone fields that reject parentheses; name fields that reject apostrophes.
+- **Hardware-style barriers in software contexts** — a modal that blocks because of a non-blocking concern.
+- **Disabled states that don't explain themselves** — user can't act and doesn't know why.
+
+The discipline: constrain real requirements; explain when surprises occur.
+
+## Resources
+
+- **Norman, D.** *The Design of Everyday Things* (1988, 2013).
+- **Lidwell, Holden & Butler** (2003).
+- **WCAG** — input-type and validation constraints contribute to accessibility.
+
+## Related sub-skills
+
+- **`constraint`** (parent).
+- **`constraint-psychological`** — the other half; symbols, conventions, mappings.
+- **`affordance`** — affordance + constraint = the action space.
+- **`accessibility-operable`** — physical constraints must be operable across assistive technologies.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint-physical/references/structural-prevention-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint-physical/references/structural-prevention-cases.md
@@ -1,0 +1,63 @@
+# Physical constraints: case reference
+
+A reference complementing `constraint-physical` with examples and patterns.
+
+## Hardware physical constraints
+
+- **USB-C connectors** — rotational symmetry eliminates orientation error.
+- **Plug-and-socket polarity** — three-prong electrical plugs only fit one way.
+- **Child-safety caps** — require simultaneous push and twist.
+- **Aircraft cockpit gear handles** — shaped differently from flap handles to prevent confusion at night.
+- **Door hinges** — limit door swing to one direction.
+
+Each removes a class of error at the structural layer.
+
+## Software physical-style constraints
+
+- **Type-restricted inputs** (`<input type="email">`, `<input type="number" min="0">`) — the browser rejects invalid values.
+- **Maxlength on inputs** — can't type past the limit.
+- **Read-only attribute** — value can be selected/copied but not changed.
+- **Disabled buttons** — can't trigger their action.
+- **Modal dialogs** — block interaction with content beneath.
+- **Drag-validity gates** — drop only fires when the target accepts the dragged item.
+- **Permission-gated routes** — server returns 403 for unauthorized requests; UI hides the entry points.
+
+## Patterns
+
+### Form validation as constraint
+
+```html
+<input type="email" required maxlength="254" />
+<input type="number" min="0" max="999" />
+<input type="date" min="2020-01-01" max="2030-12-31" />
+```
+
+The browser enforces; submission is blocked until valid.
+
+### Mode locks
+
+A "view-only" mode disables editing controls. A "presentation mode" hides chrome. Each mode is a constraint that limits the action space to what's appropriate for the current task.
+
+### Capability-based permissions
+
+Permissions in modern OSes (iOS, Android, macOS) constrain apps to declared capabilities. An app must request microphone access; the user must grant; the OS blocks until granted.
+
+### Sandboxing
+
+Web pages run in browser sandboxes that constrain access to filesystem, hardware, and other origins' content. The constraint prevents whole classes of malicious actions.
+
+## Trade-offs
+
+Physical constraints are powerful but rigid. Over-constraining frustrates legitimate use:
+
+- A name field that rejects apostrophes (O'Brien, D'Angelo) breaks for many users.
+- A phone field requiring exactly 10 digits rejects international formats.
+- A modal that blocks interaction is appropriate for some workflows; oppressive in others.
+
+Calibrate the constraint to real requirements; don't constrain more than necessary.
+
+## Resources
+
+- **Norman, D.** *The Design of Everyday Things*.
+- **OWASP** input-validation guidance (security-side constraint).
+- **WCAG** form-validation accessibility guidelines.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint-psychological/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint-psychological/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: constraint-psychological
+description: 'Use this skill when designing constraints that work through perception, expectation, and learned convention — symbols, conventions, mappings. Trigger when designing iconography, picking control conventions, or designing for behavioral predictability. Sub-aspect of `constraint`; read that first.'
+---
+
+# Psychological constraints
+
+Psychological constraints don't physically prevent action; they make wrong actions feel obviously wrong by leveraging perception, learned convention, or perceived control-effect relationships. Weaker than physical constraints, but available where physical constraints aren't.
+
+## The three subtypes (from the book)
+
+### Symbols
+
+Communicate meaning through language and imagery. Examples:
+
+- A skull-and-crossbones on a poison bottle.
+- A "WET FLOOR" sign.
+- A red traffic light.
+- A trash icon on a delete button.
+
+In software UI: any icon or label that signals what an element does or what state it's in. The user reads the symbol and adjusts behavior accordingly.
+
+### Conventions
+
+Learned practices that the user expects systems to honor. Examples:
+
+- "Red means stop, green means go."
+- "Click the X to close."
+- "Cmd-S saves; Cmd-Z undoes."
+- "The hamburger icon opens a menu."
+
+Conventions are powerful because they're transferable — a user who learned cmd-K opens the command palette in one app expects it in others. Honor conventions; deviate only with strong reason.
+
+### Mappings
+
+Perceived relationships between controls and their effects. Examples:
+
+- Stovetop knobs arranged to match burner positions.
+- Volume dial that turns clockwise to increase.
+- Light switches near the lights they control.
+
+In software UI: a row of action buttons whose layout matches the order of objects they affect; a slider whose direction matches the direction of value change.
+
+```html
+<!-- Mapping: + on the right increases, - on the left decreases -->
+<div class="counter">
+  <button>−</button>
+  <span>5</span>
+  <button>+</button>
+</div>
+```
+
+Good mapping makes the right action feel obvious; the wrong action feels wrong.
+
+## Symbols in software UI
+
+### Iconography
+
+Icons that follow established conventions:
+
+- Trash → delete.
+- Pencil → edit.
+- Magnifier → search.
+- Gear → settings.
+- Bell → notifications.
+
+Reusing conventional icons is psychological constraint via convention. Inventing new icons forces users to learn new symbols; only do so when no convention fits.
+
+### Status badges
+
+A red "ERROR" badge psychologically constrains the user from treating the item as normal. The symbol pre-empts the wrong action.
+
+### Warning labels
+
+Inline warnings ("This action cannot be undone") constrain the user from proceeding without consideration.
+
+## Conventions in software UI
+
+### Keyboard conventions
+
+- `Cmd-S` / `Ctrl-S` saves.
+- `Cmd-Z` / `Ctrl-Z` undoes.
+- `Esc` closes overlays.
+- `/` focuses search.
+- `Cmd-K` / `Ctrl-K` opens command palette.
+
+Honoring these conventions constrains the user to expected behavior. Violating them creates surprise.
+
+### Mouse conventions
+
+- Click triggers actions.
+- Right-click opens context menus.
+- Drag moves elements.
+- Hover reveals supplementary information.
+
+### Layout conventions
+
+- Logo top-left links to home.
+- Account menu top-right.
+- Primary action bottom-right of dialogs.
+- "Cancel" left of "Confirm" in dialog footers.
+
+## Mappings in software UI
+
+### Spatial mappings
+
+- A list of items in vertical order; the action buttons for each row appear next to each row.
+- A toolbar of formatting buttons; the buttons appear above the text they affect.
+
+### Direction mappings
+
+- Up arrow scrolls up.
+- "Increase" controls increase what they control.
+- A slider moves rightward to increase.
+
+### Color mappings
+
+- Brand color = primary action.
+- Red = destructive.
+- Green = success.
+
+(Color mapping intersects with semantic color systems; see `color-semantic-systems`.)
+
+## When psychological constraints fail
+
+- **First-time users** lacking the convention. They don't know cmd-K opens the palette; the constraint doesn't apply.
+- **Cross-cultural transfer** — symbols and conventions vary by region. Red means luck in some cultures, not danger.
+- **Convention drift** — old conventions (the floppy-disk save icon) become opaque to younger users.
+- **Override by stronger signal** — a brand redesign that breaks convention may overpower it.
+
+When psychological constraints fail, fall back to physical constraints (block the wrong action structurally) or explicit information (explain the rules).
+
+## Anti-patterns
+
+- **Custom icons that violate conventions** — the user's prior knowledge becomes wrong.
+- **Convention-breaking shortcuts** — Cmd-S that triggers something other than save.
+- **Arbitrary mappings** — buttons that don't correspond spatially to what they affect.
+- **Cultural-blind symbols** — a hand gesture icon that means OK in one culture and offense in another.
+
+## Heuristics
+
+1. **The convention audit.** For each interactive element, name the convention you're following or breaking. Breaking should be deliberate.
+2. **The "what does this symbol mean?" check.** Show your icons to users unfamiliar with your product. If they can't tell, the symbol isn't carrying its psychological constraint.
+3. **The mapping check.** For each control, do its position and direction match the effect? If not, mapping is failing.
+
+## Related sub-skills
+
+- **`constraint`** (parent).
+- **`constraint-physical`** — the structural complement.
+- **`mapping`** (cognition) — the broader principle.
+- **`mimicry`** — psychological constraints often borrow from familiar systems.
+- **`expectation-effect`** — convention-honoring designs match user expectations.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint-psychological/references/conventions-and-symbols.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint-psychological/references/conventions-and-symbols.md
@@ -1,0 +1,70 @@
+# Psychological constraints: convention and symbol reference
+
+A reference complementing `constraint-psychological` with a catalog of conventions and symbol patterns.
+
+## Established UI conventions worth honoring
+
+### Keyboard
+- `Cmd-S` / `Ctrl-S`: save
+- `Cmd-Z` / `Ctrl-Z`: undo; `Cmd-Shift-Z`: redo
+- `Cmd-C` / `Ctrl-C`: copy; `Cmd-V` / `Ctrl-V`: paste; `Cmd-X` / `Ctrl-X`: cut
+- `Cmd-A` / `Ctrl-A`: select all
+- `Esc`: close overlay, cancel
+- `Enter`: confirm, submit
+- `Tab` / `Shift-Tab`: next / previous focusable
+- `/`: focus search (Twitter, GitHub)
+- `Cmd-K` / `Ctrl-K`: open command palette (modern apps)
+- `?`: show keyboard-shortcut help
+
+### Mouse / touch
+- Single click: primary action
+- Double click: open / activate
+- Right click: context menu
+- Long press (touch): context menu / selection
+- Drag: move; drag with modifier: copy
+- Scroll wheel: scroll page; with modifier: zoom
+
+### Layout
+- Top-left logo: home link
+- Top-right: account menu, notifications
+- Primary action bottom-right of dialogs (LTR)
+- "Cancel" left of "Confirm" in dialog footers
+- Sidebar nav on the left (most LTR app shells)
+- Bottom tab bar on mobile
+
+### Iconography
+- Trash / X: delete / close
+- Pencil: edit
+- Magnifier: search
+- Gear: settings
+- Bell: notifications
+- Hamburger ☰: menu (mobile)
+- Plus: add / create
+- Three-dot menu (⋮ or ⋯): overflow / more options
+- Chevron (▼ or ►): expand / collapse, navigate
+
+## Cultural variations
+
+Color and symbol conventions vary by culture:
+
+- **Red**: stop / danger in Western contexts; luck / prosperity in East Asian.
+- **White**: weddings (Western); funerals (some East Asian).
+- **Thumbs-up**: approval in much of the West; offensive in parts of the Middle East.
+- **OK hand sign**: positive in much of the world; offensive in some regions; co-opted recently with negative associations.
+
+For global products, pair color and symbol with text; never rely on iconography alone.
+
+## When breaking convention is appropriate
+
+- **When the convention is broken** (the floppy-disk save icon for a generation that's never seen one).
+- **When a stronger convention conflicts** (a vertical-scroll page in a horizontal-scroll context).
+- **When user research shows the convention fails for your audience.**
+
+In each case, the deviation should be paired with explicit signaling — onboarding, labels, or prominent placement — so users learn the new pattern.
+
+## Resources
+
+- **Apple Human Interface Guidelines** — comprehensive iOS / macOS conventions.
+- **Material Design** — Android conventions.
+- **WCAG** — accessibility-related conventions.
+- **GDS / GOV.UK Design System** — UK government conventions, well-documented.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: constraint
+description: 'Use this skill whenever the design must structurally prevent invalid actions — input validation, disabled states, required fields, type-restricted inputs, mode locks, role-based gates, hardware lockouts. Trigger when designing forms, picking input types, designing destructive flows, gating multi-step procedures, or thinking about how to prevent a class of errors from being possible at all. Constraint is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) and one of the strongest design moves available — preventing wrong actions is more powerful than detecting them after the fact.'
+---
+
+# Constraint
+
+A constraint is anything that limits the actions a user can perform on a system. Some constraints are physical (you can't insert a USB-C connector upside-down because the shape rejects it). Some are psychological (you don't try to push a door labeled "PULL" because the convention overrides the impulse). Both kinds work upstream of error: instead of catching wrong actions after they happen, constraints make wrong actions hard or impossible.
+
+## Definition (in our own words)
+
+A constraint is a deliberate limitation on what the user can do. The limitation may be implemented in the physical structure of the design (a slot that only accepts one shape), in the system's software (a button disabled until preconditions are met), or in the user's psychology (a convention that makes the wrong action feel obviously wrong). All three reduce error rates dramatically — constraints are usually cheaper than recovery, because they prevent the recovery from being needed.
+
+## Origins and research lineage
+
+- **Donald Norman**, *The Design of Everyday Things* (1988). Introduced constraints as one of the central tools for usable design. Norman distinguished four types: *physical, semantic, cultural, logical*. Lidwell, Holden, and Butler simplify to two (physical and psychological), with psychological encompassing semantic, cultural, and logical.
+- **Lidwell, Holden & Butler** (2003) compactly distinguish:
+  - **Physical constraints**: paths (channels that direct motion), axes (rotary controls), barriers (block undesired actions).
+  - **Psychological constraints**: symbols (semantic communication), conventions (learned practices), mappings (perceived control-effect relationships).
+- **James Reason**, *Human Error* (1990). Argued for constraints as the strongest defense against slip-type errors — making the wrong action structurally impossible is more reliable than training operators to avoid it.
+- **Affordance theory** (J. J. Gibson, 1979) is the conceptual companion: affordance suggests what *can* be done; constraint blocks what *can't*. Together they describe the action space.
+
+## Why constraints matter
+
+Every error you prevent at the design layer is an error you don't have to detect, recover from, explain, or apologize for. Constraints are the design layer's strongest move because they operate before error occurs:
+
+- **Confirmation** asks the user to verify after they've taken the wrong-feeling action.
+- **Undo** lets them recover after they've taken the wrong action.
+- **Constraint** makes the wrong action impossible in the first place.
+
+The discipline: when you're tempted to add a confirmation, ask first whether a constraint would do the same job better. Often yes.
+
+## Physical constraints
+
+In hardware, physical constraints are the shape of an object directing how it can be used.
+
+The book identifies three subtypes:
+
+### Paths
+
+Channels that direct motion. Examples:
+
+- A scrollbar that constrains motion to one axis.
+- A slot that only accepts a specific connector shape.
+- A door with hinges on one side; it only swings one direction.
+
+In software UI: a slider input is a path constraint — the user can only move along one dimension.
+
+### Axes
+
+Rotary controls. Convert applied force into rotation. Examples:
+
+- A doorknob.
+- A trackball.
+- A volume knob.
+
+In software UI: rotation gestures, dial inputs, the "spin" of an iOS time picker.
+
+### Barriers
+
+Block, slow, or redirect motion. Examples:
+
+- A railroad crossing barrier.
+- The boundary of a screen (the cursor stops there — Fitts's edge advantage).
+- A child-safety cap on a medicine bottle.
+
+In software UI: a modal dialog blocks interaction with the page beneath; a permission gate blocks access to a feature.
+
+## Psychological constraints
+
+Constraints that don't physically prevent action but lean on perception, convention, or knowledge.
+
+The book identifies three subtypes:
+
+### Symbols
+
+Communicate meaning through language and iconography. Examples:
+
+- A skull-and-crossbones on a poison bottle.
+- The "WET FLOOR" sign.
+- A red traffic light.
+
+In software UI: a "Disabled" badge; a "Restricted" tooltip; a warning icon.
+
+### Conventions
+
+Learned practices. Examples:
+
+- "Red means stop, green means go."
+- "Click the X to close."
+- "Cmd-S saves."
+
+Conventions are a constraint because the user *expects* certain actions to do certain things; design that conforms is constrained-by-convention to behave as expected.
+
+### Mappings
+
+Perceived relationships between controls and effects. Examples:
+
+- Light switches near the lights they control.
+- A volume dial that turns the same way the user expects up/down to work.
+- A stovetop where each burner has a knob in a corresponding position.
+
+Good mappings constrain user error by making the wrong action *feel* wrong.
+
+## When to apply
+
+- **Always**, on input fields. Type, length, range, format.
+- **Always**, on actions with preconditions. Submit disabled until form valid; "Send invoice" disabled until recipient selected.
+- **On destructive actions where the constraint can be a forcing function**. Required type-to-confirm; required password re-entry.
+- **On role-gated functionality**. Admin-only actions hidden or disabled for non-admins.
+- **On state-dependent actions**. "Edit" only enabled in edit mode; "Save" only enabled when changes exist.
+
+## When NOT to over-constrain
+
+Constraints that don't reflect real requirements feel arbitrary and frustrating:
+
+- **Forced format that's stricter than necessary** — a phone field that rejects parentheses.
+- **Validation that reflects implementation, not user need** — "Display name must contain only ASCII." Why?
+- **Mode locks the user can't predict** — a "read mode" they didn't enter and can't escape.
+- **Disabled buttons with no explanation** — the user can't act and doesn't know why.
+
+The discipline: constrain *real* requirements; communicate the constraint clearly when it surprises.
+
+## Worked examples
+
+### Example 1: input type as constraint
+
+```html
+<input type="email" required maxlength="254" autocomplete="email" />
+<input type="tel" inputmode="numeric" pattern="[0-9-]+" />
+<input type="number" min="0" max="999" step="1" />
+```
+
+The browser enforces the constraints. `type="email"` rejects malformed emails; `min="0"` rejects negative numbers. The user can't submit invalid input.
+
+### Example 2: button disabled until valid
+
+```html
+<form id="signup">
+  <input name="email" type="email" required />
+  <input name="password" type="password" required minlength="12" />
+  <button id="submit" disabled>Create account</button>
+</form>
+
+<script>
+const form = document.getElementById('signup');
+const btn = document.getElementById('submit');
+form.addEventListener('input', () => {
+  btn.disabled = !form.checkValidity();
+});
+</script>
+```
+
+Submit can't trigger until the form is valid. Pair with inline validation messages so the user knows what's missing.
+
+### Example 3: role-based gating
+
+```jsx
+function DeleteButton({ project, currentUser }) {
+  const canDelete = currentUser.role === 'admin' || project.ownerId === currentUser.id;
+  if (!canDelete) {
+    return null; // hide entirely; user can't even attempt
+  }
+  return <button onClick={confirmDelete}>Delete project</button>;
+}
+```
+
+Users without permission don't see the button. The wrong action can't happen.
+
+### Example 4: type-to-confirm as a forcing-function constraint
+
+The destructive button is disabled until the user types the resource name. The constraint converts a single click into a deliberate multi-step action.
+
+```html
+<dialog>
+  <h2>Delete workspace "Acme Inc"?</h2>
+  <p>This cannot be undone. Type <strong>Acme Inc</strong> to confirm:</p>
+  <input id="confirm" />
+  <button id="delete-btn" disabled class="destructive">Delete workspace</button>
+</dialog>
+
+<script>
+document.getElementById('confirm').addEventListener('input', e => {
+  document.getElementById('delete-btn').disabled = e.target.value !== 'Acme Inc';
+});
+</script>
+```
+
+### Example 5: hardware-style physical constraint in UI
+
+A drag-and-drop with a strict drop-zone restriction:
+
+```js
+function isValidDropTarget(item, target) {
+  if (item.type === 'file' && target.acceptsFiles) return true;
+  if (item.type === 'folder' && target.acceptsFolders) return true;
+  return false;
+}
+
+dropZone.addEventListener('dragover', e => {
+  if (isValidDropTarget(draggedItem, dropZone)) {
+    dropZone.classList.add('drop-valid');
+    e.preventDefault(); // allow drop
+  } else {
+    dropZone.classList.add('drop-invalid');
+    // do not preventDefault — drop won't fire
+  }
+});
+```
+
+The browser's drag-and-drop API itself is a constraint mechanism: not preventing default during dragover prevents the drop. The user *can't* complete the wrong drop.
+
+### Example 6: USB-C as the canonical physical constraint
+
+USB-C connectors have rotational symmetry — they fit either way. USB-A connectors do not. Generations of users have struggled with the USB-A "flip the cable to insert it correctly" failure. USB-C eliminated the failure mode at the design layer; no error to recover from.
+
+The lesson for software: when you can change the design so the failure can't happen, do that.
+
+## Cross-domain examples
+
+### Aviation: the auto-pilot disengagement
+
+The auto-pilot can be disengaged by pulling back firmly on the yoke. The disengagement is *constrained* — a casual touch doesn't trigger it, a firm pull does. The constraint matches the seriousness of the action.
+
+### Medicine: child-safety pill caps
+
+A child-safety cap requires push-and-twist simultaneously. The constraint reduces accidental childhood poisoning dramatically. The cost: arthritic adults sometimes struggle with the cap. Trade-off acknowledged; the design is calibrated to the population at greatest risk.
+
+### Industrial: dead-man switches
+
+Equipment that requires continuous operator engagement (a hand on the trigger, a foot on the pedal) shuts off if the operator becomes incapacitated. The constraint protects against operator failure.
+
+### Software: capability-based security
+
+Modern security designs constrain code to only the capabilities it explicitly needs. A web page can't read your filesystem; an app can't access your microphone without explicit permission; a sandbox limits what an embedded program can do. Each is a constraint at the system layer.
+
+## Anti-patterns
+
+- **Disabled buttons with no explanation.** User doesn't know why they can't act.
+- **Constraints that don't match user need** — overly strict format requirements that reject reasonable input.
+- **Hidden constraints** — the user discovers the limit only after attempting (e.g., a character limit not mentioned until they exceed it).
+- **Constraints framed as failures** — "Invalid input" instead of "Please enter a valid email like name@example.com."
+- **Modal traps** — a modal that constrains too aggressively (no Esc, no close X) trapping the user.
+
+## Heuristics
+
+1. **The "what could the constraint replace?" check.** For each confirmation in your app, ask: could a constraint do this job? Often yes.
+2. **The disabled-button audit.** Every disabled control should have a visible explanation of why it's disabled and what would enable it.
+3. **The wrong-action thought experiment.** For each destructive flow, imagine a user attempting to take the wrong action. What constraint would prevent it?
+4. **The convention check.** Are you violating a learned convention? If yes, the convention is a constraint working against you; either honor it or surface the violation explicitly.
+
+## Related principles
+
+- **`affordance`** — affordance suggests what *can* be done; constraint limits what *can't*. Companion principles.
+- **`mapping`** — good mapping is a psychological constraint that makes wrong actions feel wrong.
+- **`forgiveness`** — when constraint isn't possible, forgiveness handles the recovery.
+- **`errors`** — constraints prevent the slip and mistake categories of error.
+- **`expectation-effect`** — constraints work better when they match user expectation.
+- **`visibility`** — constraints must be visible to be navigable.
+
+## Sub-aspect skills
+
+- **`constraint-physical`** — paths, axes, barriers; structural constraints in physical or screen-equivalent form.
+- **`constraint-psychological`** — symbols, conventions, mappings; the constraint of expectation and learned practice.
+
+## Closing
+
+Constraint is one of the most powerful design tools and one of the most under-used. The reflexive design move on encountering an error is to add a confirmation or improve recovery; the better move, when possible, is to make the wrong action structurally impossible. Constraints are unglamorous but pay continuously across every user, every day.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint/references/norman-and-design-history.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/constraint/references/norman-and-design-history.md
@@ -1,0 +1,65 @@
+# Constraint: design-history reference
+
+A reference complementing the `constraint` SKILL.md with deeper context on the principle's history and Norman's broader framework.
+
+## Norman's four-part taxonomy
+
+In *The Design of Everyday Things* (1988, 2013), Donald Norman distinguished four kinds of constraint:
+
+- **Physical**: structural prevention (a slot only accepts the right shape).
+- **Semantic**: relies on the meaning of the situation (a steering-wheel column only goes one direction because of what driving means).
+- **Cultural**: relies on convention (red means stop because of cultural agreement).
+- **Logical**: relies on reasoning ("the third button must be the one I haven't tried").
+
+Lidwell, Holden, and Butler (2003) compressed these into two: physical and psychological (where psychological subsumes Norman's semantic, cultural, and logical). The simplification is workable for design purposes; the four-part version is more precise for analysis.
+
+## Cross-domain examples of constraint design
+
+### USB-C and the elimination of orientation error
+
+USB-A required users to insert the connector "right-side up" — and most people got it wrong on the first try, often the second too. USB-C's rotational symmetry eliminated the problem at the design layer. Generations of frustration eliminated by a single design move.
+
+### Child-safety pill caps
+
+Push-and-twist simultaneously is a constraint calibrated to adult vs. child motor skill. Trade-off: arthritic adults sometimes struggle. The design acknowledges the trade-off and accepts it because childhood poisoning prevention is the higher priority.
+
+### Lockout-tagout in industrial settings
+
+Workers physically lock and tag energy sources before maintenance. The lock requires deliberate removal before re-energizing. Slips that would otherwise injure workers are blocked at the design layer.
+
+### Software type systems
+
+Strongly-typed languages constrain the values a variable can hold. A function declared to take a `User` won't accept a `String`. Many runtime errors are prevented at compile time because the constraint catches them.
+
+### Web browsers' cross-origin restrictions
+
+A web page can't read content from another origin. The constraint prevents an entire class of security vulnerabilities. Trade-off: legitimate cross-origin use cases need explicit opt-in (CORS).
+
+## Constraint vs. confirmation vs. recovery
+
+Three layers of error response:
+
+- **Constraint**: prevent the wrong action.
+- **Confirmation**: ask the user to verify before committing.
+- **Recovery**: let the user undo after the fact.
+
+The right design uses all three at different levels of stakes:
+
+- Routine reversible actions: recovery only (undo).
+- Higher-stakes reversible: confirmation + recovery.
+- Irreversible: constraint + confirmation, with structural prevention preferred.
+
+## When constraint isn't enough
+
+Some real-world systems can't constrain certain actions:
+
+- A user with admin access can delete production data. The constraint can't be "they can't delete it"; it must be "they must really mean to."
+- A pilot can override the auto-pilot's stall protection. Sometimes pilots need to do that; the constraint is balanced against authority.
+
+In these cases, layered defenses (constraint + confirmation + recovery + audit log) replace pure prevention.
+
+## Resources
+
+- **Norman, D.** *The Design of Everyday Things* (1988, 2013).
+- **Reason, J.** *Human Error* (1990).
+- **Petroski, H.** *To Engineer Is Human* (1985) — engineering-side perspective on prevention vs. response.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control-locus/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control-locus/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: control-locus
+description: 'Apply locus of control — the design choice between making the system appear to act on the user''s behalf (external locus) and making the user appear to direct the system (internal locus). Use when designing AI-assisted features, autocorrect/autocomplete behaviors, recommendation surfaces, automated workflows, and any feature where the system could either do things automatically or wait for user instruction. Internal locus produces higher engagement, learning, and satisfaction; external locus produces higher convenience but lower agency. The skill is choosing deliberately and explaining the choice in the UI.'
+---
+
+# Control — locus
+
+Locus of control is the perception of who is doing the doing. An *internal* locus of control means the user feels they are directing the system; an *external* locus means the user feels the system is directing them. Both can be useful depending on the task — but the choice has psychological consequences that often go unconsidered, especially in automated and AI-assisted features.
+
+A well-designed system makes a deliberate choice about locus, usually shifting it depending on the task: internal for creative or judgment-intensive work, external for routine or expertise-deficient tasks. The same product can have different loci in different surfaces.
+
+## Why locus matters
+
+The psychological evidence is consistent. Users with a stable internal locus of control — across life, not just in software — report higher motivation, persistence, and satisfaction. Users with a stable external locus tend toward passivity and learned helplessness. While these are stable personality traits, *situational* locus is malleable, and software design can push it in either direction.
+
+A product that does things on the user's behalf without asking — autocorrects their typing, autocategorizes their email, auto-generates recommendations — moves the situational locus toward external. Useful in moderation, this becomes problematic when overdone: users feel the product is doing the work and they're just observing. They lose the sense of authorship over the output. They learn less about the underlying system. They have less to point to as their own.
+
+A product that waits for explicit user direction — asks for confirmation before acting, presents options without picking one, requires the user to invoke each capability — moves the locus toward internal. Useful when the user has expertise and judgment, this becomes burdensome when overdone: users feel they're doing all the work and the product is just a passive instrument. They get tired. They make errors that the product could have prevented. They wonder why the product doesn't help more.
+
+The right locus depends on the task and the user, and the choice deserves more attention than it usually gets.
+
+## When external locus is appropriate
+
+External locus — the system acting on the user's behalf — is appropriate when:
+
+**The user lacks the expertise to make the choice well.** Spell-check correcting a misspelled word. Photo software auto-correcting white balance. Email apps grouping conversations into threads. The user can't reliably make these decisions, and the system can. Letting the system act creates value that wouldn't exist otherwise.
+
+**The decision is routine and recurring.** Auto-saving a document. Auto-syncing data. Auto-paying recurring bills. The user has already implicitly authorized the system to handle this category of task; making them confirm each instance would be exhausting.
+
+**The cost of error is low and recovery is easy.** Auto-correcting a typo is fine if the user can immediately re-correct it. Auto-categorizing an expense is fine if it's easy to recategorize. The system can act first because the cost of being wrong is small.
+
+**The user explicitly delegated the task.** "Set up auto-pay for this account" — the user has actively chosen to externalize the locus. The system is now expected to act without asking.
+
+## When internal locus is appropriate
+
+Internal locus — the user directing the system — is appropriate when:
+
+**The user has expertise and the choice expresses their judgment.** A musician choosing which take to keep. A photographer choosing the crop. A writer choosing the phrasing. These are the moments where the user's authorship is the entire point; the system should not pre-empt them.
+
+**The cost of error is high and recovery is hard.** Sending a message to a customer. Deleting a database row. Moving money. The system should not act on the user's behalf for actions that, if wrong, would be expensive to undo. Internal locus here is not just psychological — it's protective.
+
+**The user is learning the system.** A novice exploring a new tool benefits from seeing what each action does, building a mental model. A system that "helps" by doing things automatically prevents that learning from happening. Once expert, the user can tolerate (and welcome) more automation; while learning, more internal locus is better.
+
+**The decision is value-laden or contested.** Recommendations that imply judgment ("you should buy this," "you should follow this person") are stronger when framed as suggestions the user is evaluating rather than as actions the system is taking. The user keeps the locus by deciding; the system supports the decision.
+
+## Designing for locus deliberately
+
+The design choices that shift locus include:
+
+**Action without asking vs. suggestion with confirmation.** "Auto-categorized as 'Travel'" with a small undo affordance vs. "Suggested category: Travel — confirm?" with options. The first is external locus, the second internal.
+
+**Showing what was done vs. asking what to do.** "Removed 47 duplicate rows" vs. "We found 47 likely duplicate rows — review and remove?" Both useful in different contexts.
+
+**Defaults presented as suggestions vs. defaults presented as decisions.** A form pre-filled with values the user can change conveys "we suggest these"; the same form pre-filled with values the user has to actively change conveys "we decided these for you." The design implementations may be similar, but the framing matters.
+
+**Visibility of automated actions.** Actions performed automatically should be visible — at minimum in a log, ideally in the moment they happen. A hidden auto-action is the worst of both worlds: external locus, with no opportunity for the user to notice or learn.
+
+**Granularity of control over automation.** Even when the system acts automatically, the user should be able to disable or tune the automation. A spell-checker the user can't turn off feels imposed; one with a clear settings panel feels delegated.
+
+## Worked examples
+
+### AI writing assistants
+
+An AI writing tool can operate at different loci. A high-external version: the user types a single sentence and the AI writes the rest, presenting it for acceptance. A medium version: the AI suggests a continuation that the user can accept, modify, or reject. A high-internal version: the AI provides on-demand help (rewrite, summarize, brainstorm) only when explicitly invoked.
+
+For users who want speed and don't care about authorship — a busy executive churning out routine emails — high external is fine. For users who care about voice and authorship — a writer working on a novel — high internal is essential. The same tool may need both modes for different users or different moments.
+
+The failure mode: a writing tool that auto-completes aggressively for all users. Users who want the help benefit; users who care about authorship feel their voice being replaced and disengage. The fix is to make the locus a deliberate choice the user controls.
+
+### Autocorrect on mobile keyboards
+
+The classic external-locus feature, useful in most cases — typos are routine, recovery is easy, the user knows the correction is happening — and frustrating when wrong. The keyboard that learns the user's vocabulary and stops correcting their custom terms maintains a productive external locus; the keyboard that insists on correcting your friend's name to a common word every time produces the worst kind of automation surprise.
+
+The lesson: external locus requires the system to be reliably right, or the user feels they're fighting an uncooperative tool.
+
+### Recommendation feeds
+
+A social-media feed that shows recommended content interleaved with content from people you follow shifts locus toward external. Over time, users may feel they're consuming what the algorithm chooses rather than what they chose to follow. Some users like this (effort-free discovery); others resent it (loss of authorship over their attention).
+
+A feed that shows only what the user followed and provides recommendations as a separate, clearly-labeled section maintains an internal locus. The user sees what they chose and explicitly visits the recommended section when they want.
+
+### Rule-based automations
+
+Email rules ("when X arrives, do Y") are a high-internal-locus form of automation: the user wrote the rule, the user understands what will happen, the user can change or disable it. The locus is internal even though the system is acting automatically, because the user is the author of the action.
+
+This is one of the cleanest patterns for combining automation with internal locus: the user delegates explicitly, with clear visibility into what will happen.
+
+### Confirmation dialogs
+
+The classic mechanism for shifting locus toward internal at moments of high stakes. "Delete 47 files? This cannot be undone." The user pauses, decides, confirms. The locus stays internal because the user actively chose, even though the system did the deletion.
+
+The failure mode: confirmation dialogs for everything, including low-stakes actions. The user starts clicking through them without reading, which puts them effectively in external locus (the dialog is now ignored noise) while still imposing the friction. Calibrate confirmation to actual stakes.
+
+## Anti-patterns
+
+**Hidden automation.** The system does things on the user's behalf but doesn't show what or when. The user notices later that something changed and can't trace it back. This is the worst case: external locus with no transparency, eroding trust in the system. Always make automated actions visible.
+
+**Forced choice when the system has a confident answer.** Asking the user to choose between "Delete this draft" and "Keep this draft" when an empty draft has obviously been abandoned. The system has the information to make the call; forcing the user to choose just adds friction. Move to external locus when you can do so accurately.
+
+**Internal-locus theater.** Asking for the user's choice but presenting it in a way that funnels everyone to the same answer (a bright "Recommended" badge on one option, the other options small and gray). The locus appears internal but is actually external — the user's "choice" is the system's choice with extra steps. Either own the decision or actually present it as a real choice.
+
+**Automation that learns the wrong thing.** A system that adapts to user behavior in ways the user can't see or control. The user trains the system inadvertently and is then surprised by what it does. Adaptive automation needs visibility into what the system has learned and easy ways to correct it.
+
+**Oscillating locus.** A product that switches between automatic and manual behavior unpredictably ("usually it does X for you, but sometimes it asks"). Users can't form a stable mental model. Pick a locus per task and stick to it.
+
+## Heuristic checklist
+
+For each automated or semi-automated feature, ask: **What is the locus of control here, and is it appropriate to the user, the task, and the stakes?** If the user lacks expertise and the stakes are low, external is probably right. If the user has expertise and the stakes are high, internal is probably right. **Is the automation visible?** If not, make it so. **Can the user adjust or disable the automation?** If not, build that affordance. **Does the locus match across the surface?** Inconsistent locus within a single product confuses users.
+
+## Related sub-skills
+
+- `control` — parent principle on the level of authority delegated to the user.
+- `control-power-vs-simplicity` — sibling skill on layering controls for mixed audiences.
+- `forgiveness` — undo and reversibility allow the system to operate at a more external locus safely.
+- `feedback-loop` — the mechanism by which automated actions become visible enough to maintain trust.
+- `mental-model` — stable locus supports a stable mental model; oscillating locus undermines it.
+
+## See also
+
+- `references/automation-design.md` — patterns for designing automation that maintains appropriate locus.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control-locus/references/automation-design.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control-locus/references/automation-design.md
@@ -1,0 +1,133 @@
+# Locus of control — automation design patterns
+
+A working catalog of patterns for designing automation that maintains the right locus of control, with notes on when each applies.
+
+## Pattern: visible auto-action with undo
+
+The system performs an action automatically and shows the user immediately what was done, with an undo affordance.
+
+Example: Gmail's "Conversation moved to Trash. Undo." When the user archives or deletes by gesture, the action happens immediately and a toast offers undo. The locus is mostly external (the system did the action without asking) but the undo gives the user a window to reclaim internal locus.
+
+This pattern works when:
+
+- The action is reversible.
+- The user can plausibly want to undo (because they triggered it accidentally or changed their mind).
+- The toast is visible long enough to be noticed (typically 5–10 seconds).
+- The undo is genuinely fast and reliable.
+
+This pattern fails when the action is not actually reversible, or when the toast disappears too quickly, or when the user has multiple toasts stacking up and can't tell which undo applies to what.
+
+## Pattern: suggestion with explicit accept
+
+The system suggests an action; the user must explicitly accept (click, tap, key) to perform it. Internal locus is preserved.
+
+Example: a code editor showing autocomplete options that the user can accept with Tab or ignore by typing. The suggestion is visible; the action is the user's.
+
+This pattern works when:
+
+- Suggestions are accurate enough to be worth showing.
+- The accept gesture is fast and unambiguous.
+- Ignoring the suggestion is also fast (the user can keep working past it).
+- The user can dismiss persistent suggestions if they're unhelpful.
+
+This pattern fails when suggestions are noisy (more wrong than right), when the accept gesture is hard to distinguish from other intended input, or when ignored suggestions block the user's work.
+
+## Pattern: rule-based delegation
+
+The user explicitly defines rules; the system executes them. Internal locus is preserved despite full automation, because the user authored the rule.
+
+Example: email filters, Zapier-style automations, calendar booking rules. The user wrote "when X happens, do Y" — the system is acting on the user's pre-stated intent.
+
+This pattern works when:
+
+- Rules are easy to define for the user's actual cases.
+- The user can review what the rules have done.
+- Rules can be edited or disabled easily.
+- Rules don't accumulate so many that the user loses track.
+
+This pattern fails when rules become so numerous and inter-dependent that the user no longer understands what's happening, or when the rule language is too restrictive to express the cases the user actually has.
+
+## Pattern: confidence-gated automation
+
+The system acts automatically when confident; asks when uncertain. Locus shifts based on the system's certainty.
+
+Example: a photo-tagging system that auto-tags faces it has seen many times before but asks for confirmation on new faces. A spam filter that auto-files highly confident spam but routes uncertain mail to a "needs review" folder.
+
+This pattern works when:
+
+- The system has a reliable measure of its own confidence.
+- The user trusts the system's confidence assessment.
+- The threshold is well-calibrated (not too permissive, not too cautious).
+- The user can adjust the threshold if it's mis-set.
+
+This pattern fails when the system's confidence is poorly calibrated, when it acts too aggressively on mistaken confidence, or when "needs review" piles up and overwhelms the user.
+
+## Pattern: explicit invocation
+
+The system does nothing without explicit user request. Maximum internal locus.
+
+Example: most code editors' "format document" command. The formatter is available but doesn't run unless invoked. The user is in full control.
+
+This pattern works when:
+
+- The user knows the capability exists.
+- The user can predict what will happen when they invoke it.
+- The invocation is fast and discoverable.
+
+This pattern fails when users don't know the capability is there, or when the cost of invocation is high enough that they'd rather do without than learn the command.
+
+## Pattern: opt-in vs. opt-out automation
+
+A meta-pattern: automation can be on by default with the option to disable, or off by default with the option to enable. The choice has large psychological consequences.
+
+**Opt-out (on by default):** maximum convenience, but the user is in external locus by default. Most users never change defaults, so most users will use the system in external locus mode. Appropriate when the automation is reliably useful and the cost of being wrong is low.
+
+**Opt-in (off by default):** maximum agency, but most users won't enable. Appropriate when the automation has meaningful tradeoffs that users should evaluate, or when the cost of being wrong is high.
+
+Many products start opt-in (when launching a new automation) and shift to opt-out once the automation is proven and trusted.
+
+## Pattern: revealing automation in the background
+
+The system acts automatically but its actions are continuously visible in a background area — a log, a sidebar, a status indicator. The user can scan to see what's been happening.
+
+Example: an IDE's git auto-commit indicator. A backup tool's "last sync at 3:42pm" status. An email client's "auto-archived 12 promotional emails" summary.
+
+This pattern works when:
+
+- The user's overall workflow is in the foreground; the automation is in the periphery.
+- The user can audit what the automation has done if they want.
+- The automation doesn't surface unless something is unusual or noteworthy.
+
+This pattern fails when the indicator is hidden too well (the user never notices) or pushed too prominently (it interrupts the foreground work).
+
+## Pattern: no-confidence question
+
+When the system is uncertain enough that asking would be reasonable, but the user doesn't have the information to answer well either, sometimes the right move is to not act and not ask — just present the situation and let the user decide what to do next.
+
+Example: a package manager finding a dependency conflict it can't auto-resolve. Rather than suggesting a fix it's not confident about, it shows the conflict and lets the user investigate.
+
+This pattern works when:
+
+- The system is honest about its uncertainty.
+- The user has tools to investigate and decide.
+- The system doesn't fall into the trap of asking unanswerable questions ("Is this conflict acceptable to you?" — the user doesn't know without investigation).
+
+## Anti-patterns
+
+**The "are you sure?" treadmill.** Confirming every action regardless of stakes. Users habituate and click through without reading. The friction is paid; the locus is not actually preserved (because the user is no longer making real decisions); and stakes are not actually weighted.
+
+**Aggressive automation with no audit trail.** The system makes many decisions on the user's behalf and doesn't show any of them. The user is in pure external locus, with no ability to correct mistakes or learn the patterns.
+
+**Inconsistent locus across surfaces.** A product that auto-saves in one place but requires explicit save in another. A product that auto-categorizes some data but asks the user to categorize other data. The user can't form a stable expectation, which is a worse experience than either consistent locus.
+
+**Locus that changes based on undisclosed factors.** A product that auto-sends some emails but holds others for review based on criteria the user can't predict. The user doesn't know what to expect from the system and starts to mistrust it. Either the criteria should be disclosed or the locus should be consistent.
+
+**Soft automation that pretends to be a choice.** Pre-checked checkboxes, pre-selected radio buttons, defaults presented with strong visual nudges that all but one option is wrong. The user feels they chose but the system actually decided. This is manipulative and erodes trust when noticed.
+
+## A simple test
+
+Ask a user "what does the system do automatically, and what do you have to tell it to do?" If they can answer clearly, your locus is well-designed. If they can't — if they're surprised by automated actions or don't realize they could automate things they're doing manually — the locus is unclear and likely costing you on both convenience and agency.
+
+## Cross-reference
+
+For the broader principle of how much control to give users, see `control`. For the structural mechanism of layering controls for mixed audiences, see `control-power-vs-simplicity`.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control-power-vs-simplicity/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control-power-vs-simplicity/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: control-power-vs-simplicity
+description: 'Apply layered control — designing interfaces that serve novice and expert users in the same product without forcing one audience into the other''s interface. Use when building products that span experience levels (most consumer software, most professional tools used occasionally), choosing between "simple by default" and "powerful by default," or deciding what to expose vs. hide behind progressive disclosure. The skill is creating a default surface that suffices for novices and a depth surface that doesn''t intimidate them but is fully present for experts.'
+---
+
+# Control — power vs. simplicity
+
+The most-cited tension in control design: power users want depth, novices want simplicity, and most products have both kinds of users. The naive answers ("just make it simple," "just make it powerful") both fail. Simple products lose their experts to deeper alternatives; powerful products lose their novices before they ever discover the depth.
+
+The successful pattern across decades of product design is *layering*: a simple default surface that handles the common cases, with depth available but not promoted. A novice can use the product productively without ever encountering the advanced controls. An expert can configure, customize, and extend without leaving the application.
+
+## The core architecture
+
+Layered control rests on a few moves applied consistently.
+
+**Identify the 80/20.** What can a novice do that handles 80% of their use? That's the default surface. What does an expert need that handles the remaining 20% and the long-tail edge cases? That's the depth surface.
+
+**Make the default surface complete for the novice case.** The novice should not feel that they're missing anything important. The default surface should be a complete tool for the use case it serves, not a stripped-down preview of the "real" tool.
+
+**Make the depth surface accessible but not promoted.** The advanced controls are reachable in 1–2 actions (a "more options" button, a settings panel, an advanced mode toggle), but they don't appear in the default field of view. The novice doesn't have to dismiss them; they aren't there.
+
+**Make the depth surface complete for the expert case.** Once the expert has unlocked depth, they should find the full set of capabilities the product offers, not a half-step that requires them to leave the product for serious work. Half-depth interfaces lose experts to fully-deep alternatives.
+
+**Maintain consistent vocabulary across surfaces.** The same concepts should have the same names whether the user is in default or advanced mode. A novice who learns the product's vocabulary in default mode shouldn't have to relearn anything to graduate into advanced mode.
+
+## The four common architectures
+
+There are roughly four architectural patterns for layering control. They differ in where the depth lives and how the user reaches it.
+
+**1. Progressive disclosure within the same view.** A "Show advanced" button or expandable section reveals additional controls inline. The novice never opens it; the expert always opens it. This works well when the depth controls are conceptually related to the default controls and benefit from being visually adjacent.
+
+Example: a flight-booking interface where the basic search is "from / to / dates / passengers" and a "more options" expansion adds cabin class, refundable / non-refundable, multi-city, layover preferences. The expert opens the expansion and uses it; the novice never touches it.
+
+**2. Mode toggle (basic / advanced).** A clearly-labeled mode switch changes the entire interface from a simple to a complex layout. The user picks their mode and the product follows.
+
+Example: a photo editor with a "Quick" mode (auto-enhance, basic crop) and a "Pro" mode (curves, layers, masks). The user switches modes based on the task.
+
+This works when the two modes are genuinely different workflows, not just more or fewer controls. It fails when users expect all the basic capabilities to also exist in pro mode and find some missing.
+
+**3. Settings panel for configuration depth.** The default UI is the simple workflow; deep customization (keybindings, default values, plugin configuration) lives in a settings panel reachable through a menu. Users only visit settings when they want to change behavior.
+
+Example: VS Code, Slack, Notion. The default editing surface is approachable; the settings panel is vast and contains depth most users never see.
+
+This works for any product where the customization is configurational (set once, takes effect always) rather than per-task.
+
+**4. Power-user shortcuts.** The visual UI is simple; expert speed is provided through keyboard shortcuts, command palettes, or programmatic interfaces. Novices use the UI; experts use the shortcuts.
+
+Example: command palette (Cmd-K) interfaces in modern productivity apps. Vim and Emacs in the extreme.
+
+This works when expert speed depends on minimizing pointing and clicking; the visual UI doesn't have to grow more complex to serve experts because experts are bypassing it.
+
+## Choosing the right architecture
+
+The choice depends on the nature of the depth.
+
+- **Depth is in additional task parameters.** Use progressive disclosure within the view. The expert needs occasional access to the parameters; they don't want to leave the task.
+- **Depth is in different workflows.** Use a mode toggle. The expert is doing a fundamentally different kind of work and benefits from a different layout.
+- **Depth is in configuration that affects future behavior.** Use a settings panel. Set it once and forget it.
+- **Depth is in speed of common operations.** Use power-user shortcuts. The expert just wants to do the same things faster.
+
+A single product can use multiple architectures for different kinds of depth. Lightroom has progressive disclosure (Basic vs. Detail panels), settings (Catalog preferences), and power-user shortcuts (keyboard shortcuts for nearly every action) all at once.
+
+## Worked examples
+
+### A todo app
+
+The novice surface: a list, a "+ add task" button, a checkbox to complete. That's it.
+
+The first depth layer: due dates, priorities, projects. Available via a "..." menu on each task or an inline keyboard shortcut.
+
+The second depth layer: filters, recurring rules, custom views, integrations. Available via a settings panel and a query language.
+
+A novice using the app for personal task management never encounters any depth. An expert managing complex multi-project work uses all the depth and probably writes custom queries.
+
+The failure mode: putting due-date pickers, priority selectors, and project assignments inline on every task. The novice sees a cluttered interface and either ignores the extra fields (rendering them clutter without function) or feels intimidated. The depth should be reachable but invisible until requested.
+
+### A spreadsheet
+
+The novice surface: type values into cells, do basic sums.
+
+The first depth: formulas, cell references, basic chart types.
+
+The second depth: pivot tables, named ranges, conditional formatting, macros.
+
+The third depth: scripting (Apps Script, VBA), custom functions.
+
+Spreadsheets are the canonical example of a product with vast depth that novices use productively without ever encountering most of it. The architecture is mostly progressive disclosure (more advanced features are in less prominent menus) and power-user shortcuts (formulas are typed, scripts are written).
+
+### A trading platform vs. a consumer trading app
+
+These are not layered; they're different products. A retail trading app and a professional trading platform serve audiences too different to be combined in a single interface. The retail app is "buy / sell, dollar amount, confirm." The professional platform is the full order-type taxonomy, routing options, and live order books.
+
+This is the boundary case for layering: when the gap between novice and expert is too wide, build separate products. Trying to bridge the gap with a layered single product usually serves neither audience well.
+
+The signal that you've reached this boundary: the simple-mode users complain about complexity even though they don't use the depth, and the expert-mode users complain about workarounds for things that should be primary actions.
+
+### A search interface
+
+Default: a single text box.
+
+Depth (within the same view): a "filters" panel that opens to the side or below, with date, source, type, and other filters.
+
+Power-user depth: a query syntax (`from:alice after:2023-01-01 -spam`) that lets experts express complex queries inline.
+
+Three architectures coexisting. The novice uses the text box. The intermediate user opens the filters panel. The expert uses the query syntax. All three audiences are served without forcing any of them through the others' interface.
+
+### Configuration in a developer tool
+
+The default UI: sensible defaults, basic settings.
+
+Settings panel depth: extensive customization options across categories (editor behavior, keybindings, themes, plugin management, language-server configuration).
+
+Configuration-as-code depth: a settings JSON file (or YAML, or Lua script) that the user can edit directly to express things the settings UI doesn't support.
+
+Plugin depth: an extension API that lets the user write code that extends the tool itself.
+
+VS Code is the obvious example; the same pattern appears in JetBrains products, Sublime, and many others. Each layer of depth serves a more committed user. The vast majority of users stop at the settings panel; a small minority use the JSON; an even smaller minority writes plugins. All are served by the same product.
+
+## Anti-patterns
+
+**The "feature parity" trap.** A simple-mode UI that promises to have all the same features as the advanced mode, just with a friendlier face. Inevitably, some features don't fit the simpler architecture and have to be omitted, and users discover this and feel cheated. Better to be honest: simple mode handles the common cases; the depth is in advanced mode.
+
+**The "settings sprawl" trap.** A settings panel that has accumulated every option ever requested by anyone, with no organization. Settings become unfindable. The expert who needs to change one thing spends fifteen minutes looking for it. Organize settings into a coherent taxonomy, and prune options that no one actually uses.
+
+**The "everything in one screen" trap.** Trying to serve novices and experts with the same default view by including everything but visually demoting the advanced bits. Novices still see the visual noise; experts still have to wade past the basic controls. Pick one audience for the default and serve the other through a deliberate mechanism.
+
+**The "tutorial as substitute for design" trap.** A complex default UI accompanied by extensive onboarding to teach the novice how to use it. The onboarding works for the first session and is gone after that; the complex UI persists. Better to make the default simple and let depth be discovered as users mature.
+
+**The "depth that doesn't actually go deep" trap.** An advanced mode that adds a few extra options but is still missing the things a real expert needs. Experts open it, see that it doesn't go far enough, and leave for tools that do. If you commit to serving experts, the depth has to be real.
+
+## Heuristic checklist
+
+Before settling on the control architecture, ask: **Who are my actual audiences, and how different are their needs?** If very different, separate products may be better than layered. **What is the 80/20 of operations?** That's the default surface. **What does an expert genuinely need that the novice doesn't?** That's the depth. **Can a novice complete their core tasks without encountering any depth?** If not, the default surface is too cluttered. **Can an expert reach all needed depth in 1–2 actions?** If not, the depth is buried too far. **Does vocabulary stay consistent across surfaces?** If not, users have to relearn at each layer.
+
+## Related sub-skills
+
+- `control` — parent principle on the level of authority delegated to the user.
+- `control-locus` — sibling skill on the perceived agency dimension of control.
+- `progressive-disclosure` — the structural mechanism that implements layered control within views.
+- `80-20-rule` — the empirical observation that justifies the architectural pattern.
+- `recognition-over-recall` — power-user shortcuts trade recognition (visible UI) for recall (memorized commands); pick deliberately.
+
+## See also
+
+- `references/layering-patterns.md` — patterns for specific kinds of products and depth.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control-power-vs-simplicity/references/layering-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control-power-vs-simplicity/references/layering-patterns.md
@@ -1,0 +1,141 @@
+# Layered control — patterns by product category
+
+Specific architectural patterns for layering simple and advanced controls, organized by the kind of product or feature being designed.
+
+## Pattern: collapsible advanced section
+
+The default view shows the basic fields; an "Advanced" section toggles open to reveal additional options. The depth is inline but hidden until requested.
+
+Use when: depth is in additional task parameters that a few users will want, conceptually related to the basic task.
+
+Examples: flight booking advanced filters, signup forms with optional fields, configuration dialogs with "Show advanced settings."
+
+Pitfalls: an Advanced section that's so minimal it doesn't justify the toggle (just include the fields, or remove them); an Advanced section that becomes the universal dumping ground and contains too much for a single disclosure.
+
+## Pattern: tabbed interfaces with depth-by-tab
+
+The default surface is a primary tab; secondary tabs hold depth. Users only visit secondary tabs when they need them.
+
+Use when: the depth is in conceptually distinct categories of work that benefit from being separated.
+
+Examples: a product page with tabs for Overview, Specs, Reviews, Q&A. A settings panel with tabs for Account, Notifications, Privacy, Integrations.
+
+Pitfalls: too many tabs (more than 5–6 starts to overflow); important features hidden in tabs that users don't expect to contain them.
+
+## Pattern: drill-in for depth
+
+The default surface is a list; clicking an item drills into a detail view that contains the depth. The list is simple; the detail is rich.
+
+Use when: each item has many properties that aren't all relevant in the list view.
+
+Examples: email inbox (list of emails; click to read full email with all metadata, attachments, and reply controls). File manager (list of files; click for detailed properties).
+
+Pitfalls: drilling in is a navigation step that breaks flow; if users frequently need depth on multiple items, consider showing it inline or in a sidebar.
+
+## Pattern: split view with primary + detail
+
+The default is a list on the left; selecting an item shows its detail on the right. The user stays in context but sees depth for the selected item.
+
+Use when: users need to scan items and dive into details without navigating away from the list.
+
+Examples: email clients (list + reading pane). Settings panels (categories + detail). File managers (list + preview).
+
+Pitfalls: requires enough screen real estate; doesn't translate well to mobile (where it usually becomes drill-in).
+
+## Pattern: contextual toolbar
+
+The default UI is the main canvas; a toolbar appears with controls relevant to the current selection or mode. Depth is contextual to what the user is doing right now.
+
+Use when: depth is operation-specific and only relevant in certain contexts.
+
+Examples: text editors (formatting toolbar for selected text). Image editors (selection-tool options bar). Diagramming tools (shape-property panel for selected shape).
+
+Pitfalls: toolbars can become cluttered if every operation adds controls; the user can lose track of where the toolbar is when selection changes.
+
+## Pattern: command palette
+
+The visual UI is simple; a command palette (typically Cmd-K or Ctrl-K) provides a searchable list of every action the user can take. Experts use the palette; novices use the visual UI.
+
+Use when: depth is in many specific actions that don't all need visual real estate.
+
+Examples: VS Code, Linear, Notion, Slack, modern terminal applications.
+
+Pitfalls: novices don't know the palette exists; the action vocabulary needs to be consistent and searchable; some actions need parameters and a palette doesn't gracefully handle them.
+
+## Pattern: keyboard shortcuts
+
+Shortcuts for common actions, optionally hidden behind tooltips. Experts learn and use them; novices use the menu.
+
+Use when: speed of common operations matters and the user base will get value from learning shortcuts.
+
+Examples: every productivity tool has them. The well-designed ones make shortcuts discoverable in tooltips and menus.
+
+Pitfalls: shortcuts that conflict with system or browser shortcuts; inconsistent shortcuts across modes or contexts; shortcuts that are too clever to remember.
+
+## Pattern: settings panel for configuration
+
+Persistent configuration lives in a dedicated settings UI. Users visit it to change behavior, then return to the main UI.
+
+Use when: the configuration affects future behavior of the product (theme, default values, feature toggles, integrations).
+
+Examples: every desktop application; most modern web apps.
+
+Pitfalls: settings sprawl (too many options, no organization); settings that should be in-context (like a per-document setting that's actually in global preferences); settings the user can't predict the effect of.
+
+## Pattern: configuration as code
+
+Power users configure the product by editing a text file (JSON, YAML, Lua, etc.) rather than (or in addition to) using a settings UI.
+
+Use when: the audience includes developers who prefer programmatic control, or the configuration is too rich for a UI.
+
+Examples: VS Code's settings.json, dotfile-driven Unix tools, Neovim/Emacs configuration.
+
+Pitfalls: requires the user to learn the schema; errors are hard to surface; the UI version of settings can drift from the file version.
+
+## Pattern: extension/plugin API
+
+The product is extensible by code the user (or a third party) writes. Maximum depth, but requires programming.
+
+Use when: the audience is developer-adjacent and the use cases extend beyond what the core product can anticipate.
+
+Examples: VS Code extensions, Figma plugins, Notion's API, browser extensions, Slack apps.
+
+Pitfalls: the API surface needs to be stable; bad plugins can damage trust in the product; discovery and quality control of the plugin marketplace is its own design problem.
+
+## Pattern: separate products for separate audiences
+
+When the gap between novice and expert is too large, build different products. The novice product is approachable; the expert product is powerful. They share concepts but not interfaces.
+
+Use when: the audiences have fundamentally different workflows, not just different volumes of the same workflow.
+
+Examples: a consumer trading app vs. a professional trading platform. A consumer photo organizer vs. a professional photo editor. A consumer calendar vs. a professional scheduling system.
+
+Pitfalls: requires building and maintaining two products; users may want to graduate from one to the other and find the migration painful.
+
+## Anti-patterns
+
+**The "more options" link that goes nowhere useful.** A button labeled "Advanced settings" or "More options" that, when clicked, reveals options no one actually wants. Better to delete the link than to make users curious about it.
+
+**The mode toggle that confuses everyone.** A "Basic / Advanced" toggle in a product where the difference between modes isn't obvious. Users flip back and forth trying to find features. Either the modes should be sharply differentiated and clearly labeled, or the depth should be unified.
+
+**Settings as the universal answer.** Every option becomes a setting. The settings panel grows uncontrollably. Users can't find anything. Resist the urge to make every behavior configurable; pick sensible defaults and let users live with them.
+
+**Power users as the design target.** Building primarily for the most committed users. Leads to interfaces that intimidate or alienate the larger novice audience. Power users are loud and articulate, but they're usually a small fraction of the user base.
+
+**Novices as the design target while alienating power users.** The opposite failure: aggressively simplifying, removing features, hiding depth so successfully that experts can't find it. Power users churn to deeper alternatives, and the product loses its credibility.
+
+## Decision framework
+
+When choosing an architecture, ask:
+
+1. **Is the depth conceptually related to the basic task?** If yes, progressive disclosure within view.
+2. **Is the depth about a different kind of work?** If yes, mode toggle or separate product.
+3. **Is the depth about configuration?** If yes, settings panel.
+4. **Is the depth about speed of common operations?** If yes, keyboard shortcuts and command palette.
+5. **Is the depth about extending the product?** If yes, plugin/API surface.
+
+Most successful products combine multiple architectures. Don't think you have to pick one — pick the right one for each kind of depth.
+
+## Cross-reference
+
+For the parent principle on calibrating control to the user, see `control`. For the structural mechanism within views, see `progressive-disclosure`.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: control
+description: 'Apply the principle of Control — the level of autonomy a system gives the user, and how that level should be matched to the user''s expertise and the task''s stakes. Use when designing for novice vs. expert audiences, choosing between fully automated and manually controlled behaviors, deciding what to expose vs. abstract away, or building products that span experience levels (a tool a beginner will use once and an expert will use thousands of times). Too much control overwhelms novices; too little frustrates experts. The skill is calibrating control to the user, the task, and the moment.'
+---
+
+# Control
+
+> **Definition.** Control is the degree of authority and decision-making the system delegates to the user. A high-control system exposes parameters, asks for choices, and lets the user direct outcomes; a low-control system makes decisions on the user's behalf, hiding parameters and presenting outcomes. Neither is universally better. The right level of control depends on the user's expertise, the stakes of the task, and how often the user will perform the task.
+
+The classic illustration: a microwave. A novice user wants three buttons — popcorn, defrost, reheat. An expert wants the panel of granular options — exact wattage, time in seconds, multi-stage cooking sequences. A microwave that exposes only the three buttons frustrates the expert; a microwave that exposes only the granular panel intimidates the novice. The well-designed microwave does both: large simple presets up front, granular controls available but tucked away.
+
+The same problem appears in software a hundred times a day. A photo editor for a casual user is "auto-enhance"; for a professional, it's curves, levels, masks, and color spaces. A code editor for a beginner is "run this script"; for an expert, it's customizable shortcuts, plugin systems, and direct shell access. The challenge is rarely "what should this product do" but "how much control over the doing should the user have."
+
+## Why control matters
+
+The principle named "control" in the design literature is sometimes also called "user agency" or "user autonomy" — different traditions, same problem. The effect is well-documented: users with appropriately calibrated control perform tasks faster, with fewer errors, and report higher satisfaction. Users with insufficient control feel constrained and frustrated; users with excessive control feel overwhelmed and paralyzed.
+
+The cost of miscalibration is paid in a few specific ways. **Novices facing too much control freeze.** They can't decide which option matters and which doesn't, and either pick poorly (defaulting to whichever is most prominent) or abandon the task. **Experts facing too little control work around the system.** They open external tools, write scripts, find hacks. The work-arounds are often less reliable than the system would be if it just exposed the controls the experts need. **Mid-level users — neither novice nor expert — get the worst of both.** A simplified UI that experts work around is usually also too simplified to teach anyone how the underlying system works, leaving mid-level users perpetually stuck.
+
+## Three dimensions of control
+
+Control is not a single dial but several interacting dimensions.
+
+**Granularity.** How fine-grained are the choices? "Loud / Medium / Quiet" is low-granularity; a continuous slider with 0–100 is high-granularity. Granularity affects how precisely the user can express intent and how much cognitive effort each choice requires.
+
+**Defaults.** Even high-control systems should have sensible defaults so the user doesn't have to make every choice. A high-granularity slider with a clearly marked default position is much easier to use than the same slider with no default suggested.
+
+**Reversibility.** Are choices easy to change later? A system where every choice is reversible — undo, redo, change-your-mind — can afford to give the user more control because mistakes are recoverable. A system where choices are permanent (place an order, send a message) needs higher confirmation, lower granularity, or stronger defaults.
+
+**Visibility.** Are the controls visible at all times, or hidden behind progressive disclosure? A power-user tool can show all controls at once; a consumer tool typically hides advanced controls behind a "more options" or "settings" disclosure.
+
+A well-designed control system makes deliberate choices on each of these dimensions — not by accident but by understanding the user, the task, and the stakes.
+
+## Calibrating control to the user
+
+The right level of control depends on who's using the product and how often.
+
+**Novices and one-time users.** Reduce granularity. Hide most parameters behind sensible defaults. Make the common path obvious and the exotic paths discoverable but not pushed. The goal is to let the user complete the common task without making choices they aren't equipped to make. A novice using a video editor for the first time should be able to trim a clip without learning what a codec is.
+
+**Experts and frequent users.** Increase granularity. Expose parameters. Make the common path fast and the exotic paths possible. The goal is to let the user direct the system precisely without constant simplification. An expert using a video editor every day should be able to set frame rates, chroma subsampling, and audio bus routing without leaving the application.
+
+**Mixed audiences.** Layer the controls. Common operations are simple and obvious; advanced operations are accessible but not in the default view. Adobe Lightroom does this well: a "Basic" panel for everyday adjustments, with deeper panels available below for the user who wants them.
+
+**Rare-but-critical tasks.** Reduce control. When a task is performed rarely but matters greatly, full granularity is dangerous because the user has forgotten the conventions. Provide a guided wizard with sensible defaults, even for users who would normally want full control.
+
+## Calibrating control to the stakes
+
+The stakes of the task affect how much control is appropriate even at a fixed expertise level.
+
+**Low-stakes, recoverable.** Maximize control. Let users experiment, change their minds, undo. The cost of a wrong choice is one undo.
+
+**High-stakes, recoverable with effort.** Calibrate control to expertise. A novice should be guided; an expert should be allowed to direct. Provide clear feedback at each stage so the user can catch errors early.
+
+**High-stakes, irreversible.** Reduce control even for experts. A surgeon's interface for a robot manipulator allows fine control of motion but blocks abrupt jumps. A trading system for a professional trader allows order placement but flags any order over a threshold for confirmation. The constraint is not insulting the expert's judgment; it's catching the moments where expert judgment fails.
+
+## Sub-skills in this cluster
+
+- **control-locus** — Internal vs. external locus of control: when the system should appear to act on the user's behalf vs. when the user should appear to direct the system. Affects perceived agency, satisfaction, and trust.
+- **control-power-vs-simplicity** — How to layer interfaces so they serve novices and experts in the same product, without forcing one audience into the other's interface.
+
+## Worked examples
+
+### A consumer photo editor
+
+The default UI: large auto-enhance button, a few one-tap filters, a basic crop tool. The "More" disclosure reveals exposure, contrast, saturation, and white balance sliders. A further "Advanced" disclosure reveals curves, levels, and color masks.
+
+A novice opens the app, taps auto-enhance, gets a better photo, and is done. An expert opens the app, opens both disclosures, and uses the granular tools. Both audiences are served. The progressive disclosure is a control mechanism: it hides the high-control surface from users who don't need it.
+
+The anti-pattern: showing all the granular tools to all users. The novice is intimidated and either uses none of them or picks badly. The expert tolerates it but doesn't actually need the visual prominence.
+
+The other anti-pattern: hiding the granular tools so deeply that experts can't find them, or removing them entirely "to simplify the experience." Experts work around (open an external tool, switch products) and the product loses its credibility with the audience that drives word-of-mouth.
+
+### A search interface
+
+Default search: a single search bar. Type, get results. Maximum simplicity, low control.
+
+Advanced search (often hidden behind a link): operators, filters, date ranges, sort criteria. Maximum control for the rare expert.
+
+Both audiences served. The novice never sees the advanced surface; the expert clicks through and gets the granular tools.
+
+A common failure: putting filters in the default search interface alongside the search bar. Novices don't use the filters and find them visual clutter; experts use them but they're scattered across the screen rather than collected in one focused panel. The compromise serves no one well.
+
+### A trading interface
+
+A retail trading app shows: stock symbol, buy / sell button, dollar amount. The user can place a market order with three taps. Low control, high accessibility, suitable for casual investors.
+
+A professional trading platform shows: all the order types (market, limit, stop, stop-limit, OCO), routing options (DMA, dark pools), time-in-force settings, and live order books. High control, demanding interface, suitable for experts who would resent the simpler interface.
+
+Notice that the professional platform doesn't try to also serve the casual investor — and shouldn't. Audiences with this much divergence in expertise need different products, not layered controls.
+
+### A microwave
+
+The hardware version of the same problem. Three large buttons (popcorn, reheat, defrost) plus a numeric keypad and a "more" panel. Both audiences served by the same hardware.
+
+The failure: a microwave with only the three buttons, with no way to set custom times. Novice users are happy; expert users buy a different microwave.
+
+The opposite failure: a microwave with only the numeric keypad and no presets. Novice users squint, hesitate, and microwave their food for the wrong time.
+
+### A code editor for beginners vs. experts
+
+VS Code's default surface is a relatively simple file tree, editor, and a few panels. An expert can install extensions, customize keybindings, configure language servers, and turn it into a deeply customized environment. A beginner can use the default surface productively and grow into the customization gradually.
+
+The crucial design choice: the customization is *available* but not *promoted*. The default user is not pushed to configure things; the expert can find what they need. Both audiences are served by progressive control rather than by separate products.
+
+## When the principle backfires
+
+Two failure modes are worth knowing.
+
+**False simplicity that prevents productive use.** A product that aggressively simplifies — removes parameters, hides settings, decides things for the user — can make some tasks impossible. A photo editor that has only an "auto-enhance" button can't be used for serious editing. A spreadsheet that has only "sum" and "average" can't be used for real analysis. Aggressive simplification is appropriate for products targeting only casual users; for products that span expertise levels, it forecloses the expert use case.
+
+**Exposed complexity that paralyzes.** The opposite failure: showing every option to every user, on the theory that "the user can decide what they need." Most users can't decide because they don't know what most options do. The defaults end up doing the work for them, but the visible options still consume attention and create anxiety. Hide what most users don't need; expose what most users do need; provide a path to the rest.
+
+## Heuristic checklist
+
+Before designing the control surface, ask: **Who is the user, and how often will they do this task?** Calibrate granularity and visibility to that audience. **What are the stakes of this task?** High-stakes tasks deserve more friction even for experts. **What is the recoverability profile?** Reversible tasks can afford more control; irreversible tasks need more constraint. **Is there a single audience, or multiple?** If multiple, layer the controls; if single, calibrate to that one audience. **What's the default for each control?** Defaults are the hidden control surface — most users will accept them, so they should be sensible.
+
+## Related principles
+
+- **Progressive Disclosure** — the structural mechanism by which layered control is implemented.
+- **Affordance** — what each control suggests it can do (a control's affordance shapes how willing users are to engage with it).
+- **Constraint** — physical and logical constraints that limit the harm of poorly chosen control.
+- **Forgiveness** — the safety net that lets you give users more control without catastrophic outcomes.
+- **Mental Model** — the user's understanding of the system shapes what level of control they can exercise.
+- **80/20 Rule** — most use is concentrated in a few features; the simplification path emerges naturally from this.
+
+## See also
+
+- `references/lineage.md` — origins in human-factors engineering and HCI.
+- `control-locus/` — sub-skill on perceived agency and locus of control.
+- `control-power-vs-simplicity/` — sub-skill on layering controls for mixed audiences.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/control/references/lineage.md
@@ -1,0 +1,59 @@
+# Control — origins and research lineage
+
+## Roots in human-factors engineering
+
+The principle of control entered design thinking through aviation and industrial-process control rooms. In a cockpit or a power-plant control room, the operator's level of autonomy directly affects safety. Early autopilot systems gave the pilot full manual control or full automatic control, with no middle ground; this turned out to be unsafe in failure modes where the autopilot disengaged unexpectedly and the pilot was suddenly handed full control of an aircraft they had not been actively flying. The literature on this — including the famous Air France Flight 447 accident and the broader literature on "automation surprise" — established that the right level of control is not the maximum or the minimum, but a calibrated intermediate that keeps the human informed and engaged.
+
+This produced the framework of "supervisory control" (a term from Tom Sheridan's 1992 work *Telerobotics, Automation, and Human Supervisory Control*). The human is not the moment-to-moment operator and not a passive observer, but a supervisor of an automated system, intervening when needed and informed enough to do so. Sheridan and others ranked control on a 10-level scale from "human does it all" to "computer does it all and tells the human nothing." Most well-designed control systems sit around levels 3–6: the computer suggests, the human selects, the computer executes; or the computer executes and reports back. Pure extremes generate problems.
+
+## In HCI: user agency and direct manipulation
+
+The HCI literature picked up the same threads in the 1980s. Ben Shneiderman's work on direct manipulation argued that the most usable interfaces are those where the user appears to act directly on visible objects (drag a file, resize a window, type in a document). Direct manipulation is, at one level, a control argument: it gives the user a strong sense of agency by making the connection between action and effect immediate and visible.
+
+Don Norman's work on "the seven stages of action" (1988) provided a complementary framework: every interaction involves forming a goal, planning an action, executing it, perceiving the result, interpreting it, and evaluating it. Each stage can be supported or sabotaged by the level of control. Too much control burdens the planning stage; too little burdens the perception and interpretation stages (because the user has no idea what the system did or why).
+
+The 1990s and 2000s produced a substantial literature on "user empowerment" in software and "perceived control" in consumer products. Key findings:
+
+- Users with higher perceived control report higher satisfaction even when objective task performance is the same.
+- Users with very low perceived control attribute outcomes (good or bad) to luck or to the system, not to themselves, which reduces engagement and learning.
+- Users with very high control without adequate scaffolding (no defaults, no guidance) report higher frustration and abandon tasks more often.
+
+The sweet spot is high *perceived* control coupled with sufficient scaffolding to make the choices manageable.
+
+## In consumer software
+
+The shift from desktop software to mobile and consumer-internet products in the 2000s generated a renewed debate about control. The "design for the dumbest user" school argued for aggressive simplification — fewer options, more defaults, stronger opinions. The "respect your power users" school argued the opposite. The empirical record suggests both extremes are wrong: products that win sustained use almost always layer their controls, with simple defaults for newcomers and depth available for committed users.
+
+The successful examples — Lightroom, Notion, VS Code, Figma — all give the user substantial control while making it discoverable rather than obligatory. The unsuccessful examples — products that aggressively simplified, removed parameters, or hid settings to "improve UX" — frequently lost their power users, who departed for tools that respected their expertise.
+
+## Locus of control and self-determination theory
+
+A separate line of psychological research, originating with Julian Rotter in 1954 and elaborated by Edward Deci and Richard Ryan as Self-Determination Theory, distinguishes "internal" from "external" locus of control. An internal locus is the belief that outcomes depend on one's own actions; an external locus is the belief that outcomes depend on external forces (fate, system, others). People with a stable internal locus tend to be more motivated, more persistent, and more satisfied; people with a stable external locus tend to be more passive and less satisfied.
+
+Software design can shift a user's situational locus of control. A product that does things on the user's behalf — autocorrect, auto-categorization, AI-suggested actions — moves the locus toward external. A product that asks for choices — confirmation dialogs, manual configuration — moves the locus toward internal. Neither is universally right, but the choice has psychological consequences worth being aware of. AI-heavy interfaces in particular can drift toward an external locus that, while convenient, leaves users feeling they are not in charge of their own work.
+
+## In automation and AI design
+
+The current generation of AI tools has revived all the old debates about control. Should the AI act on the user's behalf (high automation, low control) or suggest options that the user picks (medium automation, medium control) or provide capabilities that the user invokes when they want (low automation, high control)? Different products land in different places, and the right answer varies by audience and stakes.
+
+The supervisory-control literature is directly applicable. An AI that does too much without informing the user creates the same "automation surprise" problem the cockpits did. An AI that does nothing without explicit instruction is less useful than it could be. The well-designed AI tool sits in the middle, doing useful things by default while making its actions visible, undoable, and adjustable.
+
+## Empirical regularities worth remembering
+
+The literature on control converges on a few stable findings.
+
+- Users prefer interfaces that give them perceived control, even at some cost to objective task efficiency.
+- The cost of removing control from experts is much higher than the benefit of adding it for novices, because experts churn out of products that constrain them, while novices simply find the simpler products.
+- Defaults are extremely powerful. Most users accept defaults most of the time, regardless of what those defaults are. This means the defaults function as a hidden control system — they're doing most of the work — and should be chosen carefully.
+- Reversibility expands the safe range of control. A system with full undo can afford to give users more control than a system with permanent actions.
+- Confirmation friction should be calibrated to the stakes, not to the control level. Easy actions don't need confirmation; high-stakes actions do.
+
+## Sources informing this principle
+
+- Sheridan, T. B. (1992). *Telerobotics, Automation, and Human Supervisory Control*.
+- Shneiderman, B. (1983). Direct manipulation: A step beyond programming languages.
+- Norman, D. (1988). *The Design of Everyday Things*. (Particularly the seven stages of action.)
+- Rotter, J. B. (1954). *Social Learning and Clinical Psychology*. (On locus of control.)
+- Deci, E. L., & Ryan, R. M. (1985). *Intrinsic Motivation and Self-Determination in Human Behavior*.
+- Bainbridge, L. (1983). Ironies of automation. *Automatica*. (Foundational paper on the costs of pure automation.)
+- Lee, J. D., & See, K. A. (2004). Trust in automation: Designing for appropriate reliance. *Human Factors*.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors-mistakes/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors-mistakes/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: errors-mistakes
+description: 'Use this skill when designing to prevent errors of intention — wrong actions taken because the user''s model of the situation was wrong. Trigger when designing for ambiguous information, novel situations, complex decisions, or contexts where users may proceed with confidence based on a wrong understanding. Sub-aspect of `errors`; read that first.'
+---
+
+# Mistakes: errors of intention
+
+A mistake happens when the user's action matched their intent — but the intent was wrong because their model of the situation was wrong. They misread an alarm; misjudged a chart; chose the wrong option from a menu they misunderstood. Unlike slips, mistakes are usually unrecognized at the moment they happen — the user is confident they're doing the right thing.
+
+The design responses for mistakes work upstream of action: better information, clearer system state, training, conventions that match user expectations.
+
+## The three mistake subtypes (from the book)
+
+### Perception mistakes
+
+Wrong action because of misread information.
+
+**Design responses**:
+- Improve situational awareness (clear, distinctive feedback).
+- Show trends and historical data, not just point-in-time values.
+- Provide clear and distinctive feedback at decision points.
+
+```html
+<!-- Point-in-time only — perception-mistake-prone -->
+<p>CPU: 45%</p>
+
+<!-- With trend — clearer -->
+<div class="metric">
+  <p>CPU: 45%</p>
+  <span class="trend trend--up">↑ Rising over last hour</span>
+  <canvas class="sparkline"></canvas>
+</div>
+```
+
+### Decision mistakes
+
+Wrong action under stress, bias, or overconfidence.
+
+**Design responses**:
+- Minimize information and environmental noise.
+- Use checklists and decision trees for high-stakes decisions.
+- Train on error recovery and troubleshooting.
+- Reduce time pressure where possible.
+
+A monitoring console for production incidents that surfaces a checklist of likely causes ("Check service X first, then Y, then Z") reduces decision mistakes during stressful incidents.
+
+### Knowledge mistakes
+
+Wrong action because of missing knowledge.
+
+**Design responses**:
+- Memory and decision aids in context.
+- Standardized naming and operational conventions.
+- Training using case studies and simulations.
+- Mnemonic devices.
+
+A new user encountering an unfamiliar feature for the first time benefits from inline help, walkthroughs, or progressive-disclosure of complexity.
+
+## Common mistake-prevention patterns
+
+### Surfacing system state
+
+Many mistakes flow from invisible system state. The user thinks the system is in mode A; it's actually in mode B; their action is correct for A but wrong for B.
+
+Design response: make state visible. Modal indicators, status bars, breadcrumbs all help.
+
+```html
+<header class="env-banner env-banner--prod">
+  ⚠ Production environment — actions affect live customers
+</header>
+```
+
+A visible "PROD" banner on production tools prevents the mistake of running staging-style commands against real customer data.
+
+### Decision trees and guided flows
+
+For complex decisions, walk the user through. Each step narrows the option space.
+
+```
+Are you trying to...
+  (•) Fix a customer issue
+  ( ) Make a code change
+  ( ) Run a migration
+
+[Continue]
+```
+
+Then based on the answer, the next set of options is contextual. The user can't easily make a mistake by picking from a flat list of 30 options because the context narrows the space.
+
+### Trend-aware displays
+
+Replace point-in-time displays with trend-aware ones. The single number "23%" hides a trajectory; the sparkline reveals it.
+
+### Checklists
+
+Borrowed from aviation and medicine. A checklist forces the user to verify each prerequisite explicitly. Surgical "time-out" checklists, pilot pre-takeoff checklists, and software pre-deployment checklists all prevent decision and knowledge mistakes by externalizing memory.
+
+### Conventions and standards
+
+When users encounter unfamiliar systems, they apply conventions from familiar ones. If your system honors conventions (cmd-K opens command palette, Esc closes overlays), users transfer prior knowledge correctly. If you violate them, users transfer prior knowledge incorrectly — knowledge mistakes ensue.
+
+### Inline help in context
+
+Don't rely on documentation pages users won't visit. Surface help in the moment: a "?" icon next to ambiguous fields with a tooltip, an info-banner explaining a section's purpose, contextual onboarding hints.
+
+## Mistake-prone contexts
+
+- **Novel situations** — the user's model doesn't apply.
+- **Ambiguous information** — multiple plausible interpretations.
+- **High-stakes decisions under stress** — judgment narrows.
+- **Cross-domain transfers** — applying conventions from one domain to another that doesn't share them.
+- **Edge cases** — situations the user hasn't seen before.
+- **First-time users of any feature** — knowledge gap.
+
+## Anti-patterns
+
+- **Hidden system state.** User assumes the system is in one state; it's actually in another.
+- **Cryptic error messages** that don't help the user understand what's wrong.
+- **Conventions violated without warning.** A "Save" button that doesn't save, or saves to a different location.
+- **Onboarding for new users that's just a tour.** Watching demo videos doesn't transfer knowledge as well as guided practice.
+- **Single-point-in-time displays for trending phenomena.** Hides the trajectory.
+
+## Heuristics
+
+1. **The "what's the user's model?" check.** Before designing a flow, ask what model the user is likely to bring. Designs that match it prevent mistakes; designs that violate it cause them.
+2. **The state-visibility audit.** What state are users in right now? Can they see it? If not, they can mistake.
+3. **The novel-situation walkthrough.** For unfamiliar features, walk a new user through. Note where their model diverges from the system; design responses there.
+
+## Related sub-skills
+
+- **`errors`** (parent).
+- **`errors-slips`** — the complementary error type; execution rather than intention.
+- **`mental-model`** — mistakes flow from wrong models; mental-model design prevents them.
+- **`expectation-effect`** — when the system violates expectation, mistakes follow.
+- **`visibility`** — system state must be visible to be reasoned about.
+- **`mimicry`** — borrowing conventions reduces knowledge-mistakes.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors-mistakes/references/mistake-prevention-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors-mistakes/references/mistake-prevention-cases.md
@@ -1,0 +1,123 @@
+# Mistake prevention: cases and patterns reference
+
+A reference complementing `errors-mistakes` with case studies and patterns.
+
+## High-stakes mistake cases
+
+### Three Mile Island (1979)
+
+Operators at the Three Mile Island nuclear plant misperceived the state of a relief valve (perception mistake) — a stuck-open valve was indicated as closed by a status light that reflected only the command, not the valve's actual position. The misperception cascaded into the worst US nuclear accident.
+
+Design fix: status indicators should reflect *actual* state, not commanded state. Apply to software: a "Save" indicator that turns green when the save succeeds, not when the request is sent.
+
+### Air France 447 (2009)
+
+Pilots experienced a perception mistake (mismatched airspeed readings) followed by a decision mistake (conflicting actions on the controls). The aircraft stalled into the ocean.
+
+Design fix: when sensors disagree, the system should highlight the disagreement explicitly rather than displaying a single computed value that may be wrong.
+
+### Mars Climate Orbiter (1999)
+
+Engineering teams used different units (imperial vs. metric) — a knowledge mistake about the system's expected units. The orbiter burned up in the Martian atmosphere.
+
+Design fix: explicit unit declaration; type systems that prevent unit-mismatch errors at compile time.
+
+## Mistake-prevention patterns in software
+
+### Surfacing mode
+
+When the user is in a non-default mode (capslock, edit mode, dev mode, vim's command mode), the system displays the mode prominently. Without this, mode-confusion mistakes are common.
+
+```html
+<!-- Capslock indicator on password field -->
+<div class="field" data-capslock="true">
+  <input type="password" />
+  <p class="hint">Caps Lock is on</p>
+</div>
+```
+
+### Environment indicators
+
+Multi-environment products (staging vs. production) should make the environment unmistakably visible:
+
+```html
+<header class="env-banner env-banner--staging">
+  STAGING — actions don't affect customers
+</header>
+```
+
+### Confirmation with explicit consequences
+
+For high-stakes decisions, the confirmation dialog should spell out what will happen:
+
+```
+Delete project "Acme Q4"?
+
+This will:
+  • Delete 24 tasks
+  • Remove 8 attachments (12 MB)
+  • Revoke access for 3 collaborators
+
+This action cannot be undone.
+```
+
+The user with a wrong model ("I think this is the test project") may notice the consequences don't match their expectation.
+
+### Pre-deployment checklists
+
+Software pre-deployment checklists borrow from aviation:
+
+```
+[ ] Tests passing
+[ ] Migrations reviewed
+[ ] Backwards-compatibility verified
+[ ] Feature flags configured
+[ ] Monitoring dashboards ready
+[ ] Rollback plan documented
+```
+
+Each step prevents a common mistake. The checklist's effectiveness comes from its short, focused, pause-point structure.
+
+### Decision support tools
+
+For complex decisions, a decision tree or troubleshooting flow guides the user:
+
+```
+What's the symptom?
+  ( ) Service is slow
+  ( ) Errors in logs
+  (•) Cannot connect
+
+→ When did it start?
+  (•) Just now
+  ( ) Hours ago
+
+→ Has anything changed?
+  ( ) New deployment
+  ( ) Config change
+  (•) No recent changes
+
+→ Likely causes: dependency timeout, network issue
+```
+
+## Cross-domain mistake-prevention
+
+### Medicine: structured handoff (SBAR)
+
+When transferring patient care between shifts, nurses use SBAR (Situation, Background, Assessment, Recommendation). The structured handoff prevents knowledge mistakes during transitions.
+
+### Aviation: standardized callouts
+
+"Gear down," "Flaps 30," "V1," "Rotate" — standardized callouts during critical phases of flight prevent perception and decision mistakes by externalizing system state.
+
+### Software: design reviews
+
+Code review and design review introduce second-opinion challenge. The reviewer brings a different mental model; mismatches surface as questions or pushback.
+
+## Resources
+
+- **Reason, J.** *Human Error* (1990).
+- **Vaughan, D.** *The Challenger Launch Decision* (1996).
+- **Casey, S.** *Set Phasers on Stun* (1998).
+- **Norman, D.** *The Design of Everyday Things* (2013).
+- **NTSB / aviation accident reports** — public; show how perception, decision, and knowledge mistakes cascade in high-stakes systems.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors-slips/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors-slips/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: errors-slips
+description: 'Use this skill when designing to prevent or recover from execution errors — actions that don''t match the user''s intent. Trigger when designing critical action confirmations, distinct affordances for similar-purpose elements, recovery from wrong-button presses, "I didn''t mean to do that" flows. Sub-aspect of `errors`; read that first.'
+---
+
+# Slips: errors of execution
+
+A slip happens when the user knew what they wanted to do but their action didn't match. The intent was right; the execution was wrong. Slips are common in routine tasks where conscious attention has lapsed: the user types "definately" instead of "definitely," clicks Reply when they meant Reply All, deletes the file they meant to keep.
+
+The design responses for slips don't increase the user's knowledge — the user already knew what to do. They make wrong actions structurally harder, give clear feedback when they happen, and provide easy recovery.
+
+## The two slip subtypes (from the book)
+
+### Action slips
+
+Wrong action despite correct intent. Triggered by:
+
+- Routine tasks performed automatically.
+- Distractions or interruptions.
+- Similar-looking controls.
+- Auto-pilot button-pressing on confirmations.
+
+**Design responses**:
+
+- **Distinctive affordances** — make destructive actions visibly different from common ones (color, position, shape).
+- **Defensible space** — separate destructive controls from frequent ones (the "Cancel" near "Save" and "Delete" elsewhere).
+- **Confirmation for critical tasks** — explicit confirmation step (sparingly).
+- **Constraints** — make wrong actions impossible (can't submit a form with required fields empty).
+- **Mappings** — controls match the layout of what they affect (stovetop knobs match burner positions).
+
+### Attention slips
+
+Steps missed during a procedure. Triggered by:
+
+- Interruptions (a phone call mid-procedure).
+- Long task sequences.
+- Resuming a paused task.
+
+**Design responses**:
+
+- **Status cues** that survive interruption ("You're on Step 3 of 5").
+- **Orientation aids** when resuming.
+- **Alarms or alerts** for critical steps.
+- **Highlighting** to focus attention on the current step.
+
+## Common slip-prevention patterns
+
+### Distinct destructive button styling
+
+The destructive button differs from the safe button by color (typically red), position (typically right of the safe button in modal footers), and label (specific verb: "Delete" not "OK"). This triple-difference makes the slip harder.
+
+```html
+<div class="dialog-actions">
+  <button>Cancel</button>
+  <button class="destructive">Delete project</button>
+</div>
+```
+
+### Type-to-confirm for irreversible actions
+
+The user must type the resource name to enable the destructive button. Breaks autopilot Enter-pressing.
+
+```html
+<p>To confirm, type <strong>Acme Inc</strong>:</p>
+<input id="confirm" />
+<button id="delete-btn" disabled>Delete Acme Inc</button>
+```
+
+### Undo for routine destructive actions
+
+Most slips are caught immediately. A 5–10 second undo window covers them.
+
+```js
+async function archive(item) {
+  const previous = items.slice();
+  items = items.filter(i => i.id !== item.id);
+  render();
+  showToast('Archived', { undo: () => { items = previous; render(); } });
+}
+```
+
+### Forgot-attachment detection
+
+Email clients scan body text for "attached," "attachment," etc. If found and no attachment exists, prompt before sending.
+
+### Step indicators in multi-step procedures
+
+A visible stepper or progress indicator survives interruptions. Returning users see "you were on Step 3."
+
+### Read-only by default for sensitive views
+
+Power-user surfaces (admin panels) start in read-only and require explicit "Edit mode" to change values. Reduces accidental edits.
+
+## Slip-prone contexts
+
+Some contexts produce more slips than others:
+
+- **Routine tasks** done many times — automatic execution is more likely to slip.
+- **Interrupted tasks** — resuming at the wrong step.
+- **Similar-control clusters** — adjacent buttons with similar appearance.
+- **Time pressure** — fast typing, fast clicking.
+- **Modal dialogs** users dismiss on autopilot.
+
+Audit slip-prone contexts in your product; apply prevention.
+
+## Anti-patterns
+
+- **Identical-looking destructive and safe buttons.** Slips are inevitable.
+- **Pre-selected destructive option.** Default Enter triggers destruction.
+- **No undo for routine destructive actions.** Each slip is permanent.
+- **Excessive confirmations for non-destructive actions.** Confirmation fatigue; users dismiss real ones too.
+
+## Heuristics
+
+1. **The "what slip is most likely here?" audit.** For each high-frequency action, name the slip that would happen and design against it.
+2. **The post-incident slip diagnosis.** When users report mistakes, distinguish slips from mistakes. Different fixes.
+3. **The undo-coverage check.** What percentage of routine destructive actions have undo? If less than 90%, you have slip exposure.
+
+## Related sub-skills
+
+- **`errors`** (parent).
+- **`errors-mistakes`** — the other half; intentional errors driven by wrong models.
+- **`forgiveness`** — recovery from slips after they happen.
+- **`affordance`** — distinct affordances prevent slip-type wrong-clicks.
+- **`constraint`** — structural prevention of wrong actions.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors-slips/references/slip-prevention-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors-slips/references/slip-prevention-patterns.md
@@ -1,0 +1,77 @@
+# Slip prevention: patterns and case reference
+
+A reference complementing `errors-slips` with patterns and case studies.
+
+## Common slip-prone interfaces
+
+- **Email send**: Reply All slips; wrong-recipient slips; forgot-attachment slips.
+- **Delete buttons**: clicking when meaning to archive.
+- **Form submit**: pressing Enter prematurely; double-clicking submit.
+- **Multi-tab navigation**: switching tabs in middle of a workflow.
+- **Modal dialog dismissal**: clicking the wrong button on autopilot.
+- **Drag-and-drop**: dropping in the wrong container.
+
+## Patterns that work
+
+### Distinct affordances
+
+```html
+<!-- Both buttons are clearly buttons; their roles are visually distinct -->
+<button class="btn-secondary">Cancel</button>
+<button class="btn-destructive">Delete project</button>
+```
+
+### Defensible space
+
+Position destructive controls away from frequent ones. The "Delete account" button lives in a "Danger zone" panel at the bottom of settings, not next to "Save profile."
+
+### Recovery affordances
+
+Most modern destructive actions support undo:
+
+```js
+async function archive(item) {
+  const previous = items.slice();
+  items = items.filter(i => i.id !== item.id);
+  showToast(`"${item.name}" archived`, {
+    action: { label: 'Undo', onClick: () => { items = previous; render(); } },
+    duration: 7000
+  });
+}
+```
+
+### Forgot-attachment heuristics
+
+Gmail, Outlook, and similar email clients scan body text for "attached," "attachment," and similar words. If found and no attachment exists, prompt before sending.
+
+### Two-step destructive flows
+
+For irreversible actions: a click opens a dialog with type-to-confirm. The user types the resource name; only then is the destructive button enabled.
+
+### Auto-save against losing work
+
+Any form longer than ~5 fields benefits from auto-save. The user navigating away by mistake doesn't lose progress.
+
+## Cross-domain slip prevention
+
+### Aviation: sterile cockpit rule
+
+Below 10,000 feet, only essential conversation in the cockpit. Reduces attention slips during high-workload phases (takeoff, landing).
+
+### Medicine: barcoded medication administration
+
+The nurse scans both the patient wristband and the medication. Wrong-patient or wrong-drug slips are blocked at the scan.
+
+### Industrial: dual-key authorization
+
+For hazardous operations, two operators must turn keys simultaneously. A single-person slip can't trigger the action.
+
+### Software: keyboard-shortcut conflicts
+
+Modern apps avoid global keyboard shortcuts for destructive actions. Cmd-Z is widely safe (undo); Cmd-Delete is more destructive but typically also reversible.
+
+## Resources
+
+- **Gawande, A.** *The Checklist Manifesto* (2009).
+- **Norman, D.** *The Design of Everyday Things* (2013).
+- **NN/g articles** on confirmation, undo, and form-design slip prevention.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: errors
+description: 'Use this skill whenever a design must accommodate the inevitability of human error — typos, wrong-button presses, misread instructions, mistimed actions, misunderstandings of system state. Trigger when designing form validation, input handling, destructive flows, complex multi-step procedures, alert systems, or any UI where users can do the wrong thing. Trigger when post-incident analyses reveal patterns of "human error" — most are design errors in disguise. Errors is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003), grounded in Norman''s and Reason''s foundational human-error research.'
+---
+
+# Errors
+
+Most "accidents" attributed to human error are actually design errors. The user took the action the design invited; the action's consequence wasn't what the user intended. Reframing errors as a *design* property — rather than a *user* failing — opens the design space dramatically: errors can be prevented, made impossible, made obvious, or made recoverable. The right strategy depends on the kind of error.
+
+## Definition (in our own words)
+
+An error is any action (or omission) that produces an unintended result. Errors come in two distinct kinds, and they need different design responses. **Slips** are skill-based failures: the user knew what to do but their action didn't match their intent — a typo, a wrong-button click, a slip of attention. **Mistakes** are knowledge-based failures: the user did exactly what they intended, but the intent was wrong because their model of the situation was wrong — they misread an alarm, misunderstood a diagram, made a wrong choice based on incomplete information. The two kinds happen for different reasons; they're prevented by different design moves.
+
+## Origins and research lineage
+
+- **Donald Norman**, "Categorization of Action Slips" (*Psychological Review*, 1981, vol. 88) and *The Design of Everyday Things* (1988). Norman introduced the slip/mistake distinction to design vocabulary and argued that error is a property of design, not user.
+- **James Reason**, *Human Error* (Cambridge University Press, 1990). The standard reference work in human-error research, originally from industrial-safety domains (aviation, nuclear, medical). Reason expanded Norman's framework with detailed taxonomies (skill-based / rule-based / knowledge-based errors) and the "Swiss cheese" model of cascading failures.
+- **Lidwell, Holden & Butler** (2003) compactly distinguished slips (errors of execution, automatic/unconscious) from mistakes (errors of intention, conscious mental processes). The book identifies two slip subtypes (Action, Attention) and three mistake subtypes (Perception, Decision, Knowledge).
+- **Charles Perrow**, *Normal Accidents* (1984). Argued that complex tightly-coupled systems produce errors as an emergent property of system design, not as failures of individual operators. Influential in industrial-safety and software-system design.
+- **Atul Gawande**, *The Checklist Manifesto* (2009). Documented how checklists prevent slip-type errors in complex high-stakes domains (surgery, aviation).
+
+## Why the slip/mistake distinction matters
+
+The two error types are caused by different mechanisms and prevented by different design moves:
+
+| Property | Slip | Mistake |
+|---|---|---|
+| Cause | Automatic, unconscious, distraction | Conscious, but wrong model |
+| User awareness | Often noticed immediately | Often unrecognized at the time |
+| Common context | Routine tasks, interrupted procedures | Novel situations, ambiguous information |
+| Design fix | Affordance, constraint, confirmation, undo | Better information, training, clearer system state |
+| Population most affected | Experienced users on routine tasks | Less-experienced users, or anyone in unfamiliar context |
+
+A confirmation dialog can prevent slips ("Did you really mean to click delete?") but doesn't prevent mistakes (the user *intended* to delete; they just had the wrong file selected). Conversely, better explanations help with mistakes but don't help with slips (the user already knows what they meant).
+
+Designs that treat all errors the same fail on at least one type.
+
+## The book's slip and mistake subtypes
+
+### Slip subtypes
+
+#### Action slips
+
+Wrong action despite correct intent. Examples:
+
+- Typing the wrong word despite knowing the right one.
+- Clicking the wrong button (intended Save, hit Submit).
+- Hitting Reply All when meaning to Reply.
+
+**Design responses**: confirmations for critical tasks; constraints; clear distinctive feedback; affordances and mappings that make wrong actions structurally harder.
+
+#### Attention slips
+
+Lapses in attention during procedures. Examples:
+
+- Forgetting to attach a file before sending an email.
+- Skipping a step in a multi-step process.
+- Resuming an interrupted task at the wrong point.
+
+**Design responses**: status cues that survive interruption; orientation aids when resuming; alarms for critical situations.
+
+### Mistake subtypes
+
+#### Perception mistakes
+
+Wrong action because of misread information. Examples:
+
+- Nurse misreading a temperature curve as stable when it's trending up.
+- Pilot misjudging altitude from a single-point readout.
+- User misinterpreting an icon's meaning.
+
+**Design responses**: clearer information presentation; trend / historical displays vs. point-in-time; reduce ambiguity in icons and labels.
+
+#### Decision mistakes
+
+Wrong choice under stress, bias, or overconfidence. Examples:
+
+- Software engineer choosing a quick-fix that creates bigger problems.
+- Medical professional anchoring on an initial diagnosis despite evidence.
+- Designer ignoring user research that contradicts their intuition.
+
+**Design responses**: decision trees, checklists, second-opinion mechanisms, training in error recovery.
+
+#### Knowledge mistakes
+
+Wrong action because of missing knowledge. Examples:
+
+- New user not knowing how to use an unfamiliar tool.
+- Operator unfamiliar with edge-case procedures.
+- Visitor lost in a building they've never been in.
+
+**Design responses**: memory aids, conventions and standards, training, simulations, accessible documentation, mnemonic devices.
+
+## When to apply
+
+- **Always**, on every design that involves user actions with consequences.
+- **Especially** on destructive, irreversible, or high-stakes flows.
+- **Critically** in safety-relevant domains (medical, aviation, financial, security).
+- **In post-incident analysis** — every "user error" report should be examined for the design that invited it.
+
+## Worked examples
+
+### Example 1: preventing a common slip (wrong-recipient email)
+
+The "send to wrong person" slip happens when the user types a recipient's name and the autocomplete suggests someone with a similar name; the user accepts on autopilot.
+
+**Design responses**:
+
+- **Distinct affordances** — show the recipient's full name, photo, and email when adding to To/Cc/Bcc.
+- **Confirmation for high-stakes recipients** — Gmail prompts when sending to a new external recipient: "You've never emailed person@external.com before. Are you sure?"
+- **Undo Send** — covers slips after they happen.
+- **Reply-All caution** — extra prompt when replying to large groups.
+
+```html
+<!-- After clicking Send -->
+<div class="undo-toast" role="status">
+  Sending...
+  <button onclick="cancelSend()">Undo</button>
+</div>
+<!-- After 5 seconds with no Undo, the message actually transmits. -->
+```
+
+### Example 2: preventing an attention slip (forgot the attachment)
+
+Common slip: writing "see attached" in an email, then sending without attaching the file.
+
+**Design response**: Gmail and most modern email clients scan the message body for words like "attached" or "attachment"; if found and no attachment exists, prompt before sending: "You wrote 'see attached' but didn't attach a file. Send anyway?"
+
+A simple heuristic that catches a common slip before it commits.
+
+### Example 3: preventing a perception mistake (misread chart)
+
+A monitoring dashboard shows current CPU usage as a single number: "23%."
+
+The user perceives "23%, fine" — but doesn't see that CPU has been climbing from 5% to 23% over the last hour. By the time they notice, the system is overloaded.
+
+**Design response**: show trends, not just point-in-time values. A sparkline next to the number reveals the trajectory.
+
+```html
+<div class="metric">
+  <p class="label">CPU usage</p>
+  <p class="value">23%</p>
+  <canvas class="sparkline" data-trend="up"></canvas>
+  <p class="status status--warning">Trending up over last hour</p>
+</div>
+```
+
+The same number; the perception is now of a trend, not an instant.
+
+### Example 4: preventing a decision mistake (high-stakes destructive action)
+
+A user clicks "Delete account." The decision is irreversible; making it under stress (frustration, time pressure) carries a high mistake risk.
+
+**Design response**:
+
+- **Type-to-confirm**: user must type their email to enable the destructive button.
+- **Clear consequences**: list what will be lost (12 projects, 38 team-member access, 3.2 GB of files).
+- **Recovery window**: account is soft-deleted for 30 days; user can restore.
+- **Email confirmation**: post-delete email with a "Reactivate" link.
+
+Multiple design layers turn a single decision into a deliberate process; each layer is a chance for the user to step back.
+
+### Example 5: preventing a knowledge mistake (user doesn't know the procedure)
+
+A user is troubleshooting their Wi-Fi. They don't know the steps.
+
+**Design response**: a guided walkthrough that takes them step-by-step ("First, restart your router by unplugging it for 30 seconds. Then rejoin the network."). Each step shows an image of what to do.
+
+The system provides the missing knowledge in real-time, eliminating the knowledge mistake before it can happen.
+
+## Cross-domain examples
+
+### Aviation
+
+The aviation industry has driven much of modern human-error research. Key findings:
+
+- Crew Resource Management (CRM) trains pilots and crew to challenge each other's decisions, reducing decision mistakes.
+- Standardized checklists prevent skill-based slips (the canonical case Gawande analyzes).
+- Flight-data recorders and cockpit voice recorders allow post-incident analysis to identify design patterns that contributed to errors.
+- Sterile cockpit rule (no non-essential conversation below 10,000 ft) reduces attention slips during high-workload phases.
+
+### Medicine
+
+Medical errors are a leading cause of preventable harm. Patterns:
+
+- Barcode medication administration (BCMA) prevents wrong-patient or wrong-drug slips.
+- The Universal Protocol (mark site, time-out before incision) prevents wrong-site surgery slips.
+- "Tall man lettering" for confusable drug names (DOPamine vs. DOBUTamine) reduces perception mistakes.
+- Pre-procedure huddles allow cross-checking and reduce decision mistakes.
+
+### Industrial control
+
+Lockout-tagout procedures prevent slips by physically blocking accidental activation. Two-key authorization for hazardous operations prevents single-person decision mistakes. Dead-man switches detect operator incapacitation.
+
+### Software
+
+Modern software practice borrows heavily:
+
+- **Type systems** prevent many slip-type errors at compile time.
+- **Linters** flag common mistakes pre-commit.
+- **Pre-deployment checklists** in CI/CD borrow from aviation.
+- **Code review** introduces second-opinion challenge.
+- **Canary releases** catch errors with limited blast radius before full rollout.
+
+## Anti-patterns
+
+- **Blaming the user for "human error."** The design invited the action; the user took it. Reframe.
+- **Confirmation for everything.** Confirmation fatigue means real destructive confirmations get dismissed too. Reserve confirmation for genuine high-stakes irreversible actions.
+- **Generic error messages.** "Validation failed" with no field highlighted, no fix suggested. The user can't recover.
+- **Silent failures.** An action appears to succeed but actually fails; the error surfaces only later. Always close the feedback loop.
+- **Treating slips and mistakes the same.** A confirmation prevents slips; better information prevents mistakes. Wrong tool for the wrong type fails.
+- **Pre-selected destructive option.** A confirmation dialog with "Delete" as default Enter target. Slips become catastrophic.
+
+## Heuristics
+
+1. **The slip/mistake diagnosis.** For each user error, ask: did they intend the wrong thing (mistake) or unintendedly do the wrong thing (slip)? Different design fixes.
+2. **The "what does the user know?" check.** Before assuming knowledge, ask what's the user actually likely to know? Mistakes flow from knowledge gaps.
+3. **The recovery audit.** For each error, can the user recover? If yes, the cost is small. If no, prevention must be stronger.
+4. **The post-incident review.** When an error happens, don't ask "who made the mistake"; ask "what design invited it?" Patterns emerge.
+5. **The error-message audit.** Every error message should answer: what happened, why, what to do next.
+
+## Related principles
+
+- **`forgiveness`** — error recovery is the user-side complement.
+- **`affordance`** — wrong actions become harder when affordances are clear.
+- **`constraint`** — constraints structurally prevent wrong actions.
+- **`confirmation`** — explicit verification step for high-stakes actions.
+- **`feedback-loop`** — feedback lets users notice errors quickly.
+- **`mental-model`** — mistakes flow from wrong models; better-aligned models reduce mistakes.
+- **`expectation-effect`** — when actions don't match expectation, slips happen.
+
+## Sub-aspect skills
+
+- **`errors-slips`** — designing for execution errors (wrong actions despite right intent).
+- **`errors-mistakes`** — designing for intention errors (right actions for wrong reasons).
+
+## Closing
+
+Errors are not failures of users; they are properties of designs. The most-used products in any category are usually those whose designers internalized this — they prevent what can be prevented, make recoverable what can't, and design error messages as if every user would encounter them. The investment is unglamorous and pays continuously across every user, every day.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors/references/error-research-history.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/errors/references/error-research-history.md
@@ -1,0 +1,64 @@
+# Error research and design history
+
+A reference complementing the `errors` SKILL.md with the academic and engineering history.
+
+## Norman's "Categorization of Action Slips"
+
+Donald Norman's 1981 paper in *Psychological Review* introduced the slip/mistake distinction to design vocabulary. Prior to Norman, "human error" was treated as a general category attributable to user failure. Norman's reframing — that errors are properties of design — opened the modern human-centered design tradition.
+
+The paper categorized slips by mechanism: capture (a habitual sequence overrides the intended one), description (insufficient specification of intent), data-driven (an external stimulus triggers the wrong action), associative-activation (one thought activates a wrong related thought), and others. The classification was largely descriptive but useful for distinguishing fix strategies.
+
+## Reason's *Human Error* (1990)
+
+James Reason's book is the standard reference work in the human-error literature. Key contributions:
+
+- **Skill-based, rule-based, knowledge-based** error taxonomy (slightly more granular than Norman's slips/mistakes).
+- **Latent vs. active errors** — some errors lie dormant in system design until conditions trigger them.
+- **The Swiss-cheese model** of cascading failures: complex accidents happen when multiple latent vulnerabilities align with active errors. No single point of failure causes the accident; the accident emerges from the system.
+
+Reason's work originated in industrial-safety contexts (Chernobyl, Bhopal, Three Mile Island) and has been applied to medicine, aviation, software, and product design.
+
+## Perrow's *Normal Accidents* (1984)
+
+Charles Perrow argued that complex tightly-coupled systems produce catastrophic accidents as an emergent property — the system's complexity itself makes some accidents inevitable. Tight coupling means a small failure cascades; complexity means operators can't foresee all interaction effects.
+
+Software engineering grapples with this constantly. Modern microservices architectures, with their complex inter-service dependencies, exhibit normal-accident dynamics — a single service's failure cascades unexpectedly because the coupling is tight and the system is complex.
+
+The design response: reduce coupling, simplify when possible, build observability so failures are visible, and recognize that some accidents are emergent properties of complexity rather than failures of operators.
+
+## Gawande's *The Checklist Manifesto* (2009)
+
+Atul Gawande, surgeon and writer, documented how aviation-style checklists reduce error in surgery, construction, and software. Key findings:
+
+- Checklists prevent slip-type errors by externalizing memory.
+- Resistance to checklists comes from professional pride ("I don't need a checklist for this") — but data shows even experts benefit.
+- Effective checklists are short, focused on critical steps, and used at "pause points" (preflight, time-out before incision).
+
+The book popularized checklists in software and product engineering. Pre-deployment checklists, code-review checklists, and incident-response runbooks all descend from this thinking.
+
+## Cross-domain examples
+
+### Aviation: the rise of CRM
+
+The 1977 Tenerife airport disaster — two 747s collided on a runway — was traced partly to crew dynamics: the captain's authority discouraged challenge. The aviation industry developed Crew Resource Management (CRM) training to encourage crews to challenge each other's decisions, reducing decision-mistakes. Decades of airline safety improvements descend from CRM.
+
+### Medicine: Universal Protocol
+
+The Universal Protocol (mark surgical site, time-out before incision) was developed to prevent wrong-site surgery — a high-stakes mistake that occurred more often than the public realized. Implementation reduced wrong-site surgeries dramatically.
+
+### Industrial: lockout-tagout
+
+LOTO procedures prevent slip-type errors by physically blocking accidental energizing of equipment. The locked-out lock requires deliberate removal before the equipment can be re-activated.
+
+### Software: defensive programming
+
+The slip/mistake distinction maps to software practice: type checking and assertions catch some slips at compile time; documentation, code review, and testing catch some mistakes pre-production. The practice of "defensive programming" treats user input as adversarial — not because users are adversaries but because errors are inevitable.
+
+## Resources
+
+- **Norman, D.** "Categorization of Action Slips" (*Psychological Review*, 1981).
+- **Norman, D.** *The Design of Everyday Things* (1988, 2013).
+- **Reason, J.** *Human Error* (1990).
+- **Perrow, C.** *Normal Accidents* (1984).
+- **Gawande, A.** *The Checklist Manifesto* (2009).
+- **Casey, S.** *Set Phasers on Stun* (1998) — case studies of design-induced errors.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect-design-cues/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect-design-cues/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: expectation-effect-design-cues
+description: 'Apply in-product expectation cues — typography, animation, spacing, copy tone, micro-interactions, and visual register that signal "this is the kind of product you''re using" within seconds of opening it. Use when designing the first-screen experience, picking a typography system, deciding loading-state behavior, choosing animation timing, or polishing the surface details that telegraph product quality. Surface cues set expectations for the whole session and create halo effects (positive or negative) that color every later interaction. Small surface details have outsized impact on perceived overall quality.'
+---
+
+# Expectation Effect — design cues
+
+In-product design cues are everything the user sees, hears, and feels in the first few seconds of using the product. Typography, color, spacing, animation timing, copy tone, micro-interaction polish, loading-state behavior — all set expectations almost instantly for what the rest of the experience will be like.
+
+The surface cues matter not because they're the most important parts of the product (they aren't) but because they're the *first* parts of the product. The expectations they set become the lens through which every later interaction is interpreted. A polished first impression makes a slightly slow loading state read as "the system is being thorough." An unpolished first impression makes the same loading state read as "this is broken."
+
+## What the user reads in the first 5 seconds
+
+The user is forming an evaluation in the first few seconds whether you want them to or not. The cues they're reading include:
+
+**Typography quality.** Are the typefaces chosen with intent, or are they default system fonts placed without thought? Are line heights, weights, and sizes coordinated, or do they wander? Typography is the single most-noticed surface cue because text is everywhere on screen, and a weak typography system signals weakness throughout. Conversely, considered typography signals craft instantly.
+
+**Spacing and alignment.** Are elements in deliberate relationships, or do they crowd and float at near-but-not-aligned positions? The "near miss" alignment — where two elements are not quite aligned but clearly trying to be — signals carelessness more strongly than either tight alignment or generous, intentional asymmetry.
+
+**Animation smoothness and timing.** Do transitions feel deliberate, with consistent timing and easing across the product? Or do some transitions snap, others slide jerkily, others take too long? Inconsistent animation signals a product cobbled together from disparate components.
+
+**Color discipline.** Is the palette used consistently — five or six colors with clear semantic roles — or is it sprawling, with new colors introduced for each feature? A disciplined palette signals a coherent design system; an undisciplined one signals improvisation.
+
+**Copy tone.** Does the writing have a consistent voice — formal, casual, witty, direct — or does it shift register between screens? Inconsistent tone signals multiple writers with no shared voice and primes users to expect inconsistency in functionality too.
+
+**First micro-interaction.** The very first hover, click, or tap. Does the button respond crisply? Does the form field have a clear focus state? Does the toggle animate smoothly? The first micro-interaction is a strong signal of overall craft.
+
+**Loading-state confidence.** When something has to load, does the system communicate "working on it" with a clear indicator? Or does it freeze, blank, or guess? A polished skeleton state or progress animation primes the user to read the wait as productive.
+
+## How surface cues create halos
+
+The expectation effect is asymmetric in a useful way. Once a user has formed a positive first impression, they actively look for confirming evidence and downweight contradicting evidence. A polished first impression creates a halo that makes the rest of the product feel more polished than it strictly is. A clunky first impression creates a negative halo that makes the rest feel clunkier.
+
+This means surface cues have an outsized impact on perceived overall quality. A product that invests in typography, spacing, animation timing, and copy tone — even at the cost of some functional features — often outperforms a more feature-complete competitor on user satisfaction surveys. The classic finding from the Aesthetic-Usability Effect literature: users rate the more beautiful interface as more usable even when it's measurably the same or worse on objective usability tasks.
+
+The flip side: a feature-rich but visually unpolished product is often dismissed by users who never discover the features. The first-screen failure foreclosed the rest of the evaluation.
+
+## Designing the first 5 seconds
+
+A few moves disproportionately affect first-screen impressions.
+
+**Pick typography that already signals your register.** If you want premium, choose a serif with clear authority (or a sans-serif with confident weight). If you want playful, choose a typeface with personality. If you want technical, choose something monospace-influenced or geometric. The typeface itself communicates before any specific word is read.
+
+**Choose a focal moment for the first screen.** Don't fill the first screen with everything; pick one element to be the visual focus and let it carry the impression. A hero card, a single confident headline, an inviting empty-state illustration. A focused first screen signals editorial discipline; a dense one signals "we couldn't decide."
+
+**Smooth the first interaction beyond what's strictly necessary.** Animate the first button press more smoothly than later ones. Make the first form field's focus state more polished. Spend disproportionate effort on the first 30 seconds because they create the halo for the rest.
+
+**Use the loading state as a first-impression moment.** A confident skeleton state, a smooth progress animation, or a witty loading message can turn an unavoidable wait into a moment of personality. Empty-screen-then-content is the harshest possible loading experience because it interrupts any sense of activity.
+
+**Eliminate near-miss alignment, even if you have to delete elements to do it.** A page where everything is precisely aligned, or intentionally misaligned, reads as designed. A page with elements 2 pixels off reads as careless.
+
+## Worked examples
+
+### A SaaS dashboard's first impression
+
+User opens the dashboard for the first time. In the first 2 seconds they see:
+
+- A header with their workspace name in a confident weight, paired with a clean nav.
+- A hero card showing one key metric — large, well-typed, with a sparkline.
+- Three secondary cards in a grid, each with a small heading and a single primary value.
+- A subtle skeleton loader filling the rest of the screen, animated smoothly.
+
+The user's first read: "This is a real product, well-considered, and I should pay attention." The expectation halo is set positively. When the dashboard finishes loading and reveals 12 charts with various features, the user evaluates them favorably even if individual charts have small issues.
+
+Compare to: same dashboard, same data, but with a header in default system fonts, the workspace name truncated awkwardly, the hero card and secondary cards at slightly different vertical alignments, and a 600ms blank screen before content appears. Same data, same features, but the user's first read is "feels rough" and the entire session is colored by that read.
+
+### A loading state as expectation cue
+
+A search interface returns results in 800ms — fast enough that you might think no loading state is needed. But the screen blanks for 800ms before results appear, which reads as "broken" to many users. Adding a skeleton state that appears within 100ms changes the perception entirely: the system is now "working" for 700ms before showing results, even though the actual time is the same.
+
+The expectation cue (the skeleton) re-frames the wait as productive. The user's perceived speed actually improves, even though no actual speed has improved.
+
+### Copy tone that mismatches the visual
+
+A children's educational product with bright illustrated characters, playful colors, and large rounded shapes, but copy that reads "Engagement metrics are computed using cohort-based statistical models." The visual primes users to expect approachable, child-friendly language; the copy violates the priming. Users feel a small jolt and start looking for other places where the product's character is incoherent. Aligning the copy ("we look at how kids are doing as a group") removes the jolt and lets the product feel of-a-piece.
+
+### A pricing page with subtle craft
+
+A pricing page where each tier is in a card with consistent padding, the prices are typeset in a confident display weight, the feature lists are visually weighted (primary features bold, secondary features regular), and a recommended-tier marker is positioned with intentional asymmetry. The page communicates "this product takes itself seriously" before the user has read a single feature.
+
+Compare to: same prices, same features, but in default-styled cards with mismatched padding, prices in body weight, and feature lists as bulleted lists. Same content, but the page reads as "filled out the template," and users approach the purchase decision more skeptically.
+
+### Onboarding's first interaction
+
+The very first thing the user does in the product. A name-entry field that focuses smoothly, accepts input crisply, and animates a subtle progress bar as they type primes the user for "this product feels alive." A name-entry field that takes a moment to focus, stutters during input, or has no progress feedback primes the opposite.
+
+This is one of the highest-ROI design moments in any product. It costs little to polish (it's a single input field) and the halo it sets persists through the entire session.
+
+## Anti-patterns
+
+**Inconsistent surface within the same product.** A polished marketing-page experience that breaks at the boundary into the product. A polished onboarding that gives way to a settings panel that looks default-styled. The boundary moments are exactly where users notice the inconsistency, and the lower-quality side drags down the perception of the whole.
+
+**Over-promising with surface cues.** Hyper-polished animations and luxurious typography on a product that does very little. Users initially feel "this is going to be great" and then "wait, that's all it does?" The let-down is sharper than if the surface had been more modest.
+
+**Neglecting the loading and empty states.** The "blank screen during load" and "no items yet" moments are often unpolished, treated as edge cases. They're not edge cases — they're some of the first things first-time users see, and they're disproportionately impactful for the expectation halo.
+
+**Treating surface as separate from substance.** Designers and engineers sometimes argue that "we should focus on functionality, not polish." This misses that polish *is* a kind of functionality — it's the function of communicating quality, attention, and care. A product that is functionally complete but visually rough is communicating "this team didn't think you'd notice," and users notice.
+
+**Confusing visual decoration with surface craft.** Adding more illustrations, gradients, or animations to a rough underlying design doesn't fix the surface — it adds noise. Surface craft is restraint, alignment, typography, and timing, not visual addition.
+
+## Heuristic checklist
+
+Before launch, audit the first 30 seconds. **Open the product fresh and watch your own reactions.** What's the first thing you notice? What's the first thing that feels off? **Is the typography system coherent across all surfaces the user sees in the first session?** If not, fix the most-prominent surfaces first. **Are loading states and empty states designed, or are they default?** Default loading is harsher than designed loading. **Does the first interaction feel crisp?** If not, polish it disproportionately. **Does the copy tone match the visual register?** If not, align them.
+
+## Related sub-skills
+
+- `expectation-effect-priming` — for the pre-encounter expectations this cue work has to live up to.
+- `aesthetic-usability-effect` — the related principle that beautiful designs are perceived as more usable.
+- `feedback-loop-states-and-latency` — loading and progress states are an important slice of the surface cues that set expectations.
+- `chunking-form-grouping` — well-grouped forms are part of the surface coherence that sets expectations.
+- `signal-to-noise` — restraint in the visual register reads as confidence, which sets quality expectations.
+
+## See also
+
+- `references/cue-priorities.md` — which surface cues have the largest impact on first-impression perception, and where to invest scarce design time.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect-design-cues/references/cue-priorities.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect-design-cues/references/cue-priorities.md
@@ -1,0 +1,79 @@
+# In-product expectation cues — investment priorities
+
+A working ranking of which surface cues have the largest impact on first-impression perception. Use this when design time is scarce and you need to know where to invest first.
+
+## Tier 1: outsized impact, modest cost
+
+These cues are noticed within the first 2 seconds and shape every subsequent impression. Invest here first.
+
+**Typography system.** Pick 1–2 typefaces and use them with discipline. Define a clear scale (4–6 sizes) with clear weight pairings. Use consistent line heights and letter spacing. A coherent typography system is the single highest-ROI surface investment because text is everywhere on screen and users read its quality continuously.
+
+**Spacing rhythm.** Define a base spacing unit (8px is common; 4px for tighter products) and use multiples consistently. Equal spacing in similar contexts (all card padding the same, all section margins the same) reads as designed; varied spacing reads as careless. The rhythm is more important than the exact value.
+
+**First-screen focal point.** Pick one element on the first screen to be the visual anchor and let it carry the impression. Resist the temptation to fill the screen with everything important. A single confident hero or empty-state card outperforms a dense grid of competing elements.
+
+**Loading-state behavior.** Replace blank screens with skeleton states or progress indicators. The threshold for "needs a loading state" is roughly 200ms — anything longer than that without indication reads as broken. Animate skeleton states subtly so they feel alive, not frozen.
+
+## Tier 2: large impact, moderate cost
+
+These cues are noticed within the first 10 seconds and substantially affect overall quality perception.
+
+**First micro-interaction.** Polish the very first hover, click, focus, or tap the user encounters. A crisp focus state on the first input field, a smoothly animated first button press, or a clean first toggle all signal "this product is alive."
+
+**Color discipline.** Limit the palette to 5–7 colors with clear semantic roles (primary, secondary, success, warning, error, surface, surface-strong). Avoid introducing one-off colors for individual features. Discipline reads as system; sprawl reads as improvisation.
+
+**Animation timing consistency.** Pick a small set of animation durations (e.g., 150ms for micro-interactions, 300ms for transitions, 500ms for major state changes) and apply them consistently. Inconsistent timing reads more clearly as wrong than slow timing reads as slow.
+
+**Empty-state design.** The first time a user sees a list, dashboard, or workspace, it's often empty. Designed empty states (illustrations, helpful copy, suggested actions) prime the user for "this is a thoughtful product." Default empty states ("no items yet") prime the opposite.
+
+**Copy tone consistency.** The voice of the writing — formal, casual, witty, direct — should be consistent across all screens the user encounters in the first session. A written voice that shifts register screen to screen reads as multiple authors with no shared style.
+
+## Tier 3: meaningful impact, higher cost
+
+These cues require sustained design attention but pay off in cumulative perceived quality.
+
+**Iconography craft.** A coherent icon set (consistent stroke weight, consistent corner radius, consistent metaphor style) reads as designed. A mixed set — some Material, some custom, some FontAwesome — reads as patched together. If you can't afford a custom set, use one library with discipline.
+
+**Form-field polish.** Forms are where users spend a lot of in-product time. Investing in form-field design (clear labels, helpful placeholders, smooth validation feedback, accessible focus states) pays compounding dividends because users encounter forms repeatedly.
+
+**Transition between states.** When the UI changes state (a panel opens, an item gets selected, a row expands), the transition should be smooth and reveal the change. Hard cuts between states make the UI feel jumpy; smooth transitions make it feel coherent.
+
+**Error-state design.** Designed error states — clear language, suggested next steps, visual restraint — prime users for "errors are handled with care" and significantly soften the impact of any error encounter. Default error states ("Error 500: Internal Server Error") prime "this product breaks."
+
+**Document-style polish (if applicable).** For products that present documents (notes, articles, dashboards, slides), the document-rendering polish (spacing, typography, color) directly shapes perceived product quality.
+
+## Tier 4: low individual impact, but cumulative
+
+These cues are individually small but compound across the product.
+
+**Tooltip and helper-text design.** Tooltips that match the overall visual register (instead of default browser tooltips) signal craft.
+
+**Cursor changes on hover.** Subtle but effective; the cursor changing to a pointer on hover-to-click elements is part of the "alive" feeling.
+
+**Scrollbar styling on long lists or panels.** Customized scrollbars (when subtle) feel of-a-piece with the product; default OS scrollbars in an otherwise polished product feel jarring.
+
+**Dialog and modal styling.** Modals are common but often overlooked; consistent modal padding, header styling, and button placement adds cumulative coherence.
+
+**Notification and toast design.** Notifications are small but frequent. Their visual design accumulates impression weight over the session.
+
+## Anti-patterns to avoid
+
+**Polishing surface details on a feature whose flow is broken.** Surface cues only help if the underlying flow works. A beautifully styled error message that the user can't recover from is worse than a plain error message with a clear path forward. Fix the flow first; polish the surface second.
+
+**Investing in animation at the cost of speed.** Smooth, slow animations look polished but accumulate to slow the product down. Animation timing should be quick enough that frequent users don't feel slowed by it (typically under 200ms for micro-interactions); animation that looks gorgeous at first encounter but feels sluggish on the 50th use is a bad trade.
+
+**Decorating instead of designing.** Adding illustrations, gradients, or visual effects to an unpolished underlying design doesn't fix the surface — it adds noise. Surface craft is mostly restraint, alignment, typography, and rhythm, not visual addition.
+
+**Inconsistent polish across surfaces.** A polished marketing page that breaks at the product boundary. A polished onboarding that gives way to a default-styled settings panel. The boundaries are exactly where users notice the inconsistency, and the unpolished side drags down the impression of the whole. Either polish all the surfaces a user will see in the first session, or none.
+
+**Treating "the design" as the home screen.** The first impression isn't only the home screen — it's the home screen, the first interaction, the first loading state, the first empty state, the first error, the first form, and the first transition. All of these are part of the first session and all contribute to the expectation halo.
+
+## A simple audit
+
+Open the product as if you've never seen it before. Time yourself: at 5 seconds, what impression have you formed? At 30 seconds? At 2 minutes? Note the specific moments where you formed each impression — they're usually surface cues, not feature discoveries. Those moments are your investment priorities.
+
+If you can't separate yourself from your knowledge of the product, hand it to someone outside the team and watch them. Their first 5 seconds tell you what your surface cues are actually communicating.
+
+## Cross-reference
+
+For the related principle that surface beauty primes perceived usability, see `aesthetic-usability-effect`.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect-priming/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect-priming/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: expectation-effect-priming
+description: 'Apply expectation priming — deliberately shaping the prior context (brand, marketing, price, social proof, recommendations) that users bring to a product before they ever touch it. Use when planning a launch, choosing positioning copy, deciding pricing tier, designing the marketing surface, or framing a feature for first encounter. Pre-encounter priming is often more powerful than in-product polish, because it sets the lens through which the in-product experience will be interpreted. The skill is calibrating priming honestly enough to outlast the first session.'
+---
+
+# Expectation Effect — priming
+
+Pre-encounter priming is everything that happens before the user touches the product. It includes branding, marketing copy, screenshots and demos, price, channel of arrival, social proof, and the user's prior associations with similar products. Priming sets the lens through which the user will perceive every subsequent interaction.
+
+The leverage on perception from priming is often larger than the leverage from in-product polish, because priming operates first and sets the baseline expectations that the product is then measured against.
+
+## What gets primed, and how
+
+Priming happens through several distinct channels.
+
+**Brand and visual identity.** A logotype, a color palette, a typography choice, an aesthetic register. Apple's brand primes "premium, simple, designed-for-humans." Mailchimp's brand primes "small-business friendly, casual, illustrated." Stripe's brand primes "developer-respected, technically credible, clean." These are sustained over years of consistent use and color how every new product or feature is initially read.
+
+**Pricing.** Price is one of the strongest single priming signals. A $200/year tool primes users to expect substantial value, a polished experience, and responsive support. A $5/month tool primes users to expect basic competence and limited support. A free tool primes users to expect ads, limitations, or unstable feature sets. Pricing within a category band signals "this is a premium variant" or "this is a budget variant" with high reliability.
+
+**Marketing copy and positioning.** "The world's most powerful X" primes users to expect breadth and capability. "A simple Y for everyday use" primes users to expect ease and modesty. "Built for serious professionals" primes users to expect a steeper learning curve and more depth. The exact words shape what users will look for in the product.
+
+**Screenshots, demos, and trailers.** Visual evidence of the product before use sets very specific expectations about what's inside. Curated screenshots showing the polished happy path prime users to expect that level of polish in their own use; if the actual experience is rougher, the gap reads as broken promises.
+
+**Social proof.** Reviews, testimonials, customer logos, recommendation by trusted sources. A friend's recommendation primes users much more strongly than an ad — they expect the product to be good and they actively look for confirmation. A 1-star review average primes the opposite. Social proof is one of the few priming signals that compounds: reviews shape expectations of new users, who then write reviews that shape the next cohort.
+
+**Channel of arrival.** Users who arrive through a search for a specific need have different expectations than users who arrive through a banner ad. Search-driven users expect the product to solve their stated need; ad-driven users have lower commitment and require the product to surprise them.
+
+**Category convention.** Users come to a "calendar app" with expectations shaped by every calendar app they've used before. Deviating from category convention (a calendar app that doesn't show a month grid, for instance) requires either explicit framing ("the calendar reimagined as...") or a strong onboarding moment to reset expectations.
+
+## Calibrating priming honestly
+
+The goal of priming is to set expectations slightly above the median in-product experience, so that the actual use confirms or modestly exceeds them. Set expectations too low and qualified users dismiss the product; set them too high and users churn after a disappointing first session.
+
+The calibration involves a few moves:
+
+**Match marketing register to in-product register.** If the product is a serious enterprise tool, the marketing should be sober and precise; if the product is playful and casual, the marketing should match. Mismatches produce a jolt at the moment of first use that primes users to mistrust both the marketing and the product.
+
+**Show the actual product, not a stylized version.** Marketing screenshots that are photoshopped beyond what the product can actually render set expectations the product can't meet. Show the real thing, even if it's slightly less photogenic than an idealized render.
+
+**Be specific about what's included.** Vague positioning ("everything you need to manage your business") sets expectations that any specific shortcoming can violate. Specific positioning ("invoicing, expense tracking, and tax prep for solo consultants") sets expectations the product can actually meet.
+
+**Match price to perceived value, not to ambition.** Pricing too high without the substance to back it up generates immediate disappointment. Pricing too low for the substance you've built leaves money on the table and signals "low quality" to users for whom price is a quality cue.
+
+**Use social proof that survives investigation.** Featured customer logos that turn out to be one-time users, testimonials from people without verifiable accounts, review ratings that drop sharply when filtered for verified purchases — these all damage the priming effect when discovered. Honest social proof, even if more modest, sustains expectations.
+
+## Worked examples
+
+### A premium SaaS launch
+
+A new $99/month accounting tool launches with sophisticated marketing: a film-quality demo video, prestigious customer logos, a confident tagline. Users arrive primed for premium. The product opens to a clean dashboard, a confident onboarding, and a guided first task. Premium framing met. The in-product experience confirms the priming, and users rate the product significantly better than they would have without the priming.
+
+If the same product had launched with placeholder marketing and a $9 price, users would have arrived with low expectations. The same in-product experience would have read as "surprisingly good for the price" — but few users would have arrived to begin with, and those who did would have struggled to recommend it to peers ("it's good, but the website looks unprofessional, so I'm not sure I'd send my CFO to it").
+
+### A redesign that violates category convention
+
+A weather app redesigns its main view from the conventional "current temperature, hourly forecast, daily forecast" layout to a more abstract "weather as ambient light visualization." Users arriving with category-conventional expectations find the new view confusing. The fix: explicit framing in the App Store description ("Weather, reimagined as ambient atmosphere") and a brief first-launch screen explaining the metaphor. The framing resets expectations to make the design choice readable rather than confusing.
+
+### Free tier as priming for paid
+
+A productivity tool offers a generous free tier. Users who try the free tier and find it polished and complete are primed to believe the paid tier is also polished and complete; conversion to paid is high. A different productivity tool offers a deliberately limited, somewhat clunky free tier (designed to "encourage upgrade") and finds that users don't upgrade — they instead form a negative impression of the entire product based on their free experience.
+
+The lesson: free experiences prime expectations of paid experiences. Don't sabotage the free tier to drive upgrades; that primes negatively for the paid product too.
+
+### Recommended by a trusted source
+
+A user is told by a respected colleague that "X is the best tool for Y." They arrive with high expectations and active interest in confirming the recommendation. They notice features and strengths that they would have skimmed past otherwise. Their evaluation is positively biased and they're more likely to recommend the product themselves. This is the most powerful form of priming and the hardest to engineer; it generally requires the product to actually be excellent and to spread by word of mouth.
+
+## Anti-patterns
+
+**Premium marketing on an early-stage product.** A startup with a polished marketing site and a half-built product creates a credibility gap when users actually try the product. The fix is usually either to restrain the marketing to match the current product, or to frame the marketing as "early access / beta / building toward" so expectations include the rough edges.
+
+**Vague positioning that can't be falsified.** "Reimagining how teams work together" doesn't set specific expectations, which sounds harmless but actually primes users to expect *something special* without telling them what. They form their own (often wildly varying) interpretations and are then disappointed when the product doesn't match. Specific positioning is more constraining but also more reliably met.
+
+**Inflated user counts and customer logos.** Users learn to discount inflated claims, and once discounted they spread to other claims. Modest, honest social proof builds more durable trust than spectacular but suspect claims.
+
+**Pricing that doesn't match perceived complexity.** A $5/month tool that requires a 30-day onboarding and integration with multiple data sources is mispriced — its complexity primes users to expect enterprise-tier support, which a $5/month price can't sustain.
+
+**Channel-of-arrival mismatches.** Driving paid traffic to a feature that hasn't been polished for first-time users. The paid traffic primes high expectations (the user clicked an ad, expecting something specific) and the feature can't meet them. Reserve paid acquisition for the parts of the product that survive scrutiny.
+
+## Heuristic checklist
+
+For each new launch or redesign, ask: **What are the dominant priming signals users will encounter before touching the product?** List them. **What expectations will those signals set?** Be specific about the level and kind. **Does the actual experience match those expectations?** If not, which side moves: the priming, or the experience? **What channel are users arriving from, and what does that channel imply about their expectations?** Optimize the post-arrival experience for the priming each channel produces.
+
+## Related sub-skills
+
+- `expectation-effect-design-cues` — for the in-product cues that set expectations within a session, complementing the pre-encounter priming this skill covers.
+- `aesthetic-usability-effect` — the in-product version of priming, where surface beauty primes perceived usability.
+- `mental-model` — expectations are part of the mental model the user brings.
+- `archetypes` — brand and category archetypes are powerful priming devices.
+
+## See also
+
+- `references/priming-channels.md` — a working catalog of priming signals and their relative strengths.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect-priming/references/priming-channels.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect-priming/references/priming-channels.md
@@ -1,0 +1,75 @@
+# Expectation priming — channels and their relative strengths
+
+A working catalog of the channels through which expectations are primed before users touch a product, ranked by typical impact and durability. The exact strength varies by product, audience, and category — treat this as a starting heuristic.
+
+## High-impact, slow-to-shift
+
+These priming signals shape expectations strongly and are slow to change once set. Treat them as long-term investments.
+
+**Brand reputation built over years.** Apple, Stripe, Notion, Pixar — each name primes a specific set of expectations across their entire product line. A new feature from these companies is evaluated against the brand's accumulated reputation, not against zero. Building this kind of priming is slow (years of consistent quality) but immensely valuable once established.
+
+**Pricing tier and category band.** A product priced in the enterprise band ($100+/month per seat) is interpreted very differently from one priced in the consumer band ($10/month). Users have category-level expectations about what each band delivers, and a product's price-band placement primes those expectations strongly.
+
+**Word-of-mouth recommendation from trusted source.** A peer's recommendation is the highest-impact priming channel for new product trial. Users arrive with strong positive bias and active interest in confirmation. This priming compounds: products that earn word-of-mouth get more users with high expectations, who use more deeply and recommend more.
+
+**Category convention.** Users come to a "calendar app" with expectations shaped by every calendar app they've used. Conforming to category convention sets expectations users can meet smoothly; violating convention requires explicit framing to reset expectations.
+
+## Medium-impact, faster to shift
+
+These signals matter substantially for first impressions but are faster to update or override.
+
+**Marketing copy and positioning.** The exact words used to describe a product set what users will look for in it. "The most powerful X" primes for breadth; "a simple Y" primes for ease; "built for serious professionals" primes for depth. Users adjust quickly once they see the actual product, but the initial framing colors the first session.
+
+**Hero screenshots and demo videos.** Visual evidence of the product before use sets specific expectations about what's inside. Curated highlight reels prime for the polished happy path; honest documentation primes for realistic capability. Users discount stylized renders quickly when they see the actual product, but stylization above what the product can deliver creates a credibility gap.
+
+**Onboarding's first 30 seconds.** While technically post-arrival, the first onboarding moment is so close to arrival that it functions as priming. A confident, polished welcome primes users to expect confidence and polish from the rest of the product; an awkward, broken first moment primes the opposite.
+
+**Public reviews and ratings.** App store ratings, software review aggregators, and prominent media reviews all set expectations. A 4.8-star average primes users to expect excellence; a 3.2 primes them to expect frustration. Users discount extreme reviews but trust the central tendency.
+
+## Lower-impact, but cumulative
+
+These signals individually are weaker but accumulate to shape baseline perception.
+
+**Visual design of the marketing surface.** A polished landing page primes users to expect polish in the product. An awkward landing page primes the opposite. Users may not consciously evaluate the landing page, but its quality shapes their initial expectations.
+
+**Domain name and URL structure.** A short, memorable domain primes "established and professional." A long subdomain on a generic platform primes "small or experimental." This is a small effect but contributes to overall framing.
+
+**Channel of arrival.** Users arriving from a search for a specific need have different expectations than users arriving from a banner ad or a social-media share. Search-driven users have intent and expect the product to solve their stated need; ad-driven users have lower commitment and require the product to surprise them.
+
+**Time investment before first encounter.** Users who downloaded an app, created an account, and waited for an email all bring elevated expectations to the eventual first session — they want their investment to pay off. Users who clicked a link and landed on a page have lower commitment. Products that require investment should especially deliver in the first post-investment session.
+
+## Cross-cutting: signal consistency
+
+Across all channels, the most important meta-signal is *consistency*. A product whose marketing, pricing, brand, channel, and product all signal the same level (premium-premium-premium-premium-premium, or accessible-accessible-accessible-accessible-accessible) accumulates a coherent set of expectations. A product with inconsistent signals (premium marketing, budget price, unpolished product) confuses users and primes mistrust — they sense something is off even if they can't articulate it.
+
+When in doubt about which signal to update, look for the inconsistencies and make them consistent.
+
+## Channel-specific tactical notes
+
+**For app stores.** The icon, screenshots, ratings, and short description are the entire pre-encounter surface for most users. Iterate aggressively on these. The icon especially functions as a brand-priming signal that users see for years.
+
+**For B2B SaaS.** Customer logos, ROI claims, and case studies dominate the pre-encounter surface for buyers. The actual product demo is often gated behind a sales conversation, so written and verbal positioning carry the priming load.
+
+**For physical products.** The unboxing experience is one of the strongest priming events of all — Apple, again, is the master class. The packaging, the materials, the order in which things are revealed, the first physical touch all prime perception of the product itself. Ignore unboxing at your peril.
+
+**For internal tools.** Your colleagues' opinion and the internal "feel" of the tool (is it on the company wiki? does it have an owner who responds? does it have a slick name or a generic one?) prime expectations. An internal tool with an actual brand and onboarding outperforms one with a coded name and a "see the README" introduction.
+
+**For open-source.** README quality, GitHub stars, the project's commit history, the maintainer's responsiveness in issues — all visible signals that prime expectations of stability and quality. A polished README on a young project primes well; a bare README on an established project primes badly.
+
+## Anti-patterns
+
+**Optimizing the priming surface independent of the product.** Marketing teams polishing the landing page while the product team ships unpolished features. The mismatch produces high arrival numbers and high churn — users arrive primed for polish, encounter rough edges, and leave. Coordinate the two surfaces.
+
+**Aggressive paid acquisition driving traffic to underbaked features.** The paid traffic primes high expectations; the underbaked feature can't meet them. Reserve paid acquisition for parts of the product that survive scrutiny.
+
+**Inflating social proof.** Customer logos that aren't really customers, testimonials from non-existent users, review-rating manipulation. These tactics work briefly and then collapse, often with reputational damage that lasts much longer than the brief gain.
+
+**Following a competitor's priming signals.** Using the same color palette, pricing tier, and category positioning as a successful competitor primes users to compare directly with the competitor — and you'll likely lose that comparison if the competitor was first to market and well-established. Differentiate the priming where you can differentiate the product.
+
+## Field test
+
+For each priming channel, articulate in one sentence what expectations it sets. Then articulate in one sentence what the actual first-session experience delivers. Where the two sentences match, the priming is well-calibrated. Where they don't, decide which to move.
+
+## Cross-reference
+
+For the in-product side of expectation setting, see `expectation-effect-design-cues`.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: expectation-effect
+description: 'Apply the Expectation Effect — the principle that prior expectations measurably change a person''s perception of a product or experience. Use when shaping the framing of new features, designing onboarding, choosing visual cues that signal premium vs. budget, or diagnosing why two functionally identical features feel different to users. Expectations are set by visual cues (premium materials, polished typography), language (precise, confident copy), social proof, price, and prior brand exposure. Setting expectations too high creates disappointment; too low and the product reads as mediocre. The skill is calibrating what to promise.'
+---
+
+# Expectation Effect
+
+> **Definition.** The Expectation Effect is the well-established phenomenon that what people expect from a product, service, or experience changes how they actually perceive and evaluate it. Two functionally identical things will be experienced differently if the expectations going in differ. The same wine tastes better when poured from an expensive-looking bottle. The same painkiller works more effectively when patients are told it's a brand name. The same software feels faster when its loading animation looks confident.
+
+This is one of the most thoroughly documented phenomena in cognitive psychology, marketing research, and clinical medicine. The effect is real, robust, and operates outside conscious awareness — users genuinely perceive the higher-expectation version as better, not because they're rationalizing but because their perceptual system is shaped by their prior expectations.
+
+## Why this matters for design
+
+The expectation effect is double-edged. Used well, it amplifies the perceived quality of your work — a polished onboarding flow makes the rest of the app feel polished too; a confident loading animation makes the loading time feel shorter; a premium brand makes the same feature feel more refined. Used poorly, it creates a perception–reality gap that punishes you in two ways: either expectations exceed reality and users feel cheated (the dreaded "looked great in the marketing, disappointing in use" experience), or expectations undersell reality and users dismiss the product before discovering its strengths.
+
+Most design discussions focus on the *thing being designed* — the buttons, layouts, flows. The expectation effect insists you also design what comes *before* the thing — the framing, the marketing, the first-screen impression, the price tag, the brand context. These shape how the thing itself will be perceived.
+
+## The three tiers of expectation
+
+Expectations are set in three layers, in roughly the order users encounter them.
+
+**1. Pre-encounter expectations.** Before the user touches the product, expectations are set by branding, marketing, price, recommendations, prior reputation, and category convention. A user opening a $40/month enterprise tool expects a different experience than one opening a free utility. A user who arrived through a friend's recommendation expects something different from one who arrived through a banner ad. These expectations are largely outside the product itself but shape the entire first session.
+
+**2. Surface expectations — set in the first 5 seconds.** Visual polish, typography quality, animation smoothness, color choices, copy tone — all of these set expectations almost instantly. A user who opens an app and sees default system fonts, awkward spacing, and inconsistent margins immediately downshifts their expectations of how the rest of the experience will feel. A user who opens an app with confident typography, intentional whitespace, and a single moment of delight (a smooth transition, a charming empty state) immediately upshifts their expectations.
+
+**3. Performance expectations — set during the first interaction.** Speed, responsiveness, the smoothness of the first action, the clarity of the first feedback — these set expectations for everything that follows. A first interaction that feels fast and confident creates a halo effect that makes later (slower) interactions feel acceptable. A first interaction that feels slow or clumsy creates a negative halo that makes later (fast) interactions feel like surprises rather than the norm.
+
+## The placebo and nocebo dynamics
+
+The clearest demonstration of the expectation effect comes from clinical pharmacology: the placebo effect. Patients given inert sugar pills, while told they are receiving an effective medication, frequently experience genuine symptom relief — measurable in physiological markers, not just self-reports. The effect is large enough that all rigorous drug trials must control for it.
+
+The same dynamic appears in product perception. Users told a piece of software is "powered by AI" rate the same outputs as more impressive than users told the same outputs come from a "rule-based system." Users shown a higher price perceive the product as higher quality, even when the underlying product is identical. Users told a wine is from a famous vineyard taste it as more complex.
+
+The flip side is the nocebo effect. Users primed to expect poor performance perceive even good performance as poor. A reputation for being slow makes the product feel slow even after it's been optimized. A first-impression failure casts a long shadow over later, fixed interactions.
+
+## Setting expectations honestly
+
+The temptation, when you understand the expectation effect, is to manufacture expectations as high as possible: oversell the product, premium-up the visual style, claim more than the product delivers. This works for the first session and fails for everything after. Users whose expectations are set above what the product actually delivers leave with a stronger negative impression than users whose expectations were realistic from the start.
+
+The skill is calibration. Expectations should be set just slightly above the median experience — high enough to attract attention and create the positive halo effect, low enough that the product reliably exceeds them in actual use. The Apple "unboxing" is a master class in this: the packaging promises premium, the device delivers premium, and the experience exceeds expectations even though expectations were already high.
+
+The mechanisms for honest expectation-setting include: showing the actual product (not stylized renders) in marketing; being specific about what the product does and doesn't do; using language that matches the actual register of the product (don't write enterprise-sober copy if the product is playful); pricing in a band that matches the actual quality; and resisting feature-list inflation that promises more than the product delivers.
+
+## When expectations and reality diverge
+
+Two failure modes are worth knowing.
+
+**Premium framing on an unpolished product.** Beautiful marketing, ambitious pricing, confident brand voice — and then the actual product has a default-typography settings panel, awkward error messages, and slow loading. The gap between the marketing-set expectations and the reality is more painful than if both had been more modest. Users feel deceived even when no specific deception occurred.
+
+**Apologetic framing on a strong product.** Cautious marketing, low pricing, hedged language ("a simple tool for...") on a product that actually performs at a higher level. The product never gets evaluated against its real capability because users come in with low expectations and don't push it hard enough to discover what it can do. This is common with academic, indie, or non-profit products that under-frame their work.
+
+The fix in both cases is to align the framing to the product. If the product is premium, frame it as premium and verify the surface lives up to it. If the product is plain but powerful, choose plain framing and let the work speak.
+
+## Sub-skills in this cluster
+
+- **expectation-effect-priming** — How prior context (brand, price, recommendations, marketing) shapes user perception, and how to set those priming signals deliberately.
+- **expectation-effect-design-cues** — How surface cues within the product itself (typography, animation, copy tone, micro-interactions) set in-session expectations and create halo effects.
+
+## Heuristic checklist
+
+Before launching a feature or product, ask: **What expectations are users arriving with?** From the marketing, the price, the category, the previous version. **Does the actual experience meet or exceed those expectations?** Be specific about which moments confirm and which moments disappoint. **If there's a gap, which side should move?** Sometimes the fix is to upgrade the product; sometimes the fix is to lower the framing. **What is the first 5-second impression?** That impression sets a halo that persists through the session. **What is the first interaction's performance and clarity?** That sets the performance halo for every interaction after.
+
+## When the principle is misapplied
+
+Manipulating expectations to increase short-term metrics — making things look more premium than they are, claiming features the product doesn't actually have, using social-proof copy that overstates adoption — works in the short run and backfires in the long run. The expectation effect amplifies both the experience and the disappointment when the experience falls short of what was promised. Sustained use of the principle requires honest calibration, not maximum amplification.
+
+## Related principles
+
+- **Aesthetic-Usability Effect** — beautiful designs are perceived as more usable; this is one specific case of the expectation effect.
+- **Anchoring** — pricing or first-encountered values shape evaluation of subsequent values.
+- **Mental Model** — expectations are shaped by what the user thinks the system is.
+- **Form Follows Function** — when the product looks like what it does, expectations align naturally.
+- **Mimicry** — products that mimic premium category conventions inherit the expectations of that category.
+- **Storytelling Arcs** — the narrative around a product shapes the lens through which it's experienced.
+
+## See also
+
+- `references/lineage.md` — origins in placebo research, marketing studies, and HCI.
+- `expectation-effect-priming/` — sub-skill on pre-encounter expectation setting.
+- `expectation-effect-design-cues/` — sub-skill on in-session expectation cues.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/expectation-effect/references/lineage.md
@@ -1,0 +1,79 @@
+# Expectation Effect — origins and research lineage
+
+## The placebo effect in clinical research
+
+The first rigorous documentation of the expectation effect comes from medicine. Henry Beecher's 1955 paper "The Powerful Placebo" reviewed multiple clinical trials in which patients receiving inert sugar pills, while believing they were taking active medication, showed measurable symptom relief — pain reduction, blood pressure changes, even physiological markers. Beecher estimated that roughly a third of clinical effects in the studied trials were attributable to placebo. The number has been refined and contested since, but the core finding is robust enough that all modern drug trials use double-blind placebo controls as the gold standard.
+
+The mechanism is not simply "patients lying about feeling better." Functional brain imaging studies in the 1990s and 2000s — particularly the work of Tor Wager and colleagues — showed that placebo administration produces measurable changes in neural activity in pain-processing regions, and that placebo analgesia is partially blocked by naloxone, an opioid antagonist. The expectation of relief triggers actual endogenous opioid release. This is one of the cleanest demonstrations available that "perception" is not separate from "reality" — what we expect changes what we experience at a physiological level.
+
+The flip side, the nocebo effect, was documented later but is equally robust. Patients warned about a side effect are dramatically more likely to report it. In one famous study, patients told a beta-blocker would cause sexual dysfunction reported the side effect at roughly twice the rate of patients who weren't warned, even when receiving identical doses.
+
+## Marketing and consumer research
+
+Consumer psychology adopted the same framework in the 1960s and 1970s. Studies by Allison and Uhl in 1964 demonstrated that beer drinkers could not distinguish their preferred brand from competitors in blind taste tests but rated their preferred brand as superior when labels were visible. The label set the expectation, and the expectation shaped the perception.
+
+This finding has been replicated dozens of times across product categories: wine (the same wine rated higher when poured from a more expensive bottle), audio equipment (the same speakers rated better when housed in a heavier cabinet), automotive interiors (the same materials rated more luxurious in a car with a more upscale brand badge). Brian Wansink's research on food perception extended the same finding to packaging: the same yogurt is rated as creamier when in a thicker container; the same wine is rated as smoother when from a more elegantly labeled bottle.
+
+The work of Baba Shiv and colleagues in the early 2000s went further: a placebo "energy drink" measurably improved cognitive task performance, and the effect was *larger* when the drink was sold at full price than when it was discounted. Higher price set higher expectations, which produced larger actual performance gains. This suggests the expectation effect can operate even on objective task performance, not just subjective evaluation.
+
+## In HCI and software design
+
+The HCI literature picked up the same threads in the 1990s and 2000s. Notable findings:
+
+- **Perceived performance vs. measured performance.** Users' subjective ratings of "speed" correlate only loosely with measured response time. A loading animation that suggests progress can make a slow operation feel faster than a fast operation with no progress indication. This is partly an attention effect and partly an expectation effect — the animation tells the user "this is working, hang on," and confirmed expectations feel acceptable.
+
+- **First-impression halo effects.** Studies of website credibility (notably by B.J. Fogg and the Stanford Persuasive Technology Lab) found that users rate websites' trustworthiness, accuracy, and quality based heavily on visual design — within seconds of arrival. The visual impression sets expectations that then color the user's evaluation of the actual content.
+
+- **Aesthetic-Usability Effect.** Lavie and Tractinsky's 2000 study, replicated many times, showed that users rate beautiful designs as more usable even when objectively the designs are no easier to use. This is the expectation effect operating at the surface-design level.
+
+- **Brand and provenance cues.** Studies have shown that the same software is rated as more capable when presented under a "premium" brand than under an unfamiliar one; that AI-generated outputs are rated as more impressive when labeled as AI-generated than when not; that academic papers are rated as more rigorous when from prestigious institutions. The framing changes the perception.
+
+## Mechanism: why expectations shape experience
+
+The expectation effect operates through several mechanisms that are worth understanding because they tell you when it will be strong and when it will be weak.
+
+**Attention allocation.** Users with high expectations spend more attentional effort on a product, finding more value in it (or, when expectations dramatically exceed reality, finding more disappointment). Users with low expectations skim and miss features that would have impressed them.
+
+**Interpretive ambiguity.** When a product is genuinely ambiguous — when a feature could be read as elegant or as confusing — expectations resolve the ambiguity. The same feature reads as elegant under premium framing and as confusing under cheap framing.
+
+**Confirmation bias in evaluation.** Users actively seek evidence that confirms their initial expectations. After forming a positive first impression, they notice and weight positive evidence more heavily; after a negative first impression, they notice and weight negative evidence more heavily.
+
+**Physiological priming.** As the placebo work demonstrates, expectations can change actual perceived sensation — pain feels less intense, taste feels richer, response time feels shorter. This is not a cognitive judgment about the experience; it's a change in the experience itself.
+
+These mechanisms compound. A premium-framed product gets more attention, gets ambiguous features interpreted favorably, accumulates positive evidence, and feels physiologically better. The total effect is much larger than any single mechanism would predict.
+
+## When the expectation effect is large vs. small
+
+The literature suggests the expectation effect is *larger* when:
+
+- The product or experience is ambiguous in quality (subtle wine, mid-range software, conceptual art).
+- The user has limited prior experience with the category.
+- The relevant outcomes are subjective rather than objectively measurable.
+- The framing cues are vivid, prestigious, or emotionally loaded.
+- The user has invested effort or money in the product, raising motivation to confirm the choice.
+
+The expectation effect is *smaller* when:
+
+- The product's quality is clearly measurable (a software benchmark, a stopwatch comparison).
+- The user has strong prior experience and reference points.
+- The framing is mundane and the user pays it little attention.
+- The user has no investment in the choice.
+
+This means the expectation effect matters most for the kinds of products design tends to focus on — interfaces, services, brands, experiences — where evaluation is largely subjective and prior experience varies.
+
+## Ethical considerations
+
+The expectation effect is morally neutral as a phenomenon, but how it's exploited isn't. Honest framing — using premium cues for a genuinely premium product, signaling speed for a product that is fast — works for the user as well as the producer; it amplifies a real strength. Dishonest framing — premium cues for a mediocre product, claims of capabilities that don't exist — works once and erodes trust.
+
+The literature on long-term consumer behavior is consistent: short-term gains from inflated expectations are paid back in churn, negative reviews, and brand damage. Designers who lean on the expectation effect should ask whether the experience actually delivers on the framing they're using.
+
+## Sources informing this principle
+
+- Beecher, H. (1955). The powerful placebo. *JAMA*.
+- Wager, T. D., et al. (2004). Placebo-induced changes in fMRI in the anticipation and experience of pain. *Science*.
+- Allison, R. I., & Uhl, K. P. (1964). Influence of beer brand identification on taste perception. *Journal of Marketing Research*.
+- Shiv, B., Carmon, Z., & Ariely, D. (2005). Placebo effects of marketing actions. *Journal of Marketing Research*.
+- Wansink, B. (2006). *Mindless Eating: Why We Eat More Than We Think*.
+- Fogg, B. J., et al. (2003). How do users evaluate the credibility of Web sites? *Stanford Persuasive Technology Lab*.
+- Lavie, T., & Tractinsky, N. (2004). Assessing dimensions of perceived visual aesthetics of web sites. *International Journal of Human-Computer Studies*.
+- Norman, D. (2004). *Emotional Design*. (On the visceral, behavioral, and reflective levels of product perception.)

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop-positive-vs-negative/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop-positive-vs-negative/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: feedback-loop-positive-vs-negative
+description: 'Use this skill when designing system architecture or product mechanics that involve feedback loops at a higher level than UI state — recommendation engines, gamification, growth mechanics, engagement systems, or any system where one user action affects subsequent actions in compounding or stabilizing ways. Trigger when designing growth loops, retention features, or system dynamics; when reviewing a feature for unintended consequences; when discussing engagement vs. wellbeing tradeoffs. Sub-aspect of `feedback-loop`; read that first.'
+---
+
+# Positive vs. negative feedback loops
+
+The book's distinction between *positive* (amplifying) and *negative* (stabilizing) feedback loops scales beyond UI states to system-level mechanics. Most product UI feedback is negative (stabilizing). But growth, engagement, and recommendation systems often use positive loops — and those carry risks the football-helmet case illustrates.
+
+## Positive feedback loops
+
+A positive loop's response amplifies the original input. More leads to more.
+
+Examples in software:
+
+- **Recommendation engines**: a click teaches the system; the system shows more like it; the user clicks more.
+- **Streak counters**: each day of use raises the cost of breaking the streak.
+- **Viral growth loops**: each new user can invite others; each invitation creates more users.
+- **Network effects**: more users → more value → more users.
+- **Engagement bait**: more time spent → more revenue → more reasons to optimize for engagement.
+
+Positive loops are powerful. They produce dramatic growth, viral effects, and addictive engagement. They also produce runaway dynamics if uncoupled from a moderating mechanism.
+
+### When positive loops harm
+
+The book's example: 1950s football. New plastic-with-padding helmets felt safer; players tackled more aggressively; head/neck injuries rose; designers added more padding; aggression rose further. The loop ran unchecked because no moderating mechanism (rules against helmet-first tackling) existed until much later.
+
+Software analogs:
+
+- **Filter bubbles**: recommendation engines that converge users on increasingly narrow content.
+- **Engagement-as-metric**: products optimized for time-on-app eventually optimize for hooks at the expense of user welfare.
+- **Streak anxiety**: features designed to drive habit can become sources of stress; users feel obligated rather than served.
+- **Notification escalation**: each user disengagement is met with more aggressive notifications; users disengage further.
+
+The pattern: the loop's metric and the user's welfare diverge. The system optimizes for the metric; the user suffers.
+
+## Negative feedback loops
+
+A negative loop's response counteracts the original input, returning the system toward equilibrium.
+
+Examples:
+
+- **Auto-save**: every edit triggers save; the system stays in a known-saved state.
+- **Form validation**: invalid input → flag → user corrects → equilibrium.
+- **Rate limiting**: too many requests → throttle → user adjusts pace → equilibrium.
+- **Auto-correct**: typos detected → correction offered → text returns to "intended" state.
+- **Thermostatic feedback** in any responsive UI: oscillates around a desired state.
+
+Most product UI is appropriately negative-loop dominant. The user acts; the system stabilizes; the user trusts the system.
+
+## Pairing loops: positive moderated by negative
+
+Healthy systems often pair the two: a positive growth loop moderated by a negative quality loop.
+
+Examples:
+
+- **Recommendation system + diversity injection**: the recommender amplifies similar content; the diversity mechanism injects unfamiliar content to prevent over-narrowing.
+- **Engagement metrics + friction**: a product driven by engagement adds explicit "are you done?" prompts to nudge users away when they've spent too long.
+- **Viral growth + spam controls**: invitation features paired with rate limits and consent mechanisms.
+
+The discipline: when introducing a positive loop, ask "what's the moderating loop that prevents runaway?" If you don't have an answer, the positive loop will eventually produce harms you didn't predict.
+
+## Designing loops responsibly
+
+A few questions to ask before introducing a positive loop:
+
+1. **What metric does this loop optimize for?**
+2. **Does the metric track user welfare, or only platform welfare?**
+3. **What's the moderating mechanism?**
+4. **What does runaway look like?**
+5. **Who is harmed if the loop runs unchecked?**
+
+If the answers reveal harms, redesign the loop or add explicit moderation.
+
+## Worked examples
+
+### Example 1: a recommendation system with diversity
+
+```
+[ User clicks article ]
+        ↓
+[ Recommender notes click ]
+        ↓
+[ Show more like it ]   ← positive loop
+        ↓
+[ Track diversity score ] ← moderating loop
+        ↓
+[ When diversity drops, inject unfamiliar content ]
+```
+
+The positive loop drives engagement; the diversity loop prevents narrowing.
+
+### Example 2: a growth loop with consent guardrails
+
+```
+[ User signs up ]
+        ↓
+[ Prompt to invite friends ]   ← positive growth
+        ↓
+[ Friends sign up ]
+        ↓
+[ Cap invitations per day ]    ← moderating loop
+        ↓
+[ Allow opt-out for invitations ]
+```
+
+The growth loop drives signups; the cap and opt-out prevent spam.
+
+### Example 3: an engagement system with wellbeing checks
+
+```
+[ User opens app ]
+        ↓
+[ Track session time ]
+        ↓
+[ After threshold, suggest break ]   ← moderating loop
+        ↓
+[ User wellbeing prompts ]           ← explicit pause
+```
+
+Apps designed for sustainable use rather than maximum engagement build moderating loops in.
+
+## Anti-patterns
+
+- **Pure positive loops in engagement**: gamified streaks with no off-ramp. Users feel trapped.
+- **Recommender systems without diversity**: filter bubbles, echo chambers.
+- **Growth loops without consent**: viral invitation systems that send messages without user knowledge.
+- **Optimization for metrics that don't track user benefit**: time-on-app driven up at the expense of user wellbeing.
+- **Loops that amplify already-skewed distributions**: rich-get-richer dynamics in social media (the user with 10,000 followers gets shown to more people; the user with 100 stays invisible).
+
+## Heuristics
+
+1. **The "what's the moderating loop?" check.** For each positive loop in your system, name the negative loop that prevents runaway. If you can't, design one.
+2. **The runaway-scenario thought experiment.** Imagine the positive loop running unchecked for a year. What's the worst plausible outcome? Design against it.
+3. **The metric-vs-welfare audit.** Does your loop's optimization metric track user welfare? If they diverge, the loop will eventually harm users.
+4. **The opt-out check.** Can the user disengage from the loop? If not, you've trapped them.
+
+## Related sub-skills
+
+- **`feedback-loop`** (parent).
+- **`feedback-loop-states-and-latency`** — loop implementation at the UI level.
+- **`nudge`** (interaction) — small choice-architecture decisions that shape loops.
+- **`operant-conditioning`** (interaction) — the psychology behind some positive engagement loops.
+
+## Resources
+
+- **Wiener, N.** *Cybernetics* (1948).
+- **Forrester, J. W.** *Industrial Dynamics* (1961); *Urban Dynamics* (1969).
+- **Senge, P.** *The Fifth Discipline* (1990) — systems thinking applied to organizations.
+- **Center for Humane Technology** — modern advocacy on harm-aware loop design.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop-positive-vs-negative/references/system-dynamics-and-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop-positive-vs-negative/references/system-dynamics-and-cases.md
@@ -1,0 +1,112 @@
+# Positive vs. negative loops: system-dynamics reference
+
+A reference complementing `feedback-loop-positive-vs-negative` with system-dynamics vocabulary and case studies.
+
+## System-dynamics vocabulary
+
+From Forrester's *Industrial Dynamics* and the broader system-dynamics tradition:
+
+- **Stock**: a quantity that accumulates over time (users, money, inventory, attention).
+- **Flow**: the rate at which a stock changes (sign-ups per day, churn per month).
+- **Reinforcing loop** (positive): one variable's change amplifies the next variable in the loop.
+- **Balancing loop** (negative): one variable's change is counteracted by another.
+- **Delay**: time between an action and its visible effect; delays cause oscillation in feedback loops.
+
+## The football-helmet case in detail
+
+The book's example illustrates a *runaway positive loop*:
+
+```
+[ Better helmets ] →+ [ Players feel safer ]
+                          ↓+
+                     [ More aggressive tackling ]
+                          ↓+
+                     [ More head/neck injuries ]
+                          ↓+
+                     [ Designers add more padding ]
+                          ↓+
+                     [ Better helmets ] (loop closes)
+```
+
+No balancing mechanism (rules against helmet-first tackling) existed; the loop ran unchecked for decades. Eventually moderating mechanisms were added (rule changes, public-health awareness, technique training).
+
+The pattern recurs: a well-intentioned design intervention triggers behavior changes that defeat the original goal.
+
+## Software cases
+
+### Filter bubbles
+
+```
+[ User clicks recommendation ] →+ [ Recommender boosts similar content ]
+                                       ↓+
+                                  [ User sees more similar content ]
+                                       ↓+
+                                  [ User clicks more similar content ]
+```
+
+Without a diversity-injection balancing loop, the user's content world narrows.
+
+### Engagement-as-metric
+
+```
+[ Optimize for time-on-app ] →+ [ Add hooks: notifications, streaks, autoplay ]
+                                       ↓+
+                                  [ Users spend more time ]
+                                       ↓+
+                                  [ Metric improves ]
+                                       ↓+
+                                  [ More resources to optimize for engagement ]
+```
+
+The metric improves; user wellbeing may decline. Without a wellbeing-tracking balancing loop, the optimization continues past the user's interest.
+
+### Spam invitation systems
+
+```
+[ User signs up ] →+ [ Prompted to invite contacts ]
+                          ↓+
+                     [ Contacts receive invitation ]
+                          ↓+
+                     [ Some sign up ]
+                          ↓+
+                     [ More invitations sent ]
+```
+
+Some early-2010s products produced viral growth through aggressive invitation prompts; the loops worked but generated spam complaints, regulatory attention, and user resentment. Modern equivalents add explicit consent and rate limits.
+
+## Healthy patterns: paired loops
+
+Sustainable systems pair positive and negative loops:
+
+### Recommendation + diversity
+
+A positive loop amplifies similar content; a balancing loop injects unfamiliar content periodically. Spotify's "Discover Weekly" and similar features explicitly balance the recommender's tendency to converge.
+
+### Growth + quality
+
+A positive growth loop drives signups; a balancing quality loop (onboarding requirements, fraud detection, paid conversion) maintains user quality.
+
+### Engagement + wellbeing
+
+Apple's Screen Time and Android's Digital Wellbeing add explicit moderating loops to the engagement-driven mobile environment. Whether they're enough is debated, but the design move is right: when a system has strong positive engagement loops, build moderating loops in.
+
+## Diagnostic questions
+
+For any system with a positive feedback loop:
+
+1. **What's the loop optimizing for?**
+2. **Whose interest does that metric serve?**
+3. **What's the balancing loop?**
+4. **What does runaway look like at 1 year? 5 years?**
+5. **Who is harmed if runaway happens?**
+
+If answers reveal harms or have no balancing mechanism, redesign.
+
+## Resources
+
+- **Wiener, N.** *Cybernetics* (1948).
+- **Forrester, J. W.** *Industrial Dynamics* (1961).
+- **Senge, P.** *The Fifth Discipline* (1990) — popularized system-dynamics thinking for management.
+- **Meadows, D.** *Thinking in Systems* (2008) — accessible introduction.
+- **Center for Humane Technology** (humanetech.com) — modern advocacy on feedback-loop design and harm.
+- **Doctorow, C.** writings on enshittification — runaway positive loops in platform economics.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop-states-and-latency/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop-states-and-latency/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: feedback-loop-states-and-latency
+description: 'Use this skill when designing the visible states an interactive element passes through (idle / pending / success / error) and matching feedback timing to the user''s perceptual thresholds. Trigger when designing button states, form-submit flows, file-upload progress, loading screens, or any interaction whose response time is variable. Sub-aspect of `feedback-loop`; read that first.'
+---
+
+# Feedback states and latency thresholds
+
+Most interactive actions pass through a small set of visible states; the system must communicate each. The latency of each state determines what feedback is appropriate — a 50ms response needs no spinner, a 5s response needs progress info, a 50s response needs estimated time remaining.
+
+## The four states
+
+### Idle
+The element is interactive and waiting. Affordance signals "you can do this." Static styling.
+
+### Pending
+Action triggered; system working. Disable trigger to prevent re-submit; show indicator if wait > ~500ms.
+
+### Success
+Action succeeded. Show the result in-place where possible; toast/banner if the result is on another surface.
+
+### Error
+Action failed. In-context, specific, actionable error message.
+
+```html
+<button id="action" data-state="idle">
+  <span class="label">Save</span>
+  <span class="spinner" hidden></span>
+</button>
+
+<style>
+  button[data-state="pending"] { cursor: wait; opacity: 0.7; }
+  button[data-state="pending"] .spinner { display: inline-block; }
+  button[data-state="success"] { background: var(--success); }
+  button[data-state="error"] { background: var(--destructive); }
+</style>
+```
+
+## Latency thresholds (Miller, Card et al., Doherty)
+
+| Latency | Threshold | Pattern |
+|---|---|---|
+| < 100ms | "Instant" | No indicator. Just respond. |
+| 100–400ms | "Responsive" | Light state change (button briefly disabled). |
+| 400ms–1s | "Noticeable" | Spinner or progress micro-animation. |
+| 1–10s | "Waiting" | Spinner with status text. |
+| > 10s | "Long" | Progress bar with estimated time remaining; cancel option. |
+
+**Doherty Threshold (~400ms)**: response times under this keep users in flow. Above this, attention drifts and engagement drops.
+
+## Optimistic UI
+
+For actions where the success rate is high and the action is reversible, update the UI as if the action succeeded immediately, then commit in the background. If the action fails, roll back visibly with an error message.
+
+```js
+async function toggleStar(item) {
+  // Optimistic
+  item.starred = !item.starred;
+  render();
+
+  try {
+    await api.updateStar(item.id, item.starred);
+  } catch (err) {
+    // Rollback with feedback
+    item.starred = !item.starred;
+    render();
+    showToast(`Couldn't update: ${err.message}`);
+  }
+}
+```
+
+The user gets instant feedback; failure is the exception, handled with explicit feedback.
+
+## Skeleton screens vs. spinners
+
+For loading content (not actions), prefer **skeleton screens** to spinners:
+
+```html
+<!-- While data loads -->
+<article class="post-skeleton">
+  <div class="title-skel"></div>
+  <div class="meta-skel"></div>
+  <div class="body-skel"></div>
+  <div class="body-skel"></div>
+</article>
+```
+
+Skeletons:
+- Show the page's structure immediately.
+- Reduce perceived load time.
+- Reduce visual disruption when real content arrives.
+
+Spinners are better when the wait isn't structural (a single action's pending state) or when the location of the result isn't predictable.
+
+## Progress indicators for long operations
+
+For operations > 10s:
+- **Determinate progress bar** (when % complete is known) with status text.
+- **Time-remaining estimate** (after enough data to estimate accurately).
+- **Cancel option** (don't trap the user in a stuck operation).
+- **Background continuation** option for very long ops (let them work elsewhere).
+
+```html
+<div class="upload">
+  <p>Uploading <strong>file.zip</strong></p>
+  <progress max="100" value="42">42%</progress>
+  <p class="status">42% — about 2 minutes remaining</p>
+  <button>Cancel</button>
+</div>
+```
+
+## Error feedback: in-context
+
+Errors should appear with the element that caused them, not in a generic page banner.
+
+```html
+<div class="field" data-state="error">
+  <label for="email">Email</label>
+  <input id="email" type="email" aria-invalid="true" aria-describedby="email-error" />
+  <p id="email-error" class="error">
+    We couldn't find an account with this email.
+    <a href="/signup">Sign up?</a>
+  </p>
+</div>
+```
+
+`aria-invalid` and `aria-describedby` make the error programmatically associated; screen readers announce both together.
+
+## Anti-patterns
+
+- **Silent commits.** Button submits with no visible response.
+- **Blink-and-miss success.** Confirmation appears for 100ms.
+- **Generic errors.** "Something went wrong" with no specific or actionable info.
+- **Spam confirmations.** Every save shows a "Saved!" toast users dismiss on autopilot.
+- **Wrong state colors.** Pending state same color as success.
+- **Spinners over content the user is reading.** Distracting; use skeleton or peripheral indicator.
+
+## Heuristics
+
+1. **The "what state am I in?" check.** At any moment during an action, can the user tell which of the four states they're in? If not, feedback is missing.
+2. **The latency-stopwatch.** Time each major action. Match feedback to the threshold the action falls into.
+3. **The error-recovery audit.** For each error feedback, can the user tell what to do next? If "no idea," rewrite the message.
+
+## Related sub-skills
+
+- **`feedback-loop`** (parent).
+- **`feedback-loop-positive-vs-negative`** — loop architecture; this skill is loop *implementation*.
+- **`accessibility-operable`** — `aria-live` regions communicate states to screen readers.
+- **`forgiveness`** — error feedback is recovery's first step.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop-states-and-latency/references/latency-thresholds-and-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop-states-and-latency/references/latency-thresholds-and-patterns.md
@@ -1,0 +1,133 @@
+# Latency thresholds and feedback-state patterns
+
+A reference complementing `feedback-loop-states-and-latency` with the empirical research and pattern catalog.
+
+## Latency-threshold research timeline
+
+- **Miller (1968)** "Response time in man-computer conversational transactions" — first systematic study of computer response times. Established the < 100ms / < 1s / < 10s thresholds.
+- **Doherty & Thadani (1982)** "The Economic Value of Rapid Response Time" (IBM) — refined the threshold to ~400ms; demonstrated productivity correlations.
+- **Card, Robertson, Mackinlay (1991)** *The Information Visualizer* — formalized thresholds for the modern HCI canon.
+- **Nielsen (1993)** *Usability Engineering* — popularized the thresholds for web design.
+- **Google (2020+)** Core Web Vitals — operationalized the thresholds as web performance metrics (LCP, INP, CLS).
+
+The numbers vary slightly across studies, but the shape is consistent: under 100ms feels instant, under 1s feels responsive, under 10s keeps attention, beyond 10s requires explicit progress information.
+
+## Modern web-performance budgets
+
+Google's Core Web Vitals targets (passing):
+
+- **Largest Contentful Paint (LCP)**: < 2.5s. The largest visible content rendering time.
+- **Interaction to Next Paint (INP)**: < 200ms. Responsiveness to user input.
+- **Cumulative Layout Shift (CLS)**: < 0.1. Visual stability — feedback shouldn't cause jumps.
+
+Hitting these correlates with measurably better user engagement and SEO ranking.
+
+## State-pattern catalog
+
+### Buttons and triggers
+
+```
+Idle:     normal styling, cursor pointer
+Hover:    background shift, subtle elevation
+Focus:    visible focus ring
+Pending:  disabled, spinner or label change
+Success:  brief check icon or color flash, return to idle
+Error:    error styling near the button, optional icon
+Disabled: lower opacity, cursor not-allowed
+```
+
+### Form fields
+
+```
+Idle:     normal styling
+Focus:    border color change, focus ring
+Validating: subtle indicator (spinner in field corner)
+Valid:    optional success indicator (check)
+Invalid:  red border + aria-invalid + inline error message
+Disabled: lower opacity, cursor not-allowed
+Read-only: muted background, no focus outline activation
+```
+
+### Navigation links
+
+```
+Idle:     normal styling
+Hover:    underline or color shift
+Focus:    visible focus ring
+Active:   current-page highlight (aria-current="page")
+Visited:  optional muted color (mostly for content links)
+```
+
+### Async operations (data fetches)
+
+```
+Initial:  skeleton placeholder
+Loading:  spinner or shimmer animation
+Success:  content fills in, optionally with a brief fade-in
+Empty:    designed empty state, not blank screen
+Error:    error message + retry button
+Stale:    indicator that data may be outdated
+```
+
+## Optimistic UI patterns
+
+Optimistic UI updates the interface as if the action succeeded, then commits in the background. Effective for actions where:
+
+- Success rate is high (> 95%).
+- The action is reversible.
+- Latency would otherwise be perceptible.
+
+```js
+async function archive(item) {
+  const previous = items.slice();
+  items = items.filter(i => i.id !== item.id);
+  render();
+  try {
+    await api.archive(item.id);
+  } catch (err) {
+    items = previous;
+    render();
+    showToast(`Couldn't archive: ${err.message}`);
+  }
+}
+```
+
+The user gets instant feedback; failures are explicit but rare.
+
+## Skeleton screens
+
+Skeleton screens (Lucas Cobb, 2013) replace spinners for content loading. They show the page's structure with placeholder shapes that fill in as data arrives:
+
+```html
+<article class="post post--skeleton">
+  <div class="title-skel"></div>
+  <div class="meta-skel"></div>
+  <div class="body-skel"></div>
+</article>
+
+<style>
+.post--skeleton .title-skel,
+.post--skeleton .meta-skel,
+.post--skeleton .body-skel {
+  background: linear-gradient(90deg, #eee, #f5f5f5, #eee);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s infinite;
+}
+@keyframes shimmer { to { background-position: -200% 0; } }
+</style>
+```
+
+Skeletons measurably reduce perceived load time vs. spinners — the page feels alive even before content arrives.
+
+## Anti-patterns
+
+- **Spinners that hide content the user could be reading.** Use skeletons or peripheral indicators.
+- **Animations that fight content.** A pulsing badge near a critical number distracts.
+- **State changes without visual transitions.** Jarring jumps; users don't notice the change.
+- **Inconsistent state styling across the app.** Each surface re-learns the visual language.
+
+## Resources
+
+- **web.dev / Core Web Vitals** documentation.
+- **Material Design motion guide** — well-documented state transitions.
+- **NN/g articles on response time and feedback patterns**.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: feedback-loop
+description: 'Use this skill whenever a user takes an action and the system must communicate that the action was received, is in progress, succeeded, or failed. Trigger when designing button states, form submission, file uploads, payment flows, real-time UI updates, loading states, error states, success confirmations, or any moment when the user is waiting for the system to do something. Trigger when the user mentions "feels broken," "doesn''t seem to work," "users keep clicking again," or any symptom of feedback gaps. Feedback Loop is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) — and one of the principles whose absence most reliably damages a product''s perceived quality.'
+---
+
+# Feedback Loop
+
+A feedback loop is the relationship between an action and the visible response that confirms the action happened. Every system in nature is composed of interacting feedback loops; every interface is too. When users press a button, type a character, drag an item, or commit a transaction, the system must respond — promptly, visibly, and unambiguously — to close the loop. Without that response, the user doesn't know whether the action registered, whether the system is working, or whether to try again. The cumulative effect of weak feedback is a product that feels broken even when it isn't.
+
+## Definition (in our own words)
+
+A feedback loop in interaction design is the mechanism by which the system tells the user "I received your action and here's what's happening." Loops can be *positive* (amplifying — repeated actions create accelerating change, like clicking a "+1" button that animates and grows the count) or *negative* (dampening — bringing the system back to a stable state, like a thermostat or a Segway maintaining balance). The most important loops in product UI are usually negative: the user acts; the system confirms; equilibrium is restored. When loops are missing or delayed, users repeat actions, doubt the system, or assume failure.
+
+## Origins and research lineage
+
+- **Cybernetics** (Norbert Wiener, 1948 onward). The mathematical theory of feedback in systems — biological, mechanical, and social. The intellectual foundation for everything that follows in HCI feedback design.
+- **Jay W. Forrester**, *Industrial Dynamics* (MIT Press, 1961) and *Urban Dynamics* (1969). Applied feedback-loop thinking to organizational and urban systems. Introduced the diagrams (causal loop diagrams, stock-and-flow diagrams) still used in systems analysis.
+- **Donald Norman**, *The Design of Everyday Things* (1988). Made feedback one of the central UI principles. Norman's gulf of evaluation — the gap between the user's intent and the system's perceptible state — is essentially the absence of good feedback.
+- **Lidwell, Holden & Butler** (2003) compactly distinguished positive feedback loops (amplifying — useful for change but risky if unmoderated) from negative feedback loops (stabilizing — useful for equilibrium). The book's central case: 1950s football helmets that created a positive feedback loop (more padding → more risk-taking → more injuries → more padding).
+- **Modern HCI heuristics** (Nielsen's 10 heuristics, 1994 onward). "Visibility of system status" — the first of Nielsen's 10 — is essentially the feedback principle named for usability practice.
+- **Doherty Threshold** (Doherty & Thadani, IBM, 1982). Empirical research showing that response times under 400ms keep users in flow; longer delays break engagement.
+
+## Why feedback matters
+
+Every interaction is a tacit contract: the user gives an input expecting some response. Without the response, the user is left in ambiguity. They may:
+
+- **Repeat the action** (clicking again, typing again, refreshing). Often produces unintended duplicate effects.
+- **Doubt their input** ("did I press it hard enough?", "did it register?").
+- **Assume system failure** and abandon.
+- **Develop ritualistic habits** (always pressing twice, always checking twice).
+- **Stop trusting the system**.
+
+The cost compounds: each weak feedback moment is a small tax; thousands of moments across a product become a perception of unreliability that no individual feature can repair.
+
+The reverse is also true: tight, unambiguous feedback creates confidence. The user acts, sees the system respond, and feels in command. This is what well-engineered software feels like — at the perceptual level, before the user evaluates any specific feature.
+
+## Positive vs. negative feedback loops
+
+The book's distinction matters in practice:
+
+### Positive feedback loops (amplifying)
+
+The system's response to an action makes future similar actions more likely or more impactful. Examples:
+
+- **Recommendation engines**: a user clicks a recommendation; the system learns and shows more like it; the user clicks more; the system learns more. Eventually homogeneous content; "filter bubble" risk.
+- **Streak counters**: each consecutive day of use makes the user more invested in not missing a day. Engagement amplifies.
+- **Viral product growth**: each new user invites others; each invitation creates more new users. Exponential growth — when it works.
+
+Positive loops produce change, sometimes dramatic. Without moderation by a counter-loop, they run away (the football-helmet example: more padding → more risk-taking → more injuries → more padding).
+
+### Negative feedback loops (stabilizing)
+
+The system's response brings things back toward an equilibrium. Examples:
+
+- **Form validation**: the user enters invalid input; the system flags it; the user corrects; equilibrium restored.
+- **Auto-save indicator**: "Saving..." → "Saved." Each save resets the system to a known-good state.
+- **Undo systems**: the user takes an action; if it's wrong, undo restores prior state.
+- **Real-time spell-check**: a typo creates instability; correcting restores it.
+
+Most product UI feedback is negative — the system absorbs user actions and returns to stability. Designs that lean too heavily on positive loops (gamification, streak anxiety, dopamine engineering) cross into manipulation.
+
+## When to apply
+
+- **Always**, on every interactive element. Every button, link, input, drag handle, toggle needs feedback.
+- **Especially** on actions whose result isn't immediately visible (background operations, server requests, multi-step flows).
+- **Critically** on destructive or irreversible actions where the user must know the action committed.
+- **Real-time** on continuous operations (drag, resize, scroll).
+- **Asynchronously** when the action's effect is delivered later (notifications, scheduled tasks).
+
+## Latency thresholds
+
+How fast feedback must appear depends on what's responding. The widely-cited thresholds (Miller 1968; Card, Robertson, Mackinlay 1991):
+
+- **< 100ms**: feels instant. No spinner needed; the user perceives immediate response.
+- **< 1 second**: feels responsive. No spinner needed unless something visible is taking time. The user maintains flow.
+- **1–10 seconds**: needs a visible indicator. Spinner, progress bar, status text. The user notices the wait.
+- **> 10 seconds**: needs progress information (estimated time remaining, percentage complete). The user is likely to abandon if the wait isn't justified.
+
+The Doherty threshold (Doherty & Thadani, 1982) refined the < 400ms range as the boundary at which response time stops feeling natural.
+
+## When NOT to over-apply
+
+- **Trivial confirmations.** Don't show "Loading..." for a 50ms response. The flicker is worse than no indicator.
+- **Continuous indicators that fight content.** A spinner that animates over the user's reading content is distracting. Place indicators in the periphery.
+- **Feedback for actions the user didn't take.** Auto-save indicators that appear without user input clutter the UI.
+- **Excessive haptic / sound feedback.** Each tap doesn't need to vibrate. Reserve haptics for moments that matter.
+
+## The four states of action feedback
+
+Most interactive actions have four states the system must communicate:
+
+### 1. Idle (resting)
+
+The element is interactive and ready. Affordance says "you can do this." Static styling.
+
+### 2. Pending (in progress)
+
+The action was triggered; the system is working. Common patterns:
+
+- **Disable the trigger** to prevent double-submission.
+- **Spinner or loading indicator** if the wait is > ~500ms.
+- **Button text changes** to "Saving...", "Sending...", "Loading..."
+- **Skeleton placeholder** for content that will fill in.
+
+```html
+<button id="save" type="submit">
+  <span class="label">Save</span>
+  <span class="spinner" hidden></span>
+</button>
+
+<script>
+const btn = document.getElementById('save');
+btn.addEventListener('click', async () => {
+  btn.disabled = true;
+  btn.querySelector('.label').textContent = 'Saving...';
+  btn.querySelector('.spinner').hidden = false;
+  try {
+    await save();
+    showSuccess();
+  } catch (err) {
+    showError(err);
+  } finally {
+    btn.disabled = false;
+    btn.querySelector('.label').textContent = 'Save';
+    btn.querySelector('.spinner').hidden = true;
+  }
+});
+</script>
+```
+
+### 3. Success
+
+The action succeeded. The result should be visible — preferably in-place (the row appears, the value updates) rather than via a generic "Saved!" toast that the user must trust.
+
+When in-place feedback isn't possible (the action's effect is on another page or in a backend), use a toast or banner with specific content ("Invoice #1284 sent to maria@acme.com").
+
+### 4. Error
+
+The action failed. Feedback must be:
+- **In-context** with the field or element that caused the error (not a generic top-of-page banner the user might miss).
+- **Specific** about what went wrong.
+- **Actionable** — what can the user do to recover.
+
+```html
+<div class="field" data-state="error">
+  <label for="email">Email</label>
+  <input id="email" type="email" aria-invalid="true" aria-describedby="email-error" />
+  <p id="email-error" class="error-message">
+    We couldn't find an account with this email. <a href="/signup">Sign up?</a>
+  </p>
+</div>
+```
+
+## Worked examples
+
+### Example 1: a form-submit button with all four states
+
+```html
+<form id="signup-form">
+  <input name="email" type="email" required />
+  <input name="password" type="password" required />
+  <button id="submit">Create account</button>
+  <p id="status" aria-live="polite"></p>
+</form>
+
+<script>
+const form = document.getElementById('signup-form');
+const btn = document.getElementById('submit');
+const status = document.getElementById('status');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  // Pending state
+  btn.disabled = true;
+  btn.textContent = 'Creating account...';
+  status.textContent = '';
+  try {
+    await createAccount(new FormData(form));
+    // Success state
+    status.textContent = 'Account created! Redirecting...';
+    setTimeout(() => location.href = '/welcome', 1500);
+  } catch (err) {
+    // Error state
+    btn.disabled = false;
+    btn.textContent = 'Create account';
+    status.textContent = `Couldn't create account: ${err.message}`;
+  }
+});
+</script>
+```
+
+Four states; user is never left wondering what happened.
+
+### Example 2: optimistic UI update with rollback on failure
+
+```js
+async function archive(item) {
+  // Optimistic: update UI immediately
+  const previous = items.slice();
+  items = items.filter(i => i.id !== item.id);
+  render();
+
+  try {
+    await api.archive(item.id);
+    // Implicit success — UI already reflects new state
+  } catch (err) {
+    // Rollback + error feedback
+    items = previous;
+    render();
+    showToast(`Archive failed: ${err.message}`);
+  }
+}
+```
+
+The UI feels instant; failure rolls back visibly with explicit feedback.
+
+### Example 3: long-running task with progress
+
+```html
+<div class="upload">
+  <p>Uploading <strong>vacation-photos.zip</strong></p>
+  <progress max="100" value="0" id="upload-progress">0%</progress>
+  <p id="upload-status">Preparing upload...</p>
+  <button id="cancel">Cancel</button>
+</div>
+
+<script>
+async function uploadWithProgress(file) {
+  const progress = document.getElementById('upload-progress');
+  const status = document.getElementById('upload-status');
+  const startTime = Date.now();
+
+  await uploadFile(file, {
+    onProgress: ({ loaded, total }) => {
+      const pct = Math.round(loaded / total * 100);
+      progress.value = pct;
+      const elapsed = (Date.now() - startTime) / 1000;
+      const rate = loaded / elapsed; // bytes/sec
+      const remaining = (total - loaded) / rate;
+      status.textContent = `${pct}% — ${formatTime(remaining)} remaining`;
+    }
+  });
+  status.textContent = 'Upload complete.';
+}
+</script>
+```
+
+Long-running task gets full progress feedback, including estimated time.
+
+### Example 4: real-time editing feedback
+
+```html
+<textarea id="post-body" oninput="autoSave()"></textarea>
+<p id="save-status" aria-live="polite">All changes saved</p>
+
+<script>
+let saveTimeout;
+let lastSaved = new Date();
+
+function autoSave() {
+  const status = document.getElementById('save-status');
+  status.textContent = 'Editing...';
+
+  clearTimeout(saveTimeout);
+  saveTimeout = setTimeout(async () => {
+    status.textContent = 'Saving...';
+    await api.savePost({ body: document.getElementById('post-body').value });
+    lastSaved = new Date();
+    status.textContent = `Saved at ${formatTime(lastSaved)}`;
+  }, 800);
+}
+</script>
+```
+
+Three states (editing, saving, saved) all visible. User knows the system is tracking their work.
+
+## Cross-domain examples
+
+### Industrial control: the Segway
+
+Lidwell, Holden, and Butler use the Segway as the example of a tightly-tuned negative feedback loop: the rider leans forward; the gyroscope detects the angle change; the motor adjusts wheel speed to maintain balance. This loop runs ~100 times per second. Coarser loops would produce visible oscillation; finer would be wasteful.
+
+The lesson for software: feedback frequency matches the dynamics of the user's actions. Real-time interactions need real-time feedback; slower actions can have slower feedback.
+
+### Aviation: stall warning systems
+
+A pilot pulling back on the yoke too aggressively gets immediate negative feedback: a stall warning horn, a stick-shaker, a yoke pusher. Each progressively forceful — early warnings let the pilot self-correct; late ones force correction. The graduated feedback gives the pilot agency at every level of urgency.
+
+Software analog: progressive validation. Soft inline hint → warning → block on submit → confirmation dialog for destructive.
+
+### Football helmets (the book's case)
+
+The classic positive-feedback-loop failure: in the 1950s, plastic-with-padding helmets replaced leather. Players felt safer; tackled more aggressively; head/neck injuries rose. Designers responded by adding more padding; players became even more aggressive; injuries rose further. The loop wasn't moderated by rules against helmet-first tackling until decades later.
+
+The lesson for software: positive loops without counter-mechanisms produce unintended consequences. A feature that drives engagement may drive it past the user's actual welfare; metrics that look good at first may create harms over time.
+
+### Thermostats
+
+The canonical example of a negative feedback loop. Too warm → cooling activates → temperature drops → cooling deactivates → temperature drifts up → cycle. The system maintains equilibrium without continuous user input.
+
+UI analog: any system that absorbs user actions and returns to a stable state — auto-save, undo, drift-corrected forms.
+
+## Anti-patterns
+
+- **Silent commits.** A button that submits a form with no visible response. Users click again; double-submission.
+- **Blink-and-miss feedback.** A success message that appears for 100ms before vanishing. Users miss it; doubt the action.
+- **Generic error messages.** "Something went wrong." User doesn't know what or how to fix.
+- **Wrong-channel feedback.** Errors as toasts that vanish; success as banners that linger. Mismatched persistence.
+- **No pending state.** Clicking save and seeing nothing for 3 seconds before the page refreshes. User clicks again.
+- **Spam confirmations.** Every routine action gets a "Done!" toast. User dismisses everything on autopilot.
+- **Decorative spinners.** A spinner that's not actually waiting on anything (purely visual). User loses trust when they realize.
+- **Hover-only feedback.** A button that only responds visually on hover. Touch users see no response on tap.
+
+## Heuristics
+
+1. **The "did it work?" test.** After any interaction, ask: can the user tell whether the action succeeded? If they have to guess, feedback is missing.
+2. **The double-click audit.** Watch users. Each unintended double-click is feedback that pending state was invisible.
+3. **The error-message audit.** Every error message in the app should answer: what happened, why, what to do next.
+4. **The latency-threshold check.** For each action, time it. Actions over 1s need a pending indicator; over 10s need progress info.
+5. **The accessibility check.** Visual feedback alone fails screen-reader users. Pair with `aria-live` regions for status changes.
+
+## Related principles
+
+- **`affordance`** — feedback completes the loop affordance starts.
+- **`forgiveness`** — feedback enables the recovery forgiveness depends on.
+- **`errors`** — error feedback is the most consequential feedback type.
+- **`mapping`** — feedback should map to the action that caused it.
+- **`expectation-effect`** — feedback that violates expectation creates surprise; align it.
+- **`accessibility-perceivable`** (process) — feedback must be perceivable across abilities.
+
+## Sub-aspect skills
+
+- **`feedback-loop-states-and-latency`** — designing the four states (idle, pending, success, error) and matching feedback to time thresholds.
+- **`feedback-loop-positive-vs-negative`** — choosing between amplifying and stabilizing loop architectures.
+
+## Closing
+
+Feedback is the principle that decides whether your product *feels* responsive. Every interaction that lacks visible response erodes trust at a perceptual level no specific feature can repair. Build feedback into every interactive element from the start; audit every "is this working?" complaint as a feedback gap; treat the four states as non-negotiable for any consequential action.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop/references/cybernetics-and-research.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/feedback-loop/references/cybernetics-and-research.md
@@ -1,0 +1,95 @@
+# Feedback loops: research and history reference
+
+A reference complementing the `feedback-loop` SKILL.md with deeper grounding in cybernetics and HCI feedback research.
+
+## Cybernetics: the foundational discipline
+
+Norbert Wiener coined the term *cybernetics* in 1948 as the study of control and communication in animals and machines. The central concept: *feedback* — a system's response to its own previous output — was identified as the mechanism that enabled adaptation, equilibrium, and learning across biological, mechanical, and social systems alike.
+
+Wiener's *Cybernetics: Or Control and Communication in the Animal and the Machine* (MIT Press, 1948) introduced the mathematical formalism that underpins control theory, modern robotics, and most reactive software systems.
+
+## Forrester and system dynamics
+
+Jay Forrester at MIT extended cybernetics into *system dynamics* — the study of complex systems whose behavior arises from feedback loops over time:
+
+- **Industrial Dynamics** (1961) — applied to corporate decision-making.
+- **Urban Dynamics** (1969) — applied to city growth and decline.
+- **World Dynamics** (1971) — applied to global resource and population trajectories (precursor to *Limits to Growth*).
+
+Forrester's diagrammatic conventions (causal-loop diagrams, stock-and-flow diagrams) are still used in systems analysis. The core insight: complex system behavior is rarely caused by single events; it's produced by the interaction of feedback loops.
+
+## HCI feedback research
+
+### Doherty Threshold (1982)
+
+Walter Doherty and Arvind Thadani at IBM published research showing that response times under approximately 400ms keep users engaged at peak productivity. Above this threshold, attention drifts, errors increase, and engagement drops. The "Doherty Threshold" became a benchmark for system responsiveness.
+
+Modern web-performance budgets (LCP < 2.5s, INP < 200ms) inherit this lineage.
+
+### Card, Robertson, Mackinlay (1991)
+
+Stuart Card and colleagues at Xerox PARC formalized the now-standard latency thresholds:
+
+- < 100ms: perceived as instantaneous.
+- < 1s: perceived as continuous flow.
+- < 10s: keeps user attention.
+- > 10s: user attention departs; needs progress indicator.
+
+Their *The Information Visualizer* paper documented these and influenced decades of HCI design.
+
+### Norman's gulfs (1986)
+
+Donald Norman introduced the concepts of:
+- **Gulf of execution**: the gap between what the user wants to do and the actions the system permits.
+- **Gulf of evaluation**: the gap between the system's state and the user's perception of it.
+
+Both gulfs are bridged by feedback. Good feedback closes the gulf of evaluation — the user perceives what the system did. Good affordance closes the gulf of execution — the user perceives what the system permits.
+
+### Nielsen's heuristics (1994)
+
+Jakob Nielsen's first usability heuristic: **"Visibility of system status."** The system should keep users informed about what is going on, through appropriate feedback within reasonable time. This restates Norman's principle as a usability rule.
+
+## Modern web-performance feedback
+
+The Core Web Vitals metrics (Google, 2020+) operationalize feedback latency:
+
+- **Largest Contentful Paint (LCP)**: time to render the largest visible content. Target < 2.5s.
+- **Interaction to Next Paint (INP)**: latency between user interaction and next visual update. Target < 200ms.
+- **Cumulative Layout Shift (CLS)**: visual stability — feedback shouldn't cause unexpected layout jumps.
+
+Each is a measurable feedback property. Sites that hit them feel responsive; sites that don't feel broken regardless of feature quality.
+
+## Cross-domain examples
+
+### Aircraft fly-by-wire
+
+Modern aircraft replace mechanical control linkages with electronic feedback systems. The pilot moves the stick; sensors detect the input; computers calculate the appropriate control-surface deflection; actuators apply it. Multiple negative feedback loops (stability augmentation, envelope protection) keep the plane within safe operating bounds.
+
+The same pattern in software: input layers → validation → controlled state change → visible response.
+
+### Thermostatic systems
+
+The canonical negative-feedback loop. The system maintains a setpoint by responding to deviations. Modern smart thermostats add positive feedback (learning user patterns and pre-empting demand) while preserving the negative-feedback core.
+
+### Biological systems
+
+Every regulatory mechanism in biology is a feedback loop: blood-glucose regulation, body temperature, blood pressure, cell-cycle checkpoints. Failure modes (diabetes, fever, hypertension) are loops gone wrong.
+
+The lesson: feedback isn't just a UI concept; it's a property of any system that maintains itself over time.
+
+## Anti-patterns from system-dynamics literature
+
+- **Shifting the burden**: addressing symptoms with fast feedback (a temporary fix) while underlying problems compound. The football-helmet case.
+- **Tragedy of the commons**: many positive loops sharing a finite resource; resource collapses.
+- **Eroding goals**: when the metric used by a feedback loop is itself relaxed when missed, the system drifts toward lower standards.
+- **Success to the successful**: positive loops that amplify initial advantages; rich-get-richer dynamics.
+
+## Resources
+
+- **Wiener, N.** *Cybernetics* (1948).
+- **Forrester, J. W.** *Industrial Dynamics* (1961); *Urban Dynamics* (1969).
+- **Senge, P.** *The Fifth Discipline* (1990).
+- **Meadows, D.** *Thinking in Systems* (2008) — accessible introduction to system-dynamics thinking.
+- **Doherty, W. & Thadani, A.** "The Economic Value of Rapid Response Time" (IBM, 1982).
+- **Norman, D.** *The Design of Everyday Things* (1988, 2013).
+- **web.dev / web-vitals docs** — modern web-performance feedback metrics.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-pointer-acceleration/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-pointer-acceleration/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: fitts-law-pointer-acceleration
+description: 'Use this skill when the question involves cursor speed, pointer acceleration curves, or interaction with input devices that vary in precision (mouse, trackpad, stylus, touchscreen, eye-tracking). Trigger when designing for varied input devices, building drag interactions, designing scrubbers / sliders / handles, or analyzing why a UI feels "fiddly." Sub-aspect of `fitts-law`; read that first if you haven''t already.'
+---
+
+# Fitts's Law and pointer acceleration
+
+The mouse and trackpad are not "raw" inputs — operating systems apply *acceleration curves* that translate physical movement into cursor displacement. Fast physical motion produces disproportionately fast cursor motion; slow physical motion produces precise, slow cursor motion. This curve interacts with Fitts's Law in ways that affect how target size and distance are perceived.
+
+## What pointer acceleration does
+
+A non-accelerated cursor maps physical motion to screen motion 1:1. To cross 1000 pixels, the user must move the mouse 1000 mouse-equivalent units. Fast or slow physical motion makes no difference to the resulting distance.
+
+An accelerated cursor varies the multiplier based on physical speed:
+
+- **Slow physical motion → low multiplier** (e.g., 0.5×). Used for precise positioning over small targets.
+- **Fast physical motion → high multiplier** (e.g., 3–8×). Used for crossing large screen distances quickly.
+
+The acceleration curve is what lets a single mouse on a 4K display traverse the full screen without lifting and re-anchoring (a problem 1990s mice without acceleration had).
+
+For Fitts's Law, this means:
+
+- **Distance is partly free.** Long traversals are accelerated, so movement time grows much less than the linear formula predicts.
+- **Target size still matters.** Once the user is *near* the target, they slow down for fine positioning, and target size dominates again.
+- **Trackpads and mice have different curves.** Same Fitts's task, different time outcomes.
+
+## Implications for UI design
+
+### 1. Distance matters less than naive Fitts's Law suggests on accelerated pointers
+
+A toolbar at the top of a 1440px-wide window vs. one halfway down: the difference in actual cursor travel time is smaller than the geometric distance suggests. Don't sacrifice layout sense to "place everything close together" — acceleration absorbs much of the cost.
+
+### 2. Target size matters *more* than naive Fitts's Law suggests near the target
+
+When the cursor decelerates for fine positioning, small targets become disproportionately hard. A 16×16 button is much harder than a 24×24 button — more than the 50% size increase would suggest, because deceleration phase amplifies precision cost.
+
+The takeaway: when in doubt, prefer *bigger* targets to *closer* targets. Acceleration handles distance; nothing handles fine-positioning except size.
+
+### 3. Drag operations are sensitive to acceleration
+
+A drag-and-drop interaction asks the user to move while pressing the button. Acceleration is still active, so a small physical motion can become a large cursor motion. This causes:
+
+- **Overshoot on rapid drags.** The user releases past the target.
+- **Jitter on fine drags.** Slow drags feel "sticky" or imprecise as the curve transitions.
+
+Mitigations:
+
+- **Provide visible drop zones** that are larger than the dragged item's footprint. The user has slop room.
+- **Snap-to-grid or snap-to-target** for positioning interactions. Reduces precision burden.
+- **Hold-modifier for fine control.** Hold `Shift` (or similar) to disable acceleration during drag. Common in drawing and layout tools.
+
+### 4. Sliders and scrubbers benefit from gain control
+
+A volume slider, a video scrubber, a date-range picker: the user is dragging to a precise value. With raw acceleration, large values are easy to skip past.
+
+Patterns:
+
+- **Variable gain on slider drag.** Drag near the slider track for fast scrubbing; drag away from the track (off-axis) for fine scrubbing. iOS scrubbers use this.
+- **Snap-to-tick** for slider values that should land on integers or other discrete values.
+- **Display the current value during drag** so the user can correct without lifting.
+
+### 5. Different input devices, different curves
+
+The same web app is used with:
+
+- **Desktop mouse** — moderate acceleration, medium precision.
+- **Trackpad** — high acceleration, lower precision (small physical surface), gestures.
+- **Stylus / pen** — low/no acceleration, high precision.
+- **Touchscreen** — no acceleration (1:1), but finger contact width adds imprecision.
+- **Eye-tracking** — low precision, no fine positioning, dwell-based selection.
+
+A UI that works on a 27" monitor with a precise mouse may be unusable with a trackpad on a 13" laptop. Test both.
+
+For accessibility:
+
+- **Switch devices** (single-button accessibility input) — every interactive element must be reachable through scanning, not pointer acquisition.
+- **Sip-and-puff and other adaptive devices** — same.
+
+## Worked examples
+
+### Example 1: a slider with click-to-position
+
+```html
+<input type="range" min="0" max="100" value="50" />
+```
+
+Native `<input type="range">` works across input devices. The user can click anywhere on the track to jump to that value (no drag required); drag the thumb for fine adjustment; tap arrow keys for precise stepping. All of this is built in.
+
+For custom sliders:
+
+- **Make the track full-width clickable** (not just the thumb).
+- **Make the thumb hit area ≥ 24×24** (often the visible thumb is smaller, but the hit area extends).
+- **Support arrow keys** for keyboard increment.
+
+### Example 2: a draggable list item
+
+```html
+<li draggable="true" class="task">
+  <span class="drag-handle" aria-label="Drag to reorder">⋮⋮</span>
+  Task name
+</li>
+```
+
+The drag handle is visually small but should have a 32×32+ hit area. During drag:
+
+- Show a visible placeholder where the item will drop (large drop target).
+- Display drop indicators between rows.
+- Provide a keyboard alternative (e.g., arrow keys to reorder) for users who can't drag.
+
+### Example 3: a color picker
+
+A 256×256 color square asks for very fine positioning (each pixel = a different color). Pointer acceleration makes this hard.
+
+Mitigations:
+
+- Provide numeric inputs (RGB / HSL / HEX) for users who need precision.
+- Provide preset palette swatches for common selections.
+- Allow `Shift+click` (or another modifier) for fine-position mode.
+
+### Example 4: pinch-and-zoom (touch)
+
+Touch has no acceleration, but two-finger gestures benefit from velocity-aware behavior:
+
+- **Slow pinch** = precise zoom (small zoom factor change per pixel).
+- **Fast pinch** = rapid zoom (larger zoom factor change per pixel).
+
+Implementations: track pinch velocity; multiply zoom delta by a function of velocity.
+
+## Anti-patterns
+
+- **Custom sliders without keyboard support.** A drag-only slider is unusable for keyboard, switch-device, and many assistive-tech users. Always support arrow-key increment.
+- **Tiny drag handles.** A 16×16 drag handle on a list row. The user can't reliably grab it; reordering becomes painful.
+- **Drag-only reordering.** Reordering that requires drag-and-drop with no keyboard alternative. Inaccessible by default.
+- **No snap on positioning.** A drag-to-arrange canvas with no grid, no snap-to-edge, no align-with-neighbor. Every placement requires fine positioning that pointer acceleration sabotages.
+- **Hover-precision interactions.** A hover-only menu where the dropdown is below the trigger and the user must traverse a wedge-shaped path to reach the items. The trackpad user, with high acceleration, overshoots into adjacent menu items. Either use click-to-open or design wider safe traversal areas.
+
+## Heuristics
+
+1. **Test on a trackpad.** If your interaction requires a mouse to be usable, it's broken for ~half your users.
+2. **Test with arrow keys.** Every interactive element should respond meaningfully to keyboard alternatives. (This is also accessibility.)
+3. **The fine-positioning audit.** Walk through every interaction that asks for precision. Is there a coarser alternative (typed value, snap, increment buttons)?
+
+## Related sub-skills
+
+- **`fitts-law`** (parent).
+- **`fitts-law-touch-targets`** — touch has no acceleration but its own precision constraints.
+- **`affordance`** — drag handles need visible affordance.
+- **`accessibility-operable`** (process plugin) — pointer-precision interactions must have non-pointer alternatives.
+- **`mapping`** (cognition) — sliders and scrubbers map control motion to value change; mapping must be intuitive.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-pointer-acceleration/references/pointer-mechanics.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-pointer-acceleration/references/pointer-mechanics.md
@@ -1,0 +1,82 @@
+# Pointer mechanics: deeper reference
+
+A reference complementing `fitts-law-pointer-acceleration` with deeper detail on input devices and pointer behavior.
+
+## How pointer acceleration is computed
+
+Operating systems apply a **transfer function** that maps physical input motion to cursor motion. The function is non-linear:
+
+- Slow physical motion → roughly 1:1 mapping (precise positioning).
+- Medium physical motion → 1.5–3× multiplier (general use).
+- Fast physical motion → 3–10× multiplier (cross-screen traversal).
+
+The exact curves vary by OS and user setting. macOS allows tuning via "Tracking speed" in System Settings; Windows offers similar controls. Some users (gamers, designers) disable acceleration entirely for predictability.
+
+The trade-off:
+
+- **With acceleration**: faster cross-screen traversal; harder fine positioning at high speeds.
+- **Without acceleration**: predictable motion at all speeds; slow cross-screen traversal; less hand strain on small mice.
+
+For most software UI, default OS acceleration is fine. The main implication for designers: when you can't assume what the user's curve looks like, prefer designs that don't rely on fine pointer positioning.
+
+## Input devices and their characteristics
+
+| Device | Typical acceleration | Precision | Comfort for fine work |
+|---|---|---|---|
+| Mouse | Medium | Good | Good |
+| Trackpad | High | Lower | Moderate |
+| Stylus / pen | None (1:1) | Very high | Excellent |
+| Touchscreen | None (1:1) | Limited by finger size | Poor for small targets |
+| Trackball | Medium | Good (after practice) | Good |
+| Eye tracking | None | Low (~1° visual angle) | Limited; dwell-based |
+| Switch device | N/A (scanning) | N/A | Slow; designed for accessibility |
+| VR controller | High (variable) | Moderate | Moderate; depends on tracking |
+
+A web app served to all of these must avoid designs that work only on the most precise devices.
+
+## Drag operations
+
+Drag is acceleration-sensitive in a way clicks aren't. While dragging, the user is committed — they can't pause to plan. A small physical motion can carry a large screen distance.
+
+Mitigations:
+
+- **Snap-to-grid.** Reduces precision burden; user lands on integer positions.
+- **Snap-to-target.** As the dragged item approaches a drop zone, attractor logic snaps it. Common in drawing apps.
+- **Visible drop zones.** A 100×100 drop area is much easier than a 10×10 target.
+- **Hold modifier for fine control.** Shift to disable acceleration during drag (common in design tools).
+- **Keyboard alternative.** Arrows + spacebar to reorder, for users who can't drag at all.
+
+## Scrubbers and sliders
+
+Sliders ask for precise positioning over a 1D range. Acceleration makes high-precision values hard to land on.
+
+Patterns:
+
+- **Variable-gain dragging.** Drag near the slider track for fast scrubbing; off-axis for fine. iOS scrubbers use this.
+- **Snap-to-tick.** For discrete values (1–10 ratings, integer dB).
+- **Visible value during drag.** So the user can correct without lifting.
+- **Numeric input alongside.** For values that benefit from typed precision.
+
+## Cross-domain examples
+
+### Color pickers
+
+A 256×256 color square asks for very fine positioning — every pixel is a different color. Plus typed RGB/HSL/HEX inputs (recognition over recall + numeric precision) and preset swatches (popular choices) to avoid forcing fine pointing.
+
+### Audio mixers
+
+DAWs (Logic, Ableton, Pro Tools) use both faders (drag with shift for fine control) and numeric inputs (type exact dB). The combination makes fader work fast and exact when needed.
+
+### Maps
+
+Map zoom buttons (+ / −) as discrete steps; pinch-to-zoom on touch; mouse wheel for continuous; double-click to zoom in to point. Multiple paths to the same goal, each suited to a different input device.
+
+## Resources
+
+- **MacKenzie, I. S.** *Human-Computer Interaction: An Empirical Research Perspective* (2013). Comprehensive coverage of input-device research.
+- **Card, Moran, Newell** *The Psychology of Human-Computer Interaction* (1983). Foundational HCI input research.
+- **OS-specific accessibility settings** — knowing how to test your own UI under different acceleration curves and pointer settings.
+
+## Closing
+
+Pointer acceleration is invisible when you're using your own machine and decisive when your user is on different hardware. Test on a trackpad, with arrows-only, with assistive switch input, with a stylus — and design for the union.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-screen-edges/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-screen-edges/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: fitts-law-screen-edges
+description: 'Use this skill when designing for the edges and corners of the screen — where the cursor cannot overshoot, making them effectively infinite-sized targets along one axis. Trigger when designing global navigation, system menus, sticky headers, fixed sidebars, full-bleed CTAs, or anywhere you can put the most-frequent or hardest-to-find actions. Trigger when reviewing an app that has wasteful margins on every side and asks the user to aim for tiny targets in the middle. Sub-aspect of `fitts-law`; read that first if you haven''t already.'
+---
+
+# Fitts's Law and the screen edge
+
+The screen edge is the most undervalued real estate in modern web UI. Because the cursor cannot move past the edge, an element placed flush against an edge is effectively *infinite* in size along the axis perpendicular to that edge — the user can fly the cursor past the screen boundary and the cursor stops on the target without precision.
+
+## Why edges matter
+
+The Fitts's Law equation depends on target width along the axis of motion:
+
+```
+T = a + b · log₂(D / W + 1)
+```
+
+When `W` approaches infinity, the log term collapses to nearly zero — the only remaining cost is the constant base time. This is why Mac's menu bar at the top edge is faster to acquire than a menu in a window: the cursor can fly upward without ever overshooting.
+
+Three consequences:
+
+1. **Edges are faster targets than mid-screen elements**, regardless of element size.
+2. **Corners are even faster** — they're "infinite" along *two* axes. The cursor can fly up-and-left to reach a top-left button without precision.
+3. **Modern web apps systematically waste this advantage** by adding margins, rounded containers, or "card layouts" that pull all interactive elements away from edges.
+
+## The classic examples
+
+- **macOS menu bar.** Top edge of the entire display. Reaching `File` is fast; reaching the menu inside an application window is slow. (Windows menus inside windows lose this advantage; one of the design debates of the 1990s.)
+- **Windows Start button.** Bottom-left corner of the display. Effectively infinite in two axes.
+- **iOS home indicator / app switcher gesture.** Bottom edge of the screen — your thumb can swipe up from past the edge and the gesture still registers.
+- **Browser back button (when in the browser chrome).** Top edge of the browser window.
+
+## What this means for web design
+
+### 1. Sticky headers earn their position
+
+A `position: fixed; top: 0` navigation bar puts global actions at the top edge, where the user can find them instantly without aiming. The trade-off is screen real estate — you've spent ~56px of vertical space.
+
+```html
+<header style="position: sticky; top: 0; z-index: 50; background: white; border-bottom: 1px solid hsl(0 0% 90%);">
+  <nav><!-- primary nav --></nav>
+</header>
+```
+
+The same nav placed mid-page (without sticking) is slower to reach when the user has scrolled.
+
+### 2. Bottom toolbars on mobile
+
+A bottom-anchored navigation bar on mobile combines:
+
+- Edge advantage (cursor / thumb can fly to the bottom and stop).
+- Thumb-reach advantage (lower screen is easier for thumb).
+- Persistent visibility (always reachable, no scrolling required).
+
+This is why mobile bottom-nav is the modern convention for primary navigation.
+
+### 3. Full-bleed CTAs
+
+A button that extends all the way to the screen edge is far easier to hit than the same button with 24px right margin. On mobile especially, "full-width" buttons are deliberately sized this way for Fitts's reasons.
+
+```html
+<!-- Full-bleed CTA: edge advantage on left and right -->
+<button style="width: 100%; padding: 16px; font-size: 16px;">Continue</button>
+```
+
+If the design feels like it "needs" margin around the button for aesthetic reasons, weigh the cost — you're spending speed for prettiness.
+
+### 4. Side panels and drawers
+
+A side panel that slides in from the right edge has the edge advantage on its right side: the user can fly the cursor right to reach the panel's controls without aiming. Same applies to bottom-sliding drawers.
+
+### 5. The corner advantage
+
+Corners are special. A button in a corner is the easiest target on the screen — the user can move toward both axes simultaneously without precision. Use this for:
+
+- **Account menus** (top-right corner is the convention).
+- **Close buttons on full-screen overlays** (top-right or top-left).
+- **FAB (floating action button)** on mobile (typically bottom-right corner).
+- **"Skip to content" links** (usually top-left, becomes visible on focus).
+
+## What to put at edges
+
+Not everything belongs at the edge. The edge is finite; spend it on the high-value content:
+
+- **Top edge:** global navigation, search, account menu. (Things the user needs *anywhere* in the app.)
+- **Bottom edge:** primary action on mobile (FAB, "Save," "Continue"); on desktop, status bars or persistent CTAs in conversion flows.
+- **Right edge:** detail panels, properties panes, contextual sidebars.
+- **Left edge:** primary navigation in app shells (sidebar nav).
+- **Corners:** the rarest, highest-value targets — close, account, primary global action.
+
+## Where the edge advantage is lost
+
+A few patterns that forfeit edge real estate:
+
+### "Card layout" pages with full margins
+
+Modern web apps often render content inside a `max-width: 1200px; margin: 0 auto;` container with 24–48px page margins. Everything interactive is now mid-screen; no edge advantage anywhere.
+
+This is sometimes the right trade-off (readable content width, breathing room, consistent layout across screen sizes), but it costs Fitts's Law performance. At minimum, ensure the global navigation chrome (sticky header, sidebar) does still use the edges.
+
+### Modal dialogs
+
+A modal dialog floating in the middle of the screen has *no* edge advantage. The "close" X is mid-screen, not at the edge. Good modal libraries put the close button at the modal's top-right corner — close to the edge of the modal, even if not the screen.
+
+When a dialog needs to be reachable quickly (e.g., a side sheet for editing a row), prefer a `Sheet` or `Drawer` that anchors to a screen edge over a centered `Dialog`.
+
+### Paginated content with mid-screen prev/next
+
+Content that "paginates" with prev/next buttons mid-screen forfeits the screen edge. Better: anchor prev/next to the screen edges so they're always findable.
+
+### Mobile drawers that don't reach the edge
+
+A "bottom sheet" with rounded corners that floats above the bottom edge. The visual rounding is nice; the edge advantage is forfeited. On most modern designs the sheet is allowed to touch the bottom edge for the home-indicator-clearance area.
+
+## Browser chrome confounds
+
+Web apps don't fully control the screen edges — the browser owns the very top (URL bar, tabs) and the very bottom on mobile (URL bar, system gestures). The "edge" available to a web app is the inside edge of the viewport.
+
+This is why "fullscreen mode" exists in browsers: it gives back the screen edges to the app. Apps that benefit from edge advantages (drawing tools, video editors, presentation software) often offer a "Hide UI" or fullscreen toggle.
+
+## Worked examples
+
+### Example 1: a sticky header earning its space
+
+```html
+<header style="
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  height: 56px;
+  padding: 0 16px;
+  background: rgba(255,255,255,0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid hsl(0 0% 92%);
+">
+  <a href="/" style="font-weight: 600;">Acme</a>
+  <nav style="display: flex; gap: 16px; margin-left: 32px;">
+    <a href="/products">Products</a>
+    <a href="/pricing">Pricing</a>
+    <a href="/docs">Docs</a>
+  </nav>
+  <div style="margin-left: auto; display: flex; gap: 8px;">
+    <button>Sign in</button>
+    <button class="primary">Get started</button>
+  </div>
+</header>
+```
+
+The header sticks to the top edge — easy to reach by flying upward. Account / "Get started" are top-right corner-adjacent.
+
+### Example 2: full-bleed mobile CTA
+
+```html
+<div class="page-content" style="padding: 24px;">
+  <h1>Confirm your order</h1>
+  <p>...summary...</p>
+</div>
+
+<!-- Sticky CTA at the bottom edge, full width -->
+<div style="
+  position: sticky;
+  bottom: 0;
+  padding: 12px;
+  padding-bottom: calc(12px + env(safe-area-inset-bottom));
+  background: white;
+  border-top: 1px solid hsl(0 0% 92%);
+">
+  <button class="primary" style="width: 100%; height: 48px;">Place order</button>
+</div>
+```
+
+The button is full-bleed (no horizontal margin), bottom-anchored. On mobile, the user's thumb flies down to the bottom and stops on the button. Two edge advantages stacked.
+
+### Example 3: a side sheet for row detail
+
+```html
+<!-- Main view -->
+<table>...</table>
+
+<!-- Side sheet anchored to right edge when open -->
+<aside style="
+  position: fixed;
+  top: 0; bottom: 0;
+  right: 0;
+  width: min(480px, 100vw);
+  background: white;
+  box-shadow: -4px 0 24px rgba(0,0,0,0.08);
+">
+  <header style="display: flex; justify-content: space-between; padding: 16px;">
+    <h2>Edit row</h2>
+    <button aria-label="Close" style="width: 36px; height: 36px;">×</button>
+  </header>
+  <form>...</form>
+</aside>
+```
+
+The sheet's right edge is the screen edge — the user can fly the cursor right to grab any control. The close button at the top-right is corner-adjacent.
+
+## Anti-patterns
+
+- **The all-margin app.** Every screen has 24–48px margins on all sides. No edge is reachable; every target requires precision. Common in "card-y" admin templates.
+- **The middle-screen modal with edge controls.** A centered modal where the close X is at the modal's edge but the modal is far from the screen edge. The user aims twice (to the modal, then to the X). Either anchor the modal to a screen edge (sheet) or accept that the close requires precision.
+- **The hidden global nav.** A hamburger menu that opens a panel mid-screen. Every primary navigation tap is now a precision aim. Stick the nav at an edge.
+- **The "we'll add Wifi-symbol margin around everything" reflex.** Margin-everywhere is the cosmetic fix that costs Fitts's. Reserve margin for places it actually serves visual hierarchy.
+
+## Heuristics
+
+1. **Map the high-frequency interactions.** What does the user do most? Are those at edges or mid-screen? If mid-screen, ask whether you can move them.
+2. **The "fly to it" test.** With your eyes closed, can you guess the rough location of the global navigation? If it's at an edge, yes. If it's centered with margin, no.
+3. **The precision audit.** Click each primary action. Was precision required, or did the cursor have a "wall" to stop against? Walls = edge advantage.
+
+## Related sub-skills
+
+- **`fitts-law`** (parent).
+- **`fitts-law-touch-targets`** — on touch, the safe-area inset complicates pure edge use.
+- **`affordance`** — the edge target still needs to look like a target.
+- **`visibility`** (cognition) — an edge-anchored control must be visible to be useful.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-screen-edges/references/edge-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-screen-edges/references/edge-patterns.md
@@ -1,0 +1,94 @@
+# Screen edges: pattern reference
+
+A reference complementing `fitts-law-screen-edges` with platform conventions and historical context for edge-anchored UI.
+
+## The classic edge-advantage example
+
+The macOS menu bar has lived at the top edge of the screen since 1984. The Mac team's defense of this choice (vs. Windows's per-window menus) was explicitly Fitts-grounded: a screen-edge menu has *infinite* target height along the vertical axis, because the cursor cannot move past the screen edge. The user can fly the cursor upward without precision and the cursor stops on the menu bar.
+
+This argument is decades old and still wins blind A/B tests where users complete file-menu tasks faster on macOS than on Windows-style UI when conditions are otherwise equal. The cost: only one application's menu can occupy the bar at a time, so the menu changes as you switch apps — a cognitive trade-off that might not be worth the Fitts win for casual users.
+
+## Platform-specific edge use
+
+### macOS
+- **Top edge:** menu bar (per-app commands), notch (display cutout), system status (right side).
+- **Bottom edge:** Dock by default; can be hidden or moved.
+- **Right edge:** notification center / Mission Control if configured.
+
+### Windows
+- **Bottom edge:** taskbar (default), Start button (left corner), system tray (right corner).
+- **Edge swipe gestures** for snap layouts.
+
+### iOS
+- **Top edge:** status bar, dynamic island.
+- **Bottom edge:** home indicator (system gesture area, ~25 points reserved).
+- **Left edge:** back-swipe gesture.
+- **Right edge:** control center swipe (top-right corner specifically).
+
+### Android
+- **Top edge:** status bar, notification shade pull-down.
+- **Bottom edge:** navigation bar (back/home/recents) or gesture area.
+- **Edges:** various gesture targets.
+
+### Web
+- The browser owns most of the screen edges; web apps have only the viewport's interior edge to work with.
+- Sticky headers and footers are the canonical web equivalents of edge-anchored UI.
+
+## Cross-domain examples
+
+### Television remote controls
+
+The "channel up/down" and "volume up/down" buttons typically occupy the top of the remote's button cluster — easy to find by feel. Power button is often at the very top edge. The arrangement is a tactile equivalent of Fitts's edge advantage: the edges of the remote act as physical targets for the thumb.
+
+### Calculator layout
+
+A calculator's "C" or "AC" (clear) button is typically in a corner — large, distinct color, edge-positioned. Hitting it accidentally costs the user; the corner placement makes finding it deliberate easier and finding it accidental harder.
+
+### Light switches
+
+Standard toggle light switches sit at a fixed wall location (typically near a doorway, ~48 inches from the floor). The position is a "spatial edge" — wall + door frame — that helps the user find the switch by touch in darkness. Same Fitts logic, different domain.
+
+## Things to know about web edges
+
+### Browser chrome
+
+Modern browsers reserve some edge real estate:
+
+- **Top:** URL bar (variable), tabs, system menu.
+- **Bottom (mobile):** URL bar (mobile Safari, Chrome) — moves around as you scroll.
+- **Edges:** scroll bars on desktop (sometimes hidden until scroll).
+
+Web apps must respect these reservations; the actual usable "edge" is the interior of the viewport.
+
+### Safe-area insets
+
+iOS and modern Android expose `env(safe-area-inset-*)` CSS variables for the screen-edge regions reserved for system UI (notch, home indicator):
+
+```css
+.bottom-bar {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+```
+
+Use these for edge-anchored content on mobile — otherwise your content may be hidden under the system UI.
+
+### Edge gestures and content collision
+
+A button placed flush at the bottom edge of an iPhone screen may trigger the system home gesture instead of registering as a tap. Best practice: inset 8–16px from the absolute edge for primary touchable content, while still keeping the visual element close to the edge.
+
+## Anti-patterns
+
+- **The all-margin app.** Modern web design defaults to padded layouts with no element at the screen edge. Easy to over-do.
+- **Edge-flush buttons that conflict with system gestures.** Especially mobile.
+- **Modal dialogs floating mid-screen.** The X to close is far from any edge; aim is required.
+- **Sticky headers without sticky behavior.** A nav that's only sticky on some pages forces the user to relearn its location.
+
+## Resources
+
+- **Apple HIG: Layout** — discussion of safe areas, edge-aligned UI.
+- **Material Design: Layout** — Android-side conventions.
+- **Bruce Tognazzini, "First Principles of Interaction Design"** — original popularizer of the Fitts-and-edges argument for HCI.
+
+## Closing
+
+The screen edge is the most underused real estate in modern web UI. Designers trained on print conventions instinctively reach for margins; designers trained on Fitts's research instinctively reach for edges. Worth knowing which tradition you're drawing from on a given decision.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-touch-targets/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-touch-targets/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: fitts-law-touch-targets
+description: 'Use this skill when designing for touch — phones, tablets, kiosks, in-car displays, smart-TV remotes, anything where the input is a finger or thumb rather than a precise pointer. Trigger when sizing buttons for mobile, debugging "users keep mistapping," designing a mobile bottom-nav, picking icon sizes for a phone toolbar, or reviewing whether a desktop UI is touch-friendly. Sub-aspect of `fitts-law`; read that first if you haven''t already.'
+---
+
+# Fitts's Law for touch targets
+
+The finger is a much wider, much less precise pointer than a mouse cursor. Fitts's Law still applies, but the constants change dramatically — and a few touch-specific phenomena (occlusion, thumb reach, edge gestures) layer on top. This skill covers the practical rules.
+
+## Minimum sizes
+
+Every major touch platform publishes a recommended minimum. They converge:
+
+| Platform / spec | Minimum target | Notes |
+|---|---|---|
+| **Apple HIG (iOS)** | 44×44 pt | The most-cited number; matches average finger contact. |
+| **Material Design (Android)** | 48×48 dp | Roughly equivalent to Apple's 44pt at common densities. |
+| **Microsoft (Windows touch)** | 40×40 effective px | Slightly smaller; Microsoft's research basis. |
+| **WCAG 2.5.5 (Level AAA)** | 44×44 CSS px | Strictest accessibility minimum. |
+| **WCAG 2.5.8 (Level AA, 2.2)** | 24×24 CSS px (with adequate spacing) | Newer, more lenient minimum. |
+
+The practical rule: **44×44 CSS pixels for any touchable element**. This is the safe number across platforms and accessibility levels. Going smaller is occasionally defensible in specific dense expert contexts; never as a default.
+
+The visible *icon* inside the button can be smaller (16–24px is common). The *hit area* — the actual touchable region — is what 44×44 measures.
+
+```css
+/* Right: a small icon with a generous tap area */
+.icon-button {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  padding: 10px;        /* keeps icon centered while tap area stays at 44 */
+  border: 0;
+  background: transparent;
+  border-radius: 22px;
+}
+.icon-button svg { width: 20px; height: 20px; }
+```
+
+## Spacing between targets
+
+Fitts's Law is about acquiring *one* target. When targets are clustered, *spacing* between them prevents accidental neighbor-taps. The convention:
+
+- **At least 8px of clear space** between adjacent touch targets.
+- **44×44 hit area applies to each target**, even if visually they overlap (e.g., padded buttons share visual edges).
+
+For dense clusters (chip rows, segmented controls), increase visual differentiation: bordered, with internal padding, with adequate gap.
+
+## The thumb-reach map
+
+When a phone is held one-handed, the thumb can reach some screen regions easily and others only with strain. Research (Hoober and others) maps this:
+
+```
++--------------------+
+|       hard         |  <- top of screen, far from thumb base
+|   hard | medium    |
+| medium | easy      |
+| medium | easy      |
+| medium | easy      |  <- bottom-right (right hand) is easiest
++--------------------+
+```
+
+For right-handed users, the bottom-right of the screen is easiest; the top-left is hardest. Left-handed users mirror.
+
+**Practical implications:**
+
+- **Primary actions go in the lower portion of the screen.** Floating action buttons (FAB) at bottom-right are a strong Fitts-and-thumb-reach win.
+- **Bottom navigation beats top navigation** for high-frequency tap-to-navigate patterns.
+- **Top-bar actions should be infrequent or hand-agnostic** (search, settings, profile menu — not "save" or "publish").
+- **Reachability features** (iOS double-tap-home; Android one-handed mode) exist because top corners are genuinely hard.
+
+```html
+<!-- Bottom nav: thumb-friendly, primary destinations -->
+<nav style="position: fixed; bottom: 0; left: 0; right: 0;">
+  <!-- 3-5 destinations, evenly spaced, 56px+ tall -->
+</nav>
+
+<!-- FAB: bottom-right for right-handed primary action -->
+<button style="position: fixed; bottom: 24px; right: 24px; width: 56px; height: 56px; border-radius: 28px;">
+  <PlusIcon />
+</button>
+```
+
+## Occlusion (the finger covers the target)
+
+Once the user's finger touches the screen, it covers the target. A few consequences:
+
+- **Confirm visually after touch, not just on touch-up.** The user wants to know the press registered before they lift.
+- **Don't rely on the user reading text under their finger.** Tooltips, micro-confirmations, "what does this do?" hints under the touch point are invisible.
+- **Touch targets should provide visual state changes that radiate beyond the finger** — color flash on the whole row, a ripple effect, an outline that extends past the contact area.
+
+Material Design's ripple effect is a classic occlusion-mitigation: the ripple expands outward from the touch point, providing visible feedback that survives the finger's presence.
+
+```css
+@keyframes ripple {
+  to { transform: scale(4); opacity: 0; }
+}
+.button-pressed::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.2;
+  animation: ripple 600ms;
+}
+```
+
+## Edge gestures and the safe area
+
+Modern phones use the screen edges for system gestures (back-swipe, app-switcher, control-center). A button placed at the absolute edge competes with these gestures.
+
+**Practical rule:** keep an 8–16px inset from the edges for primary interactive content. Use the system's safe-area insets for top notch and bottom home-indicator clearance:
+
+```css
+.bottom-bar {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.top-bar {
+  padding-top: env(safe-area-inset-top);
+}
+```
+
+The screen-edge Fitts-Law advantage still works for *layout* (a tap target abutting the edge is large in one dimension), but *interaction* must respect system gestures.
+
+## Hover states (and why they don't translate)
+
+Touch devices have no hover. UI patterns that rely on hover-revealed actions (a row's "Edit" / "Delete" buttons that appear on cursor over) silently fail on touch. Mitigations:
+
+- **Always-visible row actions** (perhaps dimmed; see below). Touch users see and can tap them.
+- **Press-and-hold** to reveal a context menu (analogous to right-click).
+- **Swipe gestures** for revealed actions (iOS-style swipe-to-delete on a list row).
+
+Don't ship "hover to discover the action" patterns to mobile.
+
+## Worked examples
+
+### Example 1: a row in a list with an action button
+
+**Anti-pattern (mouse-only):**
+
+```html
+<li class="list-item">
+  <span>Project Acme</span>
+  <button class="hover-only" style="opacity: 0;">Open</button>
+</li>
+<style>
+  .list-item:hover .hover-only { opacity: 1; }
+</style>
+```
+
+On touch, the button is invisible — and even if you tap it, you can't see it.
+
+**Right (touch-friendly):**
+
+```html
+<li class="list-item" style="display: flex; align-items: center; padding: 12px 16px; min-height: 56px;">
+  <span style="flex: 1;">Project Acme</span>
+  <button aria-label="Open Acme" style="width: 44px; height: 44px;">
+    <ChevronRightIcon />
+  </button>
+</li>
+```
+
+The action is always visible; the row itself meets the 44px height minimum (56px is even better).
+
+### Example 2: a numeric stepper
+
+```html
+<div class="stepper" style="display: inline-flex; align-items: center; gap: 12px;">
+  <button aria-label="Decrease" style="width: 44px; height: 44px;">−</button>
+  <input type="number" value="1" style="width: 60px; height: 44px; text-align: center;" />
+  <button aria-label="Increase" style="width: 44px; height: 44px;">+</button>
+</div>
+```
+
+Both buttons are 44×44 with 12px gap to the input — generous spacing prevents misclicks.
+
+### Example 3: a floating action button (FAB)
+
+```html
+<button class="fab" aria-label="New post" style="
+  position: fixed;
+  bottom: calc(24px + env(safe-area-inset-bottom));
+  right: 24px;
+  width: 56px; height: 56px;
+  border-radius: 28px;
+  background: var(--brand);
+  color: white;
+  display: grid; place-items: center;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+">
+  <PlusIcon />
+</button>
+```
+
+Bottom-right for thumb reach. 56×56 hit area. Safe-area-inset for home-indicator clearance. Subtle shadow because FABs *do* float above content.
+
+### Example 4: a tab bar
+
+```html
+<nav class="tab-bar" style="
+  position: fixed; bottom: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: calc(56px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+  background: white;
+  border-top: 1px solid hsl(0 0% 90%);
+">
+  <button class="tab" aria-current="page">
+    <HomeIcon style="width: 24px; height: 24px;" />
+    <span style="font-size: 10px;">Home</span>
+  </button>
+  <!-- four more tabs -->
+</nav>
+
+<style>
+  .tab {
+    display: grid; place-items: center; gap: 2px;
+    border: 0; background: transparent;
+    color: hsl(0 0% 50%);
+  }
+  .tab[aria-current="page"] { color: var(--brand); }
+</style>
+```
+
+5 tabs across the bottom. Each tab gets ~76px width × 56px height — generously above 44×44.
+
+## Anti-patterns
+
+- **Tiny X close on a popover.** A 16×16 X in the corner. On touch, nearly impossible to hit reliably.
+- **Stacked menu items at 32px row height.** The user means to tap "Settings" and gets "Sign out." Make rows ≥ 44px (preferably 48–56px) on touch.
+- **Edge-flush primary actions.** A "Send" button at the absolute right edge that triggers the system back-gesture instead. Inset 8–16px.
+- **Hover-only actions.** Row actions, contextual menus, tooltips that only appear on cursor-over. Either always-visible or accessible via tap-to-reveal.
+- **Inert spacing.** A 44×44 visual button with only 16×16 of actual touchable area (because some CSS issue). Audit with browser DevTools' touch emulator.
+
+## Heuristics
+
+1. **The thumb test.** Hold your phone one-handed, naturally. Try to tap every primary action. Anything that requires a hand-shift is wrong-position.
+2. **The fingertip overlay.** In design comps, overlay a 44×44 circle on every interactive element. Anything where the circle exceeds the visual element's bounds is fine; anything smaller than the circle is too small.
+3. **Real-device testing on the smallest target screen.** A design that works on a Pixel 7 may fail on a small Android device or iPhone SE. Test on actual hardware in actual hands.
+4. **The bystander test.** Watch someone else use your app. Where do they hesitate or correct themselves? Each correction is a Fitts-or-occlusion failure.
+
+## Related sub-skills
+
+- **`fitts-law`** (parent).
+- **`fitts-law-screen-edges`** — companion for desktop; some overlap on mobile (safe areas).
+- **`affordance`** (parent plugin) — touch targets need visual affordance to be discoverable.
+- **`accessibility-operable`** (process plugin) — touch target sizes are an accessibility minimum; don't go below.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-touch-targets/references/touch-research.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law-touch-targets/references/touch-research.md
@@ -1,0 +1,81 @@
+# Touch targets: research and platform notes
+
+A reference complementing `fitts-law-touch-targets` with the empirical research on touch input and platform-specific guidance.
+
+## Empirical findings
+
+- **Parhi, P., Karlson, A. K., Bederson, B. B.** (2006). "Target size study for one-handed thumb use on small touchscreen devices." *MobileHCI*. Found that error rates rise sharply below ~9.6mm targets for thumb input.
+- **Henze, N., Rukzio, E., Boll, S.** (2011). "100,000,000 taps: Analysis and improvement of touch performance in the large." Large-scale game data analysis confirming Fitts's Law applies to touch with target-size minimums around 9–11mm.
+- **Lee, S. & Zhai, S.** (2009). "The performance of touch screen soft buttons." *CHI*. Showed performance degrades meaningfully below 10mm touch-target widths.
+
+The convergent finding: ~10mm physical target ≈ ~44 CSS pixels at typical mobile pixel density. Apple's 44pt and Material's 48dp recommendations both round to this.
+
+## Platform target-size standards
+
+| Platform | Recommended minimum | Notes |
+|---|---|---|
+| **Apple HIG (iOS)** | 44×44 pt | Used since iOS launch; rarely violated |
+| **Material Design (Android)** | 48×48 dp | Slightly larger to accommodate variable Android device density |
+| **Microsoft (Windows touch)** | 40×40 px | Slightly smaller; documented in Windows touch guidance |
+| **WCAG 2.5.5 (AAA)** | 44×44 CSS px | Strictest accessibility level |
+| **WCAG 2.5.8 (AA, 2.2)** | 24×24 CSS px (with adequate spacing) | Minimum accessibility |
+
+The practical guideline: 44×44 CSS pixels is the safe minimum across platforms and accessibility levels. Don't go smaller without specific reason.
+
+## Thumb-reach research
+
+Steven Hoober's research (UX Matters, 2013, 2017) on how users actually hold phones found:
+
+- **49%** of users hold their phone one-handed.
+- **36%** cradle the phone in two hands but operate primarily with one thumb.
+- **15%** use two thumbs simultaneously.
+
+The implication: most-mode-of-use is thumb-on-the-same-hand-as-grip. Designs that require both hands or that place primary actions out of thumb reach lose usability for the dominant mode.
+
+Hoober's reachability map shows the bottom 60% of a typical phone screen is "easy" for thumb; the top corners are "hard." Bottom navigation and FAB placement at bottom-right exploit this directly.
+
+## Touchscreen physics
+
+Why touch is different from mouse:
+
+- **Contact area, not point.** A finger contact is ~10–15mm wide at typical pressure; the OS converts this to a single touch point, but underlying contact uncertainty persists.
+- **Occlusion.** Once the finger touches, it covers the target. Visual feedback can't appear *under* the finger; it must radiate beyond (ripple effects, glow).
+- **No hover.** Touch has no mouse-over equivalent. UI patterns relying on hover (tooltips, hover-revealed actions) must have touch alternatives.
+- **Sticky / sweaty / cold fingers** all degrade touch accuracy. Outdoor / glove use (winter, industrial) further degrades.
+
+These physics imply the target-size minimums; designs that ignore them work in lab tests and fail in the rain.
+
+## Cross-domain examples
+
+### ATM design
+
+ATMs have used large physical buttons (~25mm) for decades because the user might be wearing gloves, in poor lighting, in a hurry. Touchscreen ATMs maintain large targets for the same reasons.
+
+### Industrial controls
+
+Manufacturing floor touchscreen interfaces (HMI panels) typically use 60×60mm minimum targets — operators wear gloves, work in dusty/wet environments, and must hit targets reliably.
+
+### Voting machines
+
+Voting machine UI explicitly uses very large targets (often 80mm+) because the user population includes elderly voters, people in unfamiliar environments, and users who must vote correctly without practice.
+
+### In-vehicle infotainment
+
+Car dashboard touch targets are larger than phone targets because:
+
+- Vehicle motion makes precise touch harder.
+- Glancing-while-driving means the user sees the target only briefly.
+- Errors carry safety risk.
+
+Tesla's all-touchscreen approach has been criticized in part for inadequate target sizes for some controls.
+
+## Resources
+
+- **Apple Human Interface Guidelines** (developer.apple.com/design) — comprehensive touch guidance.
+- **Material Design** (material.io) — Android-perspective touch guidance.
+- **Hoober, S.** "How Do Users Really Hold Mobile Devices?" — UXMatters articles.
+- **WCAG 2.5.5 and 2.5.8** — accessibility minimums.
+
+## Closing
+
+Touch targets are one of the few design decisions where the right answer is well-known and rarely controversial: at least 44×44 CSS pixels, 8+ pixels of spacing between, anchored to thumb-reachable zones. Designs that violate these defaults usually do so by accident; deliberately violating requires a strong specific reason.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: fitts-law
+description: 'Use this skill whenever the question involves how easy it is to *hit* an interactive target — buttons, links, form controls, drag handles, scrollbars, mobile tap targets, anything the user must move a pointer or finger to. Trigger when sizing buttons, designing toolbars, picking a hit-area for icon buttons, designing for touch screens, debugging "users keep mis-clicking," or arguing about button density vs. usability. Trigger when the user mentions touch targets, target size, "fat fingers," pointer accuracy, edge gestures, or accessibility around motor impairments. Routes to sub-aspect skills for touch targets, screen edges, and pointer acceleration.'
+---
+
+# Fitts's Law
+
+Fitts's Law is the foundational quantitative model of how long it takes to acquire (point to) a target with a directed movement. The classic formulation:
+
+```
+T = a + b · log₂(D / W + 1)
+```
+
+Where T is movement time, D is the distance from the starting position to the target, W is the target's width along the axis of motion, and a, b are device-and-context constants. The logarithmic relationship is the core insight: doubling the size of a target reduces movement time by a constant amount; halving the distance to a target also reduces it by a constant amount; targets at the edges of the screen are effectively infinite in one dimension because the cursor stops there.
+
+## Definition (in our own words)
+
+The time to move a cursor or finger to a target is determined by two things: how *far* the target is from where you start, and how *big* the target is. Big nearby targets are fastest; small distant targets are slowest. Edges and corners of the screen are exceptional: the cursor (or finger) cannot overshoot, so they behave as effectively infinite-sized targets along that one axis.
+
+## Origins and research lineage
+
+- **Fitts (1954)** "The information capacity of the human motor system in controlling the amplitude of movement" — the original paper, derived from a peg-in-hole task with varying target sizes and distances.
+- **Card, Moran & Newell (1983)** incorporated Fitts's Law into the early HCI canon as one of the foundational "pointer mechanics" laws.
+- **MacKenzie (1992)** refined the formulation to better handle on-screen pointer tasks (the form above is "Shannon's formulation," credited to MacKenzie).
+- **Mobile / touch research** (Henze, Bailly, and many others) has extended Fitts's Law to touch-screen interaction, where the "pointer" is a finger with a wider effective contact area than a cursor.
+
+The law has held up across input modalities (mouse, trackpad, touch, stylus, eye-tracking) for over half a century. The constants change; the relationship doesn't.
+
+## Why Fitts's Law matters
+
+Every clickable element imposes a Fitts's Law cost — a small one for big nearby buttons, a large one for tiny distant ones. On a single screen the cost is barely perceptible. Multiplied across a workflow with many clicks, the costs compound.
+
+Worse, small targets aren't just slower; they're *less reliable*. The user may overshoot, undershoot, or miss entirely — leading to misclicks that cost a redo or, worse, an unintended action.
+
+For touch interfaces, Fitts's Law is also an accessibility issue. Users with motor impairments, tremor, or one-handed use cases pay a much higher cost on small targets than typical users do.
+
+## When to apply
+
+- **Sizing buttons and icon buttons.** Especially in dense UI where the temptation is to shrink them.
+- **Designing for touch.** Mobile, tablet, kiosk, and any screen the user touches.
+- **Designing toolbars and menus.** Distance between current cursor and likely target matters.
+- **Designing screen-edge interactions.** Edge gestures, edge-aligned navigation, full-bleed CTAs.
+- **Designing for accessibility.** Larger targets benefit users with motor or vision impairments and don't penalize anyone.
+- **Reviewing why users misclick something.** Almost always a Fitts's Law diagnosis.
+
+## When NOT to apply (or when to be careful)
+
+- **Very dense expert UIs.** Power users on familiar tools tolerate (and sometimes prefer) compact targets — they're using muscle memory, not search-and-acquire. A code editor's 16px tab close button is fine for daily users; not fine for new ones.
+- **When the law conflicts with safety.** Destructive actions can deliberately use *smaller* or *farther* targets to make accidental activation harder. The Fitts's Law cost is *intentional*.
+- **When the law conflicts with hierarchy.** A primary action is bigger because it's primary, not because Fitts's Law mathematically demands it. Hierarchy and Fitts's Law usually agree (primary = larger = faster), but when they don't, hierarchy is often the right tiebreaker.
+
+## Practical sizes
+
+The most common Fitts's Law decisions are about minimum target size. Standards converge on:
+
+| Context | Minimum target size | Source / convention |
+|---|---|---|
+| Touch (general) | 44×44 px | Apple HIG; matches average fingertip contact |
+| Touch (Material) | 48×48 dp | Google Material Design |
+| Touch (WCAG 2.5.5 Level AAA) | 44×44 CSS px | WCAG Success Criterion 2.5.5 |
+| Touch (WCAG 2.5.8 Level AA, 2.2) | 24×24 CSS px (with spacing) | WCAG Success Criterion 2.5.8 |
+| Mouse-pointer UI | 32×32 px (button), 24×24 (icon button with hover-friendly hit area) | Common in dense desktop apps |
+| Trackpad / fine pointer | 16×16 px is feasible but error-prone | Reserve for power-user tools |
+
+The numbers are *minimums*; bigger is usually better when space allows.
+
+## Distance: the other half of the equation
+
+Target size gets most of the attention, but distance matters equally. Two strategies:
+
+### Place high-frequency targets close to the user's natural starting position
+
+After the user clicks "Add row," their cursor is wherever they clicked. The next thing they're likely to do (label the new row) should be close by. Don't make them traverse the screen.
+
+### Use proximity for related actions
+
+If a user just clicked a row to select it, the contextual actions (edit, delete, share) should appear *near* that row — in a row-action toolbar or popover — not in a sidebar or a top toolbar 600px away. Distance kills speed.
+
+### Use anchored controls for sustained interaction
+
+A floating action button (FAB) is anchored — distance from any starting cursor position is roughly constant. For mobile in particular, this is a Fitts's Law win.
+
+## Edges and corners: the magic real estate
+
+Because the pointer cannot move past the screen edge, edges and corners act as effectively-infinite targets along one axis. This is why Mac's menu bar lives at the top edge (cursor can fly up without overshooting) and why Windows's Start button lives at the corner (zero precision required to hit).
+
+In web UIs:
+
+- **Sticky headers** at the top edge: navigation links there are easier to hit than mid-page.
+- **Fixed bottom toolbars** on mobile: thumb travels naturally to the bottom; the bottom edge stops it.
+- **Side sheets** that slide in from the right: their edge is anchored to the screen edge, easier to grab than mid-screen panels.
+
+A common modern web mistake: pages with no bleed, where every interactive element has 24px+ of margin. The screen edge advantage is forfeited.
+
+## Touch-specific notes
+
+Touch screens present a few twists Fitts's Law accounts for:
+
+- **The finger has a wide contact area.** ~10–15mm at typical pressure, much larger than a cursor. This is why touch targets need to be larger than mouse targets — but also why touch is faster than mouse for nearby targets (no fine positioning required).
+- **The finger occludes its target.** Once you press, you can't see what's under your finger. Targets need to confirm hit visually (state change after touch).
+- **Thumb reach varies.** On a phone held one-handed, the thumb easily reaches the lower portion of the screen but strains for the top corners. Place primary actions in thumb-reach zones (lower 2/3 of the screen).
+- **Edge gestures compete with edge buttons.** Modern phones use edge swipes for system gestures (back, app switcher); a button right at the edge may be triggered by accident. A small inset (8–12px from the absolute edge) keeps Fitts's edge advantage without conflicting with system gestures.
+
+## Worked examples
+
+### Example 1: an icon-only button
+
+A common case where Fitts's Law gets violated.
+
+**Anti-pattern:**
+
+```html
+<button style="
+  width: 16px; height: 16px;
+  padding: 0; border: 0;
+  background: transparent;
+">
+  <CloseIcon style="width: 16px; height: 16px;" />
+</button>
+```
+
+A 16×16 hit area is hard to hit even with a mouse and impossible reliably with touch.
+
+**Right:**
+
+```html
+<button aria-label="Close" style="
+  width: 36px; height: 36px;
+  padding: 0; border: 0; border-radius: 0.375rem;
+  background: transparent;
+  display: grid; place-items: center;
+">
+  <CloseIcon style="width: 16px; height: 16px;" />
+</button>
+```
+
+The icon stays 16px (visual weight); the button is 36×36 (easy hit). On touch surfaces, push to 44×44.
+
+### Example 2: a toolbar of icon buttons
+
+```html
+<div style="display: flex; gap: 0.25rem;">
+  <button aria-label="Bold" style="width: 32px; height: 32px;"><BoldIcon /></button>
+  <button aria-label="Italic" style="width: 32px; height: 32px;"><ItalicIcon /></button>
+  <button aria-label="Underline" style="width: 32px; height: 32px;"><UnderlineIcon /></button>
+</div>
+```
+
+Each button has a 32×32 hit area. The 4px gap is small enough to keep buttons close (low D in Fitts's formula), but large enough to prevent accidental neighbor-clicks.
+
+### Example 3: a primary action below the form
+
+```html
+<form style="display: grid; gap: 1rem;">
+  <input />
+  <input />
+  <input />
+  <button class="primary" style="
+    height: 44px;
+    padding: 0 1.5rem;
+    align-self: end;
+  ">
+    Submit
+  </button>
+</form>
+```
+
+The Submit button is 44px tall (touch-friendly), aligned to the right edge of the form (predictable position users will learn). Distance from the last input is small — the user's cursor is already nearby.
+
+### Example 4: mobile bottom navigation
+
+```html
+<nav style="
+  position: fixed; bottom: 0; left: 0; right: 0;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  height: calc(56px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+">
+  <button style="display: grid; gap: 2px; place-items: center;">
+    <HomeIcon />
+    <span style="font-size: 10px;">Home</span>
+  </button>
+  <!-- … 4 more items … -->
+</nav>
+```
+
+Bottom-anchored: thumb reaches naturally and the screen edge stops travel. Each item is ~76px wide × 56px tall — generous targets. Five-item maximum to keep per-item width above ~72px.
+
+### Example 5: edge-aligned destructive button (intentional Fitts's penalty)
+
+```html
+<!-- The save button is large, central, and easy. The destructive button is
+     small and visually demoted. The user must aim deliberately. -->
+<div style="display: flex; justify-content: space-between; align-items: center;">
+  <button class="text-button danger" style="font-size: 0.875rem;">
+    Delete account
+  </button>
+  <button class="primary" style="height: 44px; padding: 0 2rem;">
+    Save changes
+  </button>
+</div>
+```
+
+The destructive action's *small target size* and *visual demotion* are deliberate Fitts's Law penalties. They're features.
+
+## Anti-patterns
+
+- **The microscopic close button.** A 12×12 X in the corner of a popover. Hard to hit with a mouse, impossible with touch.
+- **The dense menu.** A right-click menu with 4px row heights. Fine when the user means to pick the third item; murder when they want the second-to-last.
+- **The scattered actions.** Related actions placed at opposite ends of a screen so the user must traverse for each one.
+- **The "we have so much screen real estate" trap.** Spreading buttons across the page so the eye has to travel. Cluster related actions.
+- **The ignored edge.** An app with 24px margins on every side, forfeiting the edge-as-target benefit. Modern web apps often suffer this.
+- **The misclick-friendly destructive.** Putting "Delete" right next to "Edit" with the same size and styling. Fitts's Law makes the misclick easy; the consequence is severe. Either widen the gap, demote the destructive visually, or add confirmation.
+
+## Heuristics
+
+1. **The 44px rule.** On any touch surface, every interactive element should occupy at least 44×44 CSS pixels of hit area, even if the visual element inside is smaller.
+2. **The traverse audit.** Pick a common task. Trace the cursor path through it. If the cursor crosses the screen multiple times, restructure to reduce traversal.
+3. **The edge audit.** Are any of your high-frequency actions at screen edges? If not, you may be leaving Fitts's Law performance on the table.
+4. **The misclick log.** If your analytics or support shows users frequently undoing or correcting an action, the Fitts's setup of that action is probably wrong (too small, too close to a different action, too far from the natural cursor position).
+
+## Related principles
+
+- **`affordance`** — Fitts's Law sets the *size* a target needs; affordance sets whether the user knows it's a target at all.
+- **`defensible-space`** — separating destructive controls from common ones is an *intentional* Fitts's Law penalty for safety.
+- **`mapping`** — placing controls *near* the things they affect reduces Fitts's distance.
+- **`visibility`** — a target you can't see has effectively infinite distance.
+- **`accessibility`** (process) — Fitts's Law is fundamentally about motor accessibility; bigger and edge-aligned targets help everyone.
+
+## Sub-aspect skills
+
+- **`fitts-law-touch-targets`** — applying the law to touchscreen interfaces specifically.
+- **`fitts-law-screen-edges`** — exploiting (and respecting) the screen-edge advantage.
+- **`fitts-law-pointer-acceleration`** — how cursor speed and acceleration interact with target size, especially on trackpad and mouse.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law/references/research-and-formulation.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/fitts-law/references/research-and-formulation.md
@@ -1,0 +1,107 @@
+# Fitts's Law: research and formulations
+
+A reference complementing `fitts-law` SKILL.md with the academic grounding, common formulations, and the conditions under which the law applies.
+
+## The original paper
+
+**Fitts, P. M.** (1954). "The information capacity of the human motor system in controlling the amplitude of movement." *Journal of Experimental Psychology*, 47(6), 381–391.
+
+Fitts's setup was a peg-in-hole task: subjects moved a stylus between two targets of varying width and varying separation. He measured movement time across many target combinations and found a linear relationship between movement time and the *index of difficulty*:
+
+```
+ID = log₂(2D / W)
+T = a + b · ID
+```
+
+Where D is distance and W is target width. The information-theoretic interpretation (Fitts was working in the heyday of Shannon's information theory): the index of difficulty measures the "bits" of information required to specify a target's position with the precision needed to hit it.
+
+## Modern formulations
+
+Several refinements have emerged since 1954:
+
+### MacKenzie's Shannon formulation (1992)
+
+```
+T = a + b · log₂(D / W + 1)
+```
+
+The "+1" eliminates negative ID values when W > D and better matches data when targets are very large or very close. This is the form most commonly cited in HCI literature now.
+
+### Welford's formulation (1968)
+
+```
+T = a + b · log₂(D / W + 0.5)
+```
+
+A precursor to MacKenzie's; rarely used in current HCI work but still appears in motor-control literature.
+
+### Effective width
+
+A practical refinement: in real tasks, users sometimes hit slightly outside the target boundary. Computing W from actual hit distribution (effective width) rather than nominal target width gives more accurate Fitts's Law fits. Used in HCI experimental studies.
+
+## Conditions under which Fitts's Law applies
+
+The classic Fitts's task assumes:
+
+- **A single, aimed movement** with a known starting point and known target.
+- **Visual targets** that are unambiguous (clear edges, single color).
+- **Practiced users** — not the first time they've used the device.
+- **Indoor, controlled lighting and ergonomics.**
+- **Discrete tap/select actions**, not continuous motion.
+
+When these conditions hold (most software UI), Fitts's Law predicts movement time with high reliability. When they don't (drag operations, very small/distant targets, novel input devices), the law still applies but constants change and data fits become noisier.
+
+## Cross-input findings
+
+Fitts's Law has been validated across:
+
+- Mouse (the original HCI domain).
+- Trackpad — slightly higher constants (slower than mouse).
+- Touchscreen (finger) — much larger W minimums, generally faster traversal because no fine positioning before final approach.
+- Stylus on tablet — closer to mouse performance with smaller W minimums.
+- Eye-tracking — applies, but with different constants and a saccade-vs.-fixation dynamic.
+- Mid-air gesture (VR controllers, leap motion) — applies; constants vary by display geometry.
+
+## Quantitative findings
+
+A few useful numbers:
+
+- For a typical desktop mouse, the constant `b` is roughly 100 ms/bit. So an ID of 4 bits (e.g., D = 480 px, W = 30 px → ID = log₂(480/30 + 1) ≈ 4.04) → ~400 ms additional time beyond the base latency.
+- Touch is roughly comparable in `b` but with much larger W minimums (~44 px).
+- Constants `a` (base latency) range from ~200 ms (mouse, practiced) to ~500 ms (touch with mode-switch).
+
+These numbers aren't exact but they're useful for back-of-envelope estimation.
+
+## When Fitts's Law underpredicts time
+
+- **First-time users.** They don't know where the target is; they spend time searching, not aiming.
+- **Mode-switching.** Users moving from typing to mousing pay a "homing" cost not captured in Fitts.
+- **Cognitive evaluation of which target.** When the user must read several similar buttons to decide, that reading time isn't Fitts time.
+- **Very small targets** (< 10 px). Users overshoot, undershoot, and re-aim — error correction multiplies time.
+
+## Cross-domain examples
+
+### Industrial control panels
+
+Aircraft, automotive, and industrial machinery design have applied Fitts-like principles since long before HCI: critical controls (throttle, brake, emergency stop) are large and at predictable locations; secondary controls are smaller; rare controls are tucked away.
+
+The cockpit "throttle quadrant" arrangement of throttle, mixture, and prop controls has lived through many aircraft generations because the ergonomic rationale is Fitts-grounded.
+
+### Car dashboards
+
+Climate controls, radio, gear lever — sized and placed for operation while driving. Tesla's all-touchscreen approach (eliminating physical controls) has been criticized in part because it forfeits Fitts's Law: physical knobs have edges that the finger can find by feel; touch buttons require visual attention away from the road.
+
+### Sports equipment
+
+A baseball bat's "sweet spot" is in some sense a Fitts problem inverted: you want a *wide* effective target. Bat designs over a century have crept toward shapes that maximize the sweet spot's effective width.
+
+## Resources
+
+- **Fitts, P. M.** (1954). The original paper, available in many HCI anthologies.
+- **MacKenzie, I. S.** (1992). "Fitts' law as a research and design tool in human-computer interaction." *Human-Computer Interaction*, 7, 91–139. The standard modern reference.
+- **Card, S. K., Moran, T. P., Newell, A.** (1983). *The Psychology of Human-Computer Interaction*.
+- **Soukoreff, R. W. & MacKenzie, I. S.** (2004). "Towards a standard for pointing device evaluation." *International Journal of Human-Computer Studies*. Methodology paper for Fitts's experiments.
+
+## Closing
+
+Fitts's Law is one of the most rigorously-validated quantitative laws in HCI — it has held up across input modalities, body parts, displays, and decades. When in doubt about a target sizing or placement decision, the law usually has the answer.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness-confirmation-and-prevention/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness-confirmation-and-prevention/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: forgiveness-confirmation-and-prevention
+description: 'Use this skill when the user must commit to an irreversible or high-stakes action and reversibility isn''t enough — confirmation dialogs, type-to-confirm patterns, password re-entry, two-step authentication for destructive actions, and structural prevention that makes the wrong action impossible. Trigger when designing destructive flows for genuinely-irreversible commitments, when reviewing confirmation fatigue, or when picking between a single confirm dialog and a multi-step verification. Sub-aspect of `forgiveness`; read that first.'
+---
+
+# Forgiveness through confirmation and prevention
+
+When an action can't be made reversible, the next-best forgiveness is requiring deliberate intent. The user must take an explicit, considered step before the irreversible thing happens. The challenge: confirmation overuse trains users to dismiss it on autopilot, defeating the purpose. Confirmation must be reserved for the moments when it earns its friction.
+
+## When confirmation is appropriate
+
+A useful test before adding confirmation: is the action irreversible *and* high-stakes?
+
+- **Irreversible + high-stakes** → confirm. (Account deletion, ownership transfer, large financial transaction.)
+- **Reversible + high-stakes** → use undo / soft-delete instead. Confirmation here is fatigue-inducing.
+- **Irreversible + low-stakes** → consider whether it should be reversible. If it must be irreversible, a light confirmation may suffice.
+- **Reversible + low-stakes** → no confirmation. Just do it; let undo catch mistakes.
+
+## Confirmation strength
+
+Match confirmation friction to action severity:
+
+### Light confirmation: "Yes / No" dialog
+
+```
+Cancel reservation?
+[ Cancel ]   [ Cancel reservation ]
+```
+
+For actions the user clearly initiated, where the dialog mostly catches accidental clicks. The user reads the title, picks an option.
+
+### Medium confirmation: dialog with summary
+
+```
+Delete project "Acme Q4"?
+
+This deletes 24 tasks and 8 attached files.
+
+[ Cancel ]   [ Delete project ]
+```
+
+For actions where the user benefits from seeing what they're about to lose. The summary gives them a chance to step back.
+
+### Strong confirmation: type-to-confirm
+
+```
+Delete project "Acme Q4"?
+
+This deletes 24 tasks and 8 attached files. Cannot be undone.
+
+To confirm, type the project name below:
+[ Acme Q4__________ ]
+
+[ Cancel ]   [ Delete project ]   (button enabled only when name matches)
+```
+
+For irreversible high-stakes actions. The user must actively type the resource name, breaking autopilot. The button stays disabled until the confirmation matches.
+
+### Strongest: re-authentication
+
+```
+This action requires re-authentication.
+Enter your password to continue.
+
+[ Password__________ ]
+
+[ Cancel ]   [ Continue ]
+```
+
+For account-affecting actions: deleting account, changing email, transferring ownership, viewing audit logs. Re-authentication catches both autopilot mistakes and someone-else-using-my-session attacks.
+
+## Type-to-confirm: the canonical pattern for irreversible action
+
+```html
+<dialog id="delete-dialog">
+  <h2>Delete workspace "Acme Inc"?</h2>
+  <p>
+    This permanently deletes the workspace, all 47 projects, all 12 members'
+    access, and 3.2 GB of files. This cannot be undone.
+  </p>
+  <p>To confirm, type the workspace name below:</p>
+  <input id="confirm" placeholder="Acme Inc" autocomplete="off" />
+  <div class="actions">
+    <button onclick="closeDialog()">Cancel</button>
+    <button id="confirm-btn" disabled class="destructive">
+      Delete workspace permanently
+    </button>
+  </div>
+</dialog>
+
+<script>
+const input = document.getElementById('confirm');
+const btn = document.getElementById('confirm-btn');
+input.addEventListener('input', () => {
+  btn.disabled = input.value !== workspace.name;
+});
+</script>
+```
+
+What this achieves:
+
+- The dialog must be opened deliberately.
+- The consequences are stated plainly.
+- The user must type — an active gesture that breaks autopilot.
+- The button is disabled until the typed name matches, so even autopilot Enter doesn't trigger.
+
+For actions that should genuinely never happen by accident, this stack is appropriate.
+
+## Re-authentication for security-sensitive operations
+
+```html
+<button onclick="requireReauthThen('delete-account')">
+  Delete account
+</button>
+
+<dialog id="reauth-dialog">
+  <h2>Confirm your identity</h2>
+  <p>For your security, please re-enter your password to continue.</p>
+  <input type="password" id="reauth-password" autofocus />
+  <div class="actions">
+    <button onclick="closeDialog()">Cancel</button>
+    <button id="reauth-submit">Continue</button>
+  </div>
+</dialog>
+```
+
+Use re-authentication when:
+
+- The action affects security or billing.
+- The action affects other users' access.
+- The action would be devastating if performed by someone with stolen session access.
+- Compliance requires it.
+
+The cost: an extra password entry. The benefit: a second opportunity for the user to reconsider, plus protection against session theft.
+
+## Structural prevention (the highest forgiveness)
+
+Stronger than any confirmation: making the wrong action impossible.
+
+### Disable the action when invalid
+
+A "Submit" button disabled when the form has errors. The user can't trigger the failure path. (Pair with inline error explanations so the user knows what's missing — see `affordance-false-and-anti`.)
+
+### Type-restricted inputs
+
+`<input type="email">` rejects non-email format. `<input type="number">` rejects non-numeric. `<input type="tel">` shows a numeric keyboard on mobile. Each is structural prevention of certain input errors.
+
+### Constraint by selection rather than typing
+
+A `<select>` for state names prevents typos that a free-text field would allow. A date picker prevents impossible dates. A typeahead constrained to known values prevents misspelled selections.
+
+### Physical / hardware analogies
+
+The USB-C connector that can't be inserted upside-down. The pill organizer that shows visual state. The medical injector that can't deliver a dangerous dose.
+
+### Required-field marking + blocked submit
+
+```html
+<form>
+  <label>Email <span class="required">*</span>
+    <input type="email" required />
+  </label>
+  <button>Submit</button>
+</form>
+```
+
+The browser blocks submission with focus on the missing field. Native scaffolding for prevention.
+
+## Anti-patterns
+
+- **Confirmation fatigue.** "Are you sure you want to save? / open? / apply?" Every routine action confirmed. Users dismiss everything on autopilot.
+- **Pre-selected destructive option.** A confirm dialog with the destructive button as default Enter target. Users who hit Enter without reading commit the destruction.
+- **Trivial type-to-confirm.** Forcing users to type "DELETE" for a routine archive operation. Heavy friction for low-stakes action.
+- **Hidden cancellation path.** A confirm dialog with no Esc, no backdrop dismiss, just two buttons. The user feels trapped.
+- **Confirmation as the *only* forgiveness.** Apps where every destructive action is confirmed but nothing is reversible. Confirmation alone is insufficient — users still make mistakes.
+- **Sneaky double-negatives.** "Are you sure you don't want to keep your account?" Users misread; mistakes happen.
+
+## Calibrating friction to stakes
+
+A useful framing: every confirmation step is a tax. Ask whether the tax is worth it for *this specific action*.
+
+| Action | Reversibility | Stakes | Recommended confirmation |
+|---|---|---|---|
+| Save | Reversible | Low | None |
+| Apply filter | Reversible | Low | None |
+| Archive item | Reversible (toast undo) | Low | None |
+| Delete (soft) | Recoverable in trash | Medium | None |
+| Empty trash | Irreversible | Medium | Light dialog |
+| Delete project | Irreversible | High | Strong dialog with summary |
+| Delete account | Irreversible | Very high | Type-to-confirm + reauth |
+| Transfer ownership | Irreversible | Very high | Type-to-confirm + reauth + email verification |
+
+Each step up the friction ladder should correspond to a step up in stakes.
+
+## Heuristics
+
+1. **The reversibility-first check.** Before adding any confirmation, ask: can this be made reversible instead? If yes, do that.
+2. **The autopilot test.** If a typical user would dismiss the confirmation without reading, the confirmation isn't doing its job. Either remove it or make it harder to dismiss without reading.
+3. **The "what would they regret?" test.** For irreversible actions, imagine the user a week later realizing they made a mistake. Did the confirmation do enough to prevent that?
+4. **The disabled-button question.** When you reach for confirmation, ask whether structural prevention (disabling the action when it shouldn't apply) would work better.
+
+## Related sub-skills
+
+- **`forgiveness`** (parent).
+- **`forgiveness-undo-and-soft-delete`** — the preferred alternative when reversibility is possible.
+- **`affordance-false-and-anti`** — disabled states and structural prevention.
+- **`constraint`** — input constraints prevent invalid actions.
+- **`expectation-effect`** — confirmation buttons in unexpected positions surprise users.
+- **`accessibility-understandable`** (process) — confirmation flows must be operable for all users.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness-confirmation-and-prevention/references/confirmation-design-research.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness-confirmation-and-prevention/references/confirmation-design-research.md
@@ -1,0 +1,95 @@
+# Confirmation design: research and pattern reference
+
+A reference complementing `forgiveness-confirmation-and-prevention` with deeper detail on confirmation patterns and how they degrade.
+
+## The science of confirmation fatigue
+
+Confirmation fatigue is well-documented in HCI literature. Key findings:
+
+- **Habituation kicks in fast.** After 3–5 confirmation dialogs in a session, attention to subsequent dialogs drops measurably.
+- **Same-shape dialogs degrade fastest.** If every confirmation looks the same, users dismiss them on shape recognition alone, not content.
+- **Pre-selected default options compound the problem.** When the destructive button is the default, users hit Enter without reading.
+- **Modal interruption increases dismissal rate.** A modal that blocks the page is dismissed faster than an inline confirm because users want to get back to work.
+
+The research conclusion: confirmations work *only* when they are rare, distinct, and require active engagement (typing, not just clicking).
+
+## Type-to-confirm patterns
+
+The most reliable way to break autopilot:
+
+```
+To delete this workspace, type "Acme Inc" below:
+[ ___________________ ]
+```
+
+Variations:
+
+- **Resource name** (most common): user types the project/account name. High specificity, hard to autopilot.
+- **Action verb** ("type DELETE"): used when there's no specific resource name. Lower specificity but still breaks autopilot.
+- **Random verification code**: shown in the dialog, typed by the user. Used when even the resource name might be auto-completed by browser.
+
+## Confirmation copy
+
+Effective confirm copy answers three questions:
+
+1. **What is being acted on?** Name the specific resource ("Delete project Acme Q4?"), not the generic action ("Delete?").
+2. **What is the consequence?** Spell out what will happen and what will be lost.
+3. **Is it reversible?** Either say "This cannot be undone" or describe the recovery path.
+
+```
+Delete project "Acme Q4"?
+
+This will:
+  • Delete 24 tasks
+  • Remove 8 attachments (12 MB)
+  • Revoke access for 3 collaborators
+
+This action cannot be undone.
+
+[ Cancel ]   [ Delete project ]
+```
+
+The user has enough information to decide; the friction earns the consequence.
+
+## Re-authentication patterns
+
+For account-affecting actions, requiring password re-entry:
+
+- **Acts as confirmation** by requiring active engagement.
+- **Acts as security** by verifying the current user is who they claim.
+- **Defends against session theft** — even if someone has your active session, they don't have your password.
+
+Common in: account deletion, email change, ownership transfer, billing changes, viewing audit logs.
+
+Implementation pattern: a separate dialog that intercepts before the destructive action proceeds. The user types their password; on success, the protected action runs.
+
+## Two-factor confirmation
+
+For the highest-stakes actions (transferring ownership, deleting an organization, irreversible financial commits), two-factor authentication can act as confirmation:
+
+```
+This action requires verification.
+Enter the 6-digit code from your authenticator app:
+[ _ _ _ _ _ _ ]
+```
+
+The user must access another device or app, breaking autopilot decisively. Used in: enterprise admin actions, compliance-sensitive operations, large financial transfers.
+
+## When the dialog itself is the dark pattern
+
+Confirmation can be weaponized. Examples:
+
+- **"Are you sure you want to cancel?"** with "Cancel" buttons and "Continue" buttons in confusing layouts. Designed to retain users who tried to leave.
+- **"Don't quit! Try our offer first!"** — confirmations that interpose marketing content.
+- **"You'll lose your benefits!"** — playing loss aversion to dissuade legitimate cancellation.
+
+Regulators (FTC, EU consumer protection) increasingly penalize these. Even if not yet illegal in your jurisdiction, they damage trust badly.
+
+A useful test: would this dialog be acceptable if you were the user? If you'd resent the dialog, your users probably will too.
+
+## Resources
+
+- **Norman, D.** *The Design of Everyday Things* — chapters on errors and forcing functions.
+- **Reason, J.** *Human Error* (1990) — slip vs. mistake; designing against both.
+- **NN/g** — many articles on confirmation design and dialog design.
+- **Brignull, H.** *Deceptive Patterns* (deceptive.design) — catalog of dark-pattern confirmations to avoid.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness-undo-and-soft-delete/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness-undo-and-soft-delete/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: forgiveness-undo-and-soft-delete
+description: 'Use this skill when designing reversibility — undo systems, soft delete, archive-with-recovery, version history, "Undo Send" patterns, and any mechanism that lets a user step back from an action they regret. Trigger when designing destructive actions you want to be safe rather than friction-heavy, when picking between confirmation dialogs and undo toasts, when defining recovery windows, or when planning version-history features. Sub-aspect of `forgiveness`; read that first.'
+---
+
+# Forgiveness through reversibility
+
+Reversibility is the highest-leverage form of forgiveness short of structural prevention. It makes destructive actions safe by allowing recovery — users keep speed (no friction up front) and safety (the action is undoable). Whenever an action *can* be made reversible, that's almost always preferable to confirming it.
+
+## The reversibility ladder
+
+Different actions need different reversibility approaches:
+
+### Synchronous undo (Cmd-Z)
+
+The classic. The user takes an action; pressing Cmd-Z (or Ctrl-Z) reverses it. Multi-level undo lets the user back out through a sequence of actions.
+
+**When it applies:** editing operations on a single object — text editing, image manipulation, design tool actions, code edits.
+
+**Implementation pattern:**
+- Maintain an undo stack of inverse operations.
+- On each action, push the inverse onto the stack.
+- On Cmd-Z, pop and apply the inverse.
+- On any new action after undo, optionally clear the redo stack (or maintain redo separately).
+
+```js
+const undoStack = [];
+const redoStack = [];
+
+function executeAction(action) {
+  action.do();
+  undoStack.push(action);
+  redoStack.length = 0;
+}
+
+function undo() {
+  const action = undoStack.pop();
+  if (!action) return;
+  action.undo();
+  redoStack.push(action);
+}
+
+function redo() {
+  const action = redoStack.pop();
+  if (!action) return;
+  action.do();
+  undoStack.push(action);
+}
+```
+
+### Toast-with-undo (the modern default for one-off destructive actions)
+
+The user takes an action that destroys or moves data; a toast appears with an "Undo" button for several seconds.
+
+**When it applies:** archive, delete, move-to-folder, mark-read, and similar one-shot list actions.
+
+**Implementation pattern:**
+- Optimistically update the UI (item disappears).
+- Send the destructive request to the server (or defer it for the undo window).
+- Show a toast with an Undo affordance for 5–10 seconds.
+- On Undo: reverse the optimistic update, cancel/reverse the server action.
+- On timeout: commit the action permanently.
+
+```js
+async function archive(item) {
+  const previous = items.slice();
+  items = items.filter(i => i.id !== item.id);
+  render();
+
+  let undone = false;
+  showToast(`"${item.name}" archived`, {
+    action: { label: 'Undo', onClick: () => { undone = true; items = previous; render(); } },
+    duration: 7000,
+    onDismiss: () => { if (!undone) api.commitArchive(item.id); }
+  });
+}
+```
+
+The user gets the speed of "click and it happens" plus the safety of "you have 7 seconds to undo."
+
+### Soft delete with explicit recovery
+
+A delete that doesn't actually remove the data — instead moves it to a recoverable state for some window (30 days, indefinitely, until storage cleanup).
+
+**When it applies:** account-level data the user might want back later; emails, documents, files. Common in B2B SaaS.
+
+**Implementation pattern:**
+- Mark the item as deleted with a timestamp.
+- Hide it from default views.
+- Provide a "Trash" or "Archive" view where deleted items can be restored.
+- After the recovery window, hard-delete via background job.
+
+```js
+// Soft delete
+async function softDelete(item) {
+  await api.update(item.id, { deletedAt: new Date(), deletedBy: currentUser.id });
+}
+
+// In default queries
+const visibleItems = items.filter(i => !i.deletedAt);
+
+// Recovery view
+const trashedItems = items.filter(i => i.deletedAt && daysAgo(i.deletedAt) < 30);
+
+async function restore(item) {
+  await api.update(item.id, { deletedAt: null, deletedBy: null });
+}
+```
+
+### Version history
+
+The strongest reversibility: every state of the object is preserved; the user can return to any prior state.
+
+**When it applies:** documents, code, designs, configurations — anything users edit over time and might want to revert.
+
+**Implementation pattern:**
+- Snapshot the object on each meaningful change (or at intervals, or on explicit save).
+- Provide a "Version history" UI listing past states.
+- Allow viewing, restoring, or branching from any prior version.
+
+Google Docs, Notion, Figma, GitHub all implement this. The user never fears editing because they can always restore.
+
+### The "Undo send" pattern
+
+Gmail's pattern: an action that *appears* committed actually defers for a few seconds, allowing cancellation in that window.
+
+**When it applies:** actions that the user often regrets immediately after triggering — sending an email, posting publicly, sending a message.
+
+**Implementation pattern:**
+- On "Send," show "Sending..." with an Undo affordance for N seconds.
+- Don't actually transmit until N seconds elapse with no Undo.
+- On Undo, return to draft state.
+
+The user feels they sent it; the system just defers commitment briefly. The defer window is short (5–30 seconds) — long enough to catch reflexive "wait!" moments, short enough not to delay genuine sends.
+
+## Choosing the right reversibility approach
+
+| Action type | Recommended reversibility |
+|---|---|
+| Text/edit/format change | Synchronous undo (Cmd-Z) |
+| Archive / soft delete one item | Toast-with-undo |
+| Hard delete / account changes | Soft delete + recovery view |
+| Document edits | Version history + Cmd-Z |
+| Send / publish / post | Undo-send window |
+| Bulk destructive | Soft delete + bulk-restore in trash |
+
+## When reversibility isn't possible
+
+Some actions genuinely can't be reversed at the data layer:
+
+- **External communications** (sent emails, sent SMS, public tweets) — the recipient already saw it.
+- **Financial transfers** — money has moved.
+- **Compliance / legal commits** — once signed, signed.
+- **Hardware operations** — once a physical command goes to a robot or printer, it's done.
+
+For these, lean on the next-strongest forgiveness levels: structural prevention (good affordances), confirmation (deliberate intent), and warnings.
+
+The "Undo send" pattern bridges this for some communications: the *external* action is still irreversible, but the system delays it long enough for the user to catch second thoughts.
+
+## Recovery window length
+
+For toast-with-undo: 5–10 seconds is the typical range.
+
+- < 5 seconds: too short for users who realized after a moment of reflection.
+- 5–7 seconds: covers most reflexive corrections.
+- 10+ seconds: lingers; some users dismiss the toast before reading it.
+
+For soft delete: 7–30 days is typical.
+
+- 7 days: balances storage cost with user recovery needs.
+- 30 days: standard for most SaaS; forgiving enough for vacations and weekends.
+- Indefinite: storage cost grows but maximum forgiveness.
+
+## Discoverability of recovery
+
+A reversibility mechanism that users don't know exists doesn't help. Patterns:
+
+- **Toast affordance** is its own discovery — users see the Undo button and learn the pattern.
+- **"Trash" or "Archive" navigation entry** signals that deleted items can be recovered.
+- **Onboarding mention** for version history ("All changes saved. View history at any time.").
+
+If users are filing tickets to recover data they could have restored themselves, the recovery affordance isn't visible enough.
+
+## Anti-patterns
+
+- **Toast that vanishes too fast.** A 2-second toast with an Undo button most users never see.
+- **Soft delete with no recovery UI.** Items go to a "trash" the user can't access.
+- **Version history that's hidden.** Buried under three menu levels; users don't know it exists.
+- **Cmd-Z that doesn't undo destructive actions.** Some apps undo formatting but not deletion. Inconsistent.
+- **Undo that fails silently.** Click Undo; nothing happens; no error; user is confused. If undo fails, say so.
+
+## Heuristics
+
+1. **The "did they recover?" check.** Look at support tickets for data loss. Each one is a reversibility failure.
+2. **The toast-button audit.** For every destructive action, is there a toast with Undo? If not, why not?
+3. **The trash audit.** Is there a Trash / Archive / Recycle Bin in your app? If items can be deleted but there's no recovery view, you're missing soft delete.
+
+## Related sub-skills
+
+- **`forgiveness`** (parent).
+- **`forgiveness-confirmation-and-prevention`** — the alternative when reversibility isn't possible.
+- **`feedback-loop`** — toast-with-undo is feedback that doubles as reversibility.
+- **`factor-of-safety`** (process) — engineering analog of "design with margin so errors are recoverable."

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness-undo-and-soft-delete/references/undo-pattern-history.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness-undo-and-soft-delete/references/undo-pattern-history.md
@@ -1,0 +1,81 @@
+# Undo and soft delete: pattern history and reference
+
+A reference complementing `forgiveness-undo-and-soft-delete` with deeper context on how reversibility patterns evolved and where they fit.
+
+## Brief history of undo
+
+The earliest computer undo dates to the 1970s — Larry Tesler at Xerox PARC implemented one-step undo in the Gypsy text editor. The IBM Common User Access guidelines (1987) standardized Cmd-Z (Mac) and Ctrl-Z (Windows). Multi-level undo became standard in productivity software through the 1990s.
+
+The pattern has continued to evolve:
+
+- **Single-level undo** (early word processors): one step back, then irreversible.
+- **Multi-level undo stack** (modern editors): unlimited or bounded backsteps.
+- **Branching undo / version history** (Git, Photoshop's history palette, Google Docs): each state preserved; user can return to any.
+- **Operational transforms / CRDTs** (collaborative editors): undo in multi-user environments respects concurrent edits.
+
+Each evolution increased the "safe to explore" surface for users.
+
+## Soft-delete as a database pattern
+
+The soft-delete pattern (mark a row as deleted rather than removing it) has been standard in production databases for decades. It enables:
+
+- User-initiated recovery within a window.
+- Compliance / audit (some regulations require retaining deleted data for periods).
+- Cascade-delete safety (if a related row was wrongly deleted, the cascade impact can be undone).
+- Background cleanup decoupled from user action.
+
+Implementation: a `deleted_at` timestamp column. Default queries filter out non-null. Background jobs hard-delete rows past the recovery window.
+
+## "Undo Send" — Gmail's pattern
+
+Gmail introduced "Undo Send" in Gmail Labs (2009), made it default in 2015. The pattern:
+
+- User clicks Send.
+- UI shows "Sending..." with an "Undo" link.
+- For 5–30 seconds (configurable), the message is held in an outbox state.
+- If Undo is clicked, the message returns to draft.
+- After the window, the message actually transmits.
+
+This was a quiet revolution because email had been considered irreversible since SMTP was designed in 1982. Gmail's "well, not really irreversible — we'll just delay a bit" reframing has since spread to messaging apps, comment systems, social posts.
+
+## Recovery window calibration
+
+The right recovery window depends on user context and storage cost:
+
+| Action | Typical window | Reasoning |
+|---|---|---|
+| Toast undo for archive | 5–10 sec | Reflexive correction |
+| Email undo-send | 5–30 sec | Catches "wait, that wasn't right" moments |
+| Soft-deleted email / file | 30 days | Vacation-tolerant |
+| Soft-deleted account | 30–90 days | Compliance + reconsideration window |
+| Document version history | Unlimited | Storage cost is small; recovery value is high |
+
+Shorter windows save storage; longer windows save user trust. For most consumer products, lean toward longer.
+
+## Undo across collaborative editing
+
+In multi-user editors (Google Docs, Figma), undo gets complicated:
+
+- Whose actions does Cmd-Z reverse — yours or anyone's?
+- What if your action depended on someone else's that's still pending?
+- What if an undo creates a conflict with someone else's edit?
+
+Modern collaborative editors solve this with operational transforms (OT) or conflict-free replicated data types (CRDTs). The user-facing rule typically: Cmd-Z reverses *your* actions only; you can't undo other people's edits.
+
+## Discoverability of recovery
+
+A reversibility mechanism users don't know exists doesn't help. Patterns:
+
+- **Toast Undo button** — its own discovery; users see and learn.
+- **Trash / Archive nav entry** — signals deleted items can be recovered.
+- **Onboarding mention** — explicit teaching of version history.
+- **Empty-state hints** — when a user lands in a recovery view, explain it.
+
+If users file tickets to recover data they could have restored themselves, your recovery affordance is too quiet.
+
+## Resources
+
+- **Tesler, L.** historical writings on the Gypsy editor and the origin of undo.
+- **Memon, A.** *Designing Undo* — pattern analysis.
+- **Gmail's "Undo Send" engineering blog** — public account of the design choice.
+- **Google Docs version history documentation** — illustrates the version-history pattern at scale.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: forgiveness
+description: 'Use this skill whenever a design lets users do something they might regret — delete, send, publish, charge, transfer, archive, overwrite, irrecoverably commit. Trigger when designing destructive actions, undo systems, confirmation dialogs, soft-delete recovery, draft-saving, transaction reversal, "are you sure?" patterns, or any flow where a wrong move costs the user time, data, money, or trust. Trigger when the user mentions "users keep deleting things," "we get support tickets about lost data," "is this dangerous?", or when reviewing destructive UI. Forgiveness is one of the central principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) and one of Nielsen''s 10 heuristics ("user control and freedom").'
+---
+
+# Forgiveness
+
+Forgiveness is the property of a design that helps users avoid mistakes and recover gracefully from the ones they make. The opposite — an unforgiving design — punishes errors with lost work, irreversible changes, or hostile error states. Since human error is inevitable, forgiving design is what determines whether the product is pleasant to use over time or a constant source of low-grade anxiety.
+
+## Definition (in our own words)
+
+A forgiving design recognizes that users will make mistakes — slips (correct intent, wrong action), mistakes (wrong intent because of wrong model), and accidents (the cat walked across the keyboard). It builds in mechanisms to *prevent* errors before they happen, *minimize their consequences* when they do happen, and *recover from them* when prevention and minimization both fail. The principle's central insight: error is a property of the *design*, not of the user. A design that produces lots of user error is a poorly-designed design, even if every user "could have been more careful."
+
+## Origins and research lineage
+
+- **Lidwell, Holden & Butler**, *Universal Principles of Design* (2003) compactly articulated the principle and identified six strategies for incorporating forgiveness: good affordances, reversibility of actions, safety nets, confirmation, warnings, and help. The book noted an inverse relationship: stronger affordances and reversibility reduce the need for confirmations, warnings, and help.
+- **Donald Norman**, *The Design of Everyday Things* (1988, revised 2013) emphasized that "designing for error" is a core design responsibility, not an afterthought. Norman drew heavily on safety-engineering literature.
+- **James Reason**, *Human Error* (Cambridge University Press, 1990). The standard reference work in human-error research, originally grounded in industrial-safety analysis (aviation, nuclear, medical). Reason's slip/mistake distinction (a slip is a wrong action despite correct intent; a mistake is a correct action of a wrong intent) shapes most modern error-recovery thinking.
+- **Jakob Nielsen**, "10 Usability Heuristics" (1994 onward). Two of the ten heuristics directly concern forgiveness: "User control and freedom" (undo, escape) and "Help users recognize, diagnose, and recover from errors."
+- **Aviation and medical safety design** have shaped the understanding of *how* to build forgiveness into systems where errors are catastrophic. Crumple zones, fuse boxes, double-confirmation for destructive surgical commands, and "five rights" of medication administration are all forgiveness patterns from these domains.
+
+## The forgiveness ladder
+
+Roughly ordered from preferred to least preferred — preferred ones reduce the need for the others:
+
+### 1. Good affordances (prevent the error)
+
+If the design makes the wrong action impossible or hard to do by accident, the error never occurs. A USB connector that can't be inserted upside-down (USB-C). A dialog where the destructive button is small and far from the safe one. A control that's only enabled when the operation makes sense.
+
+This is the *highest* level of forgiveness because it requires no user attention or recovery — the error is structurally prevented.
+
+### 2. Reversibility (recover from the error)
+
+If the user can undo, the error costs only the time to notice and reverse. Cmd-Z is the canonical example; soft-delete with a recovery window is its data-layer counterpart. Version history is its document counterpart.
+
+Reversibility is preferred to confirmation because it doesn't punish exploration. Users who feel safe to try things learn faster and use the product more confidently.
+
+### 3. Safety nets (catch catastrophic errors)
+
+A system or feature that minimizes damage when an error does happen and isn't reversible. Crumple zones in cars. Auto-saving drafts. Trash with a recovery window. Backup systems. The pilot's ejection seat in a fighter jet.
+
+Safety nets are insurance against the unanticipated. They cost design and engineering effort but pay off when prevention and reversibility weren't enough.
+
+### 4. Confirmation (require deliberate intent for destructive actions)
+
+The user is asked to verify before a high-stakes action commits. "Are you sure you want to delete?" "Type DELETE to confirm." "Enter your password to authorize."
+
+Confirmation is the most-overused forgiveness mechanism and the easiest to abuse. Confirmations applied to routine reversible actions get dismissed on autopilot, training users to ignore them when they finally apply to a real destructive action.
+
+### 5. Warnings (signal danger before it happens)
+
+Visual or auditory cues that something dangerous is about to happen. A "you have unsaved changes" prompt before navigating away. A warning label on industrial equipment. A road sign for a sharp curve.
+
+Warnings work when applied sparingly to genuinely high-consequence moments. They become wallpaper when applied to everything.
+
+### 6. Help (assist recovery after the error)
+
+Documentation, error messages with remediation steps, support chat, recovery flows. The lowest-preferred level because it kicks in *after* the error has already happened and disrupted the user's task.
+
+A useful diagnostic: the amount of help required is inversely proportional to the quality of the design. If users need extensive help to use your product, the help is compensating for missing forgiveness at the higher levels.
+
+## When to apply
+
+- **Every destructive action.** Delete, archive, transfer, send, publish, overwrite — each needs at least one level of forgiveness.
+- **Every irreversible change.** Account deletion, ownership transfer, plan downgrade, contract acceptance.
+- **Every high-stakes input.** Payment forms, address submissions for shipping, password setting.
+- **Every flow where users invest time.** Forms, drafts, edits — saving / auto-saving as forgiveness for navigation away.
+- **Anywhere users have reported loss.** "I lost my data" tickets are prima facie evidence of missing forgiveness.
+
+## When NOT to over-apply
+
+- **Routine reversible actions.** Don't confirm "Save" — saving is the whole point. Don't confirm "Apply filter" — the user can change the filter again.
+- **High-frequency low-stakes actions.** Confirmation fatigue is real. The user who dismisses 50 routine confirmations a day will dismiss the destructive one too.
+- **Operations the user has just initiated themselves.** If the user clicked "Delete," they probably meant to. Confirmation is for actions where the user might have *not* meant to (autopilot click, accidental keystroke).
+
+The goal isn't maximum confirmation; it's *appropriate* friction calibrated to the action's stakes.
+
+## Worked examples
+
+### Example 1: a soft-delete with undo (the modern default)
+
+Most modern apps prefer reversibility over confirmation for routine destructive actions.
+
+```html
+<button onclick="archive(item)">Archive</button>
+
+<script>
+async function archive(item) {
+  const previous = items.slice();
+  items = items.filter(i => i.id !== item.id);
+  render();
+  await api.archive(item.id);
+  showToast(`"${item.name}" archived`, {
+    action: { label: 'Undo', onClick: () => unarchive(item, previous) },
+    duration: 7000,
+  });
+}
+
+function unarchive(item, previous) {
+  items = previous;
+  render();
+  api.unarchive(item.id);
+}
+</script>
+```
+
+The action is one click; if wrong, one click in the toast restores. Most users never need the undo; the few who do have a 7-second window. No confirmation dialog, no friction on the common path.
+
+### Example 2: type-to-confirm for irreversible destruction
+
+Some actions genuinely can't be undone (or shouldn't be made undoable for security/compliance reasons). For these, raise friction deliberately.
+
+```html
+<button onclick="openDeleteDialog()">Delete account</button>
+
+<dialog id="delete-dialog">
+  <h2>Delete account permanently?</h2>
+  <p>This deletes your account, all your projects (12), and revokes access for your team (38 members). It cannot be undone.</p>
+  <p>To confirm, type your account email below:</p>
+  <input id="confirm-input" placeholder="you@example.com" />
+  <div class="actions">
+    <button onclick="closeDialog()">Cancel</button>
+    <button id="confirm-btn" disabled class="destructive">
+      Delete account permanently
+    </button>
+  </div>
+</dialog>
+
+<script>
+const input = document.getElementById('confirm-input');
+const btn = document.getElementById('confirm-btn');
+input.addEventListener('input', () => {
+  btn.disabled = input.value !== currentUser.email;
+});
+</script>
+```
+
+The user must (a) intend to open the dialog, (b) read the consequences laid out, (c) actively type their email, (d) click the destructive button. Each step is a chance to step back. For genuinely irreversible high-stakes actions, this stack is appropriate.
+
+### Example 3: auto-save as a safety net
+
+A form that auto-saves drafts protects the user from navigation accidents, browser crashes, and second-guessing.
+
+```html
+<form id="post-editor">
+  <input name="title" placeholder="Title" />
+  <textarea name="body" placeholder="Write your post..."></textarea>
+  <p class="save-status" aria-live="polite">All changes saved</p>
+  <button>Publish</button>
+</form>
+
+<script>
+const form = document.getElementById('post-editor');
+const status = form.querySelector('.save-status');
+
+form.addEventListener('input', debounce(async () => {
+  status.textContent = 'Saving...';
+  await api.saveDraft(serialize(form));
+  status.textContent = `Saved at ${formatTime(new Date())}`;
+}, 600));
+</script>
+```
+
+The user never thinks about saving; the system saves continuously. If they navigate away, the draft survives. If they refresh, the draft restores. The "Publish" button is the only commit; everything else is reversible.
+
+### Example 4: warning before navigation away with unsaved changes
+
+When the user has unsaved work and tries to leave, a warning is appropriate friction.
+
+```js
+window.addEventListener('beforeunload', (e) => {
+  if (form.dataset.dirty === 'true') {
+    e.preventDefault();
+    e.returnValue = '';  // browsers show their own confirmation
+  }
+});
+```
+
+The browser's native dialog appears. The user can cancel and stay, or confirm and lose changes. If you've also implemented auto-save, this dialog appears only briefly between auto-saves — and the saved draft is still there if they leave.
+
+### Example 5: error message that aids recovery
+
+A poorly-designed error message says "Error 503." A forgiving error message names the problem, explains what went wrong, and offers the next step.
+
+```html
+<div class="error-card">
+  <h3>We couldn't process your payment</h3>
+  <p>
+    Your card (ending in 4242) was declined. This usually means insufficient
+    funds or a billing-address mismatch.
+  </p>
+  <p>
+    <button>Try a different card</button>
+    <a href="/help/declined-payments">Why was my card declined?</a>
+  </p>
+</div>
+```
+
+The error doesn't blame the user; it explains, offers an action, and provides a path to deeper help.
+
+## Cross-domain examples
+
+### Aviation: the ejection seat
+
+The ultimate safety net. The pilot can't undo a structural failure, but they can leave the aircraft. The seat itself is a forgiveness mechanism — designed for the moment everything else has failed.
+
+### Cars: crumple zones
+
+The front and rear of a car are deliberately weakened to absorb collision energy through controlled deformation, protecting the cabin and occupants. This is "weakest link" applied to forgiveness — the chosen failure point preserves what matters.
+
+### Medical: pill organizers and barcoded medications
+
+Medication errors are a leading cause of preventable hospital harm. Forgiveness mechanisms include weekly pill organizers (good affordance — visible state of taken vs. untaken), barcode scanning (verification), and the "five rights" workflow (right patient, right drug, right dose, right route, right time).
+
+### Industrial: lockout-tagout
+
+Before maintenance on hazardous equipment, workers physically lock and tag the energy source so it can't be activated until the lock is removed. A forcing function that prevents accidental energizing — a pure prevention strategy.
+
+### Word processors: undo / redo / version history
+
+Microsoft Word and successors normalized undo as standard. Modern systems extend this to version history (Google Docs, Notion) — the user can not only undo recent changes but visit any prior state.
+
+### Email: "Undo Send"
+
+Gmail introduced an "Undo send" feature with a default 5-second window (configurable up to 30). The send doesn't actually go out for that period; cancel reverses it. A reversibility mechanism applied to a previously-irreversible action.
+
+## Anti-patterns
+
+- **Confirmation fatigue.** Confirming routine actions ("Save?", "Apply?", "Open?") trains users to dismiss confirmations on autopilot. When a real destructive confirmation appears, they dismiss that too.
+- **Modal traps without escape.** A "Are you sure?" with no Cancel, no Esc, no backdrop click. The user can only proceed.
+- **Cryptic error messages.** "Error: ENOENT" or "Operation failed" with no explanation. The user can't recover.
+- **Pre-selected destructive option.** A confirmation dialog with "Delete" pre-selected so Enter triggers it. Users hit Enter on autopilot.
+- **No undo for routine actions.** Apps where every change is committed immediately and irreversibly. Users learn fear, not confidence.
+- **Soft-delete that's not recoverable.** "Archive" that quietly purges 30 days later with no recovery window or explanation.
+- **Help as the only forgiveness layer.** "If you have problems, contact support." The user has already lost their work.
+
+## Heuristics
+
+1. **The "what if they didn't mean it?" test.** For each destructive action, ask: how does the user recover if they didn't mean to do this? If the answer is "they can't," you need at minimum strong confirmation; ideally reversibility.
+2. **The confirmation count.** Count how many confirmation dialogs a typical user encounters in a typical session. > 3 → likely confirmation fatigue. Replace some with undo.
+3. **The error-message audit.** Every error message in your app should answer (a) what happened, (b) why, (c) what to do next. Audit a sample; fix the ones that don't.
+4. **The "lose your work" test.** Try every plausible way a user might lose work: navigate away, close tab, refresh, lose connection, browser crash. For each, does the system recover? If yes, forgiveness is strong.
+
+## Related principles
+
+- **`affordance`** — good affordances *prevent* errors; this is the highest level of forgiveness.
+- **`constraint`** — constraints prevent invalid actions structurally.
+- **`errors`** — slip vs. mistake distinction shapes which forgiveness mechanism applies.
+- **`feedback-loop`** — feedback after an action lets the user catch errors quickly.
+- **`factor-of-safety`** (process) — engineering version of the same idea: design with margin so normal operation isn't at the edge of failure.
+- **`weakest-link`** (process) — crumple-zone logic; deliberately failing at a chosen point.
+- **`accessibility-understandable`** (process) — error identification and recovery are accessibility requirements.
+
+## Sub-aspect skills
+
+- **`forgiveness-undo-and-soft-delete`** — designing reversibility: undo systems, soft delete, version history, the "Undo Send" pattern.
+- **`forgiveness-confirmation-and-prevention`** — when confirmation is appropriate, how to design it, and how to prevent confirmation fatigue.
+
+## Closing
+
+Forgiveness is the principle that determines whether a product is loved or feared. Loved products let users explore, undo, and recover; users develop confidence and use them daily without anxiety. Feared products punish exploration; users develop anxious habits and stick to the obvious paths. Build for the loved version: prevent first, reverse second, confirm only when you must.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness/references/error-research-and-cross-domain.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/forgiveness/references/error-research-and-cross-domain.md
@@ -1,0 +1,129 @@
+# Forgiveness: error research and cross-domain reference
+
+A reference complementing the `forgiveness` SKILL.md with deeper grounding from human-error research and examples from safety-critical domains.
+
+## Reason's classification of error
+
+James Reason's *Human Error* (Cambridge University Press, 1990) is the standard reference for error analysis. Reason distinguishes:
+
+### Slips and lapses (skill-based errors)
+
+The user knew what to do; their action didn't match their intent. Examples:
+
+- Typing the wrong key.
+- Clicking the wrong button (intended Save, hit Submit).
+- Forgetting to attach the file before sending the email.
+
+Slips happen even to experts at familiar tasks. They are the bulk of routine errors. The forgiveness response: make the wrong action harder to take by accident (defensible space, target sizing, anti-affordance) and make the right action easy to recover (undo, soft delete).
+
+### Mistakes (rule-based or knowledge-based)
+
+The user's action matched their intent, but the intent was wrong because their model of the situation was wrong. Examples:
+
+- Following the wrong instructions because they didn't know the situation differed.
+- Choosing the wrong option because they misunderstood the choices.
+- Building the wrong feature because requirements were misread.
+
+Mistakes happen more to new users and in unusual situations. The forgiveness response: reduce ambiguity (clear copy, consistent behavior), provide help in context, surface confirmations for high-stakes actions where wrong intent is plausible.
+
+### Violations
+
+Deliberate departures from rules — sometimes routine ("speeding because everyone does it"), sometimes situational ("breaking the rule to save lives in an emergency"). Less common in software UI but worth knowing about.
+
+The slip/mistake distinction matters because the right forgiveness mechanism differs:
+
+| Error type | Best forgiveness response |
+|---|---|
+| Slip | Reversibility (undo, soft delete) |
+| Mistake | Information / explanation; confirmation of intent |
+| Violation | Constraints; audit logs; safety nets |
+
+## Forgiveness in safety-critical domains
+
+### Aviation
+
+Aviation has driven much of the modern thinking on human error. Key forgiveness patterns:
+
+- **Checklists** prevent slips by externalizing memory (Atul Gawande's *The Checklist Manifesto* documents this thoroughly).
+- **Cockpit voice recorders and flight data recorders** are safety nets — they don't prevent error but enable diagnosis after.
+- **Fly-by-wire** systems prevent some pilot inputs that would damage the aircraft (a structural prevention).
+- **Crew Resource Management** (CRM) trains crews to challenge each other on mistakes — social forgiveness.
+
+### Medicine
+
+Medical errors are the third leading cause of death in the US (per a 2016 BMJ analysis). Forgiveness patterns:
+
+- **Barcoded medication administration** (BCMA) — the nurse scans both the patient's wristband and the medication; mismatches block administration.
+- **Pharmacy double-checks** for high-risk medications.
+- **The Universal Protocol** (mark the surgical site, time-out before incision) prevents wrong-site surgery.
+- **Tall-man lettering** for confusable drug names (DOPamine vs. DOBUTamine) reduces slip rates.
+
+### Industrial
+
+- **Lockout-Tagout** (LOTO) procedures prevent equipment from being energized during maintenance.
+- **Two-key authorization** for hazardous operations (nuclear missile launch, blood-bank releases).
+- **Dead-man switches** that disengage if the operator becomes incapacitated.
+- **Crumple zones** and **fuses** as safety nets in failure scenarios.
+
+### Software's parallels
+
+Modern software has analogues:
+
+- **Two-factor authentication** ≈ two-key authorization.
+- **Pre-deployment checklists** in CI/CD ≈ aviation checklists.
+- **Soft delete with recovery window** ≈ surgical time-out.
+- **Permission systems** that prevent destructive operations from non-admins ≈ industrial access control.
+- **Audit logs** ≈ flight data recorders.
+
+The discipline of "designing for error" cross-pollinates between these domains continuously.
+
+## Norman's "designing for error"
+
+In *Design of Everyday Things* (revised 2013), Norman lists design responses to error:
+
+1. **Understand causes of error and design to minimize them.**
+2. **Make it easy to discover errors.**
+3. **Make it easy to reverse them.**
+4. **Make it hard to perform irreversible actions.**
+5. **Add forcing functions** that prevent invalid actions.
+
+Forcing functions are particularly powerful: they make the wrong action structurally impossible. Examples in software:
+
+- A "Send" button disabled until required fields are filled (forcing the user to complete the form).
+- A confirmation dialog with the destructive button disabled until the user types a verification string.
+- A multi-step flow where each step gates on the previous (the user can't accidentally skip).
+
+## The cost of unforgiving design
+
+The user-experience cost is obvious — frustration, lost data, support burden. The longer-term costs include:
+
+- **Anxious habits.** Users develop ritualistic behavior (always Cmd-S after every action) because they don't trust the system.
+- **Learned helplessness.** Users stop exploring features because exploration is risky.
+- **Workarounds.** Users develop external systems (spreadsheets, paper notebooks) to compensate for missing forgiveness.
+- **Trust erosion.** Each loss-of-data incident damages trust in the entire product, beyond the specific feature.
+- **Brand damage.** Public stories of user data loss spread; the long-term cost is reputation.
+
+The investment in forgiveness is repaid not in any one moment but in the cumulative experience of users who feel safe to use the product without anxiety.
+
+## Confirmation fatigue research
+
+The phenomenon is well-studied. Key findings:
+
+- After exposure to ~3 confirmation dialogs in a session, users dismiss new ones with declining attention.
+- Users who routinely confirm reversible actions develop "Yes" autopilot.
+- Confirmation rate that's calibrated to action stakes (rare for routine, frequent for destructive) outperforms uniform confirmation.
+- Two-step confirmation (a typed verification, not just a click) breaks autopilot for irreversible actions.
+
+The lesson: confirmation must be calibrated and rare to be effective. Reflexive "let's add a confirm to be safe" actually reduces safety because it teaches users to dismiss confirms.
+
+## Resources
+
+- **Reason, J.** *Human Error* (1990).
+- **Norman, D.** *The Design of Everyday Things* (1988, revised 2013) — chapters on errors and design.
+- **Gawande, A.** *The Checklist Manifesto* (2009).
+- **Perrow, C.** *Normal Accidents* (1984) — system-level failure analysis.
+- **NN/g** — articles on error handling, undo patterns, and confirmation design.
+
+## Closing
+
+Forgiveness is the principle that grows in importance as users come to rely on a product. A new user might tolerate an unforgiving design briefly; a daily user develops anxiety around it. Investing in forgiveness — undo, soft delete, version history, sensible confirmation — pays compounding returns in trust, in retention, and in support cost.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/interaction-router/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/interaction-router/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: interaction-router
+description: 'Use this skill whenever a design task involves what users *can do* and what happens when they do it — affordances, feedback, errors, undo, confirmation, target sizing, keyboard handling, modal vs. non-modal decisions, destructive actions, validation. Trigger when the user mentions buttons, forms, validation, error states, loading states, drag-and-drop, undo, confirmation dialogs, keyboard shortcuts, target sizes, "users keep deleting things," misclicks, or "should this be a popover or a dialog." Framework-agnostic. Routes the model to the right interaction principle in this plugin.'
+---
+
+# Interaction & control — router
+
+This plugin holds the principles that govern interaction: what is clickable, what happens when it's clicked, how mistakes are prevented and recovered. They apply to web, mobile, desktop, voice, and physical product interfaces.
+
+## Principles in this plugin
+
+Each principle has its own skill (with sub-aspect skills where useful). Principles marked **[full]** have reference-grade skill files; the rest are planned and will be added in subsequent passes.
+
+### Affordance and target sizing
+
+- **`affordance`** *[full]* — visual and behavioral cues that suggest how an element is used.
+  - Sub-skills: `affordance-buttons-vs-links`, `affordance-disabled-states`, `affordance-non-obvious-targets`.
+- **`constraint`** — limit interactions to those that are valid in context.
+- **`fitts-law`** *[full]* — time to acquire a target depends on its size and distance.
+  - Sub-skills: `fitts-law-touch-targets`, `fitts-law-screen-edges`, `fitts-law-pointer-acceleration`.
+- **`defensible-space`** — separate destructive controls from common ones.
+- **`entry-point`** — the first point of contact must invite engagement.
+
+### Feedback and errors
+
+- **`feedback-loop`** — every action gets a perceptible response.
+- **`errors`** — slips (skill failures) vs. mistakes (knowledge failures); design for both.
+- **`forgiveness`** — make actions reversible or confirmable.
+- **`garbage-in-garbage-out`** — validate at the boundary; don't let bad data flow inward.
+- **`cost-benefit`** — don't ask the user to pay for an action whose payoff isn't clear.
+- **`convergence`** — design conventions converge over time; deviate only with reason.
+
+### Control and behavior
+
+- **`control`** — users should feel in command of the system, not the reverse.
+- **`flexibility-usability-tradeoff`** — every added option harms usability for the simple case.
+- **`most-advanced-yet-acceptable`** — push novel only as far as users will tolerate.
+- **`performance-vs-preference`** — what users prefer isn't always what makes them effective.
+- **`hierarchy-of-needs`** — functionality, reliability, usability, proficiency, creativity (in order).
+
+### Persuasion and behavior shaping
+
+- **`nudge`** — small choice-architecture changes that make the better path easier.
+- **`operant-conditioning`** — behavior shaped by reinforcement; use sparingly and honestly.
+- **`classical-conditioning`** — emotional associations transfer.
+- **`shaping`** — gradually increase task complexity through practice.
+- **`expectation-effect`** — users perceive what they expect to perceive.
+- **`freeze-flight-fight-forfeit`** — under stress, users default to instinctive responses.
+- **`desire-line`** — the path users actually take, often diverging from the planned one.
+- **`interference-effects`** — competing stimuli (Stroop) slow processing.
+
+## Heuristic for which to read first
+
+- **Designing buttons/CTAs** → `affordance`, `fitts-law`, `defensible-space`.
+- **Designing forms** → `affordance`, `constraint`, `feedback-loop`, `errors`, `forgiveness`.
+- **Mobile target sizing** → `fitts-law-touch-targets`.
+- **Destructive actions** → `defensible-space`, `forgiveness`, `freeze-flight-fight-forfeit`, `expectation-effect`.
+- **Validation and error copy** → `errors`, `forgiveness`, `garbage-in-garbage-out`.
+- **Modal vs. non-modal decisions** → `control`, `entry-point`, `interference-effects`.
+- **"Should we add this option?"** → `flexibility-usability-tradeoff`, `most-advanced-yet-acceptable`.
+
+## Cross-plugin pointers
+
+- For *visual* layout, hierarchy, and grouping, see `perception-and-hierarchy-principles`.
+- For *learnability* (mental models, defaults, recognition), see `cognition-and-learnability-principles`.
+- For *aesthetic and tonal* decisions, see `aesthetics-and-emotion-principles`.
+- For *accessibility*, see `process-and-robustness-principles`.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/interaction-router/references/further-reading.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/interaction-router/references/further-reading.md
@@ -1,0 +1,44 @@
+# Further reading: interaction and control
+
+External sources for the interaction-related principles.
+
+## Foundational
+
+- **Norman, D.** (1988). *The Design of Everyday Things*. Affordance, mapping, feedback, errors — the canonical framework.
+- **Fitts, P. M.** (1954). "The information capacity of the human motor system in controlling the amplitude of movement." *Journal of Experimental Psychology*, 47(6), 381–391. The original Fitts's Law paper.
+- **Card, S. K., Moran, T. P., Newell, A.** (1983). *The Psychology of Human-Computer Interaction*. Comprehensive synthesis of motor and cognitive HCI laws.
+
+## Heuristics
+
+- **Nielsen, J.** (1994). "10 Usability Heuristics for User Interface Design." Available at nngroup.com. Heavily overlaps with the principles in this plugin (visibility, match between system and real world, user control and freedom, consistency, error prevention, recognition over recall, flexibility-usability tradeoff, aesthetic and minimalist design, error recovery, help and documentation).
+
+## Affordance and signifiers
+
+- **Gibson, J. J.** (1979). *The Ecological Approach to Visual Perception*. The original "affordance" concept (from ecological psychology, before HCI).
+- **Norman, D.** (2008). "Signifiers, not affordances." A clarification of his earlier work — what designers control are *signifiers* (visual cues) that suggest affordances; the affordance is in the user-environment relationship.
+
+## Errors and forgiveness
+
+- **Reason, J.** (1990). *Human Error*. The foundational work on slips vs. mistakes; aviation/medical-grade error analysis applicable to UI.
+- **Norman, D.** (1983). "Design rules based on analyses of human error." *Communications of the ACM*. Translates error research into UI guidance.
+
+## Mobile and touch
+
+- **Hoober, S.** (2013). "How Do Users Really Hold Mobile Devices?" *UX Matters*. Empirical thumb-reach research.
+- **Apple Human Interface Guidelines** — developer.apple.com/design/human-interface-guidelines.
+- **Material Design** — material.io/design.
+
+## Behavioral nudges
+
+- **Thaler, R. & Sunstein, C.** (2008). *Nudge*. Choice architecture and ethical persuasion.
+- **Cialdini, R.** *Influence: The Psychology of Persuasion* (1984). Six persuasion principles widely applied (and misapplied) in UI.
+
+## Online tools and references
+
+- **WAI-ARIA Authoring Practices** — w3.org/WAI/ARIA/apg. Canonical patterns for accessible interactive components.
+- **Laws of UX** — lawsofux.com. Visual reference for many of these principles.
+- **Refactoring UI** — refactoringui.com.
+
+## Closing
+
+Interaction principles are uniquely susceptible to "tradition" claims — the patterns that *exist* are claimed as the patterns that *should*. Treat with caution: many are good (cmd-K palettes, Esc to close, primary-action bottom-right of dialogs); some are inertia (hamburger menus, pop-up modal CTAs). Test against real users, not just convention.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping-cultural/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping-cultural/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: mapping-cultural
+description: 'Apply cultural mapping — using shared conventions (icons, colors, gestures, metaphors) to convey what a control does when natural spatial mapping isn''t available. Use when designing icon-based UIs, choosing colors for status indicators, picking gestures for touch interfaces, or selecting metaphors to make abstract operations concrete (the trash can, the gear, the magnifying glass). Cultural mappings are weaker than spatial ones — they require prior learning — but they''re the workhorse of icon-driven interfaces. The risk is assuming a convention is universal when it''s actually domain-specific.'
+---
+
+# Mapping — cultural (convention and signaling)
+
+Cultural mapping carries meaning through shared convention. The user knows the gear means "settings" because they've seen it a thousand times before. They know red means stop, green means go, yellow means slow. They know the trash can means delete and the magnifying glass means search. None of these mappings is innate — they all had to be learned somewhere — but within a culture that recognizes them, they're effectively free.
+
+Cultural mapping is the workhorse of icon-driven interfaces, because the spatial form of mapping is rarely available for software UI. You can't physically place a "settings" control next to "the settings"; settings are abstract. So you reach for a metaphor — a gear, a wrench, a sliders icon — and rely on the user's prior exposure to interpret it.
+
+## When cultural mapping works
+
+A cultural mapping works when three conditions are met.
+
+**The convention is genuinely universal in your audience.** A red stop sign is universal in driving cultures. A floppy disk for "save" is recognizable to most adults in industrialized cultures, though weakening as a generation that never used floppies grows up. A mortarboard hat for "education" is universal in cultures with that academic tradition.
+
+**The convention is the dominant convention, not one of several.** A magnifying glass for "search" is dominant. A gear for "settings" is dominant. But a globe icon could mean "internet," "international," "translation," or "external link" — none of those is the dominant interpretation, so the icon needs a label. When two conventions compete, you need disambiguation.
+
+**The cost of misinterpretation is low or recoverable.** If a user clicks the gear thinking it's settings and it turns out to be "advanced filtering," the cost is one click and a moment of recalibration. If a user clicks the trash can thinking it deletes the current item and it actually empties their entire account, the cost is catastrophic. Strong conventions can carry low-stakes operations; high-stakes operations need explicit labels even when conventions exist.
+
+## The four sources of cultural meaning
+
+Cultural mappings draw on four kinds of prior knowledge.
+
+**Pictographic — direct visual reference to a real-world object.** The trash can looks like a trash can; the camera icon looks like a camera; the lock icon looks like a padlock. These are the most transparent kind of cultural mapping because they require only that the user has seen the object before. They survive across most cultures because the underlying object is widely known.
+
+**Indexical — visual reference to a sign or symbol whose meaning is established.** A red octagon means stop because road signage has trained people to read it that way. The "@" symbol means email because email systems adopted it. The hash mark "#" means tag because Twitter and other platforms made it so. These conventions have to be learned, but once learned they're robust.
+
+**Metaphoric — borrowing the visual form of one domain to suggest the function of another.** The "desktop" metaphor in operating systems borrows from physical desks and folders. The "cart" icon in e-commerce borrows from supermarket shopping carts. The "feed" icon (parallel curved lines like a radio antenna) borrows from broadcasting. These metaphors require both that the user knows the source domain and that they recognize the borrowing.
+
+**Arbitrary — purely conventional symbols with no inherent meaning.** The hamburger menu (three horizontal lines) means "menu" because designers agreed it would. The kebab menu (three vertical dots) means "more options" by similar agreement. These are the most fragile mappings because they have no anchor in physical reality or other domains; they only work because users have been trained.
+
+## Choosing icons that map well
+
+When you need an icon for a function, the order of preference is usually:
+
+1. **A standard icon for that function** (gear for settings, magnifying glass for search). Use the dominant convention if one exists.
+2. **An icon that pictographically resembles the function** (a trash can for delete, a camera for take-photo). Even if it isn't the standard convention, it's likely interpretable.
+3. **An icon paired with a text label**. Adding a label is not failure; it's insurance against an unfamiliar convention. For functions used infrequently, always pair the icon with a label.
+4. **A text-only label**. When no good icon exists and the function is important, just say what it does in words. "Settings" as text is more reliable than an unfamiliar icon.
+
+The decision often comes down to: how confident are you that your audience will recognize this convention? When in doubt, label.
+
+## Worked examples
+
+### A "share" icon
+
+Three competing conventions exist: an upward arrow out of a box (Apple's preferred), a node-and-edge graph (Android's preferred), and a chain link (sometimes used for "copy link"). None is universal. A user accustomed to one platform may not immediately recognize the other. The right approach in cross-platform software is often to use the platform-native icon — Apple's icon on Apple devices, Android's icon on Android — paired with a brief label on the first encounter.
+
+### A status indicator color
+
+Green = good, red = bad, yellow = warning. This convention is so strong it survives even in interfaces designed for color-blind users (where it's typically supplemented with shape: green check, red X, yellow triangle). But the convention is culture-specific in some details — in some Asian cultures red can mean "auspicious" or "celebration," not "stop." For globally deployed software, the safe path is to use the convention but reinforce it with a non-color cue.
+
+### A gesture for "dismiss"
+
+Swipe down to dismiss a modal. Swipe up to dismiss a notification. Swipe right to archive. Swipe left to delete. All of these conventions exist in some apps. None is universal. New users typically need explicit onboarding to learn any of them, and once learned the conventions are sticky — changing them in a redesign generates user complaint disproportionate to the change.
+
+The lesson: gesture-based cultural mappings are weaker than icon- or color-based ones, because the gesture itself is invisible. Provide a discoverable visual cue (an arrow, a swipe hint, a brief animation on first use) for any gesture you rely on.
+
+### "Filter" vs. "Sort"
+
+Two icons compete: a funnel (filter) and an "A-to-Z" arrow or up-down arrows (sort). Many users confuse them, especially when both appear together in a toolbar. The fix is usually to label both — the icons alone are insufficient because the conventions are not strong enough to distinguish two related but different operations.
+
+### Refresh / reload
+
+A circular arrow is the dominant convention for "refresh." It's strong enough that most users recognize it without a label. But in contexts where "refresh" is rarely used, or where the arrow could be confused with "undo" (also sometimes a curved arrow), a label removes ambiguity.
+
+### The "more" menu
+
+The kebab menu (three vertical dots) is now the dominant convention for "more options" or "context menu." It is recognized by most desktop and mobile users. But it's a relatively recent convention — it's purely arbitrary, and it took years of consistent use across major platforms to become dominant. New conventions of this kind take longer to spread than designers usually expect.
+
+## Common anti-patterns
+
+**Using a domain-specific icon as if it were universal.** A developer-tools icon (a wrench-and-screwdriver) for a non-developer audience. A database icon (a stack of cylinders) for a non-technical user. A musical-notation icon for a non-musician. These conventions exist within their domain and are nearly invisible outside it. Use only the conventions your actual audience shares.
+
+**Relying on color alone for status.** Red borders, green check marks, yellow warnings — they all fail for the substantial fraction of users with color vision deficiencies. Always pair color with a second cue (shape, label, position).
+
+**Inventing a new convention and assuming it will catch on.** Designers occasionally try to introduce a novel icon for a common function (a custom "search" icon that isn't a magnifying glass). Even if it's well-designed, users will struggle, because they don't know the convention and have no way to learn it except by trial. Stick with the dominant convention unless you have a very strong reason to deviate.
+
+**Cultural conventions assumed across regions.** A mailbox icon shaped like a US-style flag-and-flag mailbox is meaningless in countries with different mail-collection conventions. A pound-symbol icon ("£") might mean "British currency," "weight in pounds," or "tag depending on region." International products need to verify regional recognition or default to language-localizable text.
+
+**Using a label-bearing icon and then duplicating the label.** "[gear icon] Settings" with the icon and label adjacent is fine. "[Settings: gear icon and word]" with the gear inside the word redundantly is just clutter. If you have a label, the icon is decoration; if you have an icon, the label is reinforcement. Pick a primary and let the other support it.
+
+## When natural and cultural mapping can be combined
+
+Cultural conventions can supplement natural mappings rather than replace them. A volume slider that goes up for louder (natural mapping) and is shown with a speaker icon at one end (cultural mapping reinforcing the meaning) is stronger than either alone. A brightness slider that goes right for brighter (cultural convention) with a sun icon at the bright end (cultural reinforcement) is doubly clear. Stack mappings when you can afford the visual cost.
+
+## Heuristic checklist
+
+Before relying on a cultural mapping, ask: **Is this convention dominant in my audience, or just one of several?** If multiple competing conventions exist, label. **Has my audience definitely been exposed to this convention?** If you're unsure, label or test. **What is the cost of misinterpretation?** If high, label regardless of convention strength. **Does the icon survive across cultures, regions, and abilities?** If not, supplement.
+
+## Related sub-skills
+
+- `mapping-natural` — for the (rare, valuable) cases where you don't have to fall back to convention.
+- `iconic-representation` — when and how iconic conventions form and stabilize.
+- `recognition-over-recall` — cultural mappings work because users recognize, not recall.
+- `consistency` — once a convention is established within your product, applying it consistently strengthens the mapping for your users specifically.
+
+## See also
+
+- `references/icon-vocabulary.md` — a working catalog of dominant icon conventions and where they come from.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping-cultural/references/icon-vocabulary.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping-cultural/references/icon-vocabulary.md
@@ -1,0 +1,98 @@
+# Cultural mapping — working icon vocabulary
+
+A reference catalog of dominant icon conventions, organized by function. Use this as a starting point, not a final word — convention strengths shift over time and across audiences.
+
+## Universally recognized (in industrialized cultures)
+
+These conventions are strong enough that the icon alone communicates the function for most adult users. Pair with a label only when usage is infrequent or the cost of misinterpretation is high.
+
+- **Magnifying glass — search.** Strongly established. The single dominant convention.
+- **House — home / homepage.** Strong. A few interfaces use a dot or globe instead, but the house is by far the most recognized.
+- **Gear / cog — settings or preferences.** Strong. A wrench is a weaker variant.
+- **Trash can — delete or discard.** Strong. The "X" is sometimes used as a competitor and confuses users.
+- **Plus sign — add or create.** Universal mathematical convention.
+- **Minus sign — remove or subtract.** Universal mathematical convention.
+- **Pencil — edit.** Strong. Sometimes confused with "draw" or "annotate" in design tools.
+- **Camera — take photo.** Strong, but the "video camera" variant means video, not photo.
+- **Envelope — email or messages.** Strong, slightly weakening as messaging app conventions diversify.
+- **Lock — security, locked state, private.** Strong. The "open lock" means unlocked or public.
+- **Bell — notifications.** Strong, recently dominant.
+- **Heart — favorite or like.** Strong. The "star" is a competitor with overlapping but slightly different connotations (favorite vs. quality rating).
+- **Star — rating or favorite.** Strong. Often used for quality ratings (1-5 stars).
+- **Question mark — help.** Strong.
+- **Exclamation mark — warning or alert.** Strong.
+- **Checkmark — confirm, done, or success.** Strong.
+- **X mark — close, cancel, or dismiss.** Strong, but ambiguous between "cancel this dialog" and "delete this item." Usually disambiguated by position (X in the corner of a panel = close panel; X next to an item = remove item).
+- **Arrow (left/right) — navigation back/forward.** Strong, supported by browser convention.
+- **Arrow (up/down) — sort order, scroll direction, or value change.** Context-dependent.
+- **Eye — visibility or preview.** Strong. The "eye with slash" means hidden.
+- **Sun / moon — light/dark mode, or brightness.** Strongly established in recent years.
+- **Speaker icon — audio output / volume.** Strong. The "speaker with slash" means muted.
+- **Microphone — audio input / record.** Strong.
+- **Refresh / circular arrow — reload or refresh.** Strong.
+- **Hamburger (three horizontal lines) — main menu.** Strong on mobile, weaker on desktop.
+- **Kebab (three vertical dots) — more options / context menu.** Strong on mobile, becoming dominant on desktop.
+- **Calendar — date picker or scheduling.** Strong.
+- **Clock — time picker or recent activity.** Strong.
+
+## Strong but with regional / domain variation
+
+These conventions are well-established within a context but vary significantly across cultures, regions, or audiences.
+
+- **Floppy disk — save.** Strong for adult users in industrialized cultures, but a generation that has never used floppies finds it bewildering. Some products are migrating to a downward-arrow-into-tray icon, which has not yet reached convention strength.
+- **Telephone handset — call or contact.** Strong, but the handset shape is increasingly anachronistic; a younger audience may interpret it as "old phone."
+- **Speech bubble — chat or comment.** Strong, with multiple variants (rectangular vs. cloud-shaped vs. with tail) that all read as "talk-related."
+- **Globe — internet, international, or external.** Used inconsistently for these three meanings. Always pair with a label.
+- **Share icon — share content.** No dominant cross-platform convention; Apple and Android use different shapes. Use the platform-native icon and pair with a label on first encounter.
+- **Currency symbol ($, €, £, ¥) — money or pricing.** Local. International products use a generic "coin stack" or "wallet" icon.
+- **Mailbox — physical mail.** Country-specific shape.
+- **Shopping cart — e-commerce purchase.** Strong in supermarket cultures; less recognizable in markets where supermarket carts are less common.
+
+## Weak or domain-specific
+
+These conventions exist within a specific user community but should not be assumed universal. Always label.
+
+- **Wrench / spanner — tools or developer settings.** Conflicts with "gear" for general settings.
+- **Database (cylinder stack) — data or storage.** Recognized by technical users; opaque to general audiences.
+- **Network (nodes-and-edges) — graph, connection, or sharing.** Highly variable in interpretation.
+- **Beaker / flask — experimental features or science.** Domain-specific.
+- **Lightbulb — idea or insight.** Sometimes used for "tips" or "AI suggestions"; not strongly conventional.
+- **Lightning bolt — speed, power, or "premium."** Highly variable.
+- **Key — access or authentication.** Sometimes confused with "settings."
+- **Tag — label, category, or filter.** Reasonably strong but ambiguous between these three meanings.
+- **Folder — collection or category.** Strong for desktop users; weaker for mobile-native users.
+- **Cloud — cloud storage or sync.** Strong, but conflated with "weather" in some contexts.
+- **Pin — location or "pin to top."** Two distinct meanings; disambiguate with context.
+- **Bookmark — save for later.** Strong, but conflated with "favorite."
+
+## Color conventions
+
+Color conventions interact with cultural mappings and require similar caution.
+
+- **Red — error, danger, stop, destructive action.** Strong in driving cultures; "auspicious" in some Asian cultures (use carefully in international UI).
+- **Green — success, go, confirm, positive change.** Strong in driving cultures.
+- **Yellow / amber — warning, caution, in-progress.** Strong.
+- **Blue — informational, neutral, link, default action.** Strong in software UI; sometimes "trust / corporate" in marketing.
+- **Gray — disabled, inactive, secondary.** Strong.
+
+Always pair color with a non-color cue (shape, icon, label) for accessibility.
+
+## Anti-pattern: the obscure-icon-set
+
+Designers sometimes adopt an entire custom icon set across an interface, replacing conventional icons with bespoke variants for visual coherence. The result is universally less usable: every icon now requires the user to learn it, and the convention strength accumulated by the standard icons is lost. Visual coherence is achievable through color, weight, and stroke style — the icon shapes themselves should hew to convention.
+
+A related anti-pattern is the "minimalist line-icon set" where every icon is a thin outline with no fill, designed to look harmonious. Frequently the result is a row of icons that all look similar and require careful inspection to distinguish. If your icons cannot be told apart at a glance, you've lost the central virtue of icon-based UI. Either weight the icons differently, label them all, or pick a more varied set.
+
+## Convention drift over time
+
+Icon conventions are not stable. The floppy disk for "save" is weakening as a generation grows up that has never used floppies. The telephone handset for "call" is weakening as wired-handset phones disappear. The hamburger menu was a niche convention in 2010 and is now near-universal. The kebab menu was unknown a decade ago and is now standard.
+
+When a convention is in flux, the safe path is to pair the icon with a label, at least until the new convention has stabilized. Trying to lead the convention is risky; following it once it's established is safe.
+
+## Test your icons
+
+Show the icon set, without labels, to five users from your actual audience. Ask them what each icon means. Anything that fewer than four out of five interpret correctly needs a label or a different icon. This test takes ten minutes and prevents weeks of post-launch confusion.
+
+## Cross-reference
+
+For more on when iconic forms are appropriate at all, see `iconic-representation`.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping-natural/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping-natural/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: mapping-natural
+description: 'Apply natural mapping — the strongest form of mapping, in which the spatial position, motion, or shape of a control directly corresponds to what it affects. Use when designing physical control panels, in-screen controls that affect specific regions of a UI, chart legends, multi-target remote controls, vehicle dashboards, or any situation where the user must connect "this control" to "that affected thing." A natural mapping is one a first-time user can predict without instruction. When the form factor allows it, natural mapping is essentially free correctness.'
+---
+
+# Mapping — natural (spatial and physical)
+
+Natural mapping is the form of mapping that requires no learning. The control is positioned where the affected element is, or moves the way the affected element moves, or is shaped like the affected element. The user does not have to think; they reach.
+
+Natural mapping comes in two forms.
+
+**Spatial correspondence.** The control's position in space matches the affected element's position in space. Stove knobs in a 2×2 grid that mirror the burners. The seat-position controls on a Mercedes-Benz, shaped like a tiny seat — push the headrest forward to recline, push the seat back forward to slide forward. A chart legend whose entries appear in the same vertical order as the data lines they describe, so the topmost legend entry corresponds to the topmost line. A row of speaker volume controls arranged left-to-right in the same order as the speakers in the room.
+
+**Physical analogy.** The control's motion or shape corresponds to a physical action whose meaning is universally understood — usually because it mimics gravity, force, or direction. Up = more, down = less. Right = forward in time, left = backward. Clockwise = increase, counterclockwise = decrease (in cultures that read left-to-right; the convention is local but extremely strong). Pinch out = zoom in. Pull a slider toward you = grab and bring closer. These mappings are not innate, but they're embodied — users feel them rather than think them — and breaking them generates immediate confusion that no amount of labeling will fix.
+
+## Recognizing when natural mapping is available
+
+The form factor either supports natural mapping or it doesn't. A four-burner stove with the burners in a 2×2 grid and physical room for knobs in a 2×2 grid: spatial mapping available. A cooktop with knobs along the front edge and burners behind: spatial mapping not directly available; you'll have to weaken to a labeled or angled approximation. A horizontal slider for an inherently vertical quantity (height, depth, intensity from low-to-high): natural mapping mismatched; consider rotating the slider or changing the metaphor.
+
+The question to ask early in a design is: **what is the spatial or physical structure of the thing being controlled, and can the controls share that structure?**
+
+## Worked examples
+
+### A four-burner stove control panel
+
+Bad design: four knobs in a row labeled "FL FR RL RR" (front-left, front-right, rear-left, rear-right). The user has to read the label, decode the abbreviation, locate the burner, and turn the right knob. Three cognitive steps for an action that should require zero. Approximately 5–10% of users will turn the wrong knob in distracted use.
+
+Good design: four knobs in a 2×2 grid, each knob positioned directly in front of (or below) the burner it controls. No label needed. The user reaches for the knob in the position of the burner. The error rate drops near zero.
+
+When the cooktop is too shallow for a 2×2 grid, the next-best approach is to angle the row of knobs so each knob is at least visually closer to its corresponding burner — paired with a small dot or graphic showing the relationship. This is weaker than true spatial correspondence but stronger than abstract labels.
+
+### Volume controls on a multi-speaker setup
+
+Bad design: a settings panel labeled "Speaker 1, Speaker 2, Speaker 3, Speaker 4" with sliders. The user does not remember which physical speaker is which.
+
+Good design: a small floor plan showing the speakers in their actual positions, with each volume slider positioned next to its speaker. Or, if a floor plan is too elaborate, a row of sliders arranged in the same left-to-right order as the speakers in the room, with a brief location label ("Living Room — South Wall").
+
+The principle: the user is reasoning about the room, so the controls should be arranged like the room.
+
+### Chart legend ordering
+
+Bad design: a multi-line chart with five data series; the legend is alphabetical. The user has to scan the chart, identify a line of interest, then scan the legend to find which series name corresponds to which color. Two scans, with a memory step between.
+
+Good design: the legend is ordered by the vertical position of each line at the right edge of the chart (or the left edge — pick a consistent anchor). The topmost line in the chart has the topmost legend entry. The user's eye traces from the line directly to its label. One scan.
+
+This is a small change with a large effect. It is one of the highest-ROI improvements you can make to a multi-series chart.
+
+### Video editor timeline
+
+Bad design: a "skip forward" button positioned at the top of the screen, far from the timeline. A "split clip" command in a menu somewhere.
+
+Good design: skip controls directly under the timeline, where the user is already looking. Split-clip is a button that appears at the playhead — the visual marker on the timeline — when the playhead is positioned over a clip. The control is at the location it affects.
+
+### Brightness slider direction
+
+Bad design: a brightness slider where dragging *down* makes the screen *brighter*. This violates the up-is-more convention.
+
+Good design: dragging *up* (or *right*, depending on orientation) increases brightness. The user does not have to think.
+
+This convention is so strong that violating it triggers visible double-takes from users; many will drag the slider the "right" way the first time, see the wrong result, and pause for a moment of disorientation.
+
+### Pinch to zoom
+
+The pinch-to-zoom gesture is a strong physical analogy: you are stretching the image between two fingers, the way you might stretch fabric. Reverse pinch (zoom out) corresponds to crumpling, also intuitive. The mapping is so strong that it crossed cultures and platforms within a few years of being introduced and is now nearly universal.
+
+By contrast, "double-tap to zoom in to a fixed level" is a weaker mapping — there's no physical analogy — and survives only because pinch is also available as the natural-mapping fallback.
+
+## When natural mapping is not available
+
+If the form factor or screen real estate makes natural mapping impossible, do not fake it. A diagram next to each control showing what it affects is harder to interpret than a clear label. The hierarchy of fallbacks is:
+
+1. **Use natural mapping** if available.
+2. **Use a strong cultural convention** (volume slider direction, gear icon for settings) if natural mapping is unavailable.
+3. **Use a labeled control** with an unambiguous label (this is fine — labels are not failure, they're insurance).
+4. **Use a contextual cue** that highlights the affected region when the control is touched or hovered (the speaker icon flashes when you adjust speaker 2's volume).
+
+Avoid the temptation to invent a fake spatial mapping (a tiny abstract diagram, a color-code that requires a key) when no real one exists.
+
+## Common anti-patterns
+
+**Aesthetic uniformity destroying mapping.** Designers arrange controls in a clean grid because it looks tidy, ignoring that the controlled elements are not in a corresponding grid. The four-burner stove with knobs in a row is the canonical example. The fix is to choose a layout that mirrors the controlled space, even at some cost to visual neatness.
+
+**Inverted directional mappings.** A volume slider where down is louder, a "back" button on the right of the screen, a brightness control that goes left-to-right with darker on the right. These are usually accidents of code (a coordinate system was inverted somewhere, and the visual was not corrected) but they read as design failures and generate constant low-grade confusion.
+
+**Mapping by color when color is the only cue.** Color-coded controls without spatial correspondence ("the red knob controls the red burner") force the user to look at both control and target, then mentally connect them. They also fail entirely for color-blind users. Color is a useful supplement to spatial mapping but a poor replacement.
+
+**Animating between unmapped positions.** A control whose effect snaps to a new position with no transition forces the user to re-locate the affected element each time. Animated transitions that move from old to new state preserve the mapping by showing the relationship as motion.
+
+## Heuristic checklist
+
+Before shipping a new control, ask: **Where is the thing being affected, and where is the control?** If they are not in the same location or arranged in the same pattern, ask whether they can be. **Does the motion of the control correspond to the change in the affected element?** If not, can it be made to? **If you removed all labels from the controls, could a first-time user still operate them?** If yes, the mapping is doing its job.
+
+## Related sub-skills
+
+- `mapping-cultural` — for the cases where natural mapping isn't available and you have to fall back to convention.
+- `affordance` — what the control suggests it can do (mapping picks up where affordance leaves off).
+- `proximity` — controls that affect the same thing should be close to each other (the layout-level form of mapping).
+- `recognition-over-recall` — natural mapping is recognition-driven; the user sees and reaches.
+
+## See also
+
+- `references/spatial-correspondence.md` — case studies and patterns for spatial mappings, including chart legends, dashboards, and physical control panels.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping-natural/references/spatial-correspondence.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping-natural/references/spatial-correspondence.md
@@ -1,0 +1,90 @@
+# Natural mapping — spatial correspondence patterns
+
+A library of recurring patterns where spatial mapping is achievable and where reaching for it pays large dividends.
+
+## Pattern: control-near-affected-element
+
+The simplest spatial mapping. The control sits next to (or on top of) the element it affects. Examples:
+
+- An "edit" pencil icon hovering over an editable text block, not in a global toolbar.
+- A "delete" trash icon appearing on the row being deleted in a list, not at the top of the page.
+- A row of resize handles at the corners of an image, not in a separate properties panel.
+- A volume slider next to the speaker waveform in a video player, not buried in a settings menu.
+- A "regenerate" button on the AI-generated card it would regenerate, not a global "regenerate last" command.
+
+The pattern fails when controls clutter the space they're mapped to. The fix is usually to make the controls appear on hover or selection, so the spatial mapping is preserved when needed and out of the way otherwise.
+
+## Pattern: arrange-controls-to-match-affected-layout
+
+When you have a small number of controls and a small number of corresponding things, lay them out in the same shape. Examples:
+
+- A 2×2 grid of stove knobs for a 2×2 grid of burners.
+- A 3×3 keypad for a 3×3 grid of camera-zone selections.
+- Speaker controls in the same left-right-center order as the speakers themselves.
+- A four-zone climate control panel matching front-left, front-right, rear-left, rear-right vehicle zones.
+
+This pattern fails when the geometry doesn't allow it (a deep-narrow control panel, a too-wide-to-be-useful screen). When the geometry is wrong, fall back to labeled controls — don't fake the spatial mapping with a tiny abstract diagram.
+
+## Pattern: order-by-vertical-position
+
+For multi-line charts, multi-row data tables, or stacked elements, order any related controls (legends, filters, expand/collapse triggers) in the same vertical sequence as the elements themselves. The user's eye moves down the chart and down the legend in parallel.
+
+A subtle but high-leverage form of this: in a multi-series line chart, put the legend entry for each line at the *current vertical position* of that line (or its endpoint), so the legend doubles as a labeled trailing-value display. Many financial charts do this; many don't, and pay for it in cognitive lookup.
+
+## Pattern: directional-input-matches-directional-effect
+
+When the input has a direction (a slider, a swipe, a key press, a knob), the direction should match the change it produces.
+
+- Up/right increases; down/left decreases.
+- Forward in time = right; back in time = left (in left-to-right reading cultures; reversed in right-to-left cultures).
+- Clockwise = increase or open; counterclockwise = decrease or close.
+- A pull/drag toward the user = bring forward / select; a push away = dismiss.
+
+These conventions are cultural, not innate. International products may need to localize them. But within a culture, violating them generates immediate disorientation that no label or onboarding will completely erase.
+
+## Pattern: control-shape-mirrors-affected-shape
+
+The Mercedes-Benz seat-position controls — shaped like a tiny seat, with knobs you push or pull in the direction you'd want the seat to move — are the gold standard. Other examples:
+
+- A "rotate" handle that itself rotates around the object.
+- A "resize" corner that you grab and pull diagonally.
+- A "flip" button shown as the object mirrored.
+- A "duplicate" button shown as two overlapping copies of the object.
+
+The pattern is most useful for one-time learning interactions (the user learns the seat control once and then it's effortless forever) and less useful for high-frequency interactions (where convention may dominate).
+
+## Pattern: highlight-on-touch
+
+When true spatial mapping isn't possible, you can simulate it: when the user touches a control, briefly highlight or animate the affected element. This is a temporal mapping rather than a spatial one — the user sees, in real time, what the control is doing.
+
+Examples:
+
+- Hovering a column header in a data table briefly highlights the entire column.
+- Hovering a legend entry in a chart fades all other lines so only the corresponding one is visible.
+- Hovering an icon in a control palette briefly previews its effect on the canvas (a "live preview" pattern).
+
+This is essential when a panel of controls affects elements that aren't visually close to the controls. Without the preview, the user must rely on labels and memory.
+
+## Pattern: timeline-as-spatial-map-of-time
+
+In any temporal medium (audio, video, animation), the timeline IS the spatial map of time. Controls that affect a moment in time should be located on the timeline at that moment. The playhead, the selection range, in-and-out points, markers, and edit points should all be visible directly on the timeline. Operating on time through a separate panel — entering a timestamp into a text field — is the weakest mapping; clicking the timeline at the desired moment is the strongest.
+
+## Pattern: floor-plan-as-control-map
+
+For multi-room or multi-zone systems (smart home, multi-camera surveillance, multi-speaker audio), a small floor plan with controls placed at each room's location is dramatically more usable than a list. The floor plan exploits spatial memory of the user's own home or building — a memory that requires no cognitive effort to access.
+
+This is one of the standout examples of natural mapping in modern smart-home interfaces. The systems that adopt it (some thermostats, some smart-light apps) are noticeably more usable than the ones that present a flat list of zones.
+
+## Anti-patterns
+
+**Fake spatial mapping with arbitrary diagrams.** When the real layout doesn't support spatial mapping, designers sometimes invent a tiny abstract diagram next to each control showing what it affects. This requires the user to interpret the diagram, which is harder than reading a label. Either commit to true spatial correspondence or use a clear text label.
+
+**Spatial mapping that ignores screen orientation changes.** A spatial mapping that works in landscape may fall apart in portrait. Verify that your mapping survives the orientations your users will actually use, and reflow if necessary rather than rotating an unreadable layout.
+
+**Spatial mapping that breaks across breakpoints.** A four-knob 2×2 layout on desktop that collapses to a single column on mobile loses its spatial mapping. Mobile sometimes needs an entirely different mapping (collapse to labeled tabs, for instance) rather than a scaled-down version of the desktop layout.
+
+**Letting decoration override mapping.** Designers sometimes choose layouts for visual rhythm or symmetry that destroy the mapping (the four-burner stove with knobs in a row, again). When mapping and decoration conflict, mapping should win for any control used more than occasionally.
+
+## Field-test heuristic
+
+Hand a first-time user the interface. Ask them to perform a task that requires choosing among several controls. Watch where they reach. If they reach correctly without reading labels, the mapping is working. If they hesitate, scan, or miss, the mapping is weak — and the cost will be paid every single time they (and every other user) use the feature.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: mapping
+description: 'Apply the principle of Mapping — designing the relationship between controls and their effects so the connection between input and output is immediately obvious. Use when designing controls (knobs, switches, buttons, sliders, gestures), arranging them in space relative to what they affect, or diagnosing user confusion about which control does what. Strong mappings exploit physical analogies (up = more), spatial correspondence (the left burner control is on the left), and cultural conventions (red = stop). Poor mappings force the user to memorize arbitrary pairings, generating slips and errors that compound over time.'
+---
+
+# Mapping
+
+> **Definition.** Mapping is the relationship between a control and the effect it produces. Good mapping makes the connection immediately apparent — by spatial position, shape, motion, or convention — so the user does not have to think, label, or memorize. Bad mapping requires the user to translate between control and effect, which is slow, error-prone, and quietly punishing.
+
+The classic test of mapping is the four-burner stove. Four knobs in a row, four burners in a 2×2 grid. Which knob controls which burner? In a poorly mapped stove the answer requires labels (and, even with labels, half a second of squinting); in a well-mapped stove the knobs are arranged in a 2×2 grid that matches the burner layout, and you simply reach for the knob in the position of the burner you want.
+
+The same problem appears in software a hundred times a day. The arrow keys move the cursor in the direction of the arrow — strong mapping. The "swap" button has two arrows curving in opposite directions — strong mapping. The "settings" gear icon has no inherent connection to settings — weak mapping, sustained only by convention. The number "3" next to a column header increases the column count by 3 — questionable mapping; better would be a stepper that visibly changes the column layout in real time.
+
+## Why this matters
+
+The cost of weak mapping is paid every single time the user reaches for a control. A user of a four-burner stove with bad mapping turns on the wrong burner perhaps once a month — usually when distracted, sometimes when something is on the burner and shouldn't be heated. This is the core observation that Don Norman built *The Design of Everyday Things* around: most "user error" is actually a design failure to make the mapping obvious. The user is not confused because they are stupid; the user is confused because the designer asked them to memorize an arbitrary pairing in a context where the cost of getting it wrong is real.
+
+In digital interfaces, the punishment is subtler but constant. Every weak mapping costs a few hundred milliseconds of cognitive lookup ("which one was the save icon again?"), and a percentage of the time it costs an actual error: clicking the delete button when you meant to click archive, swiping the wrong way to dismiss, hitting the wrong toggle in a settings panel because the labels and the affected setting are not visually linked. These costs are paid millions of times across a product's user base, and they compound especially in high-stakes flows (cockpit controls, medical devices, financial transactions, legal forms) where a single mismapped action can be expensive or dangerous.
+
+## The four mapping techniques
+
+There are four ways to make a mapping obvious. They are roughly in order of strength.
+
+**1. Spatial correspondence.** The control is positioned where the thing it affects is. Stove knobs in the same 2×2 grid as the burners. The volume slider on the right side of the screen, the mute button at the bottom of the screen near the audio waveform. In information design: a legend whose entries are positioned in the same vertical order as the data series on the chart, so the eye does not have to translate between key and data. This is the strongest form because it requires no learning at all — the user just looks at where the control is.
+
+**2. Physical analogy.** The control's shape, motion, or behavior mimics a physical action whose meaning is universally understood. A volume slider goes up for louder; a brightness control goes right for brighter; a temperature dial goes clockwise for warmer. These mappings are not innate — they're cultural — but they are nearly universal in industrialized cultures, and breaking them generates immediate confusion. The mapping is strong because it exploits an embodied intuition.
+
+**3. Visual signaling.** The control looks like the effect it produces, or the affected element is visually highlighted when the control is engaged. A button labeled "Bold" rendered in bold type. A color picker showing the actual color, not a name. A row of typeface samples letting you see what each font looks like before you pick it. The mapping is encoded in the rendering itself.
+
+**4. Cultural convention.** Red = stop, green = go. The trash can = delete. The gear = settings. The magnifying glass = search. These are the weakest of the four, because they require prior learning and don't transfer across cultures or unfamiliar audiences. But they're cheap to deploy and, within a culture that recognizes them, they're effectively free. The risk is treating an unfamiliar convention as a known one — using a domain-specific glyph (the developer-tools icon, the database icon) and assuming the user will recognize it.
+
+## Diagnosing a mapping problem
+
+Three symptoms indicate a mapping problem. First, **the user pauses before reaching for the control.** They scan, hover, sometimes mouth the labels. If you watch a user use a feature and they hesitate at the moment of input, the mapping is weak. Second, **the wrong action is executed and the user is surprised.** Slips of this kind almost always trace back to mapping failures — the user reached for what their motor habit told them was correct, and the layout disagreed. Third, **labels are necessary.** Labels are an admission that the mapping isn't obvious. A control that needs a tooltip, a "what does this do?" link, or an onboarding tour to be understandable is a control whose mapping has failed. Labels are not bad — they're a useful safety net — but the more labels you need, the weaker the underlying mapping.
+
+## When to apply this principle
+
+You should think hardest about mapping at three moments. **When you design a new control.** Before you settle on an icon, a position, or a gesture, ask: what does the user expect this to do, and how can I make the answer immediate? **When you arrange multiple controls together.** A row of similar buttons, a settings panel, a chart with a legend, a remote with many buttons — the spatial arrangement should mirror the conceptual arrangement of what each control affects. **When you observe user errors or slow performance on a specific interaction.** If users repeatedly miss a button, click the wrong toggle, or swipe in the wrong direction, the mapping is the first place to look.
+
+## When the principle backfires
+
+Two failure modes are worth knowing.
+
+**Forced spatial mapping in cramped layouts.** Sometimes the physical or screen real estate does not allow a true spatial correspondence — the four-burner stove with knobs along the front lacks the depth to lay them out in a 2×2 grid. Forcing the mapping by inventing fake spatial relationships (a tiny diagram next to each knob showing which burner it controls) is often worse than relying on labels, because the user has to interpret the diagram. Pick the strongest mapping that the form factor actually supports.
+
+**Cultural convention assumed where it doesn't hold.** A globe icon for "language" is widely understood; a globe icon for "external link" is recognized by many but not all; a globe icon for "go to homepage" will confuse most users. When you reach for a convention, verify that your audience actually shares it. This matters especially for international products, accessibility audiences, and domain newcomers.
+
+## Sub-skills in this cluster
+
+- **mapping-natural** — Spatial correspondence and physical analogy. The strongest forms of mapping; how to recognize when your form factor supports them and when it doesn't. Includes the stove problem, vehicle controls, video editing timelines, and chart legends.
+- **mapping-cultural** — Visual signaling and cultural convention. The weaker but more flexible forms; how to use icons, colors, and conventions without leaning on them past the point where users actually recognize them.
+
+## Heuristic checklist
+
+Before shipping any new control, ask the following. **Could a first-time user predict what this does without reading anything?** If no, can the mapping be strengthened? **Is the control's position related to the position of what it affects?** If not, is there a reason it can't be? **If you remove all labels, can the user still operate the interface?** They shouldn't have to — labels exist for a reason — but the answer tells you how much the mapping is doing on its own. **When users err, are the errors clustered around specific controls?** Those controls have weak mappings.
+
+## Related principles
+
+- **Affordance** — what a control suggests it can do (mapping picks up where affordance leaves off: affordance suggests the action is possible, mapping clarifies which target it affects).
+- **Visibility** — whether the control is visible at all in the moment it's needed.
+- **Proximity** — controls that affect the same thing should be near each other; this is a layout-level form of mapping.
+- **Consistency** — once a mapping is established, applying it consistently elsewhere strengthens recognition.
+- **Constraint** — physical and logical constraints that prevent the wrong control from being reached or activated when the mapping is weak.
+- **Recognition Over Recall** — strong mappings let users recognize the right control rather than recall its label.
+
+## See also
+
+- `references/lineage.md` — historical origins, Norman's contribution, and HCI-research support.
+- `mapping-natural/` — sub-skill on spatial and physical mappings.
+- `mapping-cultural/` — sub-skill on conventional and signaling mappings.

--- a/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/interaction-and-control-principles/skills/mapping/references/lineage.md
@@ -1,0 +1,40 @@
+# Mapping — origins and research lineage
+
+## Pre-Norman roots
+
+The idea that the spatial arrangement of controls should mirror the arrangement of what they affect is older than human-computer interaction. Aviation human-factors researchers in the 1940s and 1950s — particularly Alphonse Chapanis, Wesley Woodson, and others working on the ergonomics of cockpits, ship bridges, and industrial control rooms — identified control–display compatibility as a primary determinant of operator error. A 1953 study of B-25 cockpit crashes by Chapanis traced a recurring pattern of pilots retracting the landing gear while taxiing: the gear lever and the flap lever were physically similar, located near each other, and the consequence of confusing them was catastrophic. Adding a small wheel-shaped knob to the gear lever — a tactile mapping cue — eliminated the error class. This kind of finding, repeated across dozens of control-room studies, established that operator error is overwhelmingly a design problem, not a competence problem.
+
+The phrase "stimulus-response compatibility" entered experimental psychology around the same time, with Paul Fitts and Charles Seeger demonstrating in the 1950s that response time and error rate both rise when the spatial arrangement of stimuli does not match the spatial arrangement of the responses they require. Press the leftmost button when a light flashes on the left: fast and accurate. Press the leftmost button when the light flashes on the right: significantly slower and more error-prone. The cost is paid in cognitive translation, and the cost is consistent enough to be measured in milliseconds.
+
+## Norman's contribution
+
+Donald Norman's *The Psychology of Everyday Things* (1988, later retitled *The Design of Everyday Things*) brought the cockpit research to a general audience, using domestic and consumer objects as the running example. The four-burner stove is Norman's: he uses it to illustrate the cost of poor mapping in an object that everyone encounters and almost no one designs well. He coined the term "natural mapping" for control arrangements that exploit physical analogies (the seat-position controls in a Mercedes-Benz that are themselves shaped like a tiny seat) and traced poor mapping to a broader pattern of designers prioritizing aesthetics over usability — making the stovetop a clean grid of identical knobs because it looks tidy, ignoring that this destroys the spatial cue.
+
+Norman's framing also distinguished mapping from the related concept of *affordance*. Affordance is what a control suggests is possible (a lever suggests pulling); mapping is which thing-in-the-world the action will affect (which burner this lever turns on). The two principles compose: a control needs both a clear affordance and a clear mapping to work.
+
+## HCI and software research
+
+Once the principle entered the HCI canon in the late 1980s, it generated a substantial empirical literature on software-specific applications. Direct manipulation interfaces — Shneiderman's term for systems where the user acts directly on visible objects (drag a file to delete it; resize a window by pulling its corner) — are essentially mapping arguments: the closer the action is to the effect, in space and time, the lower the cognitive load. Spatial models in early Macintosh and Xerox Star research (positioning files in a "trash can" at the corner of the screen, organizing windows in a "desktop") were direct applications.
+
+The mapping principle also explains many findings in chart and dashboard design. Cleveland and McGill's 1984 ranking of perceptual tasks (position on a common scale beats length beats angle beats area beats color saturation for accuracy) is, at one level, a statement about which encodings map most directly to the underlying quantity. A bar chart maps numerical magnitude to vertical position — a strong mapping; a pie chart maps it to angle — a weaker one; a heatmap maps it to color — weaker still. Designers who reach for visual variety often weaken the mapping in the process.
+
+## Modern relevance
+
+Touchscreen and gesture interfaces have created a new generation of mapping problems. A swipe up does what? A long press does what? A two-finger tap does what? These gestures have no inherent meaning — they are not even cultural conventions in the way that a button-shaped object is. App designers have largely converged on a small vocabulary (swipe to dismiss, long-press for context menu, pinch to zoom) but the conventions are weaker than physical-button conventions and require explicit onboarding for new users. The cost of a weak gesture mapping is high because the gesture itself is invisible — there is nothing on screen to look at to discover what gestures are available.
+
+Voice and conversational interfaces face a more extreme version of the same problem. There is no spatial relationship between input and output in voice; the entire mapping must be carried by the language itself. This is why voice assistants converge on a very narrow vocabulary of capabilities ("set a timer for X minutes," "what's the weather in Y") — the mapping space is so weak that only the most predictable utterances reliably succeed.
+
+VR and AR interfaces, by contrast, have re-opened the possibility of strong spatial mapping in software: the controls *can* be physically located near the things they affect, because the entire space is designed. Whether designers exploit this opportunity (by placing the volume control next to the speaker in the virtual room) or squander it (by reaching for floating menus that mimic 2D interfaces) is one of the active design questions in the medium.
+
+## Empirical regularities worth remembering
+
+The literature on stimulus-response compatibility, control-display compatibility, and direct manipulation converges on a few stable findings worth knowing. Compatible mappings are roughly **2× faster** than incompatible ones for a comparable single-action task. Error rates under incompatible mapping are typically **5–10× higher** than under compatible mapping in time-pressured tasks. The cost of a mapping mismatch is **paid in proportion to use** — a control used once a year does not justify the same investment in mapping as a control used hundreds of times a day. And users develop motor habits that **persist across redesigns**: changing the mapping of a frequently used control without retraining produces a spike in error rates that may take weeks to subside.
+
+## Sources informing this principle
+
+- Chapanis, A. (1953). The Cleveland Aerial Reconnaissance Board investigation. (Cockpit-error studies foundational to control-display compatibility research.)
+- Fitts, P. M., & Seeger, C. M. (1953). S-R compatibility: Spatial characteristics of stimulus and response codes.
+- Norman, D. (1988). *The Design of Everyday Things*. (Particularly chapters on visibility, mapping, and the four-burner stove.)
+- Shneiderman, B. (1983). Direct manipulation: A step beyond programming languages.
+- Cleveland, W. S., & McGill, R. (1984). Graphical perception: Theory, experimentation, and application to the development of graphical methods.
+- Wickens, C. D., et al. (2004). *An Introduction to Human Factors Engineering*. (Standard reference for control-display compatibility findings.)

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/.claude-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/.claude-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json.schemastore.org/claude-plugin.json",
+  "name": "perception-and-hierarchy-principles",
+  "displayName": "Perception & Hierarchy Principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for visual perception and hierarchy: how the eye groups elements, where it lands first, and what makes a composition read as ordered. Covers Hierarchy, Proximity, Signal-to-Noise Ratio, Color, Alignment, Legibility, Readability, Gestalt Similarity, Closure, and Figure-Ground Relationship. Drawn from the perception-related entries of 'Universal Principles of Design' (Lidwell, Holden, Butler, 2003) and the broader Gestalt and visual-design research literature.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HDeibler/universal-design-principles.git",
+    "directory": "plugins/perception-and-hierarchy-principles"
+  },
+  "category": "design",
+  "keywords": [
+    "design",
+    "ux",
+    "ui",
+    "perception",
+    "gestalt",
+    "visual-hierarchy",
+    "layout",
+    "typography",
+    "legibility",
+    "readability",
+    "color",
+    "universal-design-principles"
+  ]
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/.codex-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "perception-and-hierarchy-principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for visual perception and hierarchy: how the eye groups elements, where it lands first, and what makes a composition read as ordered. Covers Hierarchy, Proximity, Signal-to-Noise Ratio, Color, Alignment, Legibility, Readability, Gestalt Similarity, Closure, and Figure-Ground Relationship.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": [
+    "design",
+    "ux",
+    "ui",
+    "perception",
+    "gestalt",
+    "visual-hierarchy",
+    "layout",
+    "typography",
+    "color"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Perception & Hierarchy Principles",
+    "shortDescription": "Visual perception, hierarchy, layout, and attention.",
+    "developerName": "Hunter D",
+    "category": "Design",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "longDescription": "Framework-agnostic design principles for visual perception and hierarchy: how the eye groups elements, where it lands first, and what makes a composition read as ordered. Covers Hierarchy, Proximity, Signal-to-Noise Ratio, Color, Alignment, Legibility, Readability, Gestalt Similarity, Closure, and Figure-Ground Relationship.",
+    "websiteURL": "https://github.com/HDeibler/universal-design-principles"
+  }
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/.codexignore
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/.codexignore
@@ -1,0 +1,7 @@
+.git/
+.DS_Store
+**/.DS_Store
+tmp/
+temp/
+.cache/
+scratch/

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/.cursor-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/.cursor-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "perception-and-hierarchy-principles",
+  "displayName": "Perception & Hierarchy Principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for visual perception and hierarchy: how the eye groups elements, where it lands first, and what makes a composition read as ordered. Covers Hierarchy, Proximity, Signal-to-Noise Ratio, Color, Alignment, Legibility, Readability, Gestalt Similarity, Closure, and Figure-Ground Relationship.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": ["design", "ux", "ui", "perception", "gestalt", "visual-hierarchy", "layout", "typography", "color"],
+  "category": "design",
+  "tags": ["gestalt", "hierarchy", "typography", "layout", "color", "accessibility"],
+  "skills": "./skills/"
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/LICENSE
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/LICENSE
@@ -1,0 +1,39 @@
+MIT License
+
+Copyright (c) 2026 Hunter D
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+# Notes on attribution
+
+This software is a derivative *working library* inspired by the principle
+taxonomy popularized in *Universal Principles of Design* (Lidwell, Holden, &
+Butler, Rockport Publishers, 2003). The principle names and high-level
+taxonomy are drawn from that source, used here as a research reference under
+fair use. All prose, examples, code, anti-patterns, and analyses in this
+repository are written in the authors' own words, drawing on the broader
+publicly available design and HCI research literature (Wertheimer, Hick,
+Fitts, Norman, Nielsen, Tufte, Lynch, WCAG, Lavie & Tractinsky, Csikszentmihalyi,
+Zajonc, and many others).
+
+This software is not affiliated with, endorsed by, or sponsored by Rockport
+Publishers, the Lidwell-Holden-Butler authors, or any other rightsholder of
+the original book. See `ATTRIBUTION.md` for a fuller breakdown of sources.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/README.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/README.md
@@ -1,0 +1,25 @@
+# perception-and-hierarchy-principles
+
+Framework-agnostic design principles for visual perception and hierarchy.
+
+## Status
+
+| Skill | State |
+|---|---|
+| `perception-router` | ✅ Complete |
+| **Hierarchy** (`hierarchy` + `hierarchy-typographic` + `hierarchy-spatial` + `hierarchy-color-and-tone`) | ✅ Complete (reference-grade) |
+| **Proximity** (`proximity` + `proximity-form-fields` + `proximity-data-tables` + `proximity-navigation`) | ✅ Complete |
+| **Signal-to-Noise Ratio** (`signal-to-noise-ratio` + `snr-densification` + `snr-decoration-removal` + `snr-emphasis-economy`) | ✅ Complete |
+| **Color** (`color` + `color-semantic-systems` + `color-accessibility-and-mode`) | ✅ Complete |
+| **Alignment** (`alignment` + `alignment-grid-systems` + `alignment-text-and-numerics`) | ✅ Complete |
+| **Legibility** (`legibility` + `legibility-typeface-and-size` + `legibility-contrast-and-spacing`) | ✅ Complete |
+| **Readability** (`readability` + `readability-line-length` + `readability-rhythm-and-prose`) | ✅ Complete |
+| **Gestalt Similarity** (`gestalt-similarity` + `similarity-grouping` + `similarity-and-contrast`) | ✅ Complete |
+| **Closure** (`closure` + `closure-implied-shapes` + `closure-completion-cost`) | ✅ Complete |
+| **Figure-Ground Relationship** (`figure-ground-relationship` + `figure-ground-cues` + `figure-ground-overlays-and-modals`) | ✅ Complete |
+
+34 skills total, each with a `references/` deep-dive file.
+
+## Planned (not yet built)
+
+The router lists all 33 perception-related principles. Beyond the 10 fully-built principles above, the rest are planned. Priority next builds: `golden-ratio` and `rule-of-thirds` (proportions), `gestalt-common-fate`, `continuance`, `gutenberg-diagram`, `face-detection`, `red-effect`, `layering`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/SECURITY.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Report security issues by opening a private security advisory on GitHub or by
+emailing hunterd107@gmail.com.
+
+This marketplace packages prompt-only agent skills. It does not bundle MCP
+servers, hooks, scripts, executable dependencies, credentials, or networked
+services.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment-grid-systems/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment-grid-systems/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: alignment-grid-systems
+description: 'Use this skill when designing or evaluating a grid system — picking column counts, gutter widths, breakpoints, baseline grids, or modular grids. Trigger when designing a new layout system, when an existing layout feels disorderly, when picking responsive breakpoints, or when reviewing a design that "doesn''t sit on a grid." Sub-aspect of `alignment`; read that first.'
+---
+
+# Grid systems
+
+A grid is the explicit alignment scaffold a design uses. It provides the columns, rows, and gutters that every element snaps to. Most successful design systems share one important trait: they enforce a grid that designers and engineers can both reason about.
+
+## Grid types
+
+### Column grid
+
+The most common type in web design. The page is divided into N equal columns separated by gutters; elements span 1 to N columns.
+
+```css
+.layout {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 24px;          /* gutter */
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+```
+
+Common column counts:
+- **12 columns** — the de facto web standard. Divides cleanly into 2, 3, 4, 6 columns.
+- **8 columns** — common on smaller widths.
+- **6 / 4 columns** — common on tablet / mobile.
+- **24 columns** — used in some dense enterprise systems for finer control.
+
+The 12-column grid is the safe default; deviate only with specific reason.
+
+### Modular grid
+
+Adds horizontal subdivision in addition to columns. Useful for image-heavy or magazine-style layouts where elements need to align both horizontally and vertically.
+
+### Baseline grid
+
+A grid of horizontal lines at the leading interval of body text. Headings, body, and other type all snap to these baselines, producing perfect vertical rhythm. Hard to enforce in CSS but possible with careful line-height and margin discipline.
+
+### Hierarchical / asymmetric grid
+
+A grid optimized for one specific layout — different columns for different regions of the page. Common in marketing layouts.
+
+## Gutter widths
+
+The space between columns. Common scales:
+
+- **Compact**: 8–16px (dense apps, dashboards).
+- **Standard**: 16–24px (most apps).
+- **Generous**: 32–48px (marketing pages, magazine layouts).
+
+The gutter should feel proportional to the column width. A 24px gutter on a 1200px-wide grid gives ~3% of horizontal space to gutters — a reasonable balance.
+
+## Margins and bleed
+
+The space at the page edges (outside the grid):
+
+- **Container max-width** — typical 1140–1280px for content sites; up to 1440px for wider layouts.
+- **Edge margin** — the padding inside the container at the screen edge. Typical 16–48px depending on breakpoint.
+
+Some layouts deliberately "bleed" content to the screen edges (full-bleed images, edge-flush nav). Mix bleed and contained content carefully; the rhythm needs to remain coherent.
+
+## Responsive grid behavior
+
+A grid system needs to behave at every breakpoint. Common pattern:
+
+```css
+.layout {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(4, 1fr);  /* mobile: 4 columns */
+}
+
+@media (min-width: 768px) {
+  .layout {
+    gap: 20px;
+    grid-template-columns: repeat(8, 1fr);  /* tablet: 8 columns */
+  }
+}
+
+@media (min-width: 1024px) {
+  .layout {
+    gap: 24px;
+    grid-template-columns: repeat(12, 1fr);  /* desktop: 12 columns */
+  }
+}
+```
+
+Components reference column spans (`grid-column: span 4`); the meaning of "span 4" changes with breakpoint, but the component code stays the same.
+
+## Tools
+
+- **CSS Grid** is the modern foundation; flex layouts handle simpler cases.
+- **Container queries** (CSS) let components respond to their container's width, not just the viewport — useful in dashboards.
+- **Storybook / design tokens** can codify the grid spec.
+- **Figma / Sketch grid plugins** — most design tools have built-in grid support; use it.
+
+## Anti-patterns
+
+- **Inconsistent gutters.** A 16px gutter in one region, 24px in another. The eye reads it as different grids.
+- **Pixel-perfect at one breakpoint, broken at others.** A grid that works at 1440px but is misaligned at 1280px because columns weren't tested.
+- **Mixing column-grid and free-form layout.** Components designed to span 4 grid columns interspersed with pixel-positioned elements. The grid rhythm collapses.
+- **Component widths that ignore the grid.** Cards that are 287px wide in a 12-column grid where columns are 80px. Edges don't align with anything.
+
+## Heuristics
+
+1. **Show the grid.** Toggle a CSS overlay showing column lines. Every element's edge should land on a column or a half-column.
+2. **Test at every breakpoint.** A grid design isn't done until you've checked 320, 768, 1024, 1280, and your widest target.
+3. **The snap test.** When designers move components, do they snap to the grid? If you find yourself fighting your own grid, the grid spec is wrong.
+
+## Related sub-skills
+
+- **`alignment`** (parent).
+- **`alignment-text-and-numerics`** — alignment within typography and tabular data.
+- **`hierarchy-spatial`** — spatial hierarchy operates on a grid.
+- **`fibonacci-sequence`** — proportional grid stops often follow Fibonacci-like ratios.
+
+## Resources
+
+- **Müller-Brockmann, J.** *Grid Systems in Graphic Design* (1981) — the canonical text.
+- **CSS Grid spec** (W3C) — modern layout primitive.
+- **Tailwind, Bootstrap grid docs** — practical implementations.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment-grid-systems/references/grid-frameworks.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment-grid-systems/references/grid-frameworks.md
@@ -1,0 +1,82 @@
+# Grid frameworks: practical reference
+
+A reference complementing `alignment-grid-systems` with practical web-grid framework details.
+
+## CSS Grid (the modern foundation)
+
+CSS Grid is the layout primitive most modern web design uses. Key properties:
+
+- `grid-template-columns: repeat(12, 1fr)` — 12 equal columns.
+- `gap: 24px` — consistent gutter.
+- `grid-column: span 4` — element spans 4 columns.
+- `grid-template-areas` — named regions for complex layouts.
+
+CSS Grid handles responsive grid behavior cleanly via media queries that change `grid-template-columns`.
+
+## Container queries
+
+Newer than media queries. Lets a component respond to its container's width rather than the viewport's:
+
+```css
+@container (min-width: 600px) {
+  .card { grid-template-columns: 1fr 2fr; }
+}
+```
+
+Useful for components used in multiple contexts (sidebar vs. full-width main).
+
+## Tailwind CSS
+
+Tailwind ships utility classes that make grid composition explicit:
+
+```html
+<div class="grid grid-cols-12 gap-6">
+  <div class="col-span-8">Main</div>
+  <div class="col-span-4">Sidebar</div>
+</div>
+```
+
+Default 12-column grid; configurable.
+
+## Bootstrap
+
+Older but still widely used. 12-column grid via class names:
+
+```html
+<div class="row">
+  <div class="col-md-8">Main</div>
+  <div class="col-md-4">Sidebar</div>
+</div>
+```
+
+## Material Design grid
+
+Material 3 specifies a responsive 4 / 8 / 12 column grid:
+- **Compact** (< 600px): 4 columns.
+- **Medium** (600–1239px): 8 columns.
+- **Expanded** (≥ 1240px): 12 columns.
+
+Gutter and margin scales documented per breakpoint.
+
+## Apple HIG layout
+
+Apple doesn't formalize a column-grid in the same way; HIG documents safe-area insets, dynamic sizing, and layout margins per device. The result feels less rigid than Material but achieves alignment through component-level spacing tokens.
+
+## Building your own grid spec
+
+A minimal grid spec includes:
+
+- Column count per breakpoint.
+- Gutter widths per breakpoint.
+- Margin / padding at the page edges per breakpoint.
+- Container max-width.
+- Spacing scale (e.g., 4, 8, 12, 16, 24, 32, 48, 64).
+
+Document these in your design system; reference them everywhere.
+
+## Resources
+
+- **CSS Grid spec** — w3.org/TR/css-grid-2.
+- **Tailwind grid docs** — tailwindcss.com.
+- **Material Design layout** — m3.material.io.
+- **Refactoring UI** — chapters on grid and layout systems.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment-text-and-numerics/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment-text-and-numerics/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: alignment-text-and-numerics
+description: 'Use this skill when designing text-alignment and numeric-alignment decisions — choosing between left, right, center, and justified text; right-aligning numeric columns in tables; aligning labels relative to inputs; handling decimal alignment for currency. Trigger when laying out body content, designing tables with mixed types, or fixing alignment issues in dense data displays. Sub-aspect of `alignment`; read that first.'
+---
+
+# Text and numeric alignment
+
+Text and numbers behave differently. Text wants to flow naturally, with predictable left edges so the eye can return to a known column. Numbers want to align by digit position so the user can compare magnitudes. Mixing them in a table requires deliberate alignment per column.
+
+## Text alignment
+
+### Left-aligned (the default for body)
+
+In LTR scripts, body text should almost always be left-aligned. The reasons:
+
+- **Predictable left edge** — the eye returns to a known x-position on each line.
+- **Ragged-right edge** — variations in line length signal where each line ends.
+- **No "rivers" of white space** that justified text creates.
+
+Best for: paragraphs, descriptions, body copy, lists, captions.
+
+### Right-aligned
+
+Used in narrow contexts:
+
+- **Numeric columns in tables** so digit positions stack.
+- **Labels in two-column forms** (label-flush-right, input-flush-left) so the gap between label and input is consistent regardless of label length.
+- **Some footer text** in mixed-direction layouts.
+- **Content in RTL scripts** (Arabic, Hebrew) — the equivalent of left-aligned in LTR.
+
+Avoid for body content in LTR scripts.
+
+### Center-aligned
+
+Use *sparingly* and only for short content:
+
+- **Hero headlines** (one line, focal point).
+- **Page titles** above content.
+- **Button labels** (centered within the button).
+- **Single-line CTAs** ("Sign up below" → button).
+- **Quotations or epigraphs**.
+
+Avoid for paragraphs of body text. Center-aligned body is significantly slower to read because each line starts at a different x-position.
+
+### Justified (both edges flush)
+
+Used in print where typesetting can hyphenate and adjust spacing precisely. On screens:
+
+- **Without hyphenation**: don't. The "rivers" of white space between widely-spaced words are distracting.
+- **With CSS `hyphens: auto`**: acceptable for long-form prose, particularly in narrow columns.
+
+Most modern web design uses ragged-right (left-aligned) by default.
+
+## Numeric alignment
+
+### Right-align all numeric columns
+
+Numbers should right-align so that digit positions stack:
+
+```
+        1.00
+       12.50
+      135.00
+    9,876.50
+```
+
+The eye scans the right edge to compare magnitudes. Left-aligned, the same numbers don't compare:
+
+```
+1.00
+12.50
+135.00
+9,876.50
+```
+
+Now the user has to read each number to compare; the columnar advantage is lost.
+
+### Use tabular numerals (`font-variant-numeric: tabular-nums`)
+
+Most fonts ship with proportional numerals (each digit has slightly different width — `1` is narrower than `8`). For columns of numbers, this means digit positions don't quite stack even when right-aligned. Use tabular numerals instead:
+
+```css
+.numeric-column {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+```
+
+Now every digit occupies the same width; columns align perfectly.
+
+### Decimal alignment
+
+When numbers have varying decimal places, you sometimes want to align *on the decimal point* rather than the right edge. CSS doesn't make this easy; the workarounds:
+
+- **Force consistent decimal places** ("$2.50" not "$2.5") so right-alignment serves as decimal alignment.
+- **Use a span around the integer part** and another around the decimal, with explicit width on the integer part. Fragile; reserve for cases where it matters.
+
+For most products, forcing consistent decimal places is the simpler answer.
+
+### Currency
+
+Display currency with locale-appropriate symbol position and separators:
+
+```js
+new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(1234.5);
+// "$1,234.50"
+
+new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(1234.5);
+// "1.234,50 €"
+```
+
+Right-align currency columns; use tabular numerals.
+
+## Label-input alignment
+
+Three common patterns:
+
+### Top-aligned labels (most common in vertical forms)
+
+Label sits above input. No alignment between label and input axis (they're stacked vertically).
+
+```html
+<label for="email">Email</label>
+<input id="email" type="email" />
+```
+
+Pros: simplest; works at any width; labels can be long without affecting layout.
+
+### Right-aligned labels (label-input pairs in two columns)
+
+Label flush-right against input flush-left. The gap between is consistent regardless of label length.
+
+```html
+<style>
+  .field-row { display: grid; grid-template-columns: 8rem 1fr; gap: 12px 16px; }
+  .field-row label { text-align: right; padding-top: 0.5rem; }
+</style>
+
+<div class="field-row">
+  <label for="email">Email</label>
+  <input id="email" />
+</div>
+```
+
+Pros: scannable for dense settings; predictable column widths.
+Cons: label width must accommodate the longest label; long labels look awkward right-aligned.
+
+### Left-aligned labels (label-input pairs)
+
+Both label and input left-aligned in their columns. The gap between label and input varies with label length, creating a slight visual ragged edge.
+
+Pros: more relaxed; easier to read longer labels.
+Cons: less scannable; the variable gap reads as messier.
+
+For most app settings: top-aligned labels. For compact dense forms: right-aligned. Left-aligned columnar is a third choice that some prefer aesthetically.
+
+## Anti-patterns
+
+- **Centered body text.** Reading speed drops 30%+ for centered paragraphs.
+- **Left-aligned numeric columns.** Magnitudes can't be compared.
+- **Mixed proportional + tabular numerals across a single column.** Drift accumulates.
+- **Inconsistent decimal places.** "$2", "$2.5", "$2.50" in the same column. Right-alignment doesn't save it.
+- **Justified body text without hyphenation.** Rivers of white space.
+- **Centering headers but not body** without a clear reason. The reading rhythm jumps.
+- **Mixing label alignment within a form.** Some labels left, some right, some top. Each switch is a re-orientation.
+
+## Heuristics
+
+1. **The numeric-comparison test.** Look down a numeric column. Can you spot the largest value at a glance? If not, alignment is wrong.
+2. **The reading-speed test.** Read centered body text vs. left-aligned. Notice the cognitive cost. (Then never use centered body again.)
+3. **The label-alignment audit.** Across the form, are all labels aligned the same way? If not, fix.
+4. **The currency precision test.** All currency in a column has the same decimal places. If "$2.5" sits next to "$1,234.00", fix the precision.
+
+## Related sub-skills
+
+- **`alignment`** (parent).
+- **`alignment-grid-systems`** — the structural grid that text and numbers align within.
+- **`legibility`** and **`readability`** — typography decisions interact with alignment.
+- **`proximity-data-tables`** — table-specific alignment patterns.
+
+## Resources
+
+- **Bringhurst, R.** *The Elements of Typographic Style* — comprehensive reference on text alignment in typography.
+- **Tufte, E.** *The Visual Display of Quantitative Information* — alignment in tabular data.
+- **Material Design / Apple HIG** — both document text and numeric alignment conventions.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment-text-and-numerics/references/typography-alignment-reference.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment-text-and-numerics/references/typography-alignment-reference.md
@@ -1,0 +1,106 @@
+# Text and numeric alignment: practical reference
+
+A reference complementing `alignment-text-and-numerics` with deeper detail on text and numeric alignment in production design.
+
+## Reading-speed research on text alignment
+
+Studies on reading rates (Tinker, Paterson, and many others; modern syntheses by Bringhurst and Larson) consistently show:
+
+- **Left-aligned (ragged-right)** is fastest for body text in LTR scripts.
+- **Justified (with hyphenation)** is comparable to left-aligned for narrow columns; degrades without hyphenation.
+- **Justified (without hyphenation)** is slowest; "rivers" of white space disrupt reading.
+- **Centered** is significantly slower for paragraphs (~30% slower); usable for short single-line content.
+- **Right-aligned** is impractical for body in LTR; usable for narrow contexts.
+
+For most product UI: left-aligned body, full stop. Centered body is a near-universal mistake when designers reach for it for "elegance."
+
+## Tabular numerals: how and why
+
+Most fonts ship with **proportional** numerals — each digit has slightly different width (`1` is narrow, `8` is wide, etc.). This is correct for body text where numbers appear inline. For numeric columns, it means digit positions don't quite stack.
+
+**Tabular numerals** (also called monospaced figures) make every digit the same width. CSS:
+
+```css
+.numeric-column {
+  font-variant-numeric: tabular-nums;
+}
+```
+
+Most modern fonts ship with both proportional and tabular variants; the CSS property toggles which the browser uses.
+
+For older fonts that don't support `tabular-nums`, fall back to a monospace font for numeric columns:
+
+```css
+.numeric-column {
+  font-family: 'JetBrains Mono', monospace;
+  font-variant-numeric: tabular-nums;
+}
+```
+
+## Decimal alignment patterns
+
+Three approaches:
+
+### 1. Force consistent decimal precision
+
+The simplest. Display all currency with two decimals, all percentages with one decimal:
+
+```js
+amount.toFixed(2);  // "1234.50"
+percentage.toFixed(1);  // "12.5"
+```
+
+Right-align with tabular numerals; decimals naturally align.
+
+### 2. Decimal-aligned tables (CSS)
+
+Possible with CSS but awkward. Wrap each number in a span with the integer and decimal parts:
+
+```html
+<td class="decimal-aligned">
+  <span class="integer">1,234</span><span class="decimal">.50</span>
+</td>
+
+<style>
+.decimal-aligned {
+  display: inline-flex;
+  font-variant-numeric: tabular-nums;
+}
+.integer { width: 4ch; text-align: right; }
+.decimal { width: 3ch; text-align: left; }
+</style>
+```
+
+Works but fragile; only worth it for tables where decimal alignment really matters.
+
+### 3. Modern CSS: `text-align: "."`
+
+Some browsers support `text-align` on a character (like `text-align: "."`), which aligns numbers on the decimal point. Browser support is incomplete; check before relying.
+
+## Currency display by locale
+
+Use `Intl.NumberFormat` with `style: 'currency'`:
+
+```js
+new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+  .format(1234.5);  // "$1,234.50"
+
+new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' })
+  .format(1234.5);  // "1.234,50 €"
+
+new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' })
+  .format(1234567);  // "￥1,234,567"
+```
+
+Note: yen has no decimal places by convention. The Intl API handles per-currency conventions.
+
+## Date alignment
+
+Dates in tables typically left-align if formatted as text ("May 2") or right-align if numeric/ISO ("2026-05-02"). For sortable date columns, ISO format right-aligned is the safer choice — the column sorts correctly as text and aligns visually.
+
+## Resources
+
+- **Bringhurst, R.** *The Elements of Typographic Style* — comprehensive typographic alignment.
+- **MDN: `font-variant-numeric`** — tabular-nums details and browser support.
+- **Intl API on MDN** — locale-aware formatting.
+- **NN/g** — articles on text alignment and reading speed.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: alignment
+description: 'Use this skill whenever the design has more than one element on the page — every layout, every form, every table, every page header, every card. Trigger when designing a layout, picking a grid, fixing a UI that "looks off," debating left vs. center alignment for body text, or auditing why a design feels disorderly. Alignment is one of the most foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) — every visible element''s edge or center should fall on a shared axis with at least one other element. Misalignment by even a few pixels reads as disorder.'
+---
+
+# Alignment
+
+Alignment is the placement of elements so that their edges or centers fall on shared axes — invisible vertical or horizontal lines that thread through the composition. Aligned elements feel ordered, professional, and easy to scan. Misaligned elements — even when the misalignment is small — read as accidental, sloppy, or unfinished. Of all the visual variables a designer manages, alignment is the cheapest to get right and the most expensive to get wrong.
+
+## Definition (in our own words)
+
+When elements share an alignment axis, the eye can connect them as part of a system. A row of fields all sharing a left edge reads as a coherent column. A set of buttons all sharing a baseline reads as a related group. A hero headline sharing the page's center axis reads as a deliberate focal moment. When this discipline lapses — when a button is 4px off from its neighbors, when a label hangs out from the rest of the form — the eye registers the discrepancy preattentively. The user may not articulate it, but they sense the design is "off."
+
+## Origins and research lineage
+
+- **Gutenberg's printing press** (1450s) standardized typesetting, which is fundamentally about strict alignment. Lines of type aligned to baselines; columns aligned to gutters. The discipline predates digital design by centuries.
+- **Tschichold and the New Typography** (1920s–30s). Jan Tschichold's *Die neue Typographie* argued for asymmetric, strictly-aligned compositions over the ornamented symmetric layouts of the 19th century. Influential across modernist graphic design.
+- **The Swiss style / International Typographic Style** (1950s onward). Müller-Brockmann, Hofmann, Gerstner — the canonical formalization of grid-based design. Modernist corporate identity, much of which still defines visual standards, descends from this tradition.
+- **Lidwell, Holden & Butler** (2003) compactly stated: every element should be aligned with at least one other element. The book's iconic example is the Palm Beach County "butterfly ballot" of the 2000 US presidential election — alignment failures that may have decided the result.
+- **Eye-tracking research on grid layouts** consistently shows that users scan aligned columnar content faster and more accurately than misaligned layouts.
+
+## Why alignment matters
+
+Alignment carries no information by itself — it doesn't tell the user *what* anything is. What it does is signal that the design was deliberate. A well-aligned composition reads as competent and trustworthy at a perceptual level the user doesn't consciously evaluate. Conversely, misalignment makes everything else feel suspect; if the designer couldn't get the column edges to line up, what else did they miss?
+
+The cost of misalignment compounds:
+
+- **Scanning slows.** The eye traces shared axes; broken axes force re-orientation.
+- **Trust erodes.** Misaligned UIs feel amateur, even on otherwise polished products.
+- **Hierarchy fails.** Visual hierarchy depends on rhythm; misalignment disrupts the rhythm.
+- **Errors accumulate.** Famously: Florida's "butterfly ballot" misaligned candidate names with vote-hole positions, almost certainly causing thousands of voters to vote for the wrong candidate.
+
+## When to apply
+
+- **Always.** This is one of the few principles that applies on every surface, every time, with no exceptions.
+- **In particular, on first-pass layouts** before pixel-tweaking. Decide the grid; place elements on it; only then refine.
+- **In design-system component specs** — components must align by default; designers shouldn't have to manually align components from a system that pre-aligned them.
+
+## When alignment can be deliberately broken
+
+A small set of cases where intentional misalignment serves a goal:
+
+- **Marketing surfaces wanting "energetic" or "dynamic" feel.** Magazines and posters often deliberately misalign to create visual tension. Use sparingly; never in working app surfaces.
+- **A single deliberately-emphasized element.** Misaligning one element from a grid pulls the eye to it. Effective if used once per surface; noisy if used repeatedly.
+- **Decorative or illustrative content.** A hero illustration may not align to the body grid; that's fine.
+
+In production app UI, deliberate misalignment is rare. The default is strict alignment; deviation requires justification.
+
+## Alignment dimensions
+
+### Vertical alignment (left, right, center)
+
+Elements share a vertical axis (a y-axis line). The most common form in UI work.
+
+- **Left alignment** (most common in LTR scripts) — text and form fields share their left edge with the column.
+- **Right alignment** — used for numbers in tables (so digits stack), and for some labels (label-flush-right against input-flush-left).
+- **Center alignment** — used for hero text, page titles, button labels. Avoid for body text; ragged edges on both sides slow reading.
+
+### Horizontal alignment (baseline, top, middle, bottom)
+
+Elements share a horizontal axis (an x-axis line).
+
+- **Baseline alignment** — type baselines line up across columns. The eye threads horizontally.
+- **Top / center / bottom alignment** for icons-with-labels, buttons-with-text, etc. Choose deliberately.
+
+### Grid alignment
+
+A grid imposes both vertical and horizontal alignment. Most modern web design uses 12-column grids (responsive: 12 columns for desktop, 6 for tablet, 4 for mobile).
+
+```css
+.layout {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.layout > .main { grid-column: span 8; }
+.layout > .sidebar { grid-column: span 4; }
+```
+
+Within a grid, every element's edges fall on grid columns (or align to multiples of the column width).
+
+### Optical alignment
+
+The mathematically-correct alignment doesn't always look right. Curved or pointed shapes (round buttons, triangular icons) need *optical* adjustment to look aligned with rectangular ones. Designers shift them by a pixel or two so they read as aligned.
+
+## Worked examples
+
+### Example 1: a form with strict left alignment
+
+```html
+<form style="display: grid; gap: 16px; max-width: 400px;">
+  <div class="field">
+    <label for="name">Full name</label>
+    <input id="name" type="text" />
+  </div>
+  <div class="field">
+    <label for="email">Email</label>
+    <input id="email" type="email" />
+  </div>
+  <div class="field">
+    <label for="phone">Phone</label>
+    <input id="phone" type="tel" />
+  </div>
+  <button type="submit">Submit</button>
+</form>
+
+<style>
+  .field { display: grid; gap: 4px; }
+  label, input, button { width: 100%; }
+</style>
+```
+
+Every label, every input, the submit button — all share the same left edge and the same width. The eye reads it as a single coherent column. No alignment surprises.
+
+### Example 2: a label-input grid with right-aligned labels
+
+A common pattern for dense forms, especially settings pages where the user scans labels:
+
+```html
+<form style="display: grid; grid-template-columns: 8rem 1fr; gap: 12px 16px;">
+  <label style="text-align: right; padding-top: 0.5rem;">Display name</label>
+  <input type="text" />
+
+  <label style="text-align: right; padding-top: 0.5rem;">Email</label>
+  <input type="email" />
+
+  <label style="text-align: right; padding-top: 0.5rem;">Phone</label>
+  <input type="tel" />
+</form>
+```
+
+Two columns: labels on the right, inputs on the left. Labels share a right-edge axis; inputs share a left-edge axis. The space between is the alignment gap. Scanning down either column is effortless.
+
+### Example 3: a numeric table
+
+```html
+<table>
+  <thead>
+    <tr>
+      <th style="text-align: left;">Customer</th>
+      <th style="text-align: right;">Amount</th>
+      <th style="text-align: right;">Days late</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Acme Co.</td>
+      <td style="text-align: right; font-variant-numeric: tabular-nums;">$2,480.00</td>
+      <td style="text-align: right; font-variant-numeric: tabular-nums;">14</td>
+    </tr>
+    <tr>
+      <td>Bright Labs</td>
+      <td style="text-align: right; font-variant-numeric: tabular-nums;">$98,001.50</td>
+      <td style="text-align: right; font-variant-numeric: tabular-nums;">3</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+Text columns left-align so the eye traces names. Numeric columns right-align with tabular numerals so digit positions stack — the eye can compare magnitudes by counting digits.
+
+### Example 4: a header with title and actions
+
+```html
+<header style="display: flex; align-items: center; justify-content: space-between;">
+  <div>
+    <h1 style="font-size: 1.5rem;">Invoices</h1>
+    <p style="color: hsl(0 0% 45%); font-size: 0.875rem;">Sent and overdue, this quarter.</p>
+  </div>
+  <div style="display: flex; gap: 8px;">
+    <button>Export</button>
+    <button class="primary">New invoice</button>
+  </div>
+</header>
+```
+
+The header text is left-aligned; the action buttons are right-aligned (against the right edge of the page region). Both groups share the page's vertical center axis. Three alignment axes (left edge, center horizontal, right edge) all working at once.
+
+### Example 5: optical alignment for round elements
+
+```html
+<button class="rounded-button">
+  <svg viewBox="0 0 24 24" width="20" height="20" style="margin-left: -1px;">
+    <!-- A play icon (triangle) -->
+  </svg>
+  Play
+</button>
+```
+
+A play triangle is mathematically centered in its viewBox but reads as slightly-too-far-right because the triangle's visual mass is offset. A 1px nudge left brings it into optical alignment. Many design systems handle this in their icon set; otherwise designers do it manually.
+
+## Cross-domain examples
+
+### The butterfly ballot (2000 US election)
+
+The most famous alignment failure in modern history. Palm Beach County, Florida used a "butterfly" ballot where candidate names were listed on facing pages with punch holes between. The misalignment between candidate text and punch positions was such that voters intending to vote for Al Gore (second candidate listed) frequently punched the second hole — which corresponded to Pat Buchanan, not Gore. Buchanan's vote count in Palm Beach County was statistically anomalous compared to surrounding counties; analysis suggested thousands of misvotes. The election was decided by 537 votes in Florida.
+
+A design failure with material consequence. Lidwell, Holden, and Butler use this case as the canonical alignment example precisely because the stakes were so high.
+
+### Newspaper layout
+
+Traditional newspapers use strict columnar grids. Headlines align to columns; body text wraps within column widths; photos crop to align with column edges. The discipline is what lets readers scan a dense front page in seconds.
+
+### Tax forms (US 1040)
+
+The IRS 1040 form is a masterclass in alignment. Lines align across columns; figures align to decimal points; signature blocks align across pages. Without this discipline, the form would be unreadable; with it, millions of people complete it (with effort, but they complete it).
+
+### Spreadsheets
+
+Cells align to a grid by definition. Spreadsheets succeed as a productivity tool partly because alignment is enforced at the data structure level. Word processors and HTML, by contrast, allow alignment to drift unless designers exercise discipline.
+
+### Architecture and urban planning
+
+Manhattan's grid is alignment at city scale. Rome's organic streets are aligned to nothing. Both produce navigable cities, but they navigate differently — the grid is faster to learn; the organic is more interesting to walk.
+
+## Anti-patterns
+
+- **Centered body text.** Reading speeds drop by 30%+ for centered body text vs. left-aligned. Centered text is for short emphasis (headlines, single sentences), not for paragraphs.
+- **Justified text without hyphenation.** Justified text (both edges flush) creates "rivers of white" between widely-spaced words. Use ragged-right for screens; if you must justify, enable hyphenation.
+- **Mixing alignment within a column.** Some labels left-aligned, some right-aligned. Each switch is a re-orientation cost.
+- **Invisible micro-misalignments.** Elements 2–3px off from their intended position because of inconsistent padding. The page feels "off" even if no one can identify why.
+- **Decorative misalignment in working UI.** Marketing pages can deliberately misalign for energy; settings pages cannot.
+- **Different button sizes in a row.** Buttons of varying heights or widths in the same row break the row's baseline.
+
+## Heuristics
+
+1. **The squint test.** Squint at the page. Edges should fall on shared axes. If columns appear to wobble, you have misalignment.
+2. **The grid overlay.** Show your grid as a CSS overlay. Every element's edge should fall on a grid line or a half-grid line.
+3. **The mass-block sketch.** Sketch the page as filled rectangles. The rectangles should share axes — left edges, right edges, baselines.
+4. **The mobile + desktop check.** Many alignments work on desktop and break on mobile (or vice versa). Audit at multiple breakpoints.
+5. **The dynamic content audit.** Replace placeholder text with real worst-case content (long names, big numbers, multi-line addresses). Did alignment break?
+
+## Related principles
+
+- **`good-continuation`** — alignment exploits good continuation; the eye threads along shared edges.
+- **`hierarchy`** — alignment supports hierarchy by establishing the rhythm hierarchy varies against.
+- **`proximity`** — proximity establishes grouping; alignment establishes the columns those groups inhabit.
+- **`uniform-connectedness`** — aligned items connected by a shared axis read as a system.
+- **`gutenberg-diagram`** — when alignment is uniform, the eye falls back to the Z-pattern.
+- **`aesthetic-usability-effect`** (aesthetics) — alignment is a major component of "classical" aesthetics; misaligned designs are perceived as less usable even when they work.
+
+## Sub-aspect skills
+
+- **`alignment-grid-systems`** — formal grid systems (12-column, modular grids, baseline grids) and how to use them.
+- **`alignment-text-and-numerics`** — alignment decisions specific to text (left vs. center vs. justified) and to numeric tables (right-align, tabular numerals).
+
+## Closing
+
+Alignment is the cheapest design improvement available — it costs only attention, no new content. Yet it's one of the most-violated principles in production UIs because it's invisible when right and accumulates as drift when ignored. The discipline is in noticing every element's edge and asking: what does this align to? If the answer is "nothing," fix it.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment/references/grid-history-and-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/alignment/references/grid-history-and-cases.md
@@ -1,0 +1,95 @@
+# Alignment: history and cross-domain cases
+
+A reference complementing the `alignment` SKILL.md with cross-domain context and the historical lineage of grid-based design.
+
+## Brief history of alignment in design
+
+Strict alignment in graphic design predates the computer by centuries. Gutenberg's metal-type pages had to align by physical necessity — characters cast at fixed widths, set into wood frames, locked into a press. Misaligned type literally couldn't print.
+
+Modern grid systems emerged from:
+
+- **Renaissance manuscript design** — proportional page layouts, often based on golden ratio or root rectangles.
+- **20th-century modernist typography** (Tschichold, Bauhaus) — explicit asymmetric grids, departing from the symmetric ornamented layouts of Victorian print.
+- **Swiss / International Typographic Style** (Müller-Brockmann, Hofmann) — formal grid theory codified into a teachable system. Müller-Brockmann's *Grid Systems in Graphic Design* (1981) remains the canonical text.
+- **Web grid systems** (960.gs, Bootstrap, CSS Grid) — translation of print grids to digital layout. The 12-column standard descends from print's traditional grid divisions.
+
+## The butterfly ballot case
+
+The Palm Beach County, Florida "butterfly ballot" of November 7, 2000, is the most-studied alignment failure in modern design. Candidate names were listed on facing pages with punch-hole positions in a column down the center of the spread. The visual alignment between candidate names and the corresponding holes was ambiguous: the second name on the left page aligned with what appeared to be the second hole, but that hole actually corresponded to the first name on the right page (Pat Buchanan).
+
+Statistical analysis after the election showed Buchanan received roughly 3,400 votes in Palm Beach County — far above the rate elsewhere in Florida and inconsistent with his support in other counties. The most plausible explanation: thousands of voters who intended to vote for Al Gore (the second candidate listed) punched the second hole, voting for Buchanan instead.
+
+The election's national outcome was decided by 537 votes in Florida. The ballot's misalignment may have changed the presidency.
+
+The case is the canonical example because the design failure was specifically *alignment* (the layout's visual ordering didn't match the punch positions), the cost was material, and the fix was trivial. Lidwell, Holden, and Butler used this case in *Universal Principles of Design* to illustrate why alignment matters.
+
+## Cross-domain examples
+
+### Newspaper front pages
+
+Traditional newspapers use strict 6- or 8-column grids. Headlines align to columns; body text wraps within column widths; photos crop to align with column edges. The discipline is what lets readers scan a dense front page in seconds.
+
+When digital newspapers shifted to web in the 1990s–2000s, many experimented with looser layouts. Most have returned to strict grids because user comprehension drops without them.
+
+### Tax forms
+
+The IRS 1040 form is a triumph of alignment. Every line aligns to a numbered row; numbers align to decimal points within columns; signature blocks align across pages. The form is unpleasant but completable; without alignment discipline, it would be unusable.
+
+### Spreadsheets
+
+Spreadsheets enforce alignment at the data structure. Every value is in a cell on a grid. Mismatched alignment within a spreadsheet typically indicates a data error (a header in the wrong column, a value off by a row).
+
+### Architecture: the modular building
+
+Le Corbusier's Modulor, Frank Lloyd Wright's Usonian houses, and modern modular construction all enforce dimensional alignment. Building elements (windows, doors, beams) align to a common module so they manufacture, transport, and assemble efficiently.
+
+### Music notation
+
+Standard music notation uses strict horizontal alignment: notes in different parts that play simultaneously align vertically. Misaligned music notation is a sight-reading nightmare; the discipline is essential for ensemble performance.
+
+## Common alignment patterns in production UI
+
+### App shells
+
+A well-designed app shell aligns:
+
+- **Sidebar nav width** with a fixed grid column.
+- **Top header height** with the page's vertical rhythm.
+- **Content margin** with the grid's column gutters.
+- **Card padding** as a multiple of the spacing scale.
+
+### Forms
+
+Forms align by:
+
+- **Label edge** — all labels share a left or right edge.
+- **Input edge** — all inputs share a left edge.
+- **Input width** — all single-line inputs the same width.
+- **Submit button position** — typically right-aligned at the bottom.
+
+### Data tables
+
+Tables align by:
+
+- **Column edges** — all data in a column shares the same horizontal edge.
+- **Row baselines** — all data in a row shares a baseline.
+- **Numeric right-alignment** with tabular numerals.
+
+### Dashboards
+
+Dashboards align by:
+
+- **Card heights** — cards in the same row share height.
+- **Card widths** — cards span integer numbers of grid columns.
+- **Internal padding** — consistent across cards.
+
+## Resources
+
+- **Müller-Brockmann, J.** *Grid Systems in Graphic Design* (1981) — the canonical reference.
+- **Tschichold, J.** *The Form of the Book* (1991) — book-design proportions.
+- **Hochuli, J.** *Detail in Typography* (2008) — fine-grained typographic alignment.
+- **Web grid frameworks** (Bootstrap, Tailwind, CSS Grid) — modern implementations.
+
+## Closing
+
+Alignment is one of the few design principles that pays off invisibly. Users notice misalignment immediately as "off"; aligned compositions feel right without anyone being able to articulate why. That invisibility is the principle doing its job.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure-completion-cost/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure-completion-cost/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: closure-completion-cost
+description: 'Recognize when closure is the wrong choice — when the perceptual completion work it asks of the user is too costly, ambiguous, or risky. Use when designing for accessibility audiences, novice users, high-stakes interfaces (medical, financial, safety), small rendering sizes that strain perception, or any context where the user shouldn''t have to do completion work to understand the form. The skill is judging when explicit forms serve the user better than suggested ones, even at the cost of visual elegance.'
+---
+
+# Closure — completion cost
+
+Closure is a powerful tool for visual economy and elegance, but it asks the user to do perceptual work — to complete the form. In some contexts, that work is too costly, too risky, or simply not available to the user. The skill is recognizing those contexts and committing to explicit forms instead.
+
+The decision is rarely "closure or not"; it's "how much closure is appropriate for this audience and this stakes." The same designer who reduces a logo to elegant minimalism may reasonably choose explicit, fully-drawn shapes for a critical-action button.
+
+## When closure costs too much
+
+**Accessibility audiences.** Users with vision differences may have less ability to perceive subtle visual cues. A form suggested through partial outlines or negative space may not be perceivable at all. Provide explicit forms or text alternatives.
+
+**Novice users.** First-time users haven't built up the visual vocabulary that closure depends on. A minimal icon that an expert recognizes instantly may be opaque to a novice. Pair minimal icons with labels until familiarity builds.
+
+**Small rendering sizes.** Below ~24px, many forms lose enough visual information that closure stops working. The brain can't recover what isn't there. Either make the form larger or commit to explicit visual structure.
+
+**High-stakes contexts.** A "delete" action that depends on closure to be recognized is a delete action that gets accidentally triggered. Critical operations need unambiguous forms.
+
+**International or cross-cultural audiences.** Closure depends on familiarity with the implied form. A form familiar in one culture may be unfamiliar in another.
+
+**Critical-information displays.** A medical-monitoring readout, a flight-instrument display, a financial-trading dashboard — situations where misreading has real consequences. Explicit visual structure reduces error rates.
+
+## Symptoms of closure costing too much
+
+**Users misinterpret minimal icons.** They click the wrong icon because the suggested form was ambiguous.
+
+**Users ask "what does this do?" about unlabeled controls.** The closure was too aggressive for their familiarity level.
+
+**Accessibility audits flag missing visual structure.** Screen readers, low-vision users, or color-blind users can't perceive the implied forms.
+
+**Customer support questions about what controls do.** A consistent pattern of confusion about specific elements suggests they need more explicit form.
+
+**Misclick rates higher than expected.** Users hitting the wrong button or icon, suggesting the visual differentiation isn't strong enough.
+
+## When to back off from closure
+
+The fix is usually one of:
+
+**Add explicit form to critical elements.** Reserve minimal/closure-based design for low-stakes, frequently-used items. Make critical actions explicit.
+
+**Pair minimal icons with labels.** Even a familiar minimal icon benefits from a label for users who haven't built familiarity.
+
+**Test rendering at all sizes.** Verify that minimal forms still work at the smallest sizes they'll be used at. Increase the form's complexity if needed for small rendering.
+
+**Provide alternatives for accessibility.** Explicit forms in high-contrast modes; text alternatives for screen readers; user-configurable visual options.
+
+**Be explicit in high-stakes contexts.** Medical, financial, safety-critical contexts deserve unambiguous design even at the cost of elegance.
+
+## Worked examples
+
+### A minimal icon that fails for novices
+
+A productivity tool uses a minimal icon set: 1.5px stroke outlines, no labels. Power users find the icons clean and elegant. New users open the app, see a row of similar-looking icons, and don't know what any of them do.
+
+The fix: pair icons with labels (at least in primary navigation). Power users are mildly inconvenienced by the labels; novices can actually use the product. The trade-off favors the larger novice audience.
+
+### A trading interface with closure-based design
+
+A trading app uses a clean, minimal design. The "buy" and "sell" buttons are small, with subtle color differentiation. Users occasionally hit the wrong button when stressed.
+
+The fix: make the buy and sell buttons explicit and visually distinct. The buttons are larger, in clearly different colors, with explicit labels. The visual elegance decreases; the error rate decreases more.
+
+In high-stakes contexts, explicit design serves the user even when it costs visual elegance.
+
+### A medical monitoring display with subtle hierarchy
+
+A patient-monitoring display uses subtle visual hierarchy: heart rate slightly larger than respiration, vitals on a slightly tinted background. In the calm of design review, the hierarchy is clear. In the chaos of a real medical emergency, clinicians can't quickly read the values.
+
+The fix: make critical values (the ones clinicians need to see first) much more visually prominent. Larger text, bolder weight, distinct color. The hierarchy should be unmistakable, not subtly suggested.
+
+In life-critical contexts, error from misperception is unacceptable. Explicit design is the right choice.
+
+### A logo that works as a brand mark and as a small favicon
+
+A startup designs a logo that's elegant at large sizes (closure-based, with negative-space play) but disintegrates at favicon size (16x16). The favicon reads as just a blob.
+
+The fix: design two versions of the logo — a full version for large rendering and a simplified version for small. The simplified version commits to explicit forms; the full version exploits closure.
+
+This is the "logo as a system" approach. Different rendering contexts need different forms.
+
+### Card layouts that confuse users
+
+A dashboard's cards have very subtle differentiation (slight background tint, no borders). Users can't tell where one card ends and another begins. They think the entire dashboard is one big section.
+
+The fix: increase the visual cue for containment. A subtle border, a slightly more visible shadow, or more spacing between cards. The closure is still operating but with stronger cues to support it.
+
+## When to lean into closure anyway
+
+Even in high-stakes or accessibility contexts, closure can sometimes be the right call:
+
+**Closure with redundant explicit cue.** A minimal icon paired with a clear label. The closure provides quick scan; the label supports recognition.
+
+**Closure as primary visual language with explicit overrides.** A minimalist design overall, but with explicit visual treatment for critical actions and high-stakes elements.
+
+**Closure for repeated use patterns.** Frequent users build the perceptual familiarity that closure depends on. Designs aimed at heavy users can rely on closure more than designs for first-time users.
+
+The skill is calibration, not avoidance. Closure isn't bad in any context; it's costly in some contexts.
+
+## Heuristic checklist
+
+Before relying on closure, ask: **What's my audience's familiarity with the form?** Less familiar = more explicit. **What's the stakes of misperception?** Higher stakes = more explicit. **What rendering sizes will the form appear at?** Smaller = more explicit. **Are accessibility audiences served by the implied form?** If not, provide alternatives. **Have I tested with users who don't share my visual sophistication?** Designers consistently overestimate how much closure their users can do.
+
+## Related sub-skills
+
+- `closure` — parent principle on perceptual completion.
+- `closure-implied-shapes` — sibling skill on designing for closure.
+- `accessibility` — closure interacts heavily with accessibility considerations.
+- `signal-to-noise` — closure reduces noise; sometimes the noise was actually serving users.
+- `mental-model` — closure depends on the user having the form's template in their mental model.
+
+## See also
+
+- `references/explicit-vs-implicit.md` — guidance on choosing between explicit and implicit form for different contexts.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure-completion-cost/references/explicit-vs-implicit.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure-completion-cost/references/explicit-vs-implicit.md
@@ -1,0 +1,93 @@
+# Explicit vs. implicit form — context guidance
+
+A working framework for deciding between explicit (fully-drawn) and implicit (closure-based) forms in different contexts.
+
+## Audience considerations
+
+**Power users and frequent users.** Have built up the perceptual vocabulary that closure depends on. Can recognize minimal icons, infer container structure, parse abstract forms. Closure is appropriate.
+
+**First-time users and casual users.** Lack the perceptual vocabulary. Need explicit forms to recognize what's there. Pair closure-based design with labels and reinforcement.
+
+**Accessibility audiences (low vision, color-blind, cognitive differences).** May have less ability to perceive subtle visual cues. Closure-based design needs explicit alternatives or text fallbacks.
+
+**Older users.** Often have reduced visual acuity and benefit from larger, more explicit forms.
+
+**International audiences.** Closure depends on familiarity with the implied form, which can vary by culture. Verify cultural recognition.
+
+**Children.** Generally benefit from concrete, explicit forms over abstract ones. Closure-based design works better for older children with established visual vocabulary.
+
+## Stakes considerations
+
+**Low-stakes / recoverable actions.** Closure-based design is fine. If the user makes an error, they recover with one undo. Examples: filtering a list, viewing different data, dismissing a notification.
+
+**Medium-stakes / mostly recoverable.** Calibrated mix. Common operations can use closure; less common or more impactful operations should be more explicit. Examples: editing a document (recoverable but disruptive), submitting a form (committing but usually correctable).
+
+**High-stakes / hard to recover.** Lean toward explicit. Examples: deleting data, sending messages, making purchases, changing permissions. Critical-action buttons should be unambiguous, with clear confirmation.
+
+**Life-critical or safety-critical.** Always explicit. Medical interfaces, aviation displays, industrial control systems, safety equipment. The perceptual ambiguity that closure introduces is unacceptable in these contexts.
+
+## Rendering size considerations
+
+**Large sizes (32px+ for icons, 800px+ for layouts).** Closure works well. The visual information is sufficient for the brain to complete forms.
+
+**Medium sizes (16–32px for icons, 320–800px for layouts).** Closure is conditional. Familiar forms still work; unfamiliar ones may break down. Test specifically.
+
+**Small sizes (<16px for icons, <320px for layouts).** Closure often fails. Forms need to be more explicit because there's less visual information for the brain to work with.
+
+**Very small (favicon, status-bar icons, etc.).** Commit to explicit forms or simplified versions designed specifically for small rendering.
+
+## Context considerations
+
+**Quiet visual contexts (clean layouts, minimal competing elements).** Closure-based design has more space to work. Subtle cues are noticed.
+
+**Busy visual contexts (data-dense, many competing elements).** Closure-based design fails because subtle cues are lost in the noise. Use more explicit forms.
+
+**Motion or temporal contexts (animations, transitions, time-bounded reads).** Closure needs more time to operate. Quick reads benefit from explicit forms.
+
+**Read-once vs. read-many.** Forms users will encounter many times can develop familiarity that supports closure. Forms encountered once need to communicate immediately.
+
+## Decision framework
+
+For each design element, ask:
+
+1. **What's the audience?** If novice, accessibility, or unfamiliar, lean explicit.
+2. **What's the stakes?** If high or irreversible, lean explicit.
+3. **What's the rendering size?** If small, lean explicit.
+4. **What's the visual context?** If busy or time-pressured, lean explicit.
+5. **How often will users encounter this?** If frequently, closure can develop familiarity; if rarely, explicit serves better.
+
+The answers guide the decision. Most products will have a mix: closure-based design for frequent, low-stakes elements; explicit design for critical, infrequent, or high-stakes elements.
+
+## Specific guidance
+
+**Navigation.** Pair icons with labels at minimum in primary navigation. Power users can hide labels via preference; default to labeled.
+
+**Primary actions.** Be explicit. Buttons should clearly look like buttons; primary buttons should clearly differ from secondary.
+
+**Critical actions (delete, irreversible operations).** Be very explicit. Distinct color, icon, and label. Often pair with explicit confirmation.
+
+**Status and state indicators.** Pair color with shape and (where appropriate) text. Don't rely on color alone.
+
+**Chart axes.** Implied baselines work for charts where exact values matter less; explicit baselines for analytical charts where precision matters.
+
+**Card layouts.** Subtle containment (background tint, light shadow) works for clean dashboards; more explicit containment (clear border) for data-dense or complex layouts.
+
+**Logos.** Closure can shine in logos because viewers spend time with them and develop familiarity. Provide a simplified favicon-size variant.
+
+**Icons in toolbars.** Pair with labels for first-time use; consider hover-only labels for power users; never hide labels in mobile toolbars (no hover).
+
+**Form fields.** Be explicit about what each field is for. Labels should always be visible (not just placeholder text).
+
+## Anti-patterns
+
+**Closure throughout in a high-stakes product.** Minimalism applied uniformly to a medical or financial interface. The aesthetic gain is paid back many times over in user error.
+
+**Closure-based icons with no labels in a beginner-targeted product.** Users can't learn what the icons mean. Adoption suffers.
+
+**Inconsistent application.** Some interactions use closure, others don't, with no clear logic. Users can't form expectations.
+
+**Treating "minimalism" as a virtue independent of context.** Visual reduction is a tool, not a value. Apply it where it serves; don't apply it where it doesn't.
+
+## Cross-reference
+
+For designing forms that exploit closure, see `closure-implied-shapes`. For the parent principle, see `closure`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure-implied-shapes/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure-implied-shapes/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: closure-implied-shapes
+description: 'Design forms that exploit closure — suggesting shapes through partial outlines, negative space, or strategic gaps so the user''s perception completes them. Use when designing icons that need to read at small sizes, logos that need memorability, illustrations with restraint, card layouts with implied containment, or charts with implied structure. The art is suggesting just enough that the user perceives the whole, without leaving so little that they perceive nothing.'
+---
+
+# Closure — implied shapes
+
+Designing for closure is the art of suggesting forms with the minimum visual that the user's perception can complete. A logo with hidden negative-space shapes; an icon with partial outlines that imply the whole; a card layout where containment is inferred rather than drawn.
+
+The work is calibration. Too little visual cue and the closure fails — users see fragments rather than wholes. Too much and you've drawn the form completely, foregoing the elegance and economy of suggestion.
+
+## How implied shapes work
+
+The user's visual system completes incomplete forms automatically. Your job as a designer is to provide enough cues that the completion happens reliably.
+
+The cues that aid closure:
+
+**Strategic gaps.** A circle with small breaks in its outline still reads as a circle. The gaps shouldn't be so large that the form fragments.
+
+**Aligned terminations.** When parts of a form end at a shared invisible line, the user's perception extends the line. A row of characters at the same baseline; a column of items aligned to the same edge.
+
+**Suggestive proximity.** Forms close to each other are more likely to be perceived as parts of a single whole. Gestalt proximity reinforces closure.
+
+**Familiar forms.** A familiar shape is easier to suggest than an unfamiliar one. The brain has a template to match.
+
+**Contextual support.** Surrounding visual elements that prime the perception. A face is easier to perceive in a portrait orientation than in arbitrary positions.
+
+## Worked patterns
+
+### Pattern: minimal icons
+
+Icons designed with the fewest possible strokes that still communicate the form. A house icon with just a triangle and a square; a mail icon with just an envelope outline; a search icon with just a circle and a stick.
+
+The reduction works at most sizes because the form is familiar — the brain completes it. At very small sizes (8–12px), some forms break down; check the rendering at production sizes.
+
+### Pattern: negative-space shapes in logos
+
+A logo that uses the negative space between elements to imply a third shape. The FedEx arrow (between E and X). The NBC peacock implied by the colored fan. Many other examples in modern logo design.
+
+The hidden shape needs to be:
+- Recognizable once seen.
+- Not too obvious (otherwise it's just drawn, not suggested).
+- Not too obscure (otherwise no one notices).
+
+The "noticing" is part of the appeal — viewers feel a small moment of cleverness when they see the hidden shape, which builds memorability.
+
+### Pattern: card containers without full borders
+
+Cards that imply containment through:
+- Background color slightly different from the surrounding surface.
+- Subtle drop shadow suggesting elevation.
+- Consistent internal padding setting the card boundaries.
+- Rounded corners on a tinted background.
+
+No explicit border line is needed; the container is inferred. This produces a lighter, more modern card style than fully-bordered cards.
+
+### Pattern: implied baselines in charts
+
+A chart with a thin baseline (or no baseline at all) and bars that extend upward from an inferred ground. The user perceives the chart's structure without explicit grid lines or axes.
+
+The data needs to be clear enough that the implied baseline is unambiguous. For charts with data near zero, an explicit baseline may be needed; for charts with all values clearly above zero, the baseline can be inferred.
+
+### Pattern: minimal forms in illustrations
+
+Illustrations using silhouettes, partial details, or abstracted shapes rather than fully-rendered subjects. A figure shown only in outline. A landscape implied by a few horizontal forms.
+
+Modern editorial illustration heavily relies on this. The viewer engages with the illustration by completing the form, which creates a moment of attention that fully-rendered illustrations don't.
+
+### Pattern: text emphasized by proximity
+
+A row of related items with no visual separator (no line between them, no border around them) — but consistent spacing. The proximity (similarity in spacing, alignment to a common baseline) implies grouping. A separator isn't needed if the spacing does the grouping work.
+
+## Calibrating the right level of suggestion
+
+The right level depends on context.
+
+**Familiar forms can be reduced more.** A common shape (house, person, arrow, circle) can be reduced to very minimal cues because the brain has the template.
+
+**Unfamiliar or specialized forms need more.** A specialty icon for a niche concept can't rely on the brain to complete it; provide more explicit visual cues.
+
+**Smaller rendering needs more visual structure.** At small sizes, less of the form is visible. A reduction that works at 32px may break at 16px.
+
+**Higher-stakes contexts need more explicit forms.** A "delete" icon that must communicate clearly should not be reduced to ambiguity.
+
+**Audiences with limited visual sophistication need more.** Designers tend to over-reduce because they can complete forms easily; users may not.
+
+## Worked examples
+
+### A logo iteration
+
+A startup designs a logo. Initial version: a fully-rendered illustration of a phoenix, detailed feathers, complex coloring. It's beautiful but doesn't scale to 16px and is hard to remember.
+
+Iteration 1: simplified to a stylized bird shape with three feathers. Recognizable as a bird, more memorable, scales better.
+
+Iteration 2: further simplified to an abstract V-shape with a curve at the top. Implies a bird in flight without literally drawing one. The closure principle does the work; viewers see "bird" through the suggestion.
+
+The final logo scales to any size, is memorable, and feels distinctively designed. The closure principle let the form become more confident through reduction.
+
+### A card grid
+
+A dashboard's cards initially have full 1px gray borders. The grid feels boxy and visually busy.
+
+Iteration: replace borders with a subtle background tint (5% darker than the surrounding surface). The cards still read as containers (closure: the user perceives the boundaries) but feel lighter.
+
+Further iteration: remove the background tint and use only consistent spacing and a subtle drop shadow. The cards now have minimal visual weight but still read as contained units.
+
+The progression shows how closure can be exploited progressively to reduce visual weight without sacrificing the perceptual structure.
+
+### A skeleton loading state
+
+A list of items is loading. Instead of a blank screen, show pulsing rectangles in the shape of the upcoming items. The user perceives the structure that's coming; the wait feels productive rather than empty.
+
+This is closure used temporally — implying a complete page that's still being constructed. Very effective for loading-state perception.
+
+## Anti-patterns
+
+**Over-reduction.** Reducing a form past the point of recognizability. Common in trendy minimalist redesigns.
+
+**Hidden shapes that no one notices.** A logo with a "hidden" arrow that's so subtle it's never seen. Closure requires the suggestion to be perceivable.
+
+**Closure in high-stakes UI.** A "delete" icon reduced to ambiguity. Critical actions need explicit forms.
+
+**Minimal forms at the wrong rendering size.** A logo that works at 200px and disintegrates at 24px. Test at the actual sizes.
+
+**Closure that depends on a specific context.** A logo with a hidden shape that requires being viewed in a particular way to be seen. The shape needs to be discoverable in normal use.
+
+## Heuristic checklist
+
+When designing for closure, ask: **Is the suggested form recognizable at the actual rendering sizes?** Test, don't assume. **Will users notice the suggestion?** A hidden shape that's never seen is just decoration. **Is the audience equipped to do the completion work?** Familiar forms for general audiences; explicit forms for specialty contexts. **Could over-reduction create ambiguity that costs users?** In high-stakes contexts, lean toward explicit.
+
+## Related sub-skills
+
+- `closure` — parent principle on perceptual completion of forms.
+- `closure-completion-cost` — sibling skill on when closure is the wrong choice.
+- `signal-to-noise` — closure reduces visual weight through suggestion.
+- `iconic-representation` — minimal icons rely on closure.
+- `gestalt-similarity` — similarity often reinforces closure.
+
+## See also
+
+- `references/closure-design-patterns.md` — patterns for specific applications of closure.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure-implied-shapes/references/closure-design-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure-implied-shapes/references/closure-design-patterns.md
@@ -1,0 +1,127 @@
+# Closure — design patterns
+
+Specific patterns for applying closure in different design contexts.
+
+## Pattern: minimal icon set
+
+An icon system using outlined shapes with consistent stroke weight and selective omission of detail. Each icon implies its form through a few strokes; the user's perception completes the rest.
+
+Examples: Material Symbols, Phosphor Icons, Lucide, Tabler Icons, Heroicons.
+
+Design considerations:
+- Stroke weight consistent across the set (typically 1.5–2px at 24px).
+- Corner treatment consistent (sharp, rounded, or in between).
+- Forms recognizable at the smallest rendering size (16–18px usually the floor).
+- Avoid forms that require detail to recognize (skip facial expressions, complex objects).
+
+## Pattern: card containment without borders
+
+Cards that feel contained without an explicit border:
+- Subtle background color (slightly different from the surrounding surface, often by 3–5% lightness).
+- Subtle drop shadow (2–4px blur, very low opacity).
+- Consistent internal padding establishing the "edges" through spacing.
+
+Pairs well with:
+- Generous gaps between cards (so cards don't feel crowded against each other).
+- Consistent corner radius (rounded uniformly).
+- Hover states that subtly increase elevation (subtle interaction feedback).
+
+## Pattern: text containment by spacing alone
+
+Text blocks separated by spacing rather than visual dividers. A paragraph followed by space followed by a heading followed by space followed by another paragraph: the structure is implied by the rhythm.
+
+Useful when:
+- The content is conceptually structured.
+- The visual context is clean (not competing with other elements).
+- Users will read sequentially (top to bottom).
+
+Requires:
+- Consistent spacing (so the user can perceive the rhythm).
+- Sufficient spacing to make the breaks visible.
+
+## Pattern: implied structure in charts
+
+Charts that omit explicit axes, gridlines, or legends in favor of inferred structure:
+- Bars rising from an inferred baseline.
+- Lines on a chart with subtle (not dominant) reference points.
+- Color-coded series identified through visual matching with the legend.
+
+Works when:
+- The data is clear enough that the reference points aren't ambiguous.
+- The chart is simple (few series, clear values).
+
+Less useful for:
+- Charts where exact values matter (omit gridlines and users can't read precisely).
+- Highly technical charts where structure must be unambiguous.
+
+## Pattern: logo with hidden shape
+
+A logo that uses negative space or alignment to imply a meaningful shape that's not explicitly drawn.
+
+Famous examples:
+- FedEx (arrow between E and X).
+- Toblerone (bear hidden in the mountain silhouette).
+- Amazon's smile (arrow from A to Z).
+- WWF panda (form implied by black shapes; white parts are negative space).
+
+Requirements:
+- The hidden shape should be discoverable but not immediately obvious (the moment of noticing is part of the appeal).
+- Once seen, the shape should be unmistakable.
+- The shape should reinforce the brand meaning, not be arbitrary.
+
+## Pattern: skeleton loading state
+
+Pulsing rectangles in the shape of upcoming content. The user sees the structure of the page being formed; the wait feels productive.
+
+Design considerations:
+- Match the actual content's layout (titles, body, images all at appropriate proportions).
+- Subtle animation (gentle pulse or shimmer, not distracting).
+- Replace seamlessly when content arrives (no jarring transition).
+
+## Pattern: visual hierarchy through proximity and similarity
+
+Multiple elements at different hierarchy levels, with the levels implied through spacing and styling rather than explicit separators:
+
+- A page title with significant space below.
+- Section headings with moderate space above and below.
+- Body text packed tighter, with smaller paragraph spacing.
+
+The hierarchy is perceived through the rhythmic structure; explicit dividers (lines, boxes) aren't needed.
+
+## Pattern: implied chart legend
+
+Chart series labeled directly on the data (the line's label appears at the line's endpoint, in the line's color) rather than in a separate legend box. The connection between label and data is implied by position and color.
+
+This is one of the highest-ROI improvements in chart design. It removes the cognitive cost of looking back and forth between chart and legend.
+
+## Pattern: inferred form in illustration
+
+Illustrations using:
+- Silhouettes (form implied by outline).
+- Partial details (focus on key features, omit the rest).
+- Abstracted shapes (geometric forms suggesting subjects).
+- Negative space (parts of the form left empty for the viewer to complete).
+
+Common in modern editorial and product illustration. Works because the audience can fill in the missing detail; doesn't work for technical illustrations where precision matters.
+
+## Pattern: visual rhythm without lines
+
+A page layout that uses consistent spacing and sizing to create a perceived grid, without drawing the grid lines. Elements align to the same vertical positions; columns share the same widths; spacing matches across the layout.
+
+The user perceives the structure; the visual weight stays low.
+
+## Anti-patterns
+
+**Closure where clarity is paramount.** A "delete" or "irreversible" action represented by an ambiguous form. The user needs to be sure of what they're triggering.
+
+**Hidden shapes that are too hidden.** A logo with a hidden meaning that no one notices. The closure adds nothing.
+
+**Closure that breaks at common rendering sizes.** A minimal icon that works at 24px and disintegrates at 16px. Test at the actual sizes.
+
+**Closure incompatible with accessibility.** A form that requires visual perception that some users lack (color, fine detail). Provide alternatives.
+
+**Closure as substitute for thought.** Stripping detail reflexively without considering whether the form will still communicate. Reduction should be deliberate.
+
+## Cross-reference
+
+For when closure is the wrong choice, see `closure-completion-cost`. For the parent principle, see `closure`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: closure
+description: 'Apply the Gestalt principle of Closure — the perceptual tendency to see incomplete shapes as whole. Use when designing icons (a few strokes can imply a closed shape), illustrations (negative space defines forms), logos (the IBM stripes, the WWF panda, the FedEx arrow), card layouts (cards don''t need full borders to feel like containers), or any visual that benefits from suggested rather than fully drawn shapes. Closure lets you communicate more with less; the user''s perception completes the form.'
+---
+
+# Closure
+
+> **Definition.** Closure is the Gestalt principle that the visual system tends to perceive incomplete shapes as complete — to "close" gaps in outlines and recognize implied forms. A circle with small breaks in its outline is still seen as a circle. A few strokes that suggest a face are perceived as a face. Negative space between objects can imply a third object that isn't actually drawn. The brain fills in what isn't there.
+
+The classic Gestalt demonstrations of closure use simple shapes with strategic gaps. A "circle" made of 12 dot pairs around its circumference reads as a circle, not as 24 dots. A "triangle" formed by three Pac-Man-shaped figures (the Kanizsa triangle) is perceived clearly even though no triangle is actually drawn — only the gaps imply one.
+
+This perceptual tendency has substantial design value. It lets you communicate forms with less visual information than would be needed to draw them fully. The result is interfaces that feel light, illustrations that feel modern, logos that work at many sizes, and visual cues that work even at minimum scale.
+
+## Why closure matters
+
+Closure does several useful jobs in design:
+
+**Visual economy.** A form suggested by a few strokes is faster to read than a fully-rendered form, and it scales better — a partial shape can communicate at sizes where a fully detailed shape would be a blur.
+
+**Visual elegance.** Designs that exploit closure feel modern and crafted. The viewer participates in completing the form, which creates a small moment of cognitive engagement.
+
+**Memorable iconography.** Logos and icons that use closure are often more memorable than fully-drawn equivalents. The FedEx logo's hidden arrow (in the negative space between E and X) is a famous example — once you see it, you can't unsee it.
+
+**Reduced visual weight.** A card with subtle visual cues at its corners (rather than a full border) feels lighter than a card with a heavy outline. The closure principle lets the user perceive the container even though most of its border isn't drawn.
+
+## When to use closure
+
+**Icon design.** A simple icon often communicates more clearly than a detailed one. A few strokes that imply the form let the user's perception complete it.
+
+**Logo design.** Marks that exploit closure (hidden shapes in negative space, partial outlines that suggest the whole) are more memorable and often more flexible across sizes.
+
+**Card layouts.** Cards don't always need full borders. Subtle background tinting, drop shadow, or just consistent spacing can imply containment without drawing every edge.
+
+**Illustration.** Modern illustration often relies on suggested forms — silhouettes, abstracted shapes, partial details. The viewer fills in what's not shown.
+
+**Charts and diagrams.** Implied baselines, suggested axes, and visual rhythms can replace explicit lines and grids, reducing visual noise while preserving the structure.
+
+## Diagnosing closure problems
+
+When closure fails, the user perceives the form as broken or incomplete rather than as a whole. Symptoms:
+
+**The "form" doesn't read as one shape.** Users see disconnected parts rather than the implied whole. The gaps are too large or the parts too varied.
+
+**An icon's meaning is unclear.** The simplification went too far; the user can't recognize what the icon depicts.
+
+**Cards or containers feel ambiguous.** Without a clear edge cue, users aren't sure where one container ends and another begins.
+
+**Negative-space shapes go unnoticed.** A hidden shape in a logo that no one ever sees. The closure works only if the suggestion is strong enough.
+
+## Sub-skills in this cluster
+
+- **closure-implied-shapes** — Designing forms that exploit closure: icons with partial outlines, logos with negative-space shapes, illustrations with suggested rather than drawn forms.
+- **closure-completion-cost** — When closure is the wrong choice: situations where the user shouldn't have to do completion work (high-stakes interfaces, accessibility-critical contexts, novice users).
+
+## Worked examples
+
+### A minimal card layout
+
+A dashboard shows cards with content. Instead of a full border around each card, the cards have:
+- A slight elevation (subtle drop shadow).
+- Consistent internal padding.
+- A clear color change (white on a slightly darker background).
+
+The user perceives each card as a contained unit, even though no edge is fully drawn. The closure principle does the work of containment with less visual weight than a full border would.
+
+### A logo with a hidden shape
+
+The FedEx logo: the white space between the E and the X forms an arrow. Once you see it, you always see it. The arrow communicates speed and forward-motion without being explicitly drawn. The closure principle lets the negative space carry meaning.
+
+The WWF panda logo similarly uses closure: the panda's body is suggested by a few black shapes; the white parts of the panda are entirely implied. Yet the form is unmistakable.
+
+### An icon that uses partial outlines
+
+A "send" icon often shows a paper airplane silhouette, sometimes with the back fold suggested by a single line rather than fully drawn. The user perceives the airplane through the suggested form. At small sizes, the partial drawing actually reads more clearly than a fully detailed paper airplane would.
+
+### A loading spinner that uses closure
+
+A common loading spinner: a circle with a gap that rotates. The gap implies the circle (the brain still sees a circle), and the rotation indicates progress. The minimal form is animated to convey "working" without filling the screen with detail.
+
+### Closure that fails: an over-simplified icon
+
+A custom icon for "user settings" simplifies a person + gear shape into a few abstract curves. Users can't recognize the form; the simplification went too far. The closure principle requires the user to fill in the form, but they can't fill in something they don't recognize.
+
+The fix: include enough recognizable features (a clear human silhouette + a clear gear) that the form is identifiable, then strip the rest.
+
+### Negative-space chart structure
+
+A chart showing data over time uses a subtle baseline (a thin gray line) rather than a full axis with tick marks and gridlines. The implied structure is enough; the user reads the chart correctly without the explicit scaffolding. The chart feels lighter and more elegant.
+
+## Anti-patterns
+
+**Over-simplification.** Stripping a form down past the point of recognizability. The closure principle requires that the user can complete the form; if they can't recognize what's being suggested, they can't complete it.
+
+**Closure used where clarity is critical.** A "delete" icon rendered as a few abstract strokes that the user has to interpret. In high-stakes contexts, the user needs explicit forms, not suggested ones.
+
+**Closure for decoration.** A logo or icon designed to "have a hidden shape" that's so subtle no one notices. If the closure isn't perceived, it's just decoration that adds nothing.
+
+**Container ambiguity.** Cards without clear separation from each other or from the background. Users can't tell where one card ends and another begins. Either reduce the closure work (add more cues) or commit to fully-drawn containers.
+
+**Closure that works in one rendering and fails in another.** A form that reads correctly at large sizes and breaks down at small sizes. Test at all the sizes the form will be used.
+
+**Closure ignoring accessibility.** Forms suggested through visual cues that aren't accessible to users with vision differences. Some closure designs are inherently visual (a hidden shape in a logo); others can be supported with text alternatives.
+
+## Heuristic checklist
+
+Before relying on closure, ask: **Does the suggested form read as a recognizable whole at the actual rendering size?** Test it. **Will the user notice the closure?** If the suggestion is too subtle, it adds nothing. **Is the user audience equipped to do the completion work?** Novices and accessibility audiences may benefit from explicit forms. **Is closure being used to communicate, or just to decorate?** Closure should do work, not just look clever.
+
+## Related principles
+
+- **Gestalt grouping principles generally** — closure is one of the original Gestalt principles.
+- **Figure-ground relationship** — closure interacts with figure-ground; what's perceived as "figure" tends to be the closed form.
+- **Signal-to-Noise Ratio** — closure reduces visual weight by suggesting rather than drawing.
+- **Iconic Representation** — minimal icons rely on closure to communicate.
+- **Form Follows Function** — the closure principle expresses the form's function with the minimum visual that does the job.
+
+## See also
+
+- `references/lineage.md` — origins in Gestalt psychology, particularly the Kanizsa illusions.
+- `closure-implied-shapes/` — sub-skill on designing forms that exploit closure.
+- `closure-completion-cost/` — sub-skill on when closure is the wrong choice.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/closure/references/lineage.md
@@ -1,0 +1,78 @@
+# Closure — origins and research lineage
+
+## The Gestalt school
+
+Closure is one of the original Gestalt grouping principles articulated by Max Wertheimer, Wolfgang Köhler, and Kurt Koffka in the 1910s and 1920s. The Gestalt insight: the human visual system actively organizes incomplete sensory input into structured, meaningful wholes. We don't see disconnected parts and consciously assemble them into objects; we see the objects directly, with the brain doing the assembly automatically.
+
+Closure specifically refers to the tendency to perceive incomplete shapes as complete. A circle with breaks in its outline is perceived as a circle. A face suggested by a few strokes is perceived as a face. The brain "closes" the gaps.
+
+## The Kanizsa illusions
+
+The most famous demonstrations of closure come from the Italian psychologist Gaetano Kanizsa, working in the 1950s and 1960s. The Kanizsa triangle (1955) shows three black "Pac-Man" shapes arranged so that the gaps form a triangle. Viewers perceive a clear white triangle in the middle, even though no triangle is actually drawn — only the implication.
+
+The Kanizsa illusions are striking because the perceived edges are vivid: viewers report seeing actual lines, contours, and brightness differences that don't exist in the stimulus. The brain doesn't just "guess" that there's a triangle; it constructs the percept of a triangle as if it were really there.
+
+Subsequent neuroscientific research has shown that these illusory contours activate visual cortex regions normally responsive to actual edges. The perception of the closed shape is genuine at the neural level, not a higher-order inference.
+
+## In design history
+
+Designers have exploited closure long before the Gestalt psychologists named it. Logos and marks have used minimal forms throughout the history of graphic design:
+
+- The IBM logo (Paul Rand, 1972): horizontal stripes that imply solid letterforms. The eye reads "IBM" even though the letters are made of stripes.
+- The WWF panda logo (Sir Peter Scott, 1961): black shapes that imply a complete panda; the white parts of the animal are entirely implied.
+- The FedEx logo (Lindon Leader, 1994): an arrow hidden in the negative space between E and X. Most viewers see the arrow only after it's pointed out, but once seen it can't be unseen.
+- The NBC peacock (Steve Frankfurt and others, 1956 onward): a multicolored fan that implies a peacock through arrangement rather than literal depiction.
+
+Each of these uses closure to do more with less. The marks are memorable because they engage the viewer's perception in completing them.
+
+## In modern UI
+
+The principle has been heavily applied in modern interface design:
+
+- **Minimal icons.** Icon sets like Material Symbols, Phosphor, and Lucide use simple strokes that imply forms. The user's perception completes the rendering.
+- **Card layouts.** Cards rarely use full borders in modern UI; subtle background tinting, drop shadow, or just consistent spacing imply containment.
+- **Skeleton loading states.** Pulsing rectangles in the shape of upcoming content imply the structure that will appear, supporting the user's anticipation.
+- **Negative-space typography.** Custom typefaces and logo treatments use negative space to suggest letter forms (the Cooper Black "C" with its open counter, for instance).
+
+The trend toward "flat" design over the 2010s leaned heavily on closure: stripping away visual decoration and trusting the user to perceive forms through minimal cues.
+
+## Empirical research on closure
+
+The literature supports several stable findings:
+
+- **Closure is robust across cultures.** The perceptual tendency is universal, not learned. Children show closure perception from a young age.
+- **Closure is automatic and pre-attentive.** It happens within ~200ms of exposure, before conscious analysis.
+- **Closure has limits.** Gaps can be too large for closure to operate. The brain doesn't fill in arbitrary missing sections; the suggestion has to be strong enough.
+- **Closure interacts with other Gestalt principles.** Closure tends to be stronger when other principles (proximity, similarity) reinforce it.
+- **Familiar shapes show stronger closure than novel ones.** The brain is more willing to complete a face than to complete an unfamiliar geometric form.
+
+## Closure and the limits of minimalism
+
+The principle has been overinterpreted in some design movements. The "less is more" tendency taken to an extreme produces designs that strip away so much that even closure can't recover the form. The result is unrecognizable icons, ambiguous containers, and illustrations that don't communicate.
+
+The right level of closure depends on:
+
+- The audience's familiarity with the form (familiar forms tolerate more reduction).
+- The rendering context (small sizes need more visual structure to recover).
+- The cost of misperception (high-stakes contexts shouldn't rely on closure for critical communication).
+- The visual context (closure works best when the surrounding design supports the perception).
+
+## Closure in different contexts
+
+**Print:** closure has long been a graphic-design tool for memorable logos and marks. The fixed rendering allows precise calibration.
+
+**Web and screen:** closure works at typical screen resolutions, but very small sizes (16px icons, for instance) leave less room for suggestion. Rendering quality matters: aliased edges and lower-DPI displays can degrade the perceived form.
+
+**Motion graphics:** closure can be exploited in animation — a form built up from parts gradually closes as the parts assemble.
+
+**Architecture and product design:** closure operates in three dimensions too. A chair suggested by a few intersecting planes; a building's silhouette implied by partial massing.
+
+## Sources informing this principle
+
+- Wertheimer, M. (1923). Untersuchungen zur Lehre von der Gestalt II.
+- Kanizsa, G. (1976). Subjective contours. *Scientific American*. (The Kanizsa triangle and related illusions.)
+- Koffka, K. (1935). *Principles of Gestalt Psychology*.
+- Palmer, S. E. (1999). *Vision Science: Photons to Phenomenology*.
+- Ware, C. (2012). *Information Visualization: Perception for Design*.
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*.
+- Various logo design literature (Paul Rand, Sagi Haviv, others).

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color-accessibility-and-mode/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color-accessibility-and-mode/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: color-accessibility-and-mode
+description: 'Use this skill when designing color systems that must satisfy accessibility requirements, work in both light and dark modes, support high-contrast preferences, and remain meaningful for users with color blindness or low vision. Trigger when picking text colors, designing for global compliance (WCAG, EAA, ADA), supporting dark mode, or auditing an existing palette for accessibility. Sub-aspect of `color`; read that first.'
+---
+
+# Color: accessibility and mode support
+
+Accessibility-aware color isn't a polish layer; it's a constraint that shapes the palette from the start. Adding accessibility late is much more expensive than building it in. The core constraints: WCAG contrast ratios, color-blindness compatibility, high-contrast mode support, and dark-mode parity.
+
+## WCAG contrast in practice
+
+Required ratios (relative luminance):
+
+| Content | Level AA | Level AAA |
+|---|---|---|
+| Body text (< 18pt regular or < 14pt bold) | 4.5:1 | 7:1 |
+| Large text (≥ 18pt regular or ≥ 14pt bold) | 3:1 | 4.5:1 |
+| UI components and graphical objects | 3:1 | (no AAA) |
+
+To check a color pair: any contrast tool (WebAIM, Stark, Chrome DevTools' contrast inspector). If you're picking from a designer's mockup, run every text/background pair through. Common failures:
+
+- Light grey body text on white (`#999` or `#aaa`).
+- Brand-color body links on white when the brand is mid-tone.
+- Placeholder text in inputs (often unreadable).
+- White text on light brand backgrounds.
+
+**Practical rule**: pick body text colors at neutral-700 or darker on light backgrounds; never use anything lighter than neutral-500 for content the user must read.
+
+## Color blindness
+
+Approximate prevalence in populations of European descent:
+
+- **Deuteranopia / deuteranomaly** (red-green): ~6% of men, ~0.4% of women.
+- **Protanopia / protanomaly** (red-green, slightly different): ~2% of men.
+- **Tritanopia / tritanomaly** (blue-yellow): ~0.01%.
+- **Achromatopsia** (full color blindness): ~0.003%.
+
+Other populations have different rates — generally lower red-green prevalence in some Asian populations.
+
+Practical implications:
+
+- Don't rely on red-green distinction alone for status. Use icon, text, or pattern alongside.
+- Avoid red-on-green or green-on-red combinations for important text.
+- Test with simulators: Chrome DevTools → Rendering → Emulate vision deficiencies. Or Stark, Sim Daltonism, Color Oracle.
+
+## Dark mode
+
+Dark mode is no longer optional for new products. Macs, iPhones, and Androids all default to dark in some contexts; users expect it.
+
+Common pitfalls:
+
+### Pure inversion is wrong
+
+Inverting a light palette doesn't produce a good dark palette. Saturation perception is different on dark backgrounds; very-saturated colors that read fine on white look glaring on black. Build dark-mode tokens deliberately.
+
+### Tinted neutrals work better than pure black
+
+Pure white text on pure black is high-contrast but hard on the eyes and produces strong "halation" (blur) on OLED screens. Most well-tuned dark modes use:
+
+- A near-black background (not pure black): `hsl(220 10% 8%)`.
+- Off-white text: `hsl(0 0% 90%)` or so.
+- Tinted neutrals keeping the same hue cast as light mode.
+
+### Adjust saturation downward
+
+Saturated colors that work on white backgrounds need toning down for dark. A primary brand at `hsl(220 90% 50%)` may need to be `hsl(220 70% 60%)` in dark mode to feel comfortable.
+
+### Test contrast in both modes
+
+A pair that passes AA in light mode may fail in dark mode. The luminance values differ; recheck.
+
+## High-contrast mode
+
+Many operating systems offer a high-contrast mode for low-vision users. Web equivalents:
+
+- **Windows High Contrast Mode** (now "contrast themes")
+- **`prefers-contrast: more`** CSS media query
+
+In these modes, the user has explicitly requested maximum contrast. Designs should:
+
+- Avoid relying on subtle color distinctions.
+- Ensure all text/background pairs hit AAA contrast.
+- Avoid background images or gradients that might obscure text.
+- Use strong, defined borders.
+
+```css
+@media (prefers-contrast: more) {
+  :root {
+    --neutral-700: hsl(0 0% 0%);
+    --background: hsl(0 0% 100%);
+    --border: hsl(0 0% 0%);
+    /* ...etc... */
+  }
+}
+```
+
+## Forced colors mode
+
+Some users (particularly with low vision or migraine sensitivity) override page colors entirely with system colors via Windows' Forced Colors Mode. The browser maps your colors to a small set of system tokens (`Canvas`, `CanvasText`, `LinkText`, `ButtonText`, `ButtonFace`, etc.).
+
+In this mode:
+
+- Background images may be hidden.
+- Custom colors are overridden.
+- The page should still be usable.
+
+Design implications:
+
+- Use `<button>` for buttons; the system colors map correctly.
+- Don't rely on background images for critical info.
+- Test in Forced Colors Mode (Edge: Settings → Accessibility → "High contrast").
+
+## Color and motion / animation
+
+Color transitions can trigger photosensitive epilepsy if they flash rapidly (3+ Hz, especially with red). WCAG 2.3.1: no content flashes more than 3 times per second.
+
+Design implications:
+
+- No strobing animations.
+- Loading spinners should rotate, not flash colors.
+- Auto-playing animations should respect `prefers-reduced-motion`.
+
+## Worked example: a fully accessibility-aware palette
+
+```css
+:root {
+  /* Light mode */
+  --bg: hsl(0 0% 100%);
+  --fg: hsl(220 6% 12%);          /* near-black; contrast 17:1 on white */
+  --fg-muted: hsl(220 6% 40%);    /* 7.4:1 — passes AA body, AAA large */
+  --primary: hsl(220 90% 45%);    /* 5:1 on white — AA body */
+  --destructive: hsl(0 75% 40%);  /* 5.5:1 on white — AA body */
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: hsl(220 10% 9%);
+    --fg: hsl(220 6% 92%);          /* 12:1 on dark */
+    --fg-muted: hsl(220 6% 65%);    /* 5.5:1 — AA body */
+    --primary: hsl(220 80% 65%);    /* tuned brighter for dark mode */
+    --destructive: hsl(0 70% 60%);  /* tuned brighter for dark mode */
+  }
+}
+
+@media (prefers-contrast: more) {
+  :root {
+    --fg: hsl(0 0% 0%);
+    --bg: hsl(0 0% 100%);
+    --fg-muted: hsl(0 0% 20%);
+    /* etc. */
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+## Anti-patterns
+
+- **Color-only signals.** Red asterisks for required fields with no `*` or "required." Color-blind users miss it.
+- **Light grey body text** that looks "elegant" in mockups but fails AA in production.
+- **Dark mode by inversion.** Pure inversion produces glare and saturation issues.
+- **Ignoring `prefers-contrast` and `forced-colors`.** Your design works for typical users but fails for users with explicit accessibility needs.
+- **Status that depends on hue alone.** Color-blind users can't distinguish red from green; pair with icon and text.
+
+## Heuristics
+
+1. **Run a contrast checker.** Every text/background pair, every UI/background pair. AA at minimum.
+2. **Simulate color blindness.** Chrome DevTools or a dedicated tool. Status systems that lean on red/green collapse here.
+3. **Test in dark mode.** Toggle the OS preference; check every page.
+4. **Test with forced colors.** Edge in High Contrast mode reveals what depends on color.
+5. **The grayscale test.** If the design works in grayscale, color is enhancement; if not, color is load-bearing and must satisfy accessibility constraints.
+
+## Related sub-skills
+
+- **`color`** (parent).
+- **`color-semantic-systems`** — building the semantic layer this skill makes accessible.
+- **`hierarchy-color-and-tone`** — using tone (not just hue) for hierarchy.
+- **`accessibility-perceivable`** (process) — covers color contrast and other perceivable concerns.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color-accessibility-and-mode/references/wcag-and-mode-support.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color-accessibility-and-mode/references/wcag-and-mode-support.md
@@ -1,0 +1,113 @@
+# Color accessibility and mode support: deeper reference
+
+A reference complementing `color-accessibility-and-mode` with WCAG details and mode-support patterns.
+
+## WCAG color-relevant criteria
+
+- **1.4.1 Use of Color (A)** — color is not the only visual signal.
+- **1.4.3 Contrast (Minimum) (AA)** — body 4.5:1, large/UI 3:1.
+- **1.4.6 Contrast (Enhanced) (AAA)** — body 7:1, large/UI 4.5:1.
+- **1.4.11 Non-text Contrast (AA)** — UI components and graphical objects need 3:1.
+- **1.4.13 Content on Hover or Focus (AA)** — hover-revealed content must be dismissable, hoverable, persistent.
+
+The non-text contrast requirement (1.4.11, added in WCAG 2.1) is often missed. Form-field borders, icon buttons, focus rings, and chart elements all need 3:1 against their immediate background.
+
+## Common contrast failures
+
+- **Light grey body text on white.** `#999` on white = 2.85:1. Fails AA. Common in "minimalist" designs.
+- **Brand-color body links on white.** Many brand blues fall in the 3.5–4:1 range — passes for large/UI, fails for body.
+- **Placeholder text** in inputs is frequently below 3:1; the field's accessible name needs to clear contrast.
+- **White text on light brand backgrounds.** A brand at 50% lightness with white text often misses 4.5:1.
+- **Disabled controls.** Often under 3:1; WCAG exempts them but users can't read them anyway.
+
+## Tools
+
+- **WebAIM Contrast Checker** — webaim.org/resources/contrastchecker.
+- **Chrome DevTools** — Elements panel, contrast inspector for any element.
+- **Stark** — Figma plugin and browser extension.
+- **OKLCH color picker** (oklch.com) — interactive contrast checking in OKLCH space.
+
+## Color-blindness simulation
+
+Tools:
+
+- **Chrome DevTools** → Rendering → Emulate vision deficiencies.
+- **Sim Daltonism** (macOS).
+- **Color Oracle** (cross-platform).
+- **Stark** — built-in color-blindness simulation.
+
+Test status systems particularly. Red/green distinction collapses in deuteranopia simulation; if your "Active" and "Failed" states only differ in hue, they look identical to ~6% of male users.
+
+## Dark mode patterns
+
+### Pure inversion is wrong
+
+Inverting a light palette doesn't produce a good dark palette. A few reasons:
+
+- Saturated colors that work on white look glaring on dark.
+- Pure white text on pure black causes "halation" (perceived blur) on OLED screens.
+- Brand colors often need adjustment to retain identity in dark mode.
+
+### Tinted backgrounds
+
+Most well-tuned dark modes use:
+
+- A near-black (not pure black) background: `hsl(220 10% 8%)` rather than `#000`.
+- Off-white text: `hsl(0 0% 90%)` rather than `#fff`.
+- Tinted neutrals matching the light-mode hue cast.
+
+### Adjust saturation
+
+Saturated brand colors that work on white need toning down for dark:
+
+```css
+:root {
+  --primary: hsl(220 90% 50%);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary: hsl(220 70% 60%);  /* less saturated, slightly lighter */
+  }
+}
+```
+
+### Test contrast in both modes
+
+WCAG ratios apply to whatever's actually rendered. A pair that passes in light may fail in dark.
+
+## High-contrast / forced-colors mode
+
+Two related but distinct preferences:
+
+- `prefers-contrast: more` — user requests more contrast; respect by tightening color differences.
+- Forced Colors Mode (Windows) — user has overridden page colors entirely with system colors.
+
+In forced colors mode, the browser maps your colors to system tokens (`Canvas`, `CanvasText`, `LinkText`, `ButtonText`, `ButtonFace`, etc.). Backgrounds may be hidden entirely. Design implications:
+
+- Don't rely on background images for critical info.
+- Use `<button>` for buttons; the system maps them correctly.
+- Test in Microsoft Edge with High Contrast mode toggled.
+
+## Reduced motion
+
+WCAG 2.3.3 — respect `prefers-reduced-motion`:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+For motion that's *meaningful* (state change indicator), allow a brief, subtle version even in reduced-motion mode.
+
+## Resources
+
+- **W3C WCAG** — w3.org/WAI/WCAG22.
+- **WebAIM** — webaim.org. Practitioner-focused; includes the contrast checker.
+- **MDN: prefers-color-scheme, prefers-contrast, prefers-reduced-motion** — current browser support.
+- **Inclusive Components** (Heydon Pickering) — accessible color patterns.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color-semantic-systems/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color-semantic-systems/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: color-semantic-systems
+description: 'Use this skill when building or auditing a color system that encodes meaning — status colors (success / warning / error), category colors (department, product line, user segment), brand-role colors (primary, secondary, tertiary). Trigger when designing status badges, picking chart palettes, building a design-system color spec, or fixing inconsistent color use across surfaces. Sub-aspect of `color`; read that first.'
+---
+
+# Building semantic color systems
+
+A semantic color system encodes meaning through color: green means success, red means error, blue means primary brand. Done well, users learn the system once and read every surface fluently. Done poorly, the same color means different things in different places, and users learn nothing reliably.
+
+## What semantic colors should encode
+
+Three useful categories:
+
+### Status / state
+
+Conveys the condition of a thing:
+
+- Success / completed / passed
+- Warning / pending / caution
+- Error / failed / overdue
+- Info / neutral / draft
+
+Status colors map to specific outcome semantics. Use sparingly: every visible status badge is attention spent.
+
+### Category
+
+Conveys what kind of thing this is:
+
+- Project tags (a small palette of distinct hues for project labels)
+- Department or team
+- Product line
+- User segment
+
+Categories should use perceptually distinct hues; for ≤ 7 categories, color works well. Beyond that, the user can't reliably remember which color means which.
+
+### Brand role
+
+Conveys importance or role within the design:
+
+- Primary brand color → primary CTA
+- Secondary / accent → recommended option, focused state
+- Tertiary → light emphasis (informational badges)
+
+Role colors are about hierarchy more than meaning per se.
+
+## Building a status palette
+
+A workable status set:
+
+```
+success:    hsl(142 70% ...)   green
+warning:    hsl(38 90% ...)    amber
+destructive: hsl(0 75% ...)    red
+info:       hsl(220 90% ...)   blue
+neutral:    hsl(0 0% ...)      grey
+```
+
+For each, define multiple lightness stops:
+
+- `*-50` — tinted background (used for badges, alerts, subtle treatments)
+- `*-300` — border or icon
+- `*-500` — primary use (badge color, button color)
+- `*-700` — text color (dark, used on tinted backgrounds)
+- `*-900` — text on dark backgrounds
+
+The pairing rule: `*-50` background + `*-700` text gives WCAG AA contrast at body size; `*-50` + `*-500` gives AA for large text only.
+
+## Consistency rules for semantic colors
+
+A semantic color system breaks the moment a color means different things in different places. Rules:
+
+- **One color per role.** Don't have "two reds" for "destructive" and "important emphasis." Pick one role per color.
+- **Status colors stay status.** Don't use the destructive red for marketing emphasis. The user reads it as error.
+- **Category colors stay categorical.** Don't reuse a project-tag color for a status badge.
+- **Document the system.** A color-system spec page that lists every color and its role keeps the team honest.
+
+## Building a category palette
+
+For project tags, departments, or chart series:
+
+- **5–7 hues maximum** for memorability; beyond that, users can't recall what means what.
+- **Distribute around the color wheel** so adjacent items are visually distinct.
+- **Match lightness and saturation** across the set so no one color dominates.
+- **Test with colorblind simulation** to ensure each hue remains distinct.
+
+A workable 7-color category palette:
+
+```
+hsl(220 70% 55%)    blue
+hsl(160 60% 45%)    teal
+hsl(40 90% 55%)     amber
+hsl(310 60% 55%)    pink
+hsl(10 70% 55%)     red-orange
+hsl(270 50% 55%)    violet
+hsl(85 50% 45%)     olive
+```
+
+Each at similar lightness and saturation; each visually distinct from neighbors.
+
+## Brand role palette
+
+The minimum useful set:
+
+- **Primary**: filled CTA, focused state, brand emphasis. One hue, used sparingly.
+- **Secondary**: optional alternative emphasis (often used for "recommended" highlight).
+- **Accent / tertiary**: micro-emphasis (informational icons, soft highlights).
+
+Most products need only primary plus neutrals; secondary and accent are optional.
+
+## Worked example: a complete semantic system
+
+```css
+:root {
+  /* Brand */
+  --brand-primary: hsl(220 90% 50%);
+  --brand-primary-fg: white;
+  --brand-primary-hover: hsl(220 90% 45%);
+
+  /* Neutrals (tinted toward brand) */
+  --neutral-50: hsl(220 6% 98%);
+  --neutral-100: hsl(220 6% 96%);
+  --neutral-200: hsl(220 6% 92%);
+  --neutral-300: hsl(220 6% 85%);
+  --neutral-400: hsl(220 6% 65%);
+  --neutral-500: hsl(220 6% 50%);
+  --neutral-600: hsl(220 6% 40%);
+  --neutral-700: hsl(220 6% 27%);
+  --neutral-800: hsl(220 6% 18%);
+  --neutral-900: hsl(220 6% 9%);
+
+  /* Status */
+  --success-bg: hsl(142 70% 95%);
+  --success-fg: hsl(142 70% 22%);
+  --success-border: hsl(142 60% 70%);
+
+  --warning-bg: hsl(38 95% 95%);
+  --warning-fg: hsl(38 90% 25%);
+  --warning-border: hsl(38 80% 70%);
+
+  --destructive-bg: hsl(0 80% 95%);
+  --destructive-fg: hsl(0 75% 32%);
+  --destructive-border: hsl(0 60% 70%);
+
+  --info-bg: hsl(210 80% 95%);
+  --info-fg: hsl(210 80% 30%);
+  --info-border: hsl(210 60% 70%);
+}
+```
+
+Every status pair (bg + fg) clears WCAG AA contrast. The neutrals are tinted toward the brand for cohesion.
+
+## Anti-patterns
+
+- **Brand color reused as primary semantic.** If the brand is red and red also means "destructive," every CTA looks dangerous.
+- **Decorative status color.** A red border around a card with no actual error. Users learn to dismiss the cue.
+- **Inconsistent saturation across statuses.** Bright green success, muted yellow warning, vivid red error. The visual hierarchy jumps; nothing reads coherently.
+- **Too many statuses.** A system with 8 distinct status colors no user can remember.
+- **Categories that compete with statuses.** A "project" category color happens to be the same red as your destructive status. Users get confused.
+
+## Heuristics
+
+1. **The "what does each color mean?" audit.** List every color in your design system. Can you name a single specific role for each? If yes, the system is coherent. If a color has multiple roles, conflicts are inevitable.
+2. **The grayscale test.** Convert to grayscale. Does the visual hierarchy still work? If yes, color is enhancing, not carrying. If no, you're depending on color alone.
+3. **The colorblind test.** Simulate deuteranopia. Are status colors still distinct? Categories?
+4. **The cross-surface check.** Open three different pages of the product. Does the same status look the same color across all three?
+
+## Related sub-skills
+
+- **`color`** (parent).
+- **`color-accessibility-and-mode`** — accessibility and dark-mode considerations for semantic systems.
+- **`hierarchy-color-and-tone`** — color as a hierarchy axis.
+- **`consistency`** (cognition) — semantic color is a consistency discipline.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color-semantic-systems/references/semantic-system-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color-semantic-systems/references/semantic-system-cases.md
@@ -1,0 +1,69 @@
+# Semantic color systems: case reference
+
+A reference complementing `color-semantic-systems` with case patterns from real design systems.
+
+## Material Design's status colors
+
+Material 3 defines:
+
+- **Primary** — brand emphasis.
+- **Error** — destructive / failure state.
+- **Surface** / **Background** / **Outline** — chrome neutrals.
+- **Tertiary** — optional accent for variety.
+
+Each defined as a tonal palette (13 stops) with documented mappings for light, dark, and high-contrast modes. The system is overkill for many products but useful as a reference for what a fully-thought-through semantic system looks like.
+
+## Tailwind's color naming
+
+Tailwind ships ~22 colors (gray, zinc, neutral, stone, red, orange, amber, yellow, lime, green, emerald, teal, cyan, sky, blue, indigo, violet, purple, fuchsia, pink, rose) each with 11 stops (50–950). The wide adoption has made these names common vocabulary.
+
+Tailwind itself is *not* opinionated about which color is "destructive" or "success" — that's left to the project. Most projects map:
+
+- `red-500` → destructive
+- `green-500` → success
+- `amber-500` → warning
+- `blue-500` (or brand color) → primary
+
+## shadcn/ui's semantic tokens
+
+Built on Tailwind, shadcn defines semantic CSS variables:
+
+- `--background` / `--foreground`
+- `--card` / `--card-foreground`
+- `--primary` / `--primary-foreground`
+- `--secondary` / `--secondary-foreground`
+- `--destructive` / `--destructive-foreground`
+- `--muted` / `--muted-foreground`
+- `--accent` / `--accent-foreground`
+- `--border` / `--ring`
+
+Each pair is designed to satisfy WCAG contrast. The semantic naming separates *role* from *value* — components reference `--primary`, and the project assigns the actual hex.
+
+## Bootstrap's contextual colors
+
+Bootstrap (since v3) uses semantic naming: `primary`, `secondary`, `success`, `info`, `warning`, `danger`, `light`, `dark`. Each is assigned a fixed value in the framework (overridable in custom builds).
+
+## Atlassian's color system
+
+Atlassian's design system documents both raw color tokens (e.g., `Blue 500`) and semantic role tokens (e.g., `Default Background`, `Information Icon`). Components reference role tokens; raw tokens are reserved for design exploration.
+
+## Common semantic mismatch failures
+
+- **Brand red as also destructive red.** If your brand is red and your destructive color is also red, every CTA looks like a delete button.
+- **Color reused across roles.** "Pending" and "Info" both rendered in the same blue. Users can't distinguish.
+- **Saturation creep.** Originally muted status colors get tweaked brighter for "more visibility," eventually all colors are at full saturation and none stand out.
+
+## Heuristics for semantic-system review
+
+1. **List every color in the system; for each, name its role(s).** A color with multiple roles (the same red as both brand and destructive) creates conflicts.
+2. **Check status colors are perceptually distinguishable.** Run a colorblind simulation; verify each status remains distinct.
+3. **Check the contrast pairs.** Foreground/background combinations specified by the system should clear AA.
+4. **Audit cross-product.** Is the same status color used the same way across surfaces? Drift creates inconsistency.
+
+## Resources
+
+- **Material Design 3** — m3.material.io.
+- **Tailwind CSS** color reference — tailwindcss.com/docs/colors.
+- **shadcn/ui theming** — ui.shadcn.com.
+- **Atlassian Design System** color docs.
+- **Adobe Spectrum** color spec.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: color
+description: 'Use this skill whenever color decisions matter — picking the brand primary, defining a neutral ramp, designing status semantics (success/warning/error), choosing chart palettes, selecting accent hues, supporting dark mode, ensuring colorblind-safe contrast, or auditing an existing UI for color noise. Trigger when stakeholders argue about palette, when WCAG contrast is in scope, when designing for global audiences (where color symbolism varies), or when a UI feels "too colorful" or "too monochrome." Color is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003).'
+---
+
+# Color
+
+Color attracts attention, groups related elements, signals meaning, and shapes aesthetic response. Used deliberately, it carries information at a glance and unifies a product. Used carelessly, it adds noise, fails accessibility, and means different things to different audiences. Among visual variables, color is the loudest and the most easily abused.
+
+## Definition (in our own words)
+
+Color performs four jobs in design: it draws the eye to elements that matter (attention), it visually unifies elements that belong together (grouping), it carries categorical or semantic information (meaning — green is success, red is danger), and it shapes the aesthetic register of the design (a saturated palette feels energetic; a muted one feels serious). Each color you introduce to a design takes on one or more of these roles; designs that use color promiscuously dilute every role. The discipline is in the restraint: a small palette, used consistently, with each color earning its place.
+
+## Origins and research lineage
+
+- **Josef Albers**, *Interaction of Color* (1963). The foundational treatment of perceptual color relationships — how the same color reads differently against different backgrounds. Required reading for anyone designing color systems.
+- **Johannes Itten**, *The Art of Color* (1961). The Bauhaus tradition of color theory; introduced the color wheel still used today.
+- **Maxwell, Helmholtz, Hering** — 19th-century color-perception researchers whose work underlies modern color science (trichromacy, opponent-process theory).
+- **Lidwell, Holden & Butler** (2003) compactly addressed the design implications under the headings of number of colors, combinations, saturation, and symbolism. The book emphasizes restraint: use color conservatively and never as the only signal.
+- **WCAG color-contrast research** (W3C, 2008 onward) provides the empirical basis for accessibility-aware color systems — body text needs 4.5:1 luminance contrast minimum.
+- **Modern perceptual color spaces** (CIELAB, OKLCH) provide tools for building color systems that are perceptually uniform across hues.
+
+## The four jobs of color
+
+### 1. Attention
+
+A saturated, distinct color in a sea of neutrals draws the eye. This is the basis for primary CTAs, error states, and emphasis. The mechanism is preattentive: a single colored item among uncolored items "pops out" within ~200ms.
+
+The economy: attention only works when sparse. A page where every element is colored loses the pop-out advantage entirely.
+
+### 2. Grouping
+
+Items that share a color read as related. This underlies status systems (all overdue items in red), category coding (all marketing dashboards in blue), and brand identity (all of this product's surfaces share this hue).
+
+Use this for *meaningful* relationships, not for decoration.
+
+### 3. Meaning
+
+Color carries semantic content when it's used consistently and conventionally. In Western contexts: red = danger / stop / error; green = go / success; yellow = warning. These conventions are partly cultural (red signals luck in much of East Asia; green is unlucky in some contexts), so global products should pair color with non-color signals.
+
+### 4. Aesthetics
+
+Color shapes mood. Saturated palettes feel energetic; muted palettes feel calm or serious. Warm colors (yellow, orange, red) feel active; cool colors (blue, green, purple) feel stable. These associations are partly biological (warm colors attract attention faster) and partly cultural.
+
+## Number of colors: be restrained
+
+A useful rule: limit your active palette to ~5 colors that the user must recognize.
+
+```
+Brand primary    — 1 hue
+Neutrals         — a ramp from dark to light (~9 stops)
+Success          — 1 hue (typically green)
+Warning          — 1 hue (typically yellow / amber)
+Destructive      — 1 hue (typically red)
+```
+
+Beyond this, every additional hue dilutes the system. Charts and data visualizations may need 5–8 categorical colors, but those are exceptions; the *interface chrome* should stay restrained.
+
+## Color combinations: how to compose a palette
+
+Common harmony patterns (from the color wheel):
+
+- **Monochromatic**: variations of one hue (different lightness/saturation). Calm, unified.
+- **Analogous**: hues adjacent on the wheel (blue, blue-green, green). Harmonious, low-tension.
+- **Complementary**: hues opposite on the wheel (blue + orange). High contrast, high tension.
+- **Triadic**: three hues equidistant on the wheel. Balanced, vibrant.
+- **Quadratic**: four hues from a square or rectangle on the wheel. Complex; needs careful weighting.
+
+For UI work, monochromatic + neutrals + a few semantic accents is the workhorse. Complementary and triadic palettes look striking but require more care to balance.
+
+## Saturation: the volume knob
+
+Saturation (chromatic intensity) is color's volume knob.
+
+- **Saturated colors** demand attention. Use sparingly: primary CTAs, errors, brand moments.
+- **Desaturated colors** recede. Use abundantly: backgrounds, neutrals, secondary states.
+
+A common UI mistake: saturated colors everywhere. The page becomes loud; nothing stands out. The fix: pull saturation down on most surfaces; reserve full saturation for moments.
+
+## Symbolism: cultural variation
+
+Color symbolism is *not* universal. Examples:
+
+- **Red**: danger / stop in Western contexts; luck and prosperity in Chinese contexts; mourning in some African contexts.
+- **White**: purity in Western weddings; mourning in some Asian funerals.
+- **Black**: formal / authoritative in Western; mourning broadly; rebellion in subcultures.
+- **Green**: nature / go in Western; sometimes unlucky or associated with infidelity in specific contexts.
+- **Yellow**: caution / warmth in Western; sacred in some Asian contexts; cowardice in others.
+
+For global products: don't rely on color symbolism alone. Pair color with text, icons, and position so the meaning carries across audiences.
+
+## Color is never the only signal
+
+WCAG 1.4.1 codifies what's also a basic usability principle: color must not be the only means of conveying information. About 8% of men have red-green color blindness; achievement of WCAG 1.4.1 requires that any color signal be paired with a non-color signal.
+
+Practical applications:
+
+- **Form errors**: red border + error message + icon, not just red border.
+- **Status badges**: color + icon + text, not just color.
+- **Required fields**: asterisk + "(required)" or `aria-required`, not just red label.
+- **Chart series**: color + pattern (lines: dashed, dotted) or label, not just color.
+- **Selected items**: color + checkmark or border, not just color.
+
+This isn't only for color-blind users; it serves anyone in glare, on a printed copy, in low contrast, or with degraded vision.
+
+## Color and accessibility (WCAG)
+
+Foreground/background contrast ratios (relative luminance):
+
+| Content type | Level AA | Level AAA |
+|---|---|---|
+| Body text (< 18pt regular or < 14pt bold) | 4.5:1 | 7:1 |
+| Large text (≥ 18pt regular or ≥ 14pt bold) | 3:1 | 4.5:1 |
+| UI components and graphical objects | 3:1 | (no AAA) |
+
+Common failures:
+
+- Light grey body text (`#999` on white = 2.85:1 — fails).
+- Brand-color body links (`#1e90ff` on white = 3.4:1 — fails for body, passes for large/UI).
+- Placeholder text in inputs (often <3:1 — fails for the field's accessible name).
+
+Test with a contrast checker (WebAIM, Stark, Chrome DevTools). It's faster than guessing.
+
+## Building a color system
+
+A workable system architecture:
+
+### 1. Pick the brand primary
+
+One hue. This is the color users will associate with your product. Choose with awareness of category conventions (banking is often blue; food is often warm; tech is often blue or green).
+
+### 2. Define the neutral ramp
+
+9–11 stops from white to near-black. Tinting the neutrals slightly toward the brand primary (e.g., 4% saturation of the primary hue) makes the whole UI feel cohesive without anyone consciously noticing.
+
+```
+neutral-50    background (lightest)
+neutral-100   subtle background, hover
+neutral-200   borders, dividers
+neutral-300   strong borders
+neutral-400   placeholder, icons
+neutral-500   muted text
+neutral-600   secondary text
+neutral-700   primary body text
+neutral-800   strong text, headings
+neutral-900   highest contrast
+```
+
+### 3. Define semantic colors
+
+Three to five hues for status:
+
+- **Success** (typically green).
+- **Warning** (typically amber / yellow).
+- **Destructive / Error** (typically red).
+- Optionally: **Info** (typically blue, especially if your primary is *not* blue).
+
+For each, define multiple stops: a tinted background (`green-50`), a darker text color (`green-700`), a focus or border color (`green-500`).
+
+### 4. Test in dark mode
+
+A palette tuned for light mode often fails in dark mode — saturation and contrast perception inverts. Build dark-mode tokens deliberately, not by simple inversion.
+
+### 5. Test for accessibility
+
+Every text-on-background pair you ship must clear 4.5:1 (body) or 3:1 (large/UI). Test with a contrast checker; fix what fails.
+
+## Worked examples
+
+### Example 1: a status badge system
+
+```html
+<style>
+  .badge { display: inline-flex; align-items: center; gap: 4px;
+           padding: 2px 8px; border-radius: 9999px;
+           font-size: 12px; font-weight: 500; }
+  .badge--success { background: hsl(142 70% 95%); color: hsl(142 70% 22%); }
+  .badge--warning { background: hsl(38 95% 95%);  color: hsl(38 90% 25%); }
+  .badge--error   { background: hsl(0 80% 95%);   color: hsl(0 75% 32%); }
+  .badge--neutral { background: hsl(0 0% 96%);    color: hsl(0 0% 30%); }
+</style>
+
+<span class="badge badge--success"><CheckIcon aria-hidden /> Paid</span>
+<span class="badge badge--warning"><ClockIcon aria-hidden /> Pending</span>
+<span class="badge badge--error"><AlertIcon aria-hidden /> Overdue</span>
+<span class="badge badge--neutral"><PencilIcon aria-hidden /> Draft</span>
+```
+
+Each badge uses color, icon, *and* text. Color carries category at a glance; icon and text carry it for color-blind users and for any out-of-context display.
+
+### Example 2: a primary action vs. secondary action
+
+```html
+<button class="btn-primary">Save changes</button>
+<button class="btn-secondary">Cancel</button>
+```
+
+```css
+.btn-primary {
+  background: hsl(220 90% 50%);   /* full-saturation brand */
+  color: white;
+  /* ...padding, radius... */
+}
+.btn-secondary {
+  background: white;
+  color: hsl(0 0% 27%);
+  border: 1px solid hsl(0 0% 85%); /* neutral, no color emphasis */
+}
+```
+
+The primary uses full saturation and the brand hue; the secondary uses neutrals only. The eye picks the primary instantly.
+
+### Example 3: a chart palette
+
+```css
+:root {
+  --chart-1: hsl(220 70% 55%);
+  --chart-2: hsl(160 60% 45%);
+  --chart-3: hsl(40 90% 55%);
+  --chart-4: hsl(310 60% 55%);
+  --chart-5: hsl(10 70% 55%);
+}
+```
+
+Five hues at similar lightness and saturation, distributed around the wheel. Each is distinct from the others *and* survives most color-blindness simulations. For more series, add patterns (dashed lines, dotted, hatched fills) rather than adding more hues.
+
+## Anti-patterns
+
+- **Saturation overload.** Every CTA, every chart, every badge at full saturation. Page becomes a noise field.
+- **Color-only signals.** Red asterisks for required fields with no `*` or "required" text. Color-blind users miss it.
+- **Brand color everywhere.** Every link, every heading, every accent in the brand color. Brand stops registering.
+- **Light grey body text** (`#999` on white). Fails AA contrast; fatigues all readers.
+- **Inconsistent semantic colors.** "Destructive" in one shade of red here, a different shade there. Each instance is a re-learning.
+- **Dark-mode by simple inversion.** Saturation perception differs; pure inversion produces glare.
+- **Color symbolism assumed universal.** A red Lunar New Year banner reading as "danger" because the design system equates red with errors.
+- **Too many colors.** A 12-hue palette where users can't predict what means what.
+
+## Heuristics
+
+1. **The grayscale test.** Convert to grayscale. Does the design still work? If yes, color is supportive but not load-bearing. If no, you're depending on color too much.
+2. **The contrast pass.** Every text/background pair, every UI/background pair. AA at minimum.
+3. **The colorblind simulation.** Chrome DevTools → Rendering → Emulate vision deficiencies. Status systems that lean on red/green collapse here.
+4. **The cultural check.** For global products, check color symbolism with users in target markets.
+5. **The dark-mode test.** Switch to dark mode. Does the palette still work? Are contrasts still passing?
+
+## Related principles
+
+- **`hierarchy-color-and-tone`** — color as a hierarchy axis.
+- **`highlighting`** — color is the strongest highlighting tool.
+- **`signal-to-noise-ratio`** — color discipline is at the core of SNR design.
+- **`accessibility-perceivable`** (process) — color decisions are accessibility decisions.
+- **`expectation-effect`** (interaction) — color signals shape user expectations.
+- **`uniform-connectedness`** — color is one of the strongest grouping signals.
+- **`interference-effects`** — mismatched color/meaning (red "go" button) creates Stroop interference.
+
+## Sub-aspect skills
+
+- **`color-semantic-systems`** — building status/category color systems that scale and stay consistent.
+- **`color-accessibility-and-mode`** — accessibility-aware color, dark mode, and high-contrast support.
+
+## Closing
+
+Color is the loudest single dimension a designer commands. The discipline is in the restraint: a small palette, used consistently, with each color earning its place. Designs that respect this restraint feel polished; designs that don't feel noisy. Spend color where it earns the volume.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color/references/color-theory-and-systems.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/color/references/color-theory-and-systems.md
@@ -1,0 +1,99 @@
+# Color theory, perception, and modern color systems
+
+A reference complementing the `color` SKILL.md with deeper grounding in color science and modern color-system architectures.
+
+## A short history of color theory
+
+- **Newton** (1672) — first systematic color wheel; demonstrated white light decomposes into a spectrum.
+- **Goethe** (1810) — *Theory of Colours*; emphasized perceptual and psychological dimensions over physical optics. Influential in art and design even where the physics was wrong.
+- **Helmholtz, Maxwell, Hering** (mid-late 19th century) — trichromacy and opponent-process theories of color perception, both partly correct and now combined in modern accounts.
+- **Itten and Albers** (Bauhaus, mid-20th century) — color theory for designers, focused on perceptual relationships, simultaneous contrast, and color interaction.
+- **CIE color spaces** (1931 onward) — mathematical models of color perception that underlie modern color management.
+- **OKLCH and modern perceptual color spaces** (2020s) — the CSS Color 4 spec brought perceptually-uniform color spaces into web design tools.
+
+## Color perception basics
+
+The human retina has three types of cone photoreceptors, sensitive to overlapping ranges of long, medium, and short wavelengths (roughly red, green, blue). The brain combines these signals into perceived colors.
+
+Key perceptual phenomena:
+
+- **Simultaneous contrast** — a color appears different against different backgrounds. Albers's *Interaction of Color* documented this exhaustively.
+- **Color constancy** — the brain maintains stable color perception across changing illumination. Why a white shirt still "looks white" in tungsten and daylight.
+- **Adaptation** — prolonged exposure to a color shifts perception of subsequent colors (the "afterimage" effect).
+- **Brightness vs. luminance** — perceived brightness is not linearly related to physical luminance; this is why pure yellow looks bright and pure blue looks dark at the same measured luminance.
+
+These matter because color systems built on physical metrics (RGB, HSL) often produce visually uneven results across hues. OKLCH addresses this by being perceptually uniform.
+
+## RGB, HSL, OKLCH
+
+### RGB / Hex
+
+The lowest-level web color model. Each channel 0–255 (or 0–FF). Easy to implement; hard to think in.
+
+```css
+color: rgb(220, 38, 127);
+color: #DC267F;
+```
+
+### HSL
+
+Hue (0–360°), Saturation (0–100%), Lightness (0–100%). Easier for designers; perceptually problematic — equal lightness values across hues don't look equally light.
+
+```css
+color: hsl(335 75% 50%);
+```
+
+### OKLCH
+
+Perceptually uniform. L (lightness), C (chroma), H (hue). Equal L values across hues look equally light. Available in modern browsers via CSS Color 4.
+
+```css
+color: oklch(60% 0.18 350);
+```
+
+For new systems where you control the spec, OKLCH is the future. For existing systems, HSL is fine as long as you tune lightness per hue (don't assume `hsl(220 90% 50%)` and `hsl(40 90% 50%)` are equally light — they aren't).
+
+## Color-system architectures
+
+### Material Design's tonal palettes
+
+Material 3 generates 13-stop tonal palettes per role (primary, secondary, tertiary, error, neutral). Each palette spans tone 0 to tone 100 with controlled chroma. Ensures WCAG contrast can be hit between any two stops at known tone differences.
+
+### Apple's semantic colors
+
+Apple's HIG defines colors by semantic role (`label`, `secondaryLabel`, `tertiaryLabel`, `link`, `fill`, `separator`). The OS adjusts actual values per appearance mode and accessibility setting.
+
+### Tailwind's neutral and color scales
+
+Tailwind ships 11-stop color scales (50–950) for neutrals and many hues. Each step is approximately 10% lightness apart. Wide adoption has made these stops a de facto convention.
+
+### Design-token systems
+
+The W3C Design Tokens Community Group is standardizing token formats (color, spacing, typography). Tools like Style Dictionary translate JSON tokens to per-platform format (CSS variables, iOS, Android).
+
+## Cultural and contextual color
+
+Color symbolism varies by culture. A few well-documented variations:
+
+| Color | Western | East Asian | South Asian | African (varies) |
+|---|---|---|---|---|
+| Red | Stop, danger, urgent | Luck, prosperity, celebration | Marriage, purity | Mourning (some) |
+| White | Purity, weddings | Mourning, funerals | Mourning | Varies |
+| Black | Authority, formality | Knowledge, formality | Mourning | Maturity, wisdom |
+| Green | Go, nature, money | Infidelity (Chinese) | Faith (Muslim) | Health |
+| Yellow | Caution, warmth | Sacred, royalty (some) | Sacred | Mourning (some) |
+
+For products serving global audiences, don't lean on color symbolism alone. Pair with icon and text.
+
+## Resources
+
+- **Albers, J.** *Interaction of Color* (1963). Required reading.
+- **Itten, J.** *The Art of Color* (1961).
+- **Stone, M.** *A Field Guide to Digital Color* (2003). Practical color science for screens.
+- **W3C CSS Color Module Level 4** — modern color-space spec.
+- **WebAIM Contrast Checker** — most-used contrast tool.
+- **OKLCH color picker** (oklch.com) — for working in OKLCH.
+
+## Closing
+
+Color rewards study. The principles in this plugin set are the operational layer; deeper investment in Albers, modern color science, and design-system color architecture pays off across every product you ship.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-cues/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-cues/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: figure-ground-cues
+description: 'Apply specific visual cues to control figure-ground perception — shadow, elevation, scale, contrast, saturation, opacity, and texture. Use when designing layered interfaces, focus states, hover treatments, or any context where one element should clearly stand forward against others. Each cue contributes a portion of the figure-ground signal; combining cues strengthens the effect. The skill is selecting and calibrating cues for the desired level of separation.'
+---
+
+# Figure-Ground — visual cues
+
+The figure-ground sorting that the user's perception performs depends on specific visual cues. As a designer, you choose which cues to use and how strongly to apply them, calibrated to the desired separation between figure and ground.
+
+The major cues, with notes on their relative strength:
+
+## Shadow / elevation
+
+Strongest single cue for figure-ground in modern UI. A drop shadow under an element makes it appear closer to the viewer (figure), with the rest of the layout receding. Multiple levels of shadow create multiple levels of elevation.
+
+Common implementations:
+- Cards with subtle shadow (2–4px blur) for moderate elevation.
+- Floating action buttons with stronger shadow (8–12px blur) for higher elevation.
+- Modals with very prominent shadow + scrim for highest elevation.
+
+Material Design formalized this into a system of "elevation levels" (0, 1, 2, 4, 8, 16, 24 dp) each with a specific shadow recipe. The system makes consistent figure-ground separation across a product easier to maintain.
+
+## Scrim / overlay
+
+A semi-transparent layer over the ground that makes the ground visibly recede. Most commonly used with modals: the modal sits above the scrim, the scrim sits above the page.
+
+Calibration:
+- Light scrim (10–20% opacity) for soft separation.
+- Medium scrim (40–60% opacity) for clear modal-style separation.
+- Dark scrim (70%+ opacity) for full focus on the figure (image lightboxes, video players).
+
+## Scale
+
+Larger elements tend to come forward as figure, especially when they're surrounded by smaller elements. A hero card among supporting cards reads as figure through scale.
+
+But this can flip: a tiny element on a vast background can also read as figure (the small floating action button on a large canvas is figure despite its size). The cue depends on context.
+
+## Contrast and saturation
+
+Higher contrast and more saturated colors come forward; lower contrast and muted colors recede. The active workspace at full saturation; inactive workspaces with muted colors.
+
+This cue is subtle — it's often used in combination with others rather than alone. But it's powerful for distinguishing active from inactive content.
+
+## Opacity
+
+Semi-transparent elements recede; fully opaque elements come forward. Reducing the opacity of inactive content (50–70% opacity) is a quick way to send it to the background.
+
+Be careful not to reduce opacity to the point of illegibility. Even "ground" content should usually remain readable.
+
+## Sharpness vs. blur
+
+Sharp, in-focus elements come forward; blurred elements recede. iOS uses background blur extensively — a modal's background is blurred, signaling that it's behind the modal.
+
+Blur is a strong cue but expensive computationally. Use deliberately, not casually.
+
+## Texture and detail
+
+More detailed elements come forward; smoother, less detailed elements recede. A photographic background with text overlaid feels different than a solid background with text — the texture of the photo competes with the text for figure status.
+
+## Outlines and borders
+
+A clear, visible border around an element helps it read as a closed figure. Borderless elements may merge into their background.
+
+But heavy borders can feel "heavy" or dated. Modern design often prefers shadow over border for figure separation.
+
+## Position in z-axis (layering)
+
+Elements layered on top of others occlude them, which is a strong figure cue. The element on top is figure; the element behind is ground.
+
+Implementation in CSS: z-index controls the layering order. In design systems: explicit layering levels (cards, popovers, modals, toasts each at their own z-axis level).
+
+## Combining cues
+
+The cues compound. A modal that uses shadow AND scrim AND opacity reduction on the background is more clearly figure than a modal using only one of these.
+
+For elements that need to clearly come forward (modals, popovers, focus states), combine cues. For elements that should subtly come forward (hover states, mild emphasis), use a single cue or a combination of subtle ones.
+
+Avoid combining too many cues at high intensity — the result can feel theatrical. Match the cue strength to the actual importance of the figure.
+
+## Worked examples
+
+### A modal with full figure-ground
+
+A modal opens. Cues applied:
+- Scrim: 50% opacity black overlay between modal and page.
+- Modal elevation: prominent shadow (16px blur, 40% opacity).
+- Modal background: pure white (sharp contrast against the dark scrim).
+- Page beneath: visible through scrim but clearly receding.
+
+The user's perception is unambiguous: the modal is figure, the page is ground. Attention naturally goes to the modal.
+
+### A card hover with subtle figure-ground
+
+A card in a grid is hovered. Cues applied:
+- Shadow increases (from 2px blur to 4px blur).
+- Slight scale increase (1.02×).
+- Subtle background shift (0.5% lighter).
+
+The card subtly comes forward. Other cards remain at baseline. The user gets gentle feedback about where their attention is, without dramatic visual change.
+
+### Active workspace differentiated from inactive
+
+In a multi-workspace app, the active workspace is rendered with full saturation; inactive workspaces are at 60% opacity with muted colors. The active workspace is clearly figure.
+
+When the user switches workspaces, the cues swap: the new active workspace becomes figure, the previously active workspace becomes ground.
+
+### Background photo competing with text
+
+A hero section uses a photo background with text overlaid. Without intervention, the photo's detail and color compete with the text — figure-ground is ambiguous.
+
+Add a dark gradient over the photo (figure-ground cue: scrim) to push the photo further into the background. The text now clearly reads as figure.
+
+### A card with too many cues
+
+A card has: a thick border, a heavy drop shadow, a colored background, a glow effect, AND scaling on hover. The card screams. It feels theatrical, almost cartoonish.
+
+The fix: reduce to one or two strong cues. A subtle shadow + a clean white background + a slight border on hover is enough. The figure-ground separation works without the theatrics.
+
+## Anti-patterns
+
+**Insufficient cues.** A modal that uses only a thin border and no shadow or scrim. The figure-ground separation is too weak; the modal blurs into the page.
+
+**Mixed cues that fight.** A modal with shadow (suggests it's in front) but with reduced opacity (suggests it's receding). Users get conflicting signals.
+
+**Overdone cues.** Heavy shadows on every card; high-contrast borders everywhere; aggressive scale changes on hover. The cues lose meaning when applied universally.
+
+**Inconsistent cues across surfaces.** Modals styled with shadow + scrim in one place; modals styled with just a border in another. Users can't form expectations about modality.
+
+**Cues that hurt accessibility.** Reducing opacity so low that text becomes hard to read; using color-only cues that fail for color-blind users.
+
+**Reversed cues.** Chrome (sidebar, header) styled with stronger figure cues than the content. Users look at the chrome instead of focusing on their work.
+
+## Heuristic checklist
+
+When designing figure-ground separation, ask: **What should be figure, and what should be ground?** Be deliberate. **Which cues am I using to communicate the sorting?** List them. **Are the cues consistent within the product?** Inconsistent cues confuse users. **Is the separation strong enough?** Test by glancing at the design — what comes forward? **Is the separation too aggressive?** Theatrical cues feel wrong; calibrate to the actual importance.
+
+## Related sub-skills
+
+- `figure-ground-relationship` — parent principle on figure-ground perception.
+- `figure-ground-overlays-and-modals` — sibling skill on the most common figure-ground problem.
+- `hierarchy` — figure-ground is a primary mechanism for hierarchy.
+- `signal-to-noise` — figure should be high-signal; ground low-noise.
+- `color` — color choice is one figure-ground cue.
+
+## See also
+
+- `references/elevation-systems.md` — practical guidance on building consistent elevation/figure-ground systems across a product.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-cues/references/elevation-systems.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-cues/references/elevation-systems.md
@@ -1,0 +1,128 @@
+# Figure-ground cues — elevation systems
+
+Practical guidance on building consistent elevation systems that maintain figure-ground separation across a product.
+
+## What an elevation system does
+
+An elevation system formalizes figure-ground cues into a small set of named levels, each with a specific shadow recipe (and possibly other cues). All elements in the product use one of the named levels rather than ad-hoc shadow values.
+
+The benefits:
+
+- Consistency across the product (all modals look like modals; all popovers look like popovers).
+- Easier to maintain (changing the elevation scale changes all instances).
+- Clearer communication (designers and engineers can talk about "elevation 8" rather than describing shadows).
+- Better accessibility (consistent visual hierarchy is easier to navigate).
+
+## A starter elevation scale
+
+A working scale with 6 levels:
+
+| Level | Use case | Shadow recipe |
+|---|---|---|
+| 0 | Surface (no elevation) | none |
+| 1 | Subtle card elevation | 0 1px 2px rgba(0,0,0,0.05) |
+| 2 | Card hover, subtle popover | 0 2px 4px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04) |
+| 4 | Floating action button, dropdown | 0 4px 8px rgba(0,0,0,0.08), 0 2px 4px rgba(0,0,0,0.04) |
+| 8 | Sidebar drawer, sticky header | 0 8px 16px rgba(0,0,0,0.10), 0 4px 8px rgba(0,0,0,0.05) |
+| 16 | Modal, dialog | 0 16px 32px rgba(0,0,0,0.12), 0 8px 16px rgba(0,0,0,0.06) |
+
+These are starting points. Adjust the values based on your design's overall feel.
+
+Material Design's elevation system uses a similar (though more elaborate) approach. Apple's Human Interface Guidelines use distinct treatments for different layer types (popovers, sheets, modals).
+
+## Combining elevation with other cues
+
+Shadow alone is sometimes insufficient for clear figure-ground. Combine with:
+
+**Background color.** Elevated elements often have a slightly different background — usually slightly lighter than the surface (in light mode) or slightly elevated-feeling (in dark mode).
+
+**Scrim.** For high-elevation elements (modals, lightboxes), a scrim over the page makes the separation explicit.
+
+**Border.** A subtle 1px border can reinforce a card's edge when shadow alone is too soft.
+
+**Background blur.** iOS uses background blur extensively for elevated elements (sheets, popovers). The blurred background makes the elevated element stand out crisply.
+
+**Animation.** Elements that animate to their elevated position (a modal sliding up; a popover appearing with a subtle scale-in) reinforce the elevation perceptually.
+
+## Dark mode considerations
+
+In dark mode, the typical "elevated = lighter background" pattern reverses. Elevated elements in dark mode usually have:
+
+- Slightly lighter background (because lighter feels closer to the user in dark UI).
+- Reduced shadow opacity (shadows are less visible against dark backgrounds).
+- Sometimes a subtle inner glow or border to suggest the edge.
+
+Define your elevation tokens with dark-mode variants. Don't just invert light-mode values.
+
+## Application patterns
+
+**Cards:** elevation 1 by default, elevation 2 on hover.
+
+**Sticky headers:** elevation 4 to 8 when scrolled (so they appear to lift off the page).
+
+**Dropdowns and popovers:** elevation 4 to 8.
+
+**Floating action buttons:** elevation 4 to 6 with hover bumping to slightly higher.
+
+**Side panels:** elevation 8 to 12 (significant separation from main content).
+
+**Modals:** elevation 16 to 24, often paired with a scrim.
+
+**Toasts and notifications:** elevation 8 to 16 (clearly above other content but not as dominant as modals).
+
+## Hierarchy of layers
+
+A useful mental model is the z-axis hierarchy:
+
+- Surface (the page itself).
+- Cards and contained content.
+- Sticky elements (headers, sidebars).
+- Floating UI (FABs, dropdowns).
+- Side panels and drawers.
+- Modals and dialogs.
+- Toasts and snackbars.
+- Tooltips (highest, very transient).
+
+Each layer has its own elevation. Within a layer, elevation can differ between resting and hovered states.
+
+## Common failures
+
+**No system, ad-hoc shadows.** Each card uses a different shadow. The product feels inconsistent.
+
+**Too many elevation levels.** A 12-level scale is too many to apply consistently. 5–7 levels is usually enough.
+
+**Elevation that doesn't match conceptual layering.** A modal at lower elevation than a popover. Users get confused about what's "in front."
+
+**Heavy shadows that look outdated.** Shadows from 5 years ago tended to be heavier and more dramatic than current style. Subtle, low-opacity shadows are more current. Refresh your shadow values periodically.
+
+**Different elevation cues for the same concept.** Modals use shadow in one part of the product; modals use border in another part. Pick one and apply consistently.
+
+**Elevation cues failing in dark mode.** Light-mode cues that don't translate. Always define dark-mode equivalents.
+
+## Building an elevation system into a design system
+
+Define elevation as design tokens:
+
+```
+shadow.0: none
+shadow.1: 0 1px 2px rgba(0,0,0,0.05)
+shadow.2: 0 2px 4px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)
+shadow.4: 0 4px 8px rgba(0,0,0,0.08), 0 2px 4px rgba(0,0,0,0.04)
+shadow.8: 0 8px 16px rgba(0,0,0,0.10), 0 4px 8px rgba(0,0,0,0.05)
+shadow.16: 0 16px 32px rgba(0,0,0,0.12), 0 8px 16px rgba(0,0,0,0.06)
+```
+
+And dark-mode variants:
+
+```
+shadow-dark.0: none
+shadow-dark.1: 0 1px 2px rgba(0,0,0,0.30)
+shadow-dark.2: 0 2px 4px rgba(0,0,0,0.35), 0 1px 2px rgba(0,0,0,0.25)
+... etc.
+```
+
+Components reference the named tokens; switching between light and dark mode swaps the underlying values. The named system is the contract; the values can evolve over time.
+
+## Cross-reference
+
+For modal/overlay-specific patterns, see `figure-ground-overlays-and-modals`. For the parent principle, see `figure-ground-relationship`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-overlays-and-modals/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-overlays-and-modals/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: figure-ground-overlays-and-modals
+description: 'Apply figure-ground separation specifically for overlays — modals, dialogs, drawers, popovers, dropdowns, toasts. Use when designing or auditing the moments when a UI element appears over the underlying page and needs to clearly come forward. The most common figure-ground design problem; getting it right means users naturally focus on the overlay, getting it wrong means modals blur into the page or feel jarring.'
+---
+
+# Figure-Ground — overlays and modals
+
+The most common figure-ground design problem in modern UI: an element appears over the underlying page and needs to clearly come forward. Modals, dialogs, drawers, popovers, dropdowns, toasts, tooltips, lightboxes — all are overlays that need to win the figure-ground sorting against the page beneath.
+
+When the figure-ground separation is clear, users naturally focus on the overlay; the page recedes. When it's unclear, users may not notice the overlay, or they may be uncertain about whether to focus on the overlay or the page.
+
+## Anatomy of a well-designed modal
+
+A modal that wins figure-ground separation typically uses several cues together:
+
+**1. Scrim.** A semi-transparent overlay (40–60% opacity black, typically) between the modal and the page. The scrim does several jobs: visually separates the modal from the page, mutes the page's color and detail, and indicates that the page is currently inactive.
+
+**2. Elevation (shadow).** The modal has a prominent drop shadow (16–24px blur, low opacity), suggesting it's sitting above everything else.
+
+**3. Background.** The modal's background is sharp and solid (typically white in light mode, slightly elevated dark gray in dark mode), in clear contrast with the scrim.
+
+**4. Close affordance.** A clear way to dismiss (X in the corner, button, escape key, click outside on the scrim). Users need to know how to return to the page.
+
+**5. Focus trap.** Keyboard focus is contained within the modal until it closes. Tab key cycles through the modal's interactive elements; tab doesn't escape to the page beneath.
+
+**6. ARIA roles and labels.** The modal is announced as a modal; screen readers know to focus on it.
+
+When all these align, the modal is clearly figure, the page clearly ground, and the user can interact with the modal without confusion.
+
+## Common modal failure modes
+
+**No scrim.** The modal floats over the page with no visual separation. The page is still visible at full strength; the figure-ground separation is weak.
+
+**Scrim too light.** A scrim at 10% opacity that's barely perceptible. The visual cue isn't strong enough to push the page into ground.
+
+**Modal too subtle.** A modal with no shadow, no border, light gray background that blends with surrounding gray UI. The modal doesn't read as elevated.
+
+**No clear close.** Users can't figure out how to dismiss the modal. They click around looking for the exit. The modal becomes an interruption rather than a focus point.
+
+**Focus not trapped.** Tab key escapes the modal and starts cycling through the page beneath, leading to confusion about where focus is.
+
+**Multiple modals stacked.** A modal opens, then another opens on top of it. The figure-ground sorting becomes ambiguous (which modal is figure?), and users can lose track of state.
+
+**Inconsistent modal styles.** Different modals in the same product use different scrim opacities, different shadows, different close patterns. Users can't form expectations.
+
+## Variations: drawers, popovers, dropdowns
+
+Different overlay types have different figure-ground requirements.
+
+**Drawers (side panels).** Slide in from one edge of the screen. The page beneath is partially visible (drawer doesn't cover the whole screen). Use scrim to push the visible page area into ground. Drawer itself uses elevation (shadow on the inner edge) to come forward.
+
+**Popovers (small overlays attached to a trigger).** Smaller than modals, attached to a specific UI element (a button, a link). Scrim is usually unnecessary — the popover is small and obviously associated with its trigger. Use elevation (shadow) to come forward.
+
+**Dropdowns (menus expanded from a control).** Similar to popovers but specifically a list of options. Elevation cue alone is usually enough; no scrim. The dropdown should clearly close when the user clicks outside or selects an option.
+
+**Toasts (transient notifications).** Brief overlays that appear and dismiss themselves. High elevation (shadow) makes them clearly above other content. No scrim — the page beneath should remain interactive. Toast colors usually distinct (success green, error red, info blue).
+
+**Tooltips (very transient overlays on hover).** Lowest elevation among overlays — they're informational, not action-requiring. Subtle shadow or border is sufficient.
+
+**Lightbox (full-screen image viewer).** Maximum scrim (often pure black) because the image needs full attention. The image is the only figure; everything else is hidden.
+
+Each type has its own figure-ground recipe based on its purpose.
+
+## Worked examples
+
+### A confirmation dialog
+
+User clicks "Delete account." A modal opens:
+
+- Scrim at 50% opacity black covers the page.
+- Modal centered, white background, 600px wide, with prominent shadow.
+- Headline: "Delete your account?"
+- Body: "This will permanently delete your account and all associated data. This cannot be undone."
+- Two buttons: "Cancel" (secondary) and "Delete account" (destructive primary, red).
+- X close button in upper-right.
+- Click on scrim or escape key dismisses (canceling).
+
+Figure-ground is unambiguous. The modal commands attention; the page is clearly inactive. The user can make the decision without distraction.
+
+### A dropdown menu
+
+User clicks "User settings" in the nav. A dropdown opens below the trigger:
+
+- No scrim (page remains active).
+- Dropdown has subtle shadow (4px blur) and 1px border.
+- Background white; menu items inside.
+- Click outside dismisses.
+- Escape key dismisses.
+
+The dropdown clearly comes forward through elevation but doesn't dominate; the user can dismiss easily and continue with the page.
+
+### A side drawer
+
+User clicks "Settings" icon. A side drawer slides in from the right:
+
+- Drawer takes 400px on the right side of the screen.
+- Visible page area to the left of the drawer is darkened with a scrim.
+- Drawer has shadow on its left edge (where it meets the visible page).
+- Drawer background white; settings content inside.
+- Click on scrim, X button, or escape dismisses.
+
+The drawer is figure within its layer; the visible page area is clearly secondary; the user knows where to focus.
+
+### A toast notification
+
+User saves a document. A toast appears:
+
+- Toast positioned in lower-right of screen.
+- Toast has prominent shadow and rounded background.
+- Background green (success color); text in white.
+- Auto-dismisses after 4 seconds, or user can click to dismiss.
+- No scrim (page remains active and interactive).
+
+The toast is figure briefly, then disappears. The page never becomes ground; the user can continue working uninterrupted.
+
+### A failure: modal without scrim
+
+A modal opens but no scrim is added. The page is fully visible behind the modal. Users see the modal but also see the page; figure-ground is ambiguous. They sometimes click on the page (thinking they're interacting) and miss the modal entirely.
+
+The fix: add a scrim. Even a light one (40% opacity) dramatically improves figure-ground separation.
+
+## Anti-patterns
+
+**Modals without scrim.** As above, the modal blurs into the page.
+
+**Modals that auto-dismiss while user is reading.** A modal that times out is an interruption that ended before users could engage.
+
+**Stacked modals.** Modal A opens; from Modal A, the user triggers an action that opens Modal B. Now there are two modals; figure-ground is ambiguous; state is hard to track. Avoid stacking modals; replace one modal with another or use a non-modal pattern.
+
+**Modal animations that are too slow or too theatrical.** A modal that takes 800ms to slide in feels sluggish; a modal with elaborate effects feels distracting. Quick (200–300ms) and clean is best.
+
+**Click-outside dismissal that loses user data.** A user has typed in a form modal and accidentally clicks outside; the modal dismisses and their input is lost. Either confirm dismissal when there's unsaved input, or don't allow click-outside to dismiss for input-containing modals.
+
+**Inconsistent overlay patterns.** Different drawers in the same product behave differently; some have scrim, others don't; some close on click-outside, others don't. Codify the patterns.
+
+**Tooltips that act like modals.** A tooltip that requires the user to click to dismiss, blocks page interaction, or contains a lot of content. Tooltips should be lightweight; if you need more, use a popover or modal.
+
+## Heuristic checklist
+
+For every overlay you ship, ask: **Does it have appropriate figure-ground separation from the underlying page?** Test by glancing — what stands forward? **Are the cues (scrim, elevation, shadow) calibrated to the overlay type?** Modals get more; toasts get less. **Is the close path clear?** Users should always know how to dismiss. **Is focus managed correctly?** Tab should be trapped in modals; not in toasts. **Does the overlay match the patterns established elsewhere in the product?** Inconsistency confuses users.
+
+## Related sub-skills
+
+- `figure-ground-relationship` — parent principle on figure-ground perception.
+- `figure-ground-cues` — sibling skill on the specific visual cues.
+- `forgiveness` — modal dismissal patterns interact with forgiveness (don't lose user input on accidental dismiss).
+- `feedback-loop` — toasts are feedback; their figure-ground supports their feedback role.
+- `accessibility` — overlays have specific accessibility requirements (focus trap, ARIA, escape key).
+
+## See also
+
+- `references/overlay-recipes.md` — specific design recipes for each overlay type.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-overlays-and-modals/references/overlay-recipes.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-overlays-and-modals/references/overlay-recipes.md
@@ -1,0 +1,164 @@
+# Overlay design — recipes
+
+Specific design recipes for each common overlay type.
+
+## Recipe: confirmation modal
+
+**Use for:** important decisions that interrupt the user's flow (delete account, discard unsaved changes, irreversible action).
+
+**Components:**
+- Scrim: 50% opacity black overlay.
+- Modal container: white background (or elevated dark in dark mode), rounded corners, max-width ~500px, centered horizontally and (slightly) vertically.
+- Elevation: prominent shadow (16–24px blur).
+- Headline: 18–22px, medium or semibold weight.
+- Body text: 14–16px, regular weight, max ~3 lines.
+- Primary action: button using the appropriate color (red for destructive, brand color for constructive).
+- Secondary action: neutral-styled cancel button.
+- Close affordance: X in upper-right corner.
+- Dismiss: click outside (on scrim), escape key, X button.
+- Focus: trap within modal; first focusable element auto-focused.
+
+**Animation:** quick fade-in for scrim and modal; modal scales in from 95% to 100% to feel like it's coming forward.
+
+## Recipe: form modal
+
+**Use for:** longer interactions that need focused input (creating a record, editing settings, complex configurations).
+
+**Components:**
+- Scrim: 40–50% opacity black.
+- Modal container: white, rounded corners, max-width 600–800px.
+- Elevation: prominent shadow.
+- Header: title + close X.
+- Body: scrollable form content.
+- Footer: action buttons (typically right-aligned).
+- Dismiss: X button, escape, possibly click-outside (with confirmation if there's unsaved input).
+- Focus: trap; first input auto-focused.
+
+**Considerations:** if the form is very long, consider whether a modal is the right pattern (drawer or full page might be better).
+
+## Recipe: drawer (side panel)
+
+**Use for:** secondary interactions that don't require fully covering the page (settings, details, secondary navigation).
+
+**Components:**
+- Position: anchored to one edge (typically right; sometimes left for navigation drawers).
+- Width: 320–500px depending on content.
+- Scrim: 40–50% opacity over the visible page area.
+- Elevation: shadow on the inner edge of the drawer.
+- Header: title + close X.
+- Body: scrollable content.
+- Dismiss: X button, escape, click on scrim.
+
+**Animation:** slide in from the anchored edge over 250–300ms.
+
+## Recipe: popover
+
+**Use for:** small contextual content attached to a trigger (option lists, brief detail views, color pickers).
+
+**Components:**
+- Container: small (typically 200–400px wide), positioned next to the trigger element.
+- Elevation: subtle shadow (4–8px blur).
+- Border: optional 1px border for cleaner edge.
+- Background: white (or elevated in dark mode).
+- Arrow / pointer: optional, indicating the connection to the trigger.
+- Dismiss: click outside, escape, or selecting an option (if it's a menu).
+
+**No scrim:** popovers don't need to push the page into ground because they're small and obviously contextual.
+
+## Recipe: dropdown menu
+
+**Use for:** lists of options or commands (account menu, more-actions menu, select dropdown).
+
+**Components:**
+- Container: sized to content; typically 150–300px wide.
+- Position: below the trigger by default; flips up if not enough space below.
+- Elevation: subtle shadow.
+- Items: standard list rows with hover state.
+- Dismiss: click outside, escape, selecting an item.
+
+**Considerations:** for very long lists, consider scrolling within the dropdown or switching to a different pattern (autocomplete, modal).
+
+## Recipe: toast notification
+
+**Use for:** transient feedback about an action (saved successfully, error occurred, processing complete).
+
+**Components:**
+- Container: pill-shaped or rounded rectangle.
+- Position: lower-right corner (web), bottom edge (mobile).
+- Color: success green / error red / info blue / warning yellow.
+- Text: concise (one line, max 50–60 characters).
+- Optional action button (e.g., "Undo," "View details").
+- Auto-dismiss: 3–5 seconds typically; longer for errors.
+- Manual dismiss: X button or swipe.
+
+**No scrim, no focus trap:** toasts don't interrupt the user's work.
+
+**Considerations:** stack toasts if multiple appear; older toasts shift up. Don't overwhelm with too many simultaneous toasts.
+
+## Recipe: tooltip
+
+**Use for:** brief explanatory text on hover or focus (button labels, icon meanings, term definitions).
+
+**Components:**
+- Container: small (sized to content; typically 100–250px wide).
+- Position: adjacent to the triggering element.
+- Background: dark (typically), with white text. Or light with dark text — pick one and stay consistent.
+- Border: usually none.
+- Shadow: subtle.
+- Arrow / pointer: optional, indicating the connection.
+- Trigger: hover, focus, or long-press.
+- Dismiss: mouse leaves trigger, focus moves, or after a brief timeout.
+
+**Accessibility:** tooltips must be reachable by keyboard (focus, not just hover). Mobile tooltips often use long-press or are replaced with always-visible labels.
+
+## Recipe: lightbox
+
+**Use for:** image or video viewing where the content needs full attention (gallery, attachment preview).
+
+**Components:**
+- Scrim: heavy (80–95% opacity black or pure black).
+- Image/video centered, sized to fit while preserving aspect ratio.
+- Navigation: previous/next arrows, close X.
+- Optional controls: zoom, download, share.
+- Dismiss: X button, escape, click outside the image area.
+
+**Considerations:** heavy scrim helps the image read clearly. Page beneath should be effectively invisible.
+
+## Recipe: full-screen modal (sheet)
+
+**Use for:** complex flows that don't fit in a centered modal but should still be modal (mobile editing flows, multi-step wizards, immersive tasks).
+
+**Components:**
+- Container: takes most or all of the viewport.
+- Header: with title and close action.
+- Body: scrollable content.
+- Footer: actions if needed.
+- Dismiss: typically explicit X or "Cancel" button (not always click-outside, since there's nothing outside to click).
+
+**Considerations:** essentially a full-page replacement temporarily. Often used on mobile where there's no room for a centered modal.
+
+## Cross-overlay patterns
+
+**Stacking:** generally avoid overlay-on-overlay. If a modal needs to lead to another action, replace the modal content rather than opening a new modal. Exception: very specific cases like a date picker popover within a modal.
+
+**Persistent vs. dismissible:** most overlays should be dismissible. Persistent overlays (that block until something happens) should be reserved for genuinely critical situations.
+
+**Blocking vs. non-blocking:** modals block; toasts don't. Drawers can be either depending on whether the page beneath is interactive. Be deliberate about which pattern your overlay needs.
+
+**Animation:** quick (200–300ms) and physically meaningful (slide from the edge it's anchored to; fade for centered overlays). Avoid elaborate animation.
+
+## Anti-patterns
+
+**Cookie banners as modals.** Cookie consent banners that block all interaction until acknowledged. Annoying and often illegal in some jurisdictions; consider less aggressive patterns.
+
+**Marketing modals on first visit.** Aggressive newsletter signup or feature-promotion modals on the user's first visit. Damages first impression.
+
+**Modals that disable scrolling on mobile.** Without explicit handling, opening a modal on mobile can leave the page scroll position locked weirdly.
+
+**Tooltip-only critical information.** Important help text only available via hover. Mobile users can't hover; some keyboard users miss tooltips. Critical info should be always visible.
+
+**Drawer that takes up almost the whole screen.** A drawer covering 90% of the viewport is essentially a modal but without the centering. Use the right pattern.
+
+## Cross-reference
+
+For figure-ground cues in general, see `figure-ground-cues`. For the parent principle, see `figure-ground-relationship`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-relationship/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-relationship/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: figure-ground-relationship
+description: 'Apply the Gestalt principle of Figure-Ground Relationship — the perceptual separation of what''s perceived as the figure (the focus, the object) from the ground (the surrounding context). Use when designing modals, overlays, focus states, hero elements, hover treatments, layered interfaces, or any context where one element should clearly stand forward against everything else. The user''s perception always sorts the visual field into figure and ground; designs that reinforce the desired sorting feel clear, while designs that fight it feel confusing.'
+---
+
+# Figure-Ground Relationship
+
+> **Definition.** Figure-ground relationship is the perceptual principle that the visual field is automatically sorted into "figure" (the object of focus, the thing perceived as standing forward) and "ground" (the context, the thing perceived as receding behind). The sorting is automatic and pre-conscious; the user doesn't choose what's figure and what's ground. The designer's job is to ensure that what should be figure (the active element, the focal point, the modal content) reads as figure, and that what should be ground (the chrome, the inactive content, the background) reads as ground.
+
+The classic illustration is the Rubin vase — a figure that can be perceived either as a vase (with the surroundings as ground) or as two faces in profile (with the vase shape as ground). The image is deliberately ambiguous; the visual system flips between the two interpretations because neither has clear primacy.
+
+In design we usually want unambiguous primacy. The active workspace should clearly be figure; the chrome around it should clearly be ground. The modal should clearly be figure; the page underneath should clearly recede. The hovered item should clearly come forward; the rest should fade.
+
+## The cues that signal figure
+
+The visual system uses several cues to decide what's figure and what's ground.
+
+**Definite, closed shape.** Elements with clear, complete boundaries are perceived as figure. Loose or open shapes are perceived as ground.
+
+**Apparent closeness.** Elements that appear closer (through shadow, scale, or perspective) are perceived as figure. Elements that recede are ground.
+
+**Lower position in the visual field.** Elements positioned in the lower part of the field tend to be perceived as figure (a heuristic from real-world perception, where ground is usually at the bottom).
+
+**Smaller area.** Smaller elements are typically perceived as figure against larger backgrounds, not the reverse.
+
+**Higher contrast or saturation.** Brighter, more saturated, more contrasting elements come forward. Muted, low-contrast elements recede.
+
+**Texture and detail.** More detailed elements come forward; smoother, less detailed elements recede.
+
+**Symmetry.** Symmetric shapes tend to be perceived as figure.
+
+**Overlapping (occlusion).** Elements that occlude others are perceived as in front, hence as figure.
+
+These cues compound. A small, sharply-defined, highly-contrasting element overlaying a large, muted, smoothly-textured background is unambiguously figure.
+
+## Why figure-ground matters
+
+When figure-ground is clear, the user knows where to look without effort. The active task is figure; the rest is ground. Their attention naturally goes to the figure.
+
+When figure-ground is ambiguous, the user has to do attention work — actively deciding what to focus on. This is tiring and slow. Layouts where everything competes for visual primacy feel chaotic; layouts where nothing has primacy feel flat.
+
+When figure-ground is reversed (the wrong element comes forward), the user is misled about where the focus is supposed to be. They may miss the intended focal point and pay attention to something that isn't important.
+
+## Sub-skills in this cluster
+
+- **figure-ground-cues** — The specific visual cues (shadow, scale, contrast, detail) that signal figure vs. ground, and how to apply them deliberately.
+- **figure-ground-overlays-and-modals** — The most common figure-ground design problem: overlays, modals, popovers that need to clearly come forward over the underlying page.
+
+## Worked examples
+
+### A modal with clear figure-ground
+
+A modal opens over the page. The page content fades to lower opacity (becomes ground). A scrim (semi-transparent overlay) further separates the page from the modal. The modal itself has a sharp white background, a clear edge with shadow, and full saturation.
+
+The user's perception clearly sorts: modal is figure, page is ground. Attention naturally goes to the modal. When the modal closes, the page returns to figure status.
+
+### A modal with weak figure-ground
+
+A modal opens but the page beneath isn't visually changed (no scrim, no opacity change). The modal has a subtle border but no shadow. The figure-ground separation is weak — the modal feels like another panel on the page rather than a focused overlay.
+
+Users can be unsure where to focus. The modal's interactivity isn't visually emphasized. The figure-ground principle hasn't done its work.
+
+The fix: add a scrim, increase the modal's elevation (more shadow), make the page beneath visibly recede.
+
+### Hover state with figure-ground
+
+When a user hovers over an item in a list, the item gets a slightly lifted appearance — slightly elevated shadow, slightly more saturation, slightly larger. The other items remain ground.
+
+The hover-triggered figure-ground shift signals interactivity and gives the user feedback about where their attention is.
+
+### A dashboard where everything competes
+
+A dashboard has 8 large cards, all with similar styling, similar weight, similar prominence. The user has no clear focal point. Every card feels like figure; nothing feels like ground.
+
+The fix: introduce visual hierarchy through figure-ground cues. Make the most important card larger or more prominent (figure). Keep supporting cards smaller and less emphasized (ground). The user's attention now has a clear target.
+
+### Active vs. inactive workspace
+
+An app has multiple workspaces visible (a current one and recent ones). The current workspace is rendered with full saturation, sharp shapes, and prominent contrast. The recent workspaces are rendered with reduced opacity, slightly muted colors. The figure-ground separation makes the current workspace clearly active.
+
+If both had been styled identically, users would have to read carefully to know which workspace was active. The figure-ground cue does the work.
+
+## Anti-patterns
+
+**Reversed figure-ground.** The chrome (sidebars, headers) styled more prominently than the content. Users look at the chrome instead of the content.
+
+**No figure-ground separation.** Layouts where everything has the same visual weight. Nothing feels primary; users don't know where to focus.
+
+**Modals that don't come forward enough.** Insufficient scrim, no elevation cues. The modal blurs into the page.
+
+**Overlays that come forward too aggressively.** Heavy darkening of the background, dominant overlays that feel intrusive. The figure-ground separation is too aggressive and the user feels assaulted.
+
+**Inconsistent figure-ground treatment across the product.** Modals styled differently in different places; some come forward more than others. Users can't form expectations.
+
+**Background imagery that competes with foreground.** A photo background under text where the text is hard to read because the photo is so visually rich. The figure-ground sorting is unclear.
+
+## Heuristic checklist
+
+When designing a layout, ask: **What should be figure (the focal point) and what should be ground (the context)?** Be explicit about the intended sorting. **Are the visual cues reinforcing the desired sorting?** Shadow, contrast, scale, saturation should align. **At a glance, can the user identify what's primary?** If they have to think about it, the figure-ground is weak. **Does the figure-ground sorting hold up when state changes?** A modal opens, a hover happens, an item gets selected — figure-ground should re-sort cleanly.
+
+## Related principles
+
+- **Gestalt grouping principles generally** — figure-ground is one of the original Gestalt principles.
+- **Hierarchy** — figure-ground is a primary mechanism for expressing hierarchy.
+- **Signal-to-Noise Ratio** — figure should have high signal; ground should have low.
+- **Color** — color choice affects figure-ground (saturated colors come forward, muted recede).
+- **Closure** — closed forms are more likely to be perceived as figure.
+- **Layering** — explicit visual layering is a tool for figure-ground design.
+
+## See also
+
+- `references/lineage.md` — origins in Gestalt psychology and the Rubin vase.
+- `figure-ground-cues/` — sub-skill on the specific visual cues that signal figure vs. ground.
+- `figure-ground-overlays-and-modals/` — sub-skill on the most common figure-ground design problem.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-relationship/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/figure-ground-relationship/references/lineage.md
@@ -1,0 +1,93 @@
+# Figure-Ground Relationship — origins and research lineage
+
+## The Gestalt school and Edgar Rubin
+
+Figure-ground perception was first systematically studied by the Danish psychologist Edgar Rubin in his 1915 doctoral dissertation. Rubin observed that the visual field is automatically organized into figure (the perceived object) and ground (the surrounding space), with the two playing distinct perceptual roles. The figure is perceived as having form, location, and meaning; the ground is perceived as continuing behind the figure, formless and undifferentiated.
+
+The most famous illustration is the Rubin vase, which Rubin used in his dissertation. The image can be perceived as a black vase against a white background, or as two white faces in profile against a black background. The image flips between the two interpretations because neither is unambiguously the figure — the cues are evenly balanced.
+
+Rubin identified several characteristics of figure perception:
+
+- The figure has shape; the ground is shapeless.
+- The figure is in front of the ground.
+- The ground continues behind the figure.
+- The figure is more memorable; the ground is forgettable.
+- The contour belongs to the figure, not to the ground.
+
+Rubin's work was incorporated into the Gestalt school's broader theory of perceptual organization and remains foundational to vision science.
+
+## Cues that determine figure-ground sorting
+
+Subsequent research has identified the specific cues that the visual system uses to decide what's figure and what's ground:
+
+**Surroundedness.** An element surrounded on all sides by another element tends to be perceived as figure (the small one being figure, the larger surrounding one being ground).
+
+**Size.** Smaller elements are perceived as figure against larger backgrounds. The 1922 study by Wolfgang Köhler confirmed that this is a strong cue.
+
+**Orientation and verticality.** Vertical and horizontal elements are perceived as figure more readily than diagonals.
+
+**Bottom-of-field.** Elements in the lower visual field tend to be perceived as figure (a heuristic from real-world perception, where ground is usually below).
+
+**Symmetry.** Symmetric shapes are more likely to be perceived as figure.
+
+**Familiarity.** Recognizable shapes are more likely to be perceived as figure.
+
+**Closedness.** Closed contours are perceived as figure; open contours as ground.
+
+**Convexity.** Convex shapes (bulging outward) are perceived as figure more readily than concave shapes.
+
+**Lower contrast or texture.** The element with more visual information (texture, color, detail) tends to be figure.
+
+When cues align, figure-ground is unambiguous. When cues conflict (as in the Rubin vase), perception flips between interpretations.
+
+## In design history
+
+Figure-ground has been a fundamental concern of graphic design since the field's emergence:
+
+- **Information hierarchy in print.** A page with a clear focal element (a hero image, a large headline) and supporting text uses figure-ground to direct attention. The Bauhaus tradition emphasized clean figure-ground separation as a design virtue.
+- **Logo design.** Logos that exploit figure-ground reversal (the FedEx arrow in negative space, the WWF panda) use the principle as a design device, sometimes deliberately ambiguous.
+- **Poster design.** A poster with a clear central figure and uncluttered ground reads from a distance; a poster where everything competes for attention reads as visual noise.
+- **Mapping and information visualization.** Maps that distinguish foreground content (the active layer) from background reference (the topographic base) use figure-ground sorting to guide attention.
+
+## In modern UI
+
+Figure-ground operates throughout modern interface design:
+
+- **Modal dialogs.** A modal becomes figure; the page beneath becomes ground. The scrim (semi-transparent overlay) makes the figure-ground separation visible.
+- **Hover and focus states.** Hovered or focused elements come forward (figure); other elements recede (ground).
+- **Active vs. inactive workspaces.** The active workspace is figure; inactive workspaces are ground (often shown with reduced opacity or muted color).
+- **Notifications and toasts.** A notification is figure; the underlying content is ground (briefly, until the notification dismisses).
+- **Layered interfaces.** Material Design's "elevation" system formalizes figure-ground through z-axis layering: higher elevation = closer to the user = more figure-like.
+
+The systematization of figure-ground in design systems (elevation tokens, scrim opacities, focus-state styles) is a recent development that recognizes how often the principle is applied and how valuable consistency across surfaces is.
+
+## Empirical findings worth remembering
+
+The research on figure-ground perception converges on:
+
+- **Sorting is automatic and pre-attentive.** It happens within ~100ms of visual exposure. Designs that work with the automatic sorting feel clear; designs that fight it feel confusing.
+- **Figure is more memorable than ground.** Users remember what was figure; they often can't remember what was in the ground at all.
+- **Attention follows figure.** The figure gets the attention; the ground gets minimal processing.
+- **Figure-ground can be ambiguous.** When cues are balanced, perception flips. Use this deliberately for ambiguous-on-purpose designs (like the Rubin vase or a clever logo); avoid it when you want clear primacy.
+- **Reversed figure-ground feels wrong.** When the chrome is more prominent than the content, users feel something is off even if they can't articulate it.
+
+## Related concepts
+
+**Layering.** Explicit visual layering (z-index, elevation, shadow) is the modern UI mechanism for expressing figure-ground.
+
+**Hierarchy.** Visual hierarchy depends on figure-ground sorting at multiple levels — the most important element is figure within its level; that level is figure within the larger context.
+
+**Attention and salience.** What stands out (visually salient) becomes figure; what doesn't, becomes ground.
+
+**Affordance.** Interactive elements typically read as figure (they invite attention and action); non-interactive elements should read as ground.
+
+## Sources informing this principle
+
+- Rubin, E. (1915). *Synsoplevede Figurer* (Visually Experienced Figures). His doctoral dissertation introducing the figure-ground concept.
+- Wertheimer, M. (1923). Untersuchungen zur Lehre von der Gestalt II.
+- Köhler, W. (1922). On the role of color and brightness in figure-ground perception.
+- Palmer, S. E. (1999). *Vision Science: Photons to Phenomenology*.
+- Ware, C. (2012). *Information Visualization: Perception for Design*.
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*.
+- Material Design (Google) elevation specifications.
+- Apple Human Interface Guidelines on layering and modality.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/gestalt-similarity/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/gestalt-similarity/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: gestalt-similarity
+description: 'Apply the Gestalt principle of Similarity — elements that share visual attributes (color, shape, size, orientation) are perceived as belonging together, regardless of their physical proximity. Use when grouping related items in a list, status indicators, dashboard cards, navigation, or any context where you want the user to perceive certain items as a set. Similarity is one of the strongest grouping cues; it works even when proximity says otherwise. Color is the strongest similarity cue, then size, then shape; orientation is weakest.'
+---
+
+# Gestalt Similarity
+
+> **Definition.** Similarity is the Gestalt principle that elements sharing visual attributes — color, shape, size, orientation, texture — are perceived as belonging together. Two red dots in a sea of blue dots form a group, even when they're not physically close. Three identical icons in a row of varied icons form a set. Items styled the same way "go together" in the user's perception, regardless of their position in the layout.
+
+Similarity is one of the original Gestalt grouping principles, established by Wertheimer in the early 20th century. It's one of the strongest perceptual forces in visual design: the user's brain automatically segments the visual field into groups based on visual similarity, before any conscious analysis. Designs that exploit this segmentation work with the user's perception; designs that fight it work against it.
+
+## The hierarchy of similarity cues
+
+Not all similarity is equally strong. Research consistently finds:
+
+**Color is the strongest grouping cue.** Two items with the same color are perceived as a group even when many other attributes differ. Highlighting selected items with color is one of the most reliable design techniques.
+
+**Size is second.** Items of the same size group together; different sizes form different groups. This is why heading hierarchy works — large text reads as one set (headings), smaller text as another set (body).
+
+**Shape is third.** Items with the same shape group together. Round buttons read as a different set than square buttons. Cards of the same proportions feel like one set.
+
+**Orientation is weakest.** Items oriented the same way group, but the cue is subtle. Useful for distinguishing axes (vertical vs. horizontal) more than for grouping items.
+
+When you want to group items strongly, reach for color. When you want to distinguish groups, reach for color difference. Other similarity cues are reinforcement, not primary.
+
+## Why similarity matters
+
+Similarity is doing two jobs at once:
+
+**It groups items that should be perceived together.** A row of similar buttons reads as a button bar. A column of similarly-styled cards reads as a list. A set of items with the same icon reads as the same kind of thing.
+
+**It distinguishes items that should be perceived as different.** A "destructive" button styled differently from "constructive" buttons signals its different role. A "primary" action styled differently from "secondary" actions reveals its priority. Status indicators in different colors communicate different states.
+
+The principle is: **make similar things look similar, and make different things look different**. This sounds obvious and is often violated. Two visually-identical buttons that behave differently mislead the user. Two functionally-equivalent items styled differently fragment the user's perception.
+
+## Diagnosing similarity problems
+
+Symptoms of similarity issues:
+
+**Users miss related items.** They see one item but don't realize there are others "like it" elsewhere on the screen because the visual treatment doesn't link them.
+
+**Users confuse different items as the same.** They click the destructive button thinking it was the constructive one because both are styled the same way.
+
+**A list looks fragmented.** Items in the same list have inconsistent visual treatment, so the user can't see them as a coherent set.
+
+**Status is ambiguous.** Without distinct visual treatment, statuses (active/inactive, success/failure, available/unavailable) blur together.
+
+## Sub-skills in this cluster
+
+- **similarity-grouping** — Using similarity to group related items: navigation items, status indicators, list items, dashboard cards.
+- **similarity-and-contrast** — Using deliberate dissimilarity (contrast) to distinguish items: primary vs. secondary actions, error states, emphasis.
+
+## Worked examples
+
+### Status indicators
+
+A dashboard shows servers with various statuses: green check (healthy), yellow warning (slow), red X (down), gray dash (unknown).
+
+Each status is consistently colored and shaped throughout the product. The color is the primary similarity cue (all greens are healthy), reinforced by shape (always a check) and color (always green). Users can scan a long list and identify all healthy servers at a glance.
+
+### A primary vs. secondary button distinction
+
+A form has a primary "Submit" action and secondary "Cancel" and "Save Draft" actions.
+
+The primary button uses a strong color (the brand color), bold weight, larger size. Secondary buttons use a neutral color, regular weight, same size as primary or slightly smaller. The contrast in color and weight makes the primary action immediately distinguishable.
+
+If both buttons were styled the same way, users would have to read the labels to know which was primary. With clear similarity-based contrast, the primary button is recognizable at a glance.
+
+### A list with inconsistent styling
+
+A settings page lists toggles for various options. Some toggles are styled with the system component (consistent shape, color, behavior); others are custom-styled with different colors and shapes. The user sees what should be a single list of toggles as a fragmented set of unrelated controls.
+
+The fix: apply the same toggle component (and styling) to all options. Similarity unifies the list.
+
+### Highlighting selected items
+
+A list shows multiple items, with two selected. The selected items are highlighted with a colored background (the brand color at 10% opacity). The non-selected items have no background.
+
+The color similarity makes the selected set immediately visible — even if the items are spread across a long list. The user can see at a glance how many are selected.
+
+If "selected" had been indicated with a small icon or subtle border instead, the similarity would be much weaker; users would have to scan to find selected items.
+
+### Different shapes for different roles
+
+A toolbar has navigation buttons (square), action buttons (rounded), and link buttons (no background). The shape difference signals the different roles. Within each role, the buttons share the same shape and behave similarly.
+
+This is similarity within roles and contrast between roles. Users learn the convention quickly because the shape is doing the categorization work.
+
+## Anti-patterns
+
+**Visual similarity without functional similarity.** Two buttons that look identical but trigger different kinds of actions (one navigates, one submits a form). The visual mislead is dangerous.
+
+**Functional similarity without visual similarity.** Two buttons with the same function styled differently because they appear in different parts of the UI. Users don't recognize them as related.
+
+**Color overload.** Using too many colors so similarity by color loses meaning. Five colors with clear semantic roles (primary, secondary, success, warning, error) is better than fifteen colors used arbitrarily.
+
+**Subtle differences that don't communicate.** Two button styles where the only difference is a 5% opacity change. Users can't perceive the difference, so the styling isn't doing distinguishing work.
+
+**Heavy similarity that masks real differences.** When everything in the UI is styled the same way (every card looks the same, every list item looks the same), the user can't distinguish the things that genuinely warrant different treatment.
+
+## Heuristic checklist
+
+Before settling on visual treatment, ask: **Are similar items styled similarly, and different items styled differently?** Mismatches cost user comprehension. **Is color (the strongest cue) being used to group the things that most need grouping?** If yes, reinforce with secondary cues. **Are status indicators visually distinguishable beyond just color (for accessibility)?** Pair color with shape or label. **Does the design reduce to a recognizable pattern for the user?** If users can predict that "this kind of item always looks like X," similarity is doing its job.
+
+## Related principles
+
+- **Gestalt grouping principles generally** — proximity, similarity, continuity, closure.
+- **Proximity** — items that are close in space group together; similarity reinforces or sometimes overrides proximity.
+- **Color** — color is the strongest similarity cue.
+- **Hierarchy** — similarity is one mechanism by which hierarchy is expressed.
+- **Consistency** — similarity within a product is what consistency feels like.
+- **Signal-to-Noise Ratio** — coherent similarity reduces visual noise.
+
+## See also
+
+- `references/lineage.md` — origins in Gestalt psychology and design.
+- `similarity-grouping/` — sub-skill on using similarity to create groups.
+- `similarity-and-contrast/` — sub-skill on using contrast to distinguish.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/gestalt-similarity/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/gestalt-similarity/references/lineage.md
@@ -1,0 +1,82 @@
+# Gestalt Similarity — origins and research lineage
+
+## Wertheimer and the Gestalt school
+
+The Gestalt principles of perceptual organization, including Similarity, were articulated in the 1910s and 1920s by Max Wertheimer, Wolfgang Köhler, and Kurt Koffka, working in Germany and later (after fleeing Nazi persecution) in the United States. Wertheimer's 1923 paper "Untersuchungen zur Lehre von der Gestalt II" laid out the core grouping principles that became foundational for the school.
+
+The Gestalt insight: perception is not a passive registration of sensory input. The brain actively organizes the visual field into structured wholes (Gestalten) using a small set of grouping principles. The whole is genuinely "more than the sum of the parts" — a face is not perceived as separate features but as a unified face; a melody is not perceived as separate notes but as a unified phrase.
+
+The grouping principles articulated by the Gestalt school:
+
+- **Proximity:** elements close together group.
+- **Similarity:** elements alike in some attribute group.
+- **Continuity:** elements aligned along a path group.
+- **Closure:** elements that suggest a closed figure group.
+- **Common fate:** elements moving together group.
+- **Symmetry:** symmetric elements group.
+- **Figure-ground:** elements separate into figure (object) and ground (background).
+
+Similarity was identified as one of the strongest grouping cues, particularly when shared attributes are visually salient (color, size, shape).
+
+## Subsequent research on similarity
+
+The Gestalt principles were initially proposed based on phenomenological observation (Wertheimer's classic demonstrations involve dot patterns where the grouping is intuitively obvious). Later experimental research has tested and refined the principles quantitatively.
+
+Key findings:
+
+- **Color is a stronger grouping cue than shape, which is stronger than size, in most studies.** The exact ranking depends on the specific manipulation (how different the colors, how different the shapes, etc.), but color consistently dominates.
+- **Multiple similarity cues compound.** When two items share both color and shape, the grouping is stronger than when they share only one attribute.
+- **Similarity can overcome proximity.** If items are alike in color but distant in space, the color grouping often dominates the spatial grouping. "Make all the red ones group" wins over "make all the items in this region group."
+- **Similarity grouping is automatic and pre-attentive.** It happens within ~200ms of visual exposure, before conscious analysis. Designs can rely on the user's perception forming the groups without needing instruction.
+
+## In design practice
+
+Similarity has been used in design for centuries, even before the Gestalt school named it:
+
+- **Cartography and information design.** Maps use color, shape, and size to encode categorical information (different colors for different countries, different symbols for different feature types). The Gestalt principles formalized why these techniques work.
+- **Typographic hierarchy.** All headings of the same level styled the same way (similar size, weight, color) form a coherent set; the user perceives them as the same kind of element.
+- **Wayfinding.** Signs of the same color, shape, or symbol are perceived as related (all green signs are emergency exits; all blue signs are services; all red signs are warnings).
+- **Visual communication.** Charts, diagrams, infographics rely heavily on similarity for grouping.
+
+In digital design, similarity is the foundation of design systems: components of the same type (all buttons, all cards, all modals) styled consistently form recognizable categories the user learns once.
+
+## In modern UI
+
+Modern UI conventions rely heavily on similarity:
+
+- **Status indicators:** consistent color + shape conventions for healthy/warning/error.
+- **Selection states:** consistent visual treatment (highlight color) across all selectable items.
+- **Action priority:** consistent visual treatment for primary vs. secondary actions across all surfaces.
+- **Navigation:** items in the same nav level styled similarly.
+- **Categorization in lists:** items of the same category sharing visual treatment (icon, color, badge).
+
+Without similarity, UIs become incoherent — users can't form the perceptual groups that allow them to scan and understand the layout.
+
+## Empirical findings worth remembering
+
+- **Color similarity grouping is strongest.** Reach for color when you want strong grouping.
+- **Shape similarity is moderate.** Useful for distinguishing categories.
+- **Size similarity expresses hierarchy.** Larger = more important; sizes within a level should be consistent.
+- **Multiple cues compound.** Color + shape + size together produces very strong grouping.
+- **Similarity can fight proximity.** Use deliberately; sometimes you want similarity to override proximity (highlighting selected items in a list), sometimes you want them to align (cards in a grid sharing both proximity and similarity).
+- **Pre-attentive processing is fast and automatic.** Similarity-based grouping happens before the user thinks about the screen.
+
+## When the principle is misapplied
+
+Two common misapplications:
+
+**Visual similarity for things that aren't actually similar.** Two buttons that look the same but trigger different kinds of actions. The user's perceptual grouping says "these are the same thing," and the behavior contradicts it.
+
+**Visual dissimilarity for things that are actually similar.** Two functionally-equivalent items styled differently. The user's perceptual grouping says "these are different things," and they don't recognize them as related.
+
+The principle is useful only when the visual similarity tracks functional similarity. When they diverge, similarity becomes a misleading cue.
+
+## Sources informing this principle
+
+- Wertheimer, M. (1923). Untersuchungen zur Lehre von der Gestalt II. (Foundational Gestalt grouping paper.)
+- Koffka, K. (1935). *Principles of Gestalt Psychology*.
+- Köhler, W. (1947). *Gestalt Psychology*.
+- Palmer, S. E. (1999). *Vision Science: Photons to Phenomenology*. (Modern empirical synthesis of Gestalt findings.)
+- Ware, C. (2012). *Information Visualization: Perception for Design*. (Application of perceptual psychology to information design.)
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*.
+- Wertheimer's original demonstrations of dot patterns and grouping (still widely reproduced in HCI courses).

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-color-and-tone/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-color-and-tone/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: hierarchy-color-and-tone
+description: 'Use this skill when constructing visual hierarchy through color and tone (value, contrast, saturation) — picking which elements get full-color emphasis and which recede into greys, building a tone ladder, and deciding when color should *be* the hierarchy versus when it should *support* a size/weight hierarchy. Trigger when picking the primary color, building a neutral palette, designing a status badge system, or fixing a UI where color is "too loud" or "too flat." Sub-aspect of the broader `hierarchy` principle; read that first if you haven''t already.'
+---
+
+# Hierarchy through color and tone
+
+Color is the most attention-grabbing visual dimension and the most accessibility-loaded. Used well, it can establish a hierarchy of importance at a glance. Used poorly, it creates noisy, fatiguing, or inaccessible UIs. This skill is about using color and tone deliberately, as a *third* hierarchy axis on top of size and weight — almost never as the *only* hierarchy signal.
+
+## When this is the decisive sub-aspect
+
+- You're picking the primary color, accent palette, and neutral ramp for a design system.
+- You're designing status badges, semantic colors (success/warning/danger), or a chart palette.
+- You have a layout where size and weight hierarchy work but the page still feels "flat" or "monochrome."
+- You're trying to fix a "noisy" UI — too many colors, all competing.
+- You're checking accessibility and need to keep hierarchy intact while satisfying contrast requirements.
+
+## Core ideas
+
+### Tone (value/contrast) is the universal hierarchy axis
+
+*Value* is how light or dark a color is; *contrast* is the value difference between figure and ground. Tone hierarchy works across hue, theme (light/dark), color blindness, and grayscale rendering. It's the most robust hierarchy dimension you have.
+
+A workable tone ladder for foreground text on a light background:
+
+```
+primary text       hsl(0 0% 9%)      contrast 19.9:1   /* near-black */
+secondary text     hsl(0 0% 35%)     contrast  9.9:1
+tertiary text      hsl(0 0% 50%)     contrast  6.4:1
+disabled text      hsl(0 0% 70%)     contrast  3.6:1   /* WCAG AA fails for body */
+```
+
+Use this ladder *additively* with size and weight: `display` is large + heavier *and* highest contrast; `caption` is small + light *and* lowest contrast. The three axes compound.
+
+Mirror the ladder for dark themes (light values on a dark ground), tuned for the different perceptual response to light-on-dark.
+
+### Color (hue) carries categorical meaning, not rank
+
+Hue is a categorical signal: red, blue, green are *different kinds*, not different *amounts*. Using hue to rank items ("red is most important, orange is next, yellow is third") fails for colorblind viewers and contradicts cultural expectations.
+
+Use hue to encode **category** or **state**, not rank:
+
+- **Status semantics:** green = success, yellow = warning, red = danger/destructive.
+- **Brand emphasis:** the primary brand color marks the action the brand wants you to take.
+- **Categorical data:** chart series, tag colors, project labels.
+
+For *ranking*, use tone (value) and saturation, which behave like amounts.
+
+### Saturation distinguishes emphasis from background
+
+Saturated colors call for attention; desaturated colors recede. A useful pattern: full-saturation for emphasis, desaturated/muted for background.
+
+```
+primary action       full saturation, full hue       /* "Save" button */
+recommended option   medium saturation               /* hover, selected state */
+disabled / inactive  desaturated to grey             /* unavailable items */
+```
+
+When a brand color appears everywhere at full saturation, it loses meaning — the eye dismisses it as decoration. Reserve saturation for the things you want noticed.
+
+### One primary color, one or two semantic colors, the rest neutral
+
+A common failure mode: the brand has a primary, secondary, tertiary, and accent color, plus warning, error, success, info. Eight colors in active use means the eye can't tell what means what.
+
+A robust default palette has three roles in active color:
+
+1. **Primary** — the brand color, used for primary actions and selection states.
+2. **Destructive** — red, used only for destructive actions and errors.
+3. **Success / muted positive** — used sparingly for confirmation states and positive deltas.
+
+Everything else lives in the **neutral ramp** (5–10 grey values from background to primary text). Neutrals do most of the work; color is reserved for moments.
+
+### Build a neutral ramp
+
+A useful neutral ramp at 9 stops:
+
+```
+neutral-50    background, lightest                hsl(0 0% 98%)
+neutral-100   subtle background, hover            hsl(0 0% 96%)
+neutral-200   borders, dividers                   hsl(0 0% 92%)
+neutral-300   strong borders, disabled inputs     hsl(0 0% 85%)
+neutral-400   placeholder text, icons             hsl(0 0% 65%)
+neutral-500   muted text, captions                hsl(0 0% 50%)
+neutral-600   secondary text                      hsl(0 0% 40%)
+neutral-700   primary body text                   hsl(0 0% 27%)
+neutral-800   strong text, headings               hsl(0 0% 18%)
+neutral-900   highest contrast, display text      hsl(0 0% 9%)
+```
+
+For dark themes, invert (but slightly compress, since white-on-black is more glaring than black-on-white).
+
+When you find yourself reaching for a "fourth" colored element on a page, stop. It probably belongs in the neutral ramp.
+
+### Color tinted toward the primary
+
+A subtle move that lifts perceived quality: tint your neutral ramp very slightly toward the primary brand color. Pure-grey neutrals can feel sterile; a 2–4% chroma toward the brand makes the whole UI feel cohesive.
+
+```
+/* Pure neutral */
+neutral-700: hsl(0 0% 27%);
+
+/* Tinted toward a blue brand */
+neutral-700: hsl(220 6% 28%);
+```
+
+The difference is invisible side by side and obvious on the whole UI.
+
+## Worked example: a status badge system
+
+Three badges encoding three states. Color carries the category; tone and weight carry the rank.
+
+```html
+<style>
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1.4;
+  }
+  .badge-success {
+    background: hsl(142 70% 96%);
+    color:      hsl(142 70% 22%);   /* dark text on light tint, contrast > 7:1 */
+  }
+  .badge-warning {
+    background: hsl(38 95% 95%);
+    color:      hsl(38 90% 25%);
+  }
+  .badge-destructive {
+    background: hsl(0 80% 96%);
+    color:      hsl(0 75% 32%);
+  }
+  .badge-neutral {
+    background: hsl(0 0% 96%);
+    color:      hsl(0 0% 30%);
+  }
+</style>
+
+<span class="badge badge-success">●  Paid</span>
+<span class="badge badge-warning">●  Pending</span>
+<span class="badge badge-destructive">●  Overdue</span>
+<span class="badge badge-neutral">●  Draft</span>
+```
+
+Each badge uses *both* hue (category) and tone (legibility). The dot icon adds a non-color signal so colorblind users can still differentiate at a glance.
+
+## Worked example: a primary action among secondary actions
+
+```html
+<style>
+  .btn { padding: 0.5rem 1rem; border-radius: 0.375rem; font-weight: 500; cursor: pointer; }
+  .btn-primary {
+    background: hsl(220 90% 50%);
+    color: white;
+    border: 0;
+  }
+  .btn-secondary {
+    background: white;
+    color: hsl(0 0% 27%);
+    border: 1px solid hsl(0 0% 85%);
+  }
+  .btn-tertiary {
+    background: transparent;
+    color: hsl(0 0% 40%);
+    border: 0;
+  }
+</style>
+
+<button class="btn-tertiary">Cancel</button>
+<button class="btn-secondary">Save draft</button>
+<button class="btn-primary">Publish</button>
+```
+
+The primary uses full saturation + brand hue + white text. The secondary uses neutral-on-neutral (no color emphasis). The tertiary uses no surface, just dimmer text. The eye picks the primary instantly.
+
+## Anti-patterns
+
+- **Color as the only signal.** "Required fields are red." A red asterisk works in conjunction with the word "required" or `aria-required`. Color alone fails ~8% of male users (red-green color blindness) and anyone in glare or with degraded vision.
+- **Brand color everywhere.** When every link, every heading, every active state, every illustration is the brand color, the brand color stops registering. Reserve it for moments.
+- **Saturated everything.** A page of fully-saturated icons, badges, illustrations, and CTAs is a noise field. Pick which 1–3 things deserve full saturation; mute the rest.
+- **Mid-tone trap.** Body text at hsl(0 0% 50%) (mid-grey) on white *just* clears WCAG AA at 18px. It feels elegant in design comps and tires real users in real lighting. Use neutral-700 or darker for body.
+- **Decorative status colors.** A red border around a card that has no error, just because it "looks important." Status colors should only carry semantic meaning; otherwise users learn to dismiss them.
+- **Ten-color palette.** Every product role gets its own bespoke color. Users can't learn the system; the brand fragments. A workable palette is small.
+
+## Heuristics and accessibility
+
+1. **Grayscale test.** Convert your design to grayscale. Hierarchy that survives is robust. If everything collapses to similar-grey, you were leaning on color alone.
+2. **Contrast ratios.** Body text ≥ 4.5:1 (WCAG AA); large text ≥ 3:1; UI components and graphical objects ≥ 3:1. Use any contrast checker. Failing contrast is a hierarchy failure as well as an accessibility one — low-contrast text *literally* recedes from view.
+3. **Color-blindness simulation.** View the design through a deuteranopia filter (Chrome DevTools → Rendering → Emulate vision deficiencies). Status that depends on red/green collapse here.
+4. **The "first color you notice" check.** Ask someone to glance at the page for 1 second; what color do they remember? It should be your intended emphasis. If it's an accidental detail (a stock photo, an icon), the hierarchy is wrong.
+
+## Trade-offs and warnings
+
+- **Color is non-portable across cultures.** Red signals luck and prosperity in much of East Asia, danger and stop in much of the West. Don't assume your palette transfers.
+- **Color is non-portable across themes.** A palette tuned for light theme often fails in dark — saturation perception inverts, contrast ratios change. Test both.
+- **Color is non-portable across devices.** OLED vs. LCD vs. e-ink, calibrated vs. uncalibrated, sun vs. dim. Tone ladders are more portable than hue choices.
+- **Color is non-portable across abilities.** Build a hierarchy that works in grayscale; add color *on top* of it as enhancement, not as the substrate.
+
+## Related principles
+
+- **`hierarchy`** — parent skill. Read it for full framing.
+- **`hierarchy-typographic`** and **`hierarchy-spatial`** — color works best as a third axis on top of these.
+- **`color`** — the broader principle of color-as-language; cultural meaning, accessibility.
+- **`red-effect`** — red specifically; reserve for genuine urgency.
+- **`signal-to-noise-ratio`** — too many colors reduces SNR; restraint multiplies the signal.
+- **`accessibility`** (process plugin) — color decisions are accessibility decisions; build for both.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-color-and-tone/references/color-systems.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-color-and-tone/references/color-systems.md
@@ -1,0 +1,89 @@
+# Color systems and contrast research
+
+A reference on color hierarchy beyond the practical patterns: the perceptual research underneath, common color-system architectures, and cross-domain examples.
+
+## Perceptual research underpinning
+
+### Why tone (value) is the universal signal
+
+The retina has roughly 120 million rod cells (sensitive to brightness only) and 6 million cone cells (sensitive to color). Brightness perception is faster, more peripheral, and operates in low-light conditions where color perception fails. This is why grayscale photography reads as readily as color, and why a tone-driven hierarchy survives nearly any viewing condition.
+
+WCAG contrast ratios are calibrated against luminance (a photometric measure of brightness), not hue. A hierarchy that works in luminance works in monochrome, in color blindness, and in glare.
+
+### Color blindness statistics
+
+Approximate prevalence in populations of European descent:
+
+- Red-green color blindness (deuteranopia or protanopia): ~8% of men, ~0.5% of women.
+- Blue-yellow color blindness (tritanopia): ~0.01% of all populations.
+- Total color blindness (achromatopsia): ~0.003%.
+
+Other populations have different rates — generally lower red-green prevalence in some Asian and African populations.
+
+The takeaway: color hierarchy choices must work for ~10% of male viewers who can't distinguish red and green at typical saturations. Pair color with shape, position, or text always.
+
+### Color and emotion
+
+Color perception is partly innate (red attracts attention; blue calms) and partly learned (color associations vary by culture). For software targeting global audiences, lean on the innate effects (warm = energetic, cool = calm) and treat the learned effects as preferences your local audience may have.
+
+## Color system architectures
+
+### The HSL ramp
+
+Modern design systems often define color as **a brand hue plus a neutral ramp**, with semantic variants (success/warning/error) drawn from fixed hues. The HSL color model makes this tractable:
+
+```
+neutral-100  hsl(var(--brand-hue), 6%, 96%)
+neutral-200  hsl(var(--brand-hue), 6%, 92%)
+neutral-300  hsl(var(--brand-hue), 6%, 85%)
+…
+neutral-900  hsl(var(--brand-hue), 6%, 9%)
+```
+
+Tinting neutrals slightly toward the brand hue (here, 6% saturation) makes the whole UI feel cohesive without anyone consciously noticing.
+
+### The OKLCH movement
+
+CSS Color 4 introduces the OKLCH color space, which is *perceptually uniform* — equal numerical jumps correspond to equal perceived jumps. This solves a real HSL problem: at the same lightness value, blues look darker than yellows because human luminance perception varies by hue. Tone ramps in HSL drift unpredictably; OKLCH ramps stay perceptually consistent.
+
+Worth using when your design system needs precise tonal control across hues.
+
+### Material Design's tonal palettes
+
+Material 3 generates 13-stop tonal palettes per color role (primary, secondary, tertiary, error, neutral, neutral-variant). Each palette spans tone 0 to tone 100 with controlled chroma. The system ensures that any role can produce a WCAG-compliant text/background pair.
+
+The architecture is overkill for many products but useful as a reference: it shows what a fully thought-through tone system looks like.
+
+### Apple's semantic colors
+
+Apple's HIG defines colors by *semantic role* (label, secondaryLabel, tertiaryLabel, link, fill, separator, etc.) rather than by name. The OS adjusts the actual values for light/dark mode, accessibility settings, and contrast preferences. Designers don't pick "grey #888"; they pick "secondaryLabel."
+
+This semantic-naming approach is a strong pattern for any product that ships across modes.
+
+## Cross-domain examples
+
+### Wayfinding color codes
+
+The London Underground uses a fixed palette of line colors, applied consistently across maps, station signage, and trains. Each line has a unique hue. Color carries the categorical signal (which line); position and text carry the rest.
+
+This works because the system is **closed and small** (~12 lines). A color system with 50 categories couldn't sustain this.
+
+### Topographic maps
+
+Maps use color to encode altitude (greens for low, browns for high, white for snow). The choice isn't arbitrary — it tracks intuitive associations (vegetation, soil, ice). And the *value* progression (light to dark, or dark to light) carries the magnitude signal even for color-blind viewers.
+
+### Status lights
+
+Traffic-light red/yellow/green is the canonical Western status code. Software status badges inherit it. But: in some Asian contexts, red signals luck/celebration, not stop. A globally-shipped product should pair color status with icon/text.
+
+## Tools
+
+- **Realtime Colors** (realtimecolors.com) — preview a palette across real UI.
+- **Stark** (Figma plugin) — contrast checking, color blindness simulation.
+- **Coolors** (coolors.co) — palette generation.
+- **Adobe Color** — palettes derived from harmony rules; useful for non-monochrome systems.
+- **Sim Daltonism** (macOS) and **Color Oracle** (cross-platform) — color blindness simulators.
+
+## Closing
+
+Color is the loudest single dimension a designer commands. Spending it deliberately — and only on things that earn the volume — is what separates polished UIs from noisy ones.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-spatial/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-spatial/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: hierarchy-spatial
+description: 'Use this skill when constructing visual hierarchy through layout, position, size, and whitespace — not type, not color. Trigger when laying out a page or section and deciding what gets the dominant region, where to place the focal element, how much breathing room to give it, and how secondary elements should arrange around it. Trigger when reviewing a layout that "feels cramped" or "feels lost," when a hero''s CTA is competing with surrounding content, or when a dashboard''s primary KPI is the same size as everything else. Sub-aspect of the broader `hierarchy` principle; read that first if you haven''t already.'
+---
+
+# Hierarchy through space
+
+Spatial hierarchy uses three tools: **position**, **size** (relative to neighbors), and **whitespace** (isolation around an element). Together they can carry a complete hierarchy without depending on typography or color. Spatial hierarchy is what makes a magazine spread or a museum poster work even before you read a word.
+
+## When this is the decisive sub-aspect
+
+- You're laying out a hero, dashboard, gallery, or any composition where placement and size are doing more work than type.
+- You're reviewing a screen where "everything has the same weight" — the typographic hierarchy is fine but the layout is flat.
+- You need to elevate one element among many roughly equivalent ones (a featured project, a recommended plan, a primary metric).
+- You're working in a constrained type system (one or two sizes) and need hierarchy from elsewhere.
+
+## Core ideas
+
+### Size relative to neighbors carries hierarchy
+
+Absolute size matters less than *relative* size. A 200×200 card next to other 200×200 cards is neutral. The same card at 200×200 next to seven 100×100 cards is dominant. Scale operates *against the local norm*; design hierarchy by establishing a norm and then breaking it deliberately.
+
+In CSS Grid, this is `grid-column: span N` and `grid-row: span N`:
+
+```html
+<section style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem;">
+  <article class="featured" style="grid-column: span 2; grid-row: span 2;">…primary…</article>
+  <article>…secondary…</article>
+  <article>…secondary…</article>
+  <article>…secondary…</article>
+  <article>…secondary…</article>
+  <article>…secondary…</article>
+  <article>…secondary…</article>
+</section>
+```
+
+The featured article occupies four times the area of its neighbors. The eye lands there first.
+
+### Position privileges (in left-to-right scripts)
+
+The eye, given an unfamiliar uniform layout, falls back to the **Z-pattern** (Gutenberg Diagram): top-left → top-right → bottom-left → bottom-right. Use this:
+
+- **Top-left** is the *primary optical area*. A logo, page title, or brand mark goes here naturally.
+- **Top-right** is the *strong fallow*. Useful for a primary CTA or account chrome.
+- **Bottom-right** is the *terminal area*. The eye exits here; place the conversion CTA in conversion-focused layouts.
+- **Bottom-left** is the *weak fallow*. Recede secondary content here.
+
+When hierarchy is *strong*, this default is overridden by the dominant element. When hierarchy is *weak*, the Z-pattern takes over by default.
+
+In RTL scripts, mirror the pattern.
+
+### Whitespace as a hierarchy signal
+
+Whitespace around an element communicates importance. A primary heading with 4rem of margin above and below reads as more significant than the same heading with 0.5rem of margin. The element seems to *occupy* its space, not merely *fill* it.
+
+The rough rule: *the more space around an element, the more important it appears* — up to a point where excess space starts to read as accident or empty page.
+
+A worked example using a vertical rhythm:
+
+```css
+:root {
+  --rhythm-tight: 0.25rem;   /* between label and input */
+  --rhythm-base:  1rem;      /* between fields in a section */
+  --rhythm-loose: 2rem;      /* between sections */
+  --rhythm-major: 4rem;      /* between page regions */
+  --rhythm-hero:  8rem;      /* hero/marketing surfaces */
+}
+
+.field-group   > * + * { margin-top: var(--rhythm-tight); }
+.section       > * + * { margin-top: var(--rhythm-base); }
+.page          > section + section { margin-top: var(--rhythm-loose); }
+.page-region   { padding-block: var(--rhythm-major); }
+.hero-section  { padding-block: var(--rhythm-hero); }
+```
+
+Five rhythm levels, each ~2x the previous. The eye reads the spacing as nesting: the things closest are most related; the things farthest are most separate (Proximity); the things with the most surrounding space are most important (Hierarchy).
+
+### Aspect ratio and orientation
+
+A wide element reads as expansive (banner, hero); a tall element reads as deep (sidebar, column); a square element reads as neutral (card, tile). Choose aspect ratio to match the role:
+
+- **Hero / banner / page header** — wide (≥ 16:9 or 21:9). Establishes presence.
+- **Card / tile** — square or 4:3 / 3:4. Neutral; designed to repeat.
+- **Sidebar / column** — tall and narrow. Recedes laterally.
+- **Modal / dialog** — typically 4:3 or 3:2 — wide enough for content, tall enough to feel deliberate.
+
+Mismatching aspect to role makes hierarchy fight the layout.
+
+### Centering and alignment as hierarchy signals
+
+Center alignment is high-attention but inflexible (you can't add another centered thing without competition). Left alignment is lower-attention but extensible. Right alignment is rare and signals secondary action (e.g., toolbar overflow menu).
+
+A useful rule: **center the one element you want the user to look at first; left-align everything else.**
+
+```html
+<section class="hero">
+  <h1 style="text-align: center;">Run payroll in minutes</h1>      <!-- centered: the focal element -->
+  <p   style="text-align: center;">Not hours. Not the next morning.</p>  <!-- centered: paired support -->
+  <div style="text-align: center;"><button>Start free trial</button></div>
+</section>
+
+<section class="features" style="margin-top: 6rem;">
+  <h2>What you get</h2>           <!-- left-aligned: secondary section -->
+  <ul>
+    <li>Automatic tax calculations</li>
+    <li>Direct deposit to 50 states</li>
+    <li>Year-end W-2 / 1099 generation</li>
+  </ul>
+</section>
+```
+
+The hero is centered; the rest is left-aligned. The eye registers the difference and treats the hero as the moment.
+
+## Worked example: a marketing landing page
+
+Combining all the spatial hierarchy tools:
+
+```html
+<main class="landing">
+  <!-- Hero: centered, generous space, dominant -->
+  <section style="padding: 8rem 1rem; text-align: center;">
+    <h1 style="font-size: 4rem; max-width: 32ch; margin: 0 auto;">
+      Run payroll in minutes, not hours
+    </h1>
+    <p style="font-size: 1.25rem; max-width: 50ch; margin: 1.5rem auto 0;">
+      Built for small teams that don't have a dedicated finance person.
+    </p>
+    <div style="margin-top: 3rem;">
+      <button class="primary">Start free trial</button>
+    </div>
+  </section>
+
+  <!-- Features: 3-up grid, left-aligned, recessed -->
+  <section style="padding: 4rem 1rem; max-width: 1100px; margin: 0 auto;">
+    <h2>Designed for small teams</h2>
+    <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 2rem; margin-top: 3rem;">
+      <article><h3>Automatic taxes</h3><p>...</p></article>
+      <article><h3>Direct deposit</h3><p>...</p></article>
+      <article><h3>Year-end forms</h3><p>...</p></article>
+    </div>
+  </section>
+
+  <!-- Featured customer: dominant within its section -->
+  <section style="padding: 4rem 1rem; background: #f7f7f7;">
+    <div style="display: grid; grid-template-columns: 2fr 1fr; gap: 4rem; max-width: 1100px; margin: 0 auto;">
+      <blockquote style="font-size: 1.5rem; line-height: 1.5;">
+        "We went from spending two days on payroll each month to twenty minutes."
+      </blockquote>
+      <div>
+        <p>Clara Mendoza</p>
+        <p>COO, Bright Labs</p>
+      </div>
+    </div>
+  </section>
+</main>
+```
+
+Three spatial hierarchies: hero dominant via centering + space; features uniform via grid; testimonial dominant within its section via 2:1 split. The page reads top-to-bottom with clear focal moments.
+
+## Anti-patterns
+
+- **Equal-space everything.** Every section the same height, every gap the same size. The eye gets no rhythm; the whole page feels mechanical.
+- **Centered everything.** Centering for emphasis works because most content is left-aligned. Center every paragraph and the emphasis collapses.
+- **The fold panic.** Cramming the hero, three features, and a CTA "above the fold" because of an imagined scroll-aversion. Modern users scroll without resistance; let the hero breathe and the CTA earn its place.
+- **The wall of cards.** A grid of identical cards with no featured tile is a "browsing" composition, not a "reading" composition. If the user is supposed to act, elevate one card.
+- **Whitespace where attention should be.** Massive whitespace around a recessive element makes the eye land on emptiness. Whitespace amplifies attention; aim it at things that earn it.
+
+## Heuristics
+
+1. **Mass diagram.** Sketch the page as filled black blocks with no detail. The dominant block should be 2–4× any other. If all blocks are similar size, hierarchy is flat.
+2. **The 30-foot test.** Stand back from your screen at distance until labels are unreadable. The composition should still tell you what's important.
+3. **Trace the eye-path.** Draw the line your eye follows through the composition. It should land on the primary first, sweep through secondaries, and exit at a CTA or terminal. If your eye-path is chaotic or returns to the primary repeatedly, refine.
+
+## Related principles
+
+- **`hierarchy`** — parent skill. Read it for full framing.
+- **`hierarchy-typographic`** — type-driven hierarchy; combines with spatial.
+- **`proximity`** — spacing between elements (Gestalt grouping); compounds with spatial hierarchy.
+- **`alignment`** — spatial hierarchy operates on a grid; misalignment fights it.
+- **`gutenberg-diagram`** — the default eye-path when hierarchy is absent.
+- **`horror-vacui`** — the impulse to fill empty space; resist it on important surfaces.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-spatial/references/composition-traditions.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-spatial/references/composition-traditions.md
@@ -1,0 +1,99 @@
+# Spatial composition: traditions and cross-domain examples
+
+A reference on spatial hierarchy beyond software UI — drawn from painting, photography, architecture, and graphic design traditions where these techniques were refined for centuries before the screen existed.
+
+## Composition traditions
+
+### The classical grid
+
+Renaissance painters and Beaux-Arts architects used proportional grids derived from the human body, the golden ratio, and root rectangles (√2, √3). The same proportions show up in:
+
+- **Le Corbusier's Modulor** — a proportional system based on human dimensions, used to lay out the buildings at La Tourette.
+- **Tschichold's typography** — Jan Tschichold's *Die neue Typographie* (1928) translated grid systems from print to graphic design.
+- **The Swiss Style** — Müller-Brockmann's grid systems for Helvetica-era posters and books, eventually inheriting the entire visual vocabulary of corporate identity in the 60s–70s.
+
+A modern 12-column responsive web grid is a direct descendant of these traditions.
+
+### Rule of thirds
+
+In painting, the rule of thirds (placing focal elements on the intersections of a 3×3 grid) goes back at least to Sir Joshua Reynolds (18th century) and was codified by John Thomas Smith (1797). It became standard in photography composition.
+
+The rule isn't a law — Renaissance painters often centered focal points (Leonardo's *Mona Lisa*) — but for off-center compositions where dynamic tension matters, thirds-grid intersections feel "right" in a way symmetric centers don't.
+
+### The golden rectangle
+
+Whether the golden ratio's appearance in nature and art is causal or coincidental is debated, but it's repeatedly chosen by designers as a "starting proportion" for hero compositions. Mondrian's grid paintings, Greek temple facades, and many film aspect ratios approximate golden ratios.
+
+For software hero layouts, `grid-template-columns: 1fr 1.618fr` is a useful starting point that often feels right.
+
+## Whitespace as a hierarchy signal
+
+The most expensive luxury good in spatial design is often *the absence of content*. A page with vast whitespace around a single element communicates "this matters." A page with everything stuffed against the margins communicates "we couldn't decide what mattered."
+
+Cross-domain examples:
+
+- **Apple's product pages.** A single product floating on a white field. Every pixel of empty space around it costs revenue (no upsell content can live there) — and the empty space is part of the brand.
+- **High-end print advertising.** A small logo and tagline in a sea of color. The Tiffany blue is whitespace.
+- **Museum signage.** Wall text labels for paintings sit in 12-inch-tall fields with maybe 30 words. The negative space around them gives the painting room to be the figure.
+
+Software UIs underdo whitespace by default because content is "free" — adding another card costs nothing. The discipline of leaving emptiness costs nothing in pixels but adds enormous perceived value.
+
+## Mass and visual weight
+
+Spatial hierarchy isn't only about position; it's about visual *mass* — how much visual weight an element carries.
+
+Mass increases with:
+
+- Size (larger = more mass).
+- Density (more elements packed together = more mass).
+- Contrast (darker, more saturated = more mass).
+- Texture (busier surface = more mass).
+- Vertical position (higher on the page often reads as more mass, perhaps because gravity intuitions).
+
+When laying out a composition, balance the *masses* across the layout, not the bounding boxes. A large empty area can balance a small dense area.
+
+This is what painters mean by "compositional balance" — and it's what Bertin's *Sémiologie graphique* formalized as the visual variable of *value* and *texture*.
+
+## Thumbnail composition
+
+A useful exercise borrowed from painting: thumbnail your layouts. Draw 10 thumbnails (each ~3 inches square) of possible compositions, blocking out the masses without any detail. Pick the strongest few; refine.
+
+Designers who rush to high-fidelity mockups skip this — and end up over-investing in a composition that's spatially weak. The thumbnail audit is fast, cheap, and reveals the strongest hierarchy decisions before pixels are spent.
+
+## Z-pattern, F-pattern, and beyond
+
+When a layout has *no* dominant hierarchy, eye-tracking research shows the eye follows learned reading patterns:
+
+- **Z-pattern** for uniform pages with little content (typical landing pages): top-left → top-right → bottom-left → bottom-right.
+- **F-pattern** for content-dense pages (news, blogs): horizontal sweep across top, then down the left edge with shorter horizontal sweeps.
+- **Layer cake** for sectioned content: a horizontal sweep at each section heading, then skip down.
+
+Strong hierarchy *overrides* these patterns. Weak hierarchy lets them dominate. As a designer, you can either fight the default pattern (with strong hierarchy) or work with it (positioning important content where the eye lands by default).
+
+## Mobile composition
+
+Mobile screens compress every spatial decision. A few rules:
+
+- **Vertical stacking is the default.** Don't try to preserve a desktop two-column layout at 375px wide.
+- **Bottom-zone for primary action.** Thumb reach + edge advantage.
+- **Generous tap targets ≥ 44px.** No "compact" version on touch.
+- **Lighter spacing scale.** A scale that uses 32px section gaps on desktop probably uses 24px on mobile to fit more content per scroll-screen.
+
+Mobile rewards single-column, sequential layouts with clear hierarchy. Don't try to be clever with multi-column on small screens.
+
+## Edge cases
+
+- **Right-to-left scripts.** Mirror Z-pattern and F-pattern. Many spatial intuitions reverse: leading edges are right-side, terminal areas are left.
+- **Non-Latin typography.** CJK languages don't have the same letter-shape variation that drives some Western type-hierarchy choices; weight and size matter more, italics matter less.
+- **Voice and screen-reader contexts.** No spatial hierarchy. Linear order matters; structural markup (headings, landmarks) carries the equivalent role.
+
+## Resources
+
+- **Müller-Brockmann, J.** *Grid Systems in Graphic Design* (1981). The reference work on grid theory from one of the masters of the Swiss Style.
+- **Tschichold, J.** *The Form of the Book* (1991). On book design proportions.
+- **Itten, J.** *Design and Form* (1963). On compositional balance.
+- **NN/g eye-tracking studies** on F-pattern, Z-pattern, layer cake — many publicly available articles.
+
+## Closing thought
+
+Spatial hierarchy looks effortless when it works because the eye finds focal points without effort. The work is in the editor's restraint: deciding what *not* to put on the page so what remains has room to dominate.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-typographic/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-typographic/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: hierarchy-typographic
+description: 'Use this skill when the question is specifically about how to construct visual hierarchy through typography — picking a type scale, ladders of weight, line-height steps, and the relationships between display, heading, body, and caption type. Trigger when designing type systems, choosing fonts, picking heading sizes, defining a design system''s typographic tokens, fixing a "no clear focal point in the headline area" issue, or reviewing why a long-form page feels like a wall of text. Sub-aspect of the broader `hierarchy` principle; read that first if you haven''t already.'
+---
+
+# Hierarchy through typography
+
+Typography alone can carry a complete hierarchy without color, color alone, or layout tricks. A well-constructed type system gives you 4–6 distinct ranks of importance using nothing but size, weight, and (sometimes) tracking and tone. This skill covers how to build that system.
+
+## When this is the decisive sub-aspect
+
+- You're picking the type tokens for a new design system (display, h1, h2, h3, h4, body-lg, body, body-sm, caption, micro).
+- You're working in a constrained color palette (monochrome, a single brand color) and need hierarchy without leaning on hue.
+- The page is text-heavy (docs, articles, settings descriptions, emails) and feels like a wall.
+- You're reviewing a layout where headings, sub-heads, and body text don't read as distinct ranks.
+
+## Core ideas
+
+### Pick a type scale, not arbitrary sizes
+
+A *type scale* is a multiplicative ratio applied to a base size to generate a series of harmonious sizes. Common scales:
+
+- **1.125** (Major Second) — very subtle. Good for dense application UI where step changes between sizes shouldn't shout.
+- **1.2** (Minor Third) — gentle, common in software UI.
+- **1.25** (Major Third) — a solid default for general web; what Tailwind's default scale approximates.
+- **1.333** (Perfect Fourth) — feels editorial; good for content sites.
+- **1.414** (Augmented Fourth, √2) — common in print.
+- **1.5** (Perfect Fifth) — bold, feels like a magazine layout.
+- **1.618** (Golden Ratio) — dramatic, marketing/hero scale.
+
+Pick *one* ratio per project. Mixing ratios across sizes destroys the rhythm.
+
+A worked scale at base 16px and ratio 1.25:
+
+```
+caption  10.24 px   (16 / 1.25 / 1.25)
+body-sm  12.80 px   (16 / 1.25)
+body     16.00 px   (base)
+body-lg  20.00 px   (16 * 1.25)
+h4       25.00 px   (16 * 1.25^2)
+h3       31.25 px   (16 * 1.25^3)
+h2       39.06 px   (16 * 1.25^4)
+h1       48.83 px   (16 * 1.25^5)
+display  61.04 px   (16 * 1.25^6)
+```
+
+Rounded to friendly numbers (10, 13, 16, 20, 25, 31, 39, 49, 61), this gives you a 9-step ladder with consistent visual jumps between any two adjacent steps.
+
+### Use weight as a second axis
+
+Size alone is enough for hierarchy in body-vs.-heading contexts but is a blunt tool when you need fine distinctions. Weight gives you a second axis. A useful weight ladder:
+
+```
+hairline / thin    100   — display only, never body
+light              300   — large display sizes; never small
+regular            400   — body
+medium             500   — UI labels, buttons
+semibold           600   — headings, emphasis
+bold               700   — strong emphasis, heavy display
+black              900   — display only
+```
+
+Most software UIs need only three weights: regular (400), medium (500), and semibold (600). Reach for bolder weights only at display sizes; bold at body size is hard to read.
+
+### Combine size and weight, don't trade them
+
+A common mistake is treating size *or* weight as the hierarchy signal. They compound:
+
+- A 24px-semibold heading reads as much higher in the hierarchy than a 24px-regular heading, even though the size is identical.
+- A 16px-regular body paragraph and a 16px-medium label are perceived as different ranks despite identical size.
+
+When constructing a step in your hierarchy, *both* dial up: bigger headings should also be bolder. The exception is display type (very large), which often *decreases* in weight at the largest sizes (light or regular at 60px+ reads as elegant; black at 60px+ reads as shouting).
+
+### Line height (leading) is part of the system
+
+Tighter leading (1.1–1.25) suits display and headings. Looser leading (1.5–1.75) suits body. Mismatch a heading with body leading (1.5) and the heading feels droopy; mismatch a body with display leading (1.2) and reading becomes hard.
+
+A workable mapping:
+
+```
+display, h1, h2:   line-height 1.1–1.25
+h3, h4:            line-height 1.25–1.4
+body, body-lg:     line-height 1.5–1.75
+body-sm, caption:  line-height 1.4–1.6
+```
+
+### Line length (measure)
+
+For sustained reading, constrain body text to roughly 45–75 characters per line (≈ 65ch is a common default). Longer lines fatigue eye-tracking; shorter lines fragment thought. Headings can be wider; captions and labels can be tighter.
+
+```css
+.body-text { max-width: 65ch; }
+```
+
+### Tracking (letter-spacing)
+
+Generally leave tracking alone. Two cases where it earns adjustment:
+
+- **All-caps labels and small caps:** add ~0.04–0.08em of tracking; they read tightly otherwise.
+- **Very large display type:** subtract a small amount (-0.01 to -0.02em); large type looks loose without it.
+
+## Worked example: a complete typographic hierarchy in CSS
+
+```css
+:root {
+  /* Type scale at ratio 1.25, base 16px */
+  --text-caption: 0.64rem;   /* 10.24 */
+  --text-sm:      0.80rem;   /* 12.80 */
+  --text-base:    1.00rem;   /* 16.00 */
+  --text-lg:      1.25rem;   /* 20.00 */
+  --text-xl:      1.563rem;  /* 25.00 */
+  --text-2xl:     1.953rem;  /* 31.25 */
+  --text-3xl:     2.441rem;  /* 39.06 */
+  --text-4xl:     3.052rem;  /* 48.83 */
+  --text-display: 3.815rem;  /* 61.04 */
+
+  /* Weight ladder */
+  --weight-body:     400;
+  --weight-label:    500;
+  --weight-emphasis: 600;
+  --weight-display:  700;
+
+  /* Leading */
+  --leading-display: 1.1;
+  --leading-heading: 1.25;
+  --leading-body:    1.6;
+  --leading-tight:   1.4;
+}
+
+.display {
+  font-size: var(--text-display);
+  font-weight: 400;          /* display gets lighter weight, paradoxically */
+  line-height: var(--leading-display);
+  letter-spacing: -0.02em;
+}
+h1 {
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-emphasis);
+  line-height: var(--leading-heading);
+  letter-spacing: -0.01em;
+}
+h2 {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-emphasis);
+  line-height: var(--leading-heading);
+}
+h3 {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-emphasis);
+  line-height: var(--leading-heading);
+}
+h4 {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-label);
+  line-height: var(--leading-heading);
+}
+body, p {
+  font-size: var(--text-base);
+  font-weight: var(--weight-body);
+  line-height: var(--leading-body);
+  max-width: 65ch;
+}
+.label, button, .ui-control {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-label);
+  line-height: var(--leading-tight);
+}
+.caption, small, .micro {
+  font-size: var(--text-caption);
+  font-weight: var(--weight-body);
+  line-height: var(--leading-tight);
+  color: rgb(0 0 0 / 0.55);   /* tone reduction adds tertiary recession */
+}
+```
+
+Eight clear ranks, all derived from one ratio, three weights, three leading values, and one tone reduction at the very bottom. This is enough hierarchy to handle any UI or content surface.
+
+## Anti-patterns
+
+- **Random sizing.** "Make this 18px" / "this 19px" / "this 22px" — close-but-not-equal sizes look like accidents. If two things should be the same rank, give them the same size; if different ranks, make the difference clear.
+- **Bold everything.** When every label, every heading, and every value is bold, none of them read as emphasized. Reserve bold for one or two roles.
+- **Gigantic body type.** Body text larger than ~18–20px starts to feel like a slide deck. Reserve large type for headings; keep body in the 14–18px range.
+- **Tiny captions.** Below 11px, anti-aliasing destroys legibility. If you find yourself reaching for 9px or 10px, you have too much content for the space — cut content rather than shrink type.
+- **Inconsistent weight per role.** "Card titles are semibold here, medium there." Decide once per role.
+
+## Heuristics
+
+1. **Print-test.** Print the page in grayscale on regular paper. Hierarchy that survives this test is robust. Hierarchy that requires color or screen brightness is fragile.
+2. **Three-rank squint.** Squint until detail blurs. You should still see a primary tier, a secondary tier, and a recessive tier. If everything is one tone of grey, hierarchy is too flat.
+3. **The body-only test.** Hide all headings; the body should still feel like prose, not a wall. If it feels like a wall, your `max-width` or leading is wrong.
+
+## Related principles
+
+- **`hierarchy`** — the parent skill. Read it for the full framing.
+- **`hierarchy-spatial`** — when type alone isn't enough, spatial hierarchy carries the rest.
+- **`hierarchy-color-and-tone`** — color and tone as a third axis on top of size+weight.
+- **`legibility`** and **`readability`** — the typeface- and layout-side of typography that hierarchy depends on.
+- **`signal-to-noise-ratio`** — too many active ranks reduces SNR; restraint multiplies the effect of each rank.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-typographic/references/type-scale-and-history.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy-typographic/references/type-scale-and-history.md
@@ -1,0 +1,106 @@
+# Type-scale history and reference
+
+A deeper reference on typographic hierarchy: where common type scales come from, why specific ratios feel right, and how typographic hierarchy is constructed in print and digital contexts beyond the modern web.
+
+## Historical type scales
+
+The "type-scale ratios" used in modern web design are not invented — they descend from centuries of typesetting practice.
+
+### The traditional metal-type sizes
+
+Before computers, typefaces were cast at fixed point sizes. The set of sizes a typesetter typically had to work with was:
+
+```
+6, 8, 9, 10, 11, 12, 14, 16, 18, 24, 30, 36, 42, 48, 60, 72
+```
+
+These aren't arbitrary; they evolved as a working compromise between geometric ratios and the practical economics of metal foundry production. The ratio between adjacent sizes is roughly 1.15–1.2, comfortable for body type. Display sizes (24+) jump in larger ratios because subtle differences are imperceptible at scale.
+
+A modern type scale at ratio 1.2 (Minor Third) approximates this traditional scale closely.
+
+### Renaissance proportions
+
+Renaissance typesetters (Aldus Manutius, Claude Garamond) often worked from geometric proportions rooted in classical architecture: the golden ratio (1.618) for page layouts, simpler integer ratios (3:4, 2:3) for type scales.
+
+Robert Bringhurst's *The Elements of Typographic Style* documents these traditions in detail. They're worth reading because the same proportional logic that worked for 15th-century books still produces calm, balanced layouts on screens.
+
+### Modular scales for the web
+
+In 2011, Tim Brown's "More Meaningful Typography" article introduced the modern web design community to *modular scales* — using a single mathematical ratio to generate a series of harmonious sizes from a base value. The popular ratios:
+
+| Ratio | Name | Where it shines |
+|---|---|---|
+| 1.067 | Minor Second | Subtle UI; very tight ladder |
+| 1.125 | Major Second | Dense application UI |
+| 1.2 | Minor Third | General software UI (Tailwind default approximates) |
+| 1.25 | Major Third | Web content sites |
+| 1.333 | Perfect Fourth | Editorial layouts |
+| 1.414 | Augmented Fourth | Print, classical |
+| 1.5 | Perfect Fifth | Bold magazines |
+| 1.618 | Golden Ratio | Hero/marketing scale |
+| 1.778 | Major Seventh | Cinematic, oversized hero |
+
+Some teams use *two* ratios — a tighter ratio for body-related sizes (caption, body, body-large) and a wider ratio for display sizes (h1, display). This produces a calm reading experience while still delivering dramatic display type.
+
+## Cross-domain examples
+
+### Newspaper typography
+
+A newspaper front page often shows 5–6 distinct type sizes:
+
+- Masthead (display, often custom typeface): 60–80 pt.
+- Lead headline: 36–48 pt.
+- Secondary headline: 18–24 pt.
+- Section heading / kicker: 9–12 pt.
+- Body: 8–10 pt.
+- Caption: 7–8 pt.
+
+Notice the *condensed* range at the body end (8, 9, 10) and the wider jumps at the display end. This is the two-ratio approach in practice.
+
+### Apple's San Francisco type system
+
+Apple's San Francisco (SF) typeface ships with a documented type scale and weight ladder spanning ~9 sizes (Caption 2 through Large Title) and ~9 weights (Ultralight through Black). The system encodes hierarchy decisions that designers don't have to re-derive every project.
+
+### Google Material's type system
+
+Material Design 3 documents a specific scale: Display Large, Display Medium, Display Small, Headline Large, Headline Medium, Headline Small, Title Large, Title Medium, Title Small, Body Large, Body Medium, Body Small, Label Large, Label Medium, Label Small. Fifteen tiers — overkill for most applications, but the structure is useful as a reference.
+
+### Web fonts and font loading
+
+A practical reality: web fonts add render-blocking work. Three patterns:
+
+- **System font stack** — `font-family: -apple-system, BlinkMacSystemFont, ...` — uses OS-default. Zero load cost; varies by platform.
+- **Variable fonts** — one file with weight and width axes. Allows continuous weight/size variation; cuts file count.
+- **Subset and preload** — load only the glyphs you use; preload critical fonts.
+
+For typographic hierarchy specifically: variable fonts are a quiet revolution. They let you fine-tune weight at every size — slightly thinner display, slightly heavier body — at no extra file cost.
+
+## The leading question
+
+Line-height (leading) interacts with type size and reading mode:
+
+- **Display type at ~1.0–1.1 line-height** — tight, no excessive air between lines.
+- **Headings at ~1.2–1.3** — distinct from body, but not so loose they break.
+- **Body at 1.5–1.7** — the canonical reading range.
+- **Captions and small labels at 1.4–1.5** — slightly tighter than body because text is smaller.
+
+The reason: the optimal line-height varies inversely with size up to a point. Big type needs less leading because the visual gap between lines is already large in absolute terms; small type needs more because the gap collapses fast as size shrinks.
+
+## Anti-patterns from print that recur on the web
+
+- **Widows and orphans.** Single-word last lines or single-line first lines on a page. Print typesetters fixed these manually; CSS now offers `widows`, `orphans`, and `text-wrap: balance` for similar control.
+- **Justified body without manual hyphenation.** Looks tidy in mockups; produces "rivers of white" in real text. Use ragged-right (`text-align: left`) for screen body; `hyphens: auto` if you must justify.
+- **Mixed typefaces without intent.** Two body typefaces and one display, none related. Pick one or two families and use weight/style to differentiate.
+
+## Resources for going further
+
+- **Bringhurst, R.** *The Elements of Typographic Style* — comprehensive print-grounded reference.
+- **Lupton, E.** *Thinking with Type* — accessible introduction.
+- **Type-Scale.com** — interactive scale generator.
+- **Modular Scale** (Tim Brown) — modularscale.com.
+- **System Font Stack** — systemfontstack.com — for OS-default fallbacks.
+- **Variable Fonts** — v-fonts.com — gallery of variable fonts.
+
+## Closing thought
+
+Typographic hierarchy is an intersection of math (the scale) and craft (the choices about which weights, leadings, and tracking values match the type at each size). The math gets you 80% of the way; the last 20% is taste developed by looking at lots of typeset pages.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: hierarchy
+description: 'Use this skill whenever a design has more than one element competing for the viewer''s attention — which is essentially every design. Trigger when laying out a screen, page, slide, poster, dashboard, or any composition where you must decide what gets seen first, what supports it, and what recedes. Trigger when reviewing a design and the user says "everything looks the same," "I don''t know where to look," "the page feels flat," or "what''s the most important thing here?" Trigger when picking type sizes, when deciding which actions to emphasize among many, or when an MVP screen has gone from one button to ten and the screen has lost its focal point. Hierarchy is the most decisive visual principle; this skill teaches how to construct it deliberately, and routes to sub-aspect skills for typographic, spatial, and color/tone hierarchy.'
+---
+
+# Hierarchy
+
+Hierarchy is the ranking of importance among visible elements, made legible to the eye through differences in size, weight, color, contrast, position, density, and surrounding space. It is the single most decisive principle in visual design: when hierarchy is well-constructed, the rest of the layout almost designs itself; when it is missing, no amount of polish recovers the page.
+
+## Definition (in our own words)
+
+A composition has *visual hierarchy* when the viewer can, at a glance and without instruction, identify a primary focal element, secondary supporting elements, and recessive background elements. Hierarchy is created by introducing **deliberate differences** along one or more visual dimensions (size, weight, color, position, density, motion). It is destroyed by making everything the same — and equally by making everything different at maximum intensity. Hierarchy is a *contrast* principle: emphasis is meaningful only against a quieter background.
+
+## Origins and research lineage
+
+The deliberate construction of visual hierarchy is one of the oldest practices in graphic communication. Its modern theoretical grounding draws from several lines of work:
+
+- **Gestalt psychology** (Wertheimer, Köhler, Koffka, c. 1910–1930) established that perception groups stimuli into wholes whose structure precedes their parts. The Gestalt laws (figure/ground, proximity, similarity, continuation) are the mechanisms by which hierarchy is read.
+- **Information design** (Bertin's *Sémiologie graphique*, 1967; Tufte's *Visual Display of Quantitative Information*, 1983) formalized the visual variables (position, size, value, texture, color, orientation, shape) that encode rank and difference.
+- **Cognitive load theory** (Sweller, 1988 onward) explains why hierarchy reduces effort: a well-ranked composition lets the viewer offload sequencing decisions onto the perceptual system.
+- **Eye-tracking studies** (Pernice, Nielsen, Pelli, and many others) have repeatedly shown that viewers fixate first on elements that are larger, brighter, higher-contrast, or positioned at common entry points (top-left in left-to-right scripts), before sweeping the rest of the page.
+
+The takeaway: hierarchy is not an aesthetic preference; it is a structural property that determines whether the composition will be readable at all.
+
+## Why hierarchy matters
+
+When you scan a page, your eye is doing two things in rapid alternation: detecting *salient* features (high-contrast, isolated, unusual) and predicting *meaningful* features based on prior knowledge of the layout type. Hierarchy aligns those two: the salient features are the meaningful ones. Without that alignment, the viewer's eye is pulled to whatever is loudest (a stray red icon, a bold word, a big image) regardless of whether that thing is important.
+
+The cost of weak hierarchy compounds: every visit, every screen, every interaction, the viewer pays a small tax to figure out what to look at. Multiply by daily users and the tax is significant.
+
+## When to apply
+
+- **Every composition with more than one element.** Even a "minimal" page with three elements is making hierarchy decisions, intentionally or otherwise.
+- **When your first draft "feels flat."** Flatness is almost always a hierarchy problem, not a color or whitespace problem.
+- **When users report not knowing where to look or what to do next.** This is hierarchy diagnosing itself.
+- **At the start of a layout pass, before pixel-perfect adjustments.** Hierarchy decisions cascade; tweak them after the fact and the cascade reverses.
+
+## When NOT to apply (or when to be careful)
+
+- **In neutral-comparison contexts.** Pricing tables, side-by-side feature comparisons, equal-weight survey options — these *want* equivalence. Adding hierarchy here biases the user. Distinguish "neutral comparison" from "recommended option" deliberately.
+- **In dense data tables where every row has equal status.** Adding hierarchy *between rows* is wrong; reserve hierarchy for the chrome (header, footer, totals) and let the rows be uniform.
+- **When you don't know what's most important yet.** Don't fake hierarchy by making something arbitrarily bigger. Hierarchy only works when it tracks real importance.
+
+## How hierarchy is constructed: the visual dimensions
+
+Hierarchy is built by varying one or more visual dimensions across elements. Each dimension has different strengths and trade-offs:
+
+| Dimension | What it does well | Cost / risk |
+|---|---|---|
+| **Size** | Strongest single signal; reads at any distance. | Cheap to overdo; gigantic headlines crowd context. |
+| **Weight** | Strong, subtle, additive to size. | Bold-fatigue when overused; loses meaning if everything is bold. |
+| **Color (hue)** | Carries categorical meaning; high attention pull. | Accessibility and cultural pitfalls; never the only signal. |
+| **Tone (value/contrast)** | Most universal; works in monochrome and accessibility modes. | Subtle; needs other dimensions for headline-level emphasis. |
+| **Position** | Top, center, leading edge — privileged by reading habits. | Real estate is finite; not every important thing fits at the top. |
+| **Whitespace / isolation** | Gives an element room to breathe; reads as importance. | Costs space; can leave a layout thin if overused. |
+| **Density / repetition** | Items repeated together read as a system; the lone item reads as primary. | Backfires if the "system" items become noise. |
+| **Motion** | Strongest attention pull; cannot be ignored. | Easily overwhelming; accessibility (vestibular triggers, motion sensitivity); use sparingly. |
+
+The competent use of hierarchy is **stacking** these dimensions: a primary heading is larger *and* heavier *and* darker *and* further from neighbors. A secondary action is medium-sized *and* outlined *and* placed left of the primary. Stacking compounds the signal; relying on a single dimension makes the hierarchy fragile.
+
+## The three-tier rule
+
+A workable default for most compositions: aim for **three** levels of hierarchy.
+
+1. **Primary** — the focal element. There should usually be exactly one per visible region. (More than one fights for attention.)
+2. **Secondary** — supporting elements that contextualize the primary. There may be several at this level.
+3. **Tertiary** — recessive background elements: navigation chrome, metadata, fine print, captions.
+
+Too few levels (everything primary, or everything tertiary) is flat. Too many levels (5+) blur into one another and the eye treats them as a continuous gradient rather than discrete ranks.
+
+## Worked examples
+
+The examples below are framework-agnostic — written in plain HTML/CSS to make the principle decisions visible. Apply them to any framework.
+
+### Example 1: a page header with title, subtitle, and metadata
+
+A common case where weak hierarchy makes the page feel flat. Three elements; we want one to dominate.
+
+**Anti-pattern (flat):**
+
+```html
+<header class="page-header">
+  <h1 style="font-size: 1.25rem; font-weight: 500;">Invoices</h1>
+  <p style="font-size: 1.25rem; color: #555;">Sent and overdue, this quarter.</p>
+  <p style="font-size: 1.25rem; color: #555;">Last updated 3 minutes ago</p>
+</header>
+```
+
+Three lines all roughly the same size, weight, and color. The eye finds no focal point.
+
+**Right (three tiers):**
+
+```html
+<header class="page-header" style="display: grid; gap: 0.25rem;">
+  <h1 style="font-size: 1.875rem; font-weight: 600; line-height: 1.2;">Invoices</h1>
+  <p style="font-size: 0.95rem; color: #555;">Sent and overdue, this quarter.</p>
+  <p style="font-size: 0.8rem; color: #888; margin-top: 0.25rem;">Last updated 3 minutes ago</p>
+</header>
+```
+
+Now the title dominates by size + weight + tone. The subtitle supports it (smaller, mid-tone). The metadata recedes (smaller still, lower contrast). Three clear tiers, one focal point.
+
+### Example 2: a button row with primary, secondary, and tertiary actions
+
+A frequent case in modal footers, form submissions, and toolbars. The wrong distribution of weight here is one of the most common UI mistakes.
+
+**Anti-pattern (all equal, eye doesn't know which to pick):**
+
+```html
+<div class="actions">
+  <button class="btn">Cancel</button>
+  <button class="btn">Save draft</button>
+  <button class="btn">Publish</button>
+</div>
+```
+
+Three same-styled buttons. The user must read all three labels and decide; primary intent is invisible.
+
+**Right (one primary, two recessive):**
+
+```html
+<div class="actions" style="display: flex; gap: 0.5rem; justify-content: flex-end;">
+  <button class="btn-ghost">Cancel</button>      <!-- tertiary: text-only, low weight -->
+  <button class="btn-outline">Save draft</button> <!-- secondary: bordered, neutral -->
+  <button class="btn-primary">Publish</button>    <!-- primary: filled, high contrast -->
+</div>
+```
+
+```css
+.btn-primary { background: #111; color: white; padding: 0.5rem 1rem; border-radius: 0.375rem; }
+.btn-outline { background: transparent; border: 1px solid #d1d5db; padding: 0.5rem 1rem; border-radius: 0.375rem; }
+.btn-ghost   { background: transparent; border: 0; color: #555; padding: 0.5rem 1rem; }
+```
+
+The primary action wins on color and weight. The secondary is recognizably a button (bordered) but quiet. Cancel is a soft escape — necessary but never the focal point.
+
+### Example 3: a dashboard tile grid
+
+Twelve KPI tiles, all the same. The eye gives up. Pick a primary KPI, make it dominate, let the rest recede.
+
+```html
+<section class="dashboard" style="display: grid; gap: 1rem; grid-template-columns: repeat(4, 1fr);">
+  <article class="tile primary" style="grid-column: span 2; grid-row: span 2;">
+    <p class="label">Monthly revenue</p>
+    <p class="value" style="font-size: 3rem; font-weight: 600;">$48.2k</p>
+    <p class="delta" style="color: #16a34a;">+12% vs last month</p>
+  </article>
+  <!-- 8 secondary tiles, smaller, recessed -->
+  <article class="tile"><p class="label">Active users</p><p class="value">12,481</p></article>
+  <article class="tile"><p class="label">Churn</p><p class="value">2.1%</p></article>
+  <article class="tile"><p class="label">NPS</p><p class="value">42</p></article>
+  <!-- ... -->
+</section>
+```
+
+The primary tile spans 2x2 grid cells, has a 3rem value, includes a delta, and dominates the composition. The secondary tiles are smaller, single-line values, no delta. The eye reads the dashboard in seconds.
+
+### Example 4: a form with required and optional sections
+
+Even forms have hierarchy: the required path is primary; optional fields are secondary; help text is tertiary.
+
+```html
+<form>
+  <fieldset class="primary">
+    <legend>Account</legend>
+    <label>Email <input type="email" required /></label>
+    <label>Password <input type="password" required /></label>
+  </fieldset>
+
+  <details class="secondary">
+    <summary>Profile (optional)</summary>
+    <label>Display name <input /></label>
+    <label>Bio <textarea></textarea></label>
+  </details>
+
+  <p class="tertiary" style="font-size: 0.8rem; color: #888;">
+    By signing up you agree to the Terms of Service.
+  </p>
+
+  <button class="btn-primary">Create account</button>
+</form>
+```
+
+Required fields are visible and primary. Optional fields are tucked behind a `<details>` disclosure (secondary). Legalese is tertiary in size and tone. The user's eye lands on the necessary path first.
+
+## Anti-patterns
+
+- **The "hierarchy of bold."** Every label is bold, every heading is bold, every number is bold. Bold has lost all meaning; the page is noisy and flat at the same time. Fix: reserve bold for one or two roles.
+- **Color as the only signal.** Important things are blue; everything else is grey. Works for sighted, non-colorblind users in good lighting; fails everywhere else. Fix: stack color with size and weight.
+- **The aspirational primary.** Designer makes the "Sign up" CTA gigantic on a settings page where 99% of users are signed in. The primary action should be the *most likely* action on this surface, not the one the business wishes were primary.
+- **Hierarchy through volume.** "Important" things are wrapped in colored boxes with thick borders and exclamation icons. Reserve heavy treatments for genuinely critical UI — destructive confirmations, errors, system warnings.
+- **No primary at all.** Every element is "secondary" because the designer didn't want to play favorites. Result: equal-weight noise. Fix: pick a primary even if it feels arbitrary; you can always change it after a usability test.
+
+## Heuristics and measurement
+
+A few quick checks for whether hierarchy is working:
+
+1. **The squint test.** Squint at the design (or blur it in Photoshop / via a CSS `filter: blur(8px)`). Can you still see one element dominating? If not, hierarchy is too weak.
+2. **The eye-trace.** Show the design to someone for 3 seconds, hide it, ask them what they remember. The thing they remember should be your primary. If it isn't, hierarchy is wrong.
+3. **The grayscale test.** Convert to grayscale. If the hierarchy collapses, you were leaning on color alone; restore it through size and weight.
+4. **The five-tier check.** Count the distinct visual ranks in your composition. More than 4–5? You probably have too much hierarchy and it's blurring.
+
+## Related principles
+
+- **`alignment`** — hierarchy operates *along* a grid; misalignment fights hierarchy.
+- **`proximity`** — proximity establishes *grouping*; hierarchy establishes *ranking* between groups.
+- **`signal-to-noise-ratio`** — strong hierarchy increases SNR by making one thing carry the message.
+- **`highlighting`** — emphasis works only when sparse; hierarchy is the systemic version.
+- **`von-restorff-effect`** — the deliberately-different element is remembered; primary action of a composition leverages this.
+- **`gutenberg-diagram`** — when hierarchy is *absent*, the eye falls back to the Z-pattern.
+
+## Sub-aspect skills (read these for specific applications)
+
+- **`hierarchy-typographic`** — type-scale, weight ladders, and how to construct hierarchy entirely through typography.
+- **`hierarchy-spatial`** — using position, size, and whitespace to establish hierarchy.
+- **`hierarchy-color-and-tone`** — using color, value, and contrast as a hierarchy dimension without sacrificing accessibility.
+
+## Final caution
+
+Hierarchy is one of the few principles where "more is more" is genuinely a trap. The temptation is always to make the primary *more* primary — bigger, brighter, redder. This works once, briefly. After two or three uses the eye desensitizes and you're back where you started, but with a louder page. Restraint preserves the dimension you're spending. Spend it on the things that earn it.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy/references/research-and-cross-domain.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/hierarchy/references/research-and-cross-domain.md
@@ -1,0 +1,101 @@
+# Hierarchy: research grounding and cross-domain examples
+
+This reference complements the `hierarchy` SKILL.md by going deeper into the research grounding and showing how the same hierarchy principles operate across domains beyond software UI.
+
+## Research grounding
+
+### Eye-tracking studies
+
+Decades of eye-tracking research consistently show that initial fixation patterns on novel pages are dominated by two factors: **bottom-up salience** (what's bright, large, high-contrast, isolated) and **top-down expectation** (where users have learned to expect certain things). Hierarchy is the design lever that aligns the two — making the salient elements *also* the meaningful ones.
+
+Notable findings:
+
+- **Pernice & Whitenton, NN/g eye-tracking studies (2014, 2017)** — users fixate first on items with strong visual contrast, large size, and isolation. F-pattern reading (top-left → right → down-left → right again) emerges only when no strong hierarchy directs attention otherwise.
+- **Itti & Koch (2001)**, *Computational Modelling of Visual Attention* — saliency maps predict where the eye lands within ~200ms based on low-level features (color, intensity, orientation). Strong hierarchy *aligns* saliency with intended focal points.
+- **Buscher, Cutrell, Morris (2009)**, "What do you see when you're surfing?" — a multi-page scan study showing that pages with stronger visual hierarchy are processed faster and with less re-fixation.
+
+### Working memory and ranking
+
+Hierarchy reduces cognitive load by externalizing the importance ranking. Without hierarchy, the user must hold the entire option set in working memory while evaluating; with hierarchy, the eye picks the primary first and only consults secondaries if needed.
+
+This connects to **Sweller's cognitive load theory (1988)**, particularly the concept of *extraneous cognitive load*: load imposed by how information is presented rather than the information itself. Poor hierarchy is extraneous load.
+
+### The "above the fold" myth
+
+A persistent designer fear: critical content must be above the fold (visible without scrolling). Eye-tracking studies (NN/g) consistently find that users scroll readily when hierarchy invites them to. A poorly-hierarchical page above the fold loses more users than a well-hierarchical page that requires scrolling.
+
+The corollary: don't compress hierarchy to fit the fold. Let the primary breathe.
+
+## Cross-domain examples
+
+### Print design
+
+Hierarchy is the oldest design discipline, predating software by centuries. Examples that illuminate the principle:
+
+- **Newspaper front pages.** The above-the-fold lead story has the largest headline, often a hero image, and the first columns of body. Smaller stories below, briefer headlines further. The whole front is a 3–5 tier hierarchy.
+- **Book typography.** Title page → chapter opener → section heading → body → footnote → page number. Six tiers handled entirely with type size, weight, and white space.
+- **Movie posters.** Title (largest), tagline (medium), credits (smallest, often in a "billing block" with strict legal sizing). The hero image dominates everything; type is secondary.
+
+A useful exercise for designers: study a Penguin Modern Classics cover or a Swiss-style Helvetica poster from the 1960s. Hierarchy with very few tools, executed precisely.
+
+### Wayfinding and signage
+
+Airports, train stations, and roadways are pure hierarchy machines.
+
+- **Highway signs.** Destination name (largest), route number (smaller), exit number (small badge), distance (smallest). Drivers parse this in 2 seconds at 70 mph because the hierarchy is unmistakable.
+- **Airport terminal signs.** Gates (large), then concourse direction, then services (food, restrooms, baggage) at progressively smaller sizes and distinct colors.
+- **Hospital wayfinding.** Department names large; sub-services smaller; navigation arrows in a separate visual register entirely.
+
+What software UI can borrow: ruthless tier ranking, oversized primary information, simple color codes for category.
+
+### Industrial product design
+
+A car dashboard is an information-density problem solved with hierarchy:
+
+- **Speedometer**: largest, centered, highest-contrast.
+- **Tachometer, fuel, temperature**: secondary tier — visible but smaller.
+- **Indicator lights**: tertiary; visible only when activated.
+- **Navigation/infotainment**: separate region, separate hierarchy.
+
+Failures: dashboards from the 2010s where every gauge was the same size in a digital display, requiring drivers to read labels to find the speed. Tesla's Model S had this issue early; later updates restored hierarchy.
+
+### Architecture
+
+A cathedral is hierarchy at scale: the entry pulls the eye to the altar (focal end of the nave); side aisles recede; chapels are tertiary spaces. The Gothic ribbed vault organizes the eye upward toward the boss at the keystone.
+
+A modern open-plan office, by contrast, often has *no* hierarchy — every desk equivalent, every meeting room similar. Wayfinding fails; visitors get lost.
+
+### Information graphics
+
+Charles Joseph Minard's 1869 map of Napoleon's Russian campaign (the "best statistical graphic ever drawn," per Tufte) is hierarchy applied to data:
+
+- The width of the army's path (representing troop strength) is the dominant visual.
+- Geography is secondary — it's there for context, drawn with light strokes.
+- Temperature curve at the bottom is tertiary, related to the path by date.
+
+Six dimensions of data, three tiers of hierarchy, instantly readable.
+
+### Music
+
+Hierarchy isn't visual-only. A symphony has primary melody, supporting harmony, accompaniment, percussion — orchestrated so that the primary melody is always perceivable above the texture. Mixing engineers in popular music make the same choices: vocals foreground, drums and bass mid, pads recessed.
+
+The principle is the same: a primary signal made unambiguously dominant against a quieter background.
+
+## Quantitative findings to lean on
+
+When a stakeholder pushes back on a hierarchy decision, these numbers can help:
+
+- **F-pattern reading** (NN/g): on uniform pages, users read in an F-shape, missing 70%+ of bottom-right content. Strong hierarchy can override this.
+- **3-second test**: shown for 3 seconds, users can recall the page's primary subject if hierarchy is strong; not if it's flat.
+- **Scroll depth on long pages**: pages with strong hierarchy retain readers ~2x longer than flat pages of the same content (multiple agency case studies).
+- **Conversion uplift from primary-CTA emphasis**: A/B tests consistently show 10–30% conversion lift from elevating the primary CTA's visual weight (size + color + isolation), holding all other content constant.
+
+## Edge cases
+
+- **Hierarchy in dense data tools.** Bloomberg terminals, IDEs, DAWs all violate "use only 3 tiers" because expert users don't *scan* — they fly to known locations. Hierarchy still exists but is more subtle and modal-context-sensitive.
+- **Hierarchy in voice UI.** No visual hierarchy applies; replaced by narrative ordering ("most important first") and prosody. The same logic, different modality.
+- **Hierarchy in print-on-demand and templating.** Templates impose a fixed hierarchy that can't accommodate every content type. Some content forces designers to fight the template; better to design templates with hierarchy *flexibility* (modular regions that can be promoted/demoted).
+
+## Closing thought
+
+Hierarchy is among the easiest principles to *demonstrate* and the hardest to *teach in the abstract*. The most effective learning is the squint test, repeated across many designs, until you can feel which one has hierarchy and which doesn't before you can articulate why.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility-contrast-and-spacing/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility-contrast-and-spacing/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: legibility-contrast-and-spacing
+description: 'Apply contrast and spacing for legibility — calibrating color contrast between text and background, character tracking, and line leading so a chosen typeface and size actually render legibly. Use when picking text colors, choosing background colors that will carry text, evaluating accessibility against WCAG, fine-tuning typography for production rendering, or auditing why text "looks designed" but is hard to read. Even a perfect typeface at the right size will fail if contrast is too low, tracking too tight, or leading too cramped.'
+---
+
+# Legibility — contrast and spacing
+
+A typeface and size are necessary but not sufficient for legibility. The conditions under which type is rendered — contrast against background, spacing between characters, spacing between lines — determine whether the chosen typography actually communicates. Most legibility failures in production are spacing or contrast failures, not typeface failures.
+
+## Color contrast
+
+Color contrast is the difference in luminance between text and its background. WCAG codifies minimum thresholds:
+
+- **4.5:1** for normal text (under 18pt regular or 14pt bold).
+- **3:1** for large text (18pt+ regular or 14pt+ bold).
+- **3:1** for graphical objects and UI components (icons, button outlines).
+- **7:1** for AAA conformance — recommended for users with low vision or in poor viewing conditions.
+
+These are floors, not targets. Best practice is to substantially exceed them where possible.
+
+Common contrast failures:
+
+**Light gray text on white.** Common because designers like the "soft" feel. #999 on white is roughly 2.8:1, well below WCAG AA. #767676 is roughly 4.5:1. Below this, you're failing the standard.
+
+**Brand color on white that doesn't pass.** A brand color in the medium-blue range (e.g., #5BA0E6) on white is often around 3:1 — fine for large display text, fails for body text. Pick text colors with adequate contrast even if the brand color is borderline.
+
+**Text on photos or gradients without protection.** Text overlaid on busy photos or gradients can fail in some places and pass in others. Solutions: a dark scrim over the photo, a solid text background, or moving the text out of the photo area.
+
+**Low-contrast helper or muted text.** Helper text intentionally de-emphasized often drifts into illegibility. Don't go below 4.5:1 (or 3:1 if it's larger text and clearly secondary).
+
+**Color-only state indicators.** A red error message that loses meaning when rendered to a colorblind user, or a green success message that's invisible to others. Always pair color with shape, label, or icon.
+
+Tools for verifying contrast:
+
+- WebAIM contrast checker.
+- Browser dev tools' built-in contrast picker.
+- axe, Lighthouse, WAVE for automated audits.
+- Stark or similar Figma/Sketch plugins for design-time checking.
+
+## Tracking (letter spacing)
+
+Tracking is the space between characters. The right tracking depends on the typeface, the size, and the use.
+
+**Body text:** typefaces are usually designed for body sizes with built-in correct tracking. Don't adjust tracking for body unless you have a specific reason.
+
+**Display sizes (large):** large text often benefits from tighter tracking (-1% to -2%) to prevent characters from feeling too far apart. Many display typefaces are designed expecting some negative tracking at large sizes.
+
+**Small sizes (especially below 12px):** small text may need slightly looser tracking (+0.5% to +1%) to prevent characters from merging into ambiguous shapes.
+
+**All caps:** uppercase text needs significantly looser tracking (+5% to +10%) because capital letters have less visual differentiation in their outlines.
+
+**Bold text:** can sometimes need slightly looser tracking to prevent visual crowding.
+
+Common tracking failures:
+
+**Default tracking on display sizes.** Many typefaces look loose at large sizes; tighten to -1% to -3%.
+
+**Tight tracking on small text.** A common cause of "blurry-looking" small text. Loosen slightly.
+
+**Untracked all-caps.** Uppercase without extra tracking looks crowded and reads slowly.
+
+## Leading (line height)
+
+Leading is the space between lines. The right leading depends on the typeface, the line length, and the use.
+
+**Body text:** 1.4× to 1.6× the font size. So for 16px text, line height of 22–26px. This range is comfortable for sustained reading.
+
+**Display / headline text:** 1.0× to 1.2× the font size. Tighter leading at display sizes prevents headlines from feeling fragmented.
+
+**UI labels and dense text:** 1.2× to 1.4× the font size. Tighter than body but loose enough to keep characters from overlapping.
+
+**Long-form prose:** 1.5× to 1.7× the font size. Slightly more generous than UI body text for sustained reading comfort.
+
+Common leading failures:
+
+**Default browser leading on body text.** Browsers default to about 1.2× line height, which is too tight for body text. Set explicit line-height: 1.5 or higher for prose.
+
+**Leading too tight for the font's x-height.** Fonts with tall x-heights (Verdana, Inter) need slightly more leading than fonts with shorter x-heights (Times, Garamond) at the same size.
+
+**Inconsistent leading across the type system.** Body, headings, captions all should have leading that's calibrated to their use; one-size-fits-all is rarely right.
+
+**Tight leading on multi-line UI elements.** Buttons, table cells, form labels with multiple lines often have insufficient line height, causing the lines to crowd.
+
+## Word spacing and paragraph spacing
+
+Less critical than tracking and leading for most UI but worth checking:
+
+**Word spacing.** Default word spacing in most typefaces is appropriate. Adjust only for specific cases (justified text, very large display).
+
+**Paragraph spacing.** Space between paragraphs should be larger than line spacing. A common ratio: paragraph spacing = 0.75× to 1× the font size, in addition to leading.
+
+**First-line indent vs. block paragraphs.** Most digital UI uses block paragraphs with space between. First-line indents are reserved for editorial / book contexts.
+
+## Worked examples
+
+### A button that fails contrast
+
+A button with white text (#FFFFFF) on a light blue background (#7AB8FF). Contrast ratio: 2.1:1. Below WCAG AA for both normal and large text.
+
+The fix: darken the blue (#1E78D6 gives 4.5:1) or change the text to a darker color. White on the original blue is too low contrast for accessibility.
+
+### Body text with too-tight leading
+
+Default browser styling: 16px body text with default line-height (about 1.2 = 19px). The text feels cramped; users skim faster than they should and miss content.
+
+The fix: set line-height to 1.5 or higher for body text. 24px line height for 16px text is a comfortable baseline for sustained reading.
+
+### A headline with too-loose tracking
+
+A 48px display headline using a typeface with default (positive) tracking. The letters feel separated; the headline doesn't read as a unit.
+
+The fix: tighten tracking to -1% or -2% at this size. The headline now reads as a cohesive title rather than as separate letters.
+
+### All-caps navigation that's hard to read
+
+A navigation bar uses ALL CAPS labels at 13px with default tracking. The text feels crowded and reads slowly because all-caps lacks the ascender/descender silhouette that aids word recognition.
+
+The fix: add positive tracking (+5% to +8%) to give the capitals room to breathe; consider whether all-caps is necessary at all (sentence-case or title-case is usually more readable).
+
+### Helper text that drifts into illegibility
+
+Helper text under form fields is set in #BBBBBB on white. Contrast ratio: 1.6:1. Many users can't read it at all; even those who can, struggle.
+
+The fix: darken to #767676 or similar (gives 4.5:1). The helper text remains clearly secondary but is now legible.
+
+### Code that's hard to scan
+
+Code blocks in a documentation site use a serif typeface at 14px with default tracking and line-height. The text is technically legible but feels dense and hard to scan.
+
+The fix: switch to a monospace typeface (JetBrains Mono or similar), set line-height to 1.6 (a bit more generous than body for visual scanning), and add some background tinting to set code apart from prose.
+
+## Anti-patterns
+
+**Designing on high-contrast displays then shipping to low-contrast contexts.** Mobile devices in sunlight, lower-DPI external monitors, projectors all reduce effective contrast. Test in the worst conditions you'll actually encounter.
+
+**Using opacity for text instead of explicit colors.** A semi-transparent black text on a colored background can produce unpredictable contrast depending on the underlying color. Use explicit colors, computed against the actual background.
+
+**Ignoring user-chosen color schemes.** Dark mode, high-contrast mode, and user-overridden colors all change the effective contrast. Test your typography in all the modes your users will use.
+
+**Tracking adjustments without testing.** Tracking is sensitive to typeface and size. A -2% adjustment that improves a 48px headline may break a 14px body. Calibrate each adjustment to its specific use.
+
+**Set-and-forget design tokens for typography.** Typography tokens that haven't been audited in years often drift away from current best practices. Review your typography system periodically.
+
+**Relying on automated contrast checkers without visual review.** Automated tools catch the most obvious failures but miss situations like text over photos, gradient backgrounds, or color combinations that pass technically but feel low-contrast.
+
+## Heuristic checklist
+
+Before shipping any typography decision, ask: **Does the contrast meet WCAG AA at minimum (4.5:1 normal, 3:1 large)?** Check with a contrast tool. **Does the contrast hold up in dark mode?** Test both modes. **Is the leading appropriate for the use case?** 1.5× for body, 1.2× for display. **Is the tracking appropriate for size and case?** Tighter for display, looser for small or all-caps. **Have you tested in production conditions?** Actual devices, actual browsers, actual viewing conditions.
+
+## Related sub-skills
+
+- `legibility` — parent principle on visual character clarity.
+- `legibility-typeface-and-size` — sibling skill on typeface and size choices.
+- `color` — color choices that affect contrast.
+- `accessibility` — contrast is one critical accessibility dimension.
+- `signal-to-noise` — well-spaced, high-contrast type is signal; the opposite is noise.
+
+## See also
+
+- `references/contrast-spacing-recipes.md` — specific recipes for common situations (light mode, dark mode, hero text, code, captions).

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility-contrast-and-spacing/references/contrast-spacing-recipes.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility-contrast-and-spacing/references/contrast-spacing-recipes.md
@@ -1,0 +1,137 @@
+# Contrast and spacing — recipes for common situations
+
+Specific defaults and starting points for typography in different contexts. Use as a baseline; adjust based on your typeface and audience.
+
+## Light mode body text
+
+**Color:** dark text on white background. #1A1A1A on #FFFFFF gives ~17:1 contrast, very comfortable. Pure black (#000) on white is sometimes seen as too harsh; #1A1A1A or #222222 reads more comfortably while still passing AAA.
+
+**Size:** 16px is a comfortable baseline for sustained reading. 14px is acceptable for denser UI; below 14 starts to require careful design.
+
+**Leading:** 1.5× to 1.6× the font size. So 24–26px line height for 16px text.
+
+**Tracking:** default for the typeface (don't adjust unless the typeface is known to need it).
+
+## Dark mode body text
+
+**Color:** light text on dark background. #E6E6E6 on #1A1A1A gives ~14:1 contrast. Don't use pure white (#FFFFFF) on pure black (#000000) — that's harsh and can produce eye strain. Reduce contrast slightly for dark mode by using a softer white and a not-quite-black background.
+
+**Size:** same as light mode, possibly 1px larger if the typeface gets thinner-looking in dark mode (which some typefaces do).
+
+**Leading:** same as light mode.
+
+**Tracking:** consider +0.5% to +1% in dark mode; light text on dark backgrounds can feel slightly tighter optically.
+
+## UI labels and helper text
+
+**Body label color:** #1A1A1A or similar dark on light backgrounds.
+
+**Helper / muted text color:** #6C6C6C or #767676 on white. Stays above 4.5:1 contrast. Don't go lighter for "softer" feel — it crosses into illegibility.
+
+**Size:** 14–15px for primary labels; 12–13px for helper text or captions. Don't go below 12px for text users need to read.
+
+**Leading:** 1.4× for label text, 1.5× for helper text.
+
+## Display headlines
+
+**Color:** same as body, or use a muted color (#444 or similar) for secondary headings.
+
+**Size:** scaled by your typographic ratio. Common scale: 24px (h3), 32px (h2), 48px (h1), 64–96px (hero).
+
+**Leading:** 1.0× to 1.2× the font size at display sizes. Tighter than body to keep headlines feeling unified.
+
+**Tracking:** -1% to -3% at display sizes. Most display typefaces look loose at default tracking when scaled up.
+
+## Hero text on photos
+
+**Color:** white text on a dark scrim (a semi-transparent black overlay over the photo). The scrim should be dark enough to bring contrast above 4.5:1.
+
+**Alternative:** text on a solid background area beside or below the photo, rather than overlaid.
+
+**Tracking:** small negative tracking (-1% to -2%) for visual cohesion at large sizes.
+
+**Leading:** tight (1.0× to 1.1×).
+
+## Buttons
+
+**Primary button:** white text on a brand color background. The brand color should give at least 4.5:1 contrast against white. Most "modern" tech blues (#3B82F6, #2563EB) do; lighter blues often don't.
+
+**Secondary button:** dark text on a light background, or brand-color text on white with a brand-color border. Whatever combination, verify contrast.
+
+**Disabled button:** muted text on muted background. Disabled buttons are exempt from WCAG contrast requirements but should still be visually distinguishable.
+
+**Size:** 14–16px text. 16px gives more visual weight and is preferred for primary actions.
+
+**Padding:** vertical padding should be at least equal to the font size. So 16px text in a button needs at least 16px vertical padding (top + bottom = 32px), giving the button a comfortable 48px+ height (good for touch targets).
+
+## Forms
+
+**Field label:** 14–16px, weight 500 or 600 (slightly emphasized). High contrast against background.
+
+**Field value (user's input):** 16px regular weight (resist going smaller — input text is critical and should be very legible).
+
+**Placeholder text:** muted color (#999 on white is on the edge — go with #767676 to stay accessible). Don't use placeholder as a substitute for label.
+
+**Helper text:** 12–14px, muted color, below the field.
+
+**Error text:** 12–14px, error color (red), high contrast. Reinforce with an icon (don't rely on color alone).
+
+## Tables and data
+
+**Header text:** 14px, weight 500 or 600, slightly emphasized.
+
+**Body text:** 14–15px regular weight, high contrast.
+
+**Numeric values:** consider tabular figures if the typeface offers them. They give consistent column widths. If not, use a monospace typeface for tables of numbers.
+
+**Leading:** 1.3× to 1.5×. Tables benefit from slightly tighter leading than prose for scannability.
+
+**Color:** standard body colors. Avoid alternating row backgrounds at low contrast (they can hurt scannability rather than help).
+
+## Code blocks
+
+**Typeface:** monospace (JetBrains Mono, Fira Code, Source Code Pro, etc.).
+
+**Size:** 14–16px. Slightly larger than UI body text because code is denser and benefits from the extra breathing room.
+
+**Leading:** 1.5× to 1.7×. Code benefits from generous leading for visual scanning.
+
+**Background:** subtle tint (light gray on light mode, slightly darker than the surface in dark mode) to set code apart from prose.
+
+**Syntax highlighting colors:** verify each color against the background for contrast. Many syntax themes have one or two colors (often the comment color) that fall below 4.5:1. Adjust those colors.
+
+## Captions and footnotes
+
+**Size:** 12–14px.
+
+**Color:** muted (#767676 or similar) — clearly de-emphasized but still legible.
+
+**Leading:** 1.4× to 1.5×.
+
+**Use sparingly:** captions and footnotes drift into illegibility quickly because designers want them to "feel small." Resist setting them below 12px.
+
+## Marketing / hero copy
+
+**Size:** larger than UI text. 18–20px for body marketing copy; 24–32px for sub-headlines; 48–96px for hero.
+
+**Leading:** 1.4× to 1.6× for body marketing copy.
+
+**Line length:** aim for 50–75 characters per line. Marketing text is often read more carefully than UI text and benefits from comfortable measure.
+
+**Spacing between sections:** generous. Don't pack marketing sections tight; let them breathe.
+
+## Anti-patterns to avoid
+
+**Using opacity for text colors.** `color: rgba(0,0,0,0.6)` is unpredictable on colored backgrounds. Use explicit colors computed against the actual background.
+
+**Forgetting that font weight affects perceived contrast.** Light weights at small sizes look low-contrast even when the color contrast technically passes. Use medium weights for small text.
+
+**Designing for one mode and not the other.** Light-mode designs that haven't been verified in dark mode often fail in subtle ways: helper text becomes invisible, brand colors clash, contrast inverts incorrectly.
+
+**Setting line-height in pixels instead of unitless multipliers.** `line-height: 24px` doesn't scale with the font size. `line-height: 1.5` does. Use unitless values for body text.
+
+**Tracking applied uniformly across all sizes.** Tracking should vary by size — tighter at large, looser at small or all-caps.
+
+## Cross-reference
+
+For typeface selection, see `legibility-typeface-and-size`. For the parent principle, see `legibility`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility-typeface-and-size/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility-typeface-and-size/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: legibility-typeface-and-size
+description: 'Apply typeface and size choices for legibility — picking the right typeface for the use case (display, body, code, UI) and sizing it appropriately for the rendering context. Use when designing a type system for a product, choosing a brand typeface, evaluating an existing typeface against rendering conditions, picking sizes for body, headings, captions, code, or UI elements. The two most fundamental legibility decisions; everything else (contrast, spacing) is layered on top.'
+---
+
+# Legibility — typeface and size
+
+The two most fundamental legibility decisions: which typeface to use, and at what size. Everything else — contrast, spacing, weight, color — is calibrated against these choices. A typeface that's wrong for the use case can't be saved by any other adjustment; a size that's wrong for the rendering context produces text that no contrast or spacing tweak will fix.
+
+## Choosing typefaces by use case
+
+Different uses demand different typefaces. The major categories:
+
+**Display typefaces** are designed for headlines, posters, and other large-size uses where the typeface is meant to make a visual statement. Often have high contrast between thick and thin strokes (Bodoni, Didot), unusual proportions (condensed, expanded), or expressive personality (script, modern serif). They look striking at large sizes and lose distinguishability at small sizes — many become unreadable below 18–24px.
+
+Use display typefaces only at display sizes (typically 24px and up). Don't use them for body text, UI labels, or anything small.
+
+**Body / text typefaces** are designed for sustained reading at body sizes (typically 14–18px on screens, 9–12pt in print). They have moderate stroke contrast, generous apertures, and proportions optimized for legibility in long-form prose. Examples: Garamond, Caslon, Georgia (serif); Helvetica, Inter, Source Sans (sans-serif).
+
+Use body typefaces for body copy and most UI text.
+
+**UI typefaces** are body typefaces with adjustments for screen UI use: even more generous spacing, slightly heavier weights, sometimes designed for specific rendering targets. Examples: SF Pro (Apple), Roboto (Google), Inter (open-source), Segoe UI (Microsoft).
+
+UI typefaces and body typefaces overlap heavily. The distinction matters most when you're designing for a specific platform that has a strong native typeface.
+
+**Monospace / code typefaces** have every character occupying the same width. Essential for code (column alignment) and useful for tabular data. The best ones (JetBrains Mono, Fira Code, Source Code Pro) have explicit attention to character disambiguation (0/O, 1/I/l).
+
+Use monospace for code, terminal output, structured numeric data, and tabular layouts where alignment matters.
+
+**Specialty typefaces** for specific functions: Atkinson Hyperlegible for accessibility-first contexts; Highway Gothic-style typefaces for distance signage; numbers-only typefaces optimized for spreadsheet display.
+
+Most products need at most 2–3 typefaces: a body typeface for the bulk of text, a display typeface for headlines (sometimes the same as body, in heavier weight), and a monospace typeface for code if applicable.
+
+## Sizing for the rendering context
+
+The right size depends on:
+
+**Viewing distance.** Closer viewing tolerates smaller text; further viewing requires larger. Mobile devices are held at ~25–35cm; desktop monitors at ~50–80cm; TVs at 2–3m; signage at variable distances.
+
+**Display DPI.** Higher-DPI displays render small text more legibly because antialiasing has more pixels to work with. A 12px font that's legible on a Retina display may be illegible on a lower-DPI external monitor.
+
+**Lighting and environment.** Bright sunlight, glare, low ambient light all reduce legibility. Outdoor and mobile contexts often need larger sizes than indoor desktop contexts.
+
+**User population.** Older users, low-vision users, and users in unfamiliar languages need larger text. If your audience skews toward any of these, baseline sizes should scale up.
+
+A practical baseline for modern UI:
+
+- Body text: 14–16px
+- Smaller UI text (helper, captions): 12–14px (don't go below 12 for primary content)
+- Headings: scale based on hierarchy (24, 32, 48, 64+)
+- Code: 13–15px for inline; 14–16px for blocks
+- Hero text: 48–96px (or larger, depending on layout)
+
+These are starting points. Specific products should test with their actual users in their actual conditions.
+
+## A typographic scale
+
+Most well-designed type systems use a scale rather than ad-hoc sizes. A typographic scale defines a small set of sizes (typically 5–8) related by a consistent ratio. Common ratios:
+
+- **Major Second (1.125):** subtle progression, lots of size steps. Used for tight UI systems.
+- **Minor Third (1.2):** moderate progression. The most common modern UI scale.
+- **Major Third (1.25):** stronger progression, fewer steps. Used for products that emphasize hierarchy.
+- **Perfect Fourth (1.333):** strong progression. Used for editorial or display-heavy designs.
+- **Golden Ratio (1.618):** dramatic progression. Used for highly hierarchical layouts.
+
+Pick a base size (often 16px) and a ratio. Each size in the scale is the previous one multiplied by the ratio (or divided, going down). The result is a small set of sizes that work harmoniously.
+
+For example, with base 16px and Minor Third (1.2): 11, 13, 16, 19, 23, 28, 33, 40, 48 px. Round to nearest pixel for crisp rendering.
+
+The scale should cover all your needs. If you find yourself wanting a size between two scale values, the right answer is usually to use one of the existing values (the constraint is helpful) rather than adding a new one.
+
+## Choosing a system typeface
+
+Some products use the platform-default system typeface (San Francisco on Apple, Roboto on Android, Segoe UI on Windows) for body and UI text. Pros:
+
+- Free (no licensing cost).
+- Optimized for the platform's rendering.
+- Familiar to platform users.
+- Performant (no font loading required).
+
+Cons:
+
+- Limited brand differentiation.
+- Inconsistent across platforms (your product looks slightly different on each).
+
+For most products that aren't building a strong brand identity through typography, system typefaces are a reasonable choice. They're free, performant, and well-tested.
+
+For products with a stronger brand commitment, a custom or licensed typeface (Inter, IBM Plex, or a proprietary brand typeface) provides more consistency and personality, at some cost in licensing and performance.
+
+## Worked examples
+
+### A SaaS product's type system
+
+**Typefaces:** Inter for UI and body. Inter Display for very large headings. JetBrains Mono for code.
+
+**Scale (1.2 ratio, base 16px):** 11, 13, 16, 19, 23, 28, 33, 40 px.
+
+**Usage:**
+- Body text and UI labels: 16px Inter Regular.
+- Helper text and captions: 13px Inter Regular.
+- Section headings: 19px Inter Medium or 23px Inter Semibold.
+- Page titles: 28–33px Inter Bold or Inter Display.
+- Hero headlines: 40+px Inter Display.
+- Code: 14px JetBrains Mono.
+
+The system covers all needs with three typefaces and a single scale. New designers and engineers can reach for the system without creating new variants.
+
+### A consumer product with brand display type
+
+**Typefaces:** A custom display typeface for headlines, marketing surfaces, and some hero UI. Inter for body and UI text. JetBrains Mono for code.
+
+**Usage:** the display typeface is reserved for moments where it shines (hero, marketing, occasional UI flourish). Body text uses Inter for legibility at small sizes. The display typeface would be illegible at body sizes.
+
+The system honors brand identity through display typography while ensuring functional UI legibility through body typography.
+
+### A code editor's type choice
+
+**Typeface:** JetBrains Mono. Specifically chosen for character disambiguation (0 has a slash, l and 1 are clearly different, O and 0 are different) and programming ligatures.
+
+**Size:** 14px default, with user adjustment up to 18px+ for those who prefer larger code.
+
+**Why not Inter:** proportional fonts make code alignment ambiguous; column-based code reading depends on monospace.
+
+### A landing page that picks the wrong type
+
+A startup uses an elegant high-contrast modern serif (a Didot-style typeface) for both headlines and body copy. The headlines look beautiful. The body copy is hard to read: at 16px, the thin strokes of the typeface are nearly invisible on most displays, and the high contrast between thick and thin makes the text feel "broken."
+
+The fix: use the modern serif only for display sizes (32px+). For body copy, switch to a humanist serif or sans-serif designed for sustained reading.
+
+## Anti-patterns
+
+**Display typefaces in body copy.** A typeface chosen for headlines used at body sizes loses its distinguishing features and becomes hard to read.
+
+**Body typefaces in display use.** Less harmful but feels weak; the typeface doesn't have the visual presence that display sizes can support.
+
+**Too many typefaces.** Three typefaces is plenty. Four or five starts to feel like a patchwork. Each additional typeface adds cognitive load and visual noise.
+
+**Ad-hoc sizes.** Choosing 13.5px because it "looks right" instead of using a scale value. Over time, the type sizes spread across many arbitrary values and the system feels inconsistent.
+
+**Sizes too small for the audience.** Designers often set body text smaller than is comfortable because the design canvas makes everything look bigger than production. Test on actual devices with actual users.
+
+**Ignoring monospace for code.** Code in proportional fonts is hard to scan, hard to align, and ambiguous in some characters. Use monospace.
+
+**Brand typefaces that don't render well at UI sizes.** A custom brand typeface designed for marketing materials but applied to UI may not have the legibility characteristics needed for small sizes. Either commission a UI variant of the brand typeface or use a separate UI typeface.
+
+## Heuristic checklist
+
+Before settling on type choices, ask: **Is each typeface chosen for its intended use (display, body, code, UI)?** Mismatches cost legibility. **Is the size appropriate for the rendering context?** Test on actual devices, not just your design canvas. **Does the scale provide all needed sizes without forcing ad-hoc values?** A complete scale prevents drift. **Are there too many typefaces?** Three is a good limit. **Have you tested with users from your actual audience?** Designer intuition about legibility is unreliable.
+
+## Related sub-skills
+
+- `legibility` — parent principle on visual character clarity.
+- `legibility-contrast-and-spacing` — sibling skill on the rendering conditions.
+- `readability` — for sustained reading of prose.
+- `consistency-internal` — type systems are part of internal consistency.
+- `signal-to-noise` — well-chosen type is signal; poorly chosen is noise.
+
+## See also
+
+- `references/typeface-selection.md` — practical guidance on choosing specific typefaces for specific use cases.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility-typeface-and-size/references/typeface-selection.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility-typeface-and-size/references/typeface-selection.md
@@ -1,0 +1,115 @@
+# Legibility — typeface selection guide
+
+A practical guide to selecting typefaces for specific use cases. Includes general recommendations and notes on when to pick each kind.
+
+## For UI text and body copy
+
+The critical requirement: legibility at small sizes (12–16px) on screens, with sustained reading comfort.
+
+**Inter** (Rasmus Andersson, 2017). Open source. Designed specifically for UI text on screens. Excellent legibility, neutral personality, broad weight range. The default choice for most modern web apps.
+
+**IBM Plex Sans** (IBM, 2017). Open source. Slightly more personality than Inter. Designed as IBM's corporate typeface and works well in product UI.
+
+**Source Sans Pro** (Adobe, 2012). Open source. Generous proportions, good legibility. Slightly older feel than Inter.
+
+**Roboto** (Google, 2011). Open source. Android's system typeface. Good legibility, somewhat geometric personality.
+
+**Open Sans** (Steve Matteson, 2010). Open source. The original "free, friendly, screen-readable" typeface. Still solid; aesthetically dating slightly.
+
+**SF Pro** (Apple, 2014). Apple's system typeface. Free for use on Apple platforms. Excellent legibility, optimized for Apple's rendering.
+
+**Segoe UI** (Microsoft, 2004). Windows system typeface. Good legibility.
+
+**System UI fallback stack:** if you don't want to license a typeface, use the platform default: `font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;`
+
+## For display and headlines
+
+The critical requirement: visual impact and personality at large sizes (24px+).
+
+**Inter Display** (companion to Inter, optimized for larger sizes). When you want display type that matches the body Inter.
+
+**Söhne** (Klim Type Foundry, 2019). Premium licensed. Strong personality, modern, used by many tech brands.
+
+**Migra** (Pangram Pangram, 2021). Premium licensed. Modern serif with excellent display capabilities.
+
+**Editorial New** (Pangram Pangram). Premium licensed. Editorial-feeling serif.
+
+**Bodoni** (any of several digital revivals). Classic high-contrast serif. Striking at large sizes; unusable at small.
+
+**Recoleta** (LatinoType, 2018). Premium licensed. Distinctive geometric serif.
+
+**Custom commissioned typeface.** For products with strong brand identity and budget for typography commissioning. Vendors include Klim, Pangram Pangram, Hoefler & Co., Commercial Type, and many more.
+
+## For code and structured data
+
+The critical requirement: monospace, character disambiguation, readability at code sizes (13–16px).
+
+**JetBrains Mono** (JetBrains, 2020). Open source. Designed specifically for code reading. Excellent character disambiguation. Programming ligatures.
+
+**Fira Code** (Mozilla, 2014). Open source. Programming ligatures (=> renders as a single arrow). Character disambiguation.
+
+**Cascadia Code** (Microsoft, 2019). Open source. Designed for Windows Terminal and VS Code.
+
+**Source Code Pro** (Adobe, 2012). Open source. Adobe's open-source code typeface.
+
+**SF Mono** (Apple, 2016). Free for Apple platforms. Apple's monospace typeface.
+
+**IBM Plex Mono** (IBM, 2017). Open source. Companion to Plex Sans.
+
+**iA Writer Mono** / **Monaspace** (more recent options). Newer entrants with various design philosophies.
+
+For prose code (inline code in articles), most code typefaces work. For long code blocks, JetBrains Mono and Fira Code are particularly strong.
+
+## For accessibility-first contexts
+
+The critical requirement: maximum character distinguishability for users with vision differences.
+
+**Atkinson Hyperlegible** (Braille Institute, 2020). Open source. Designed specifically for low-vision readers. Maximally distinct character shapes.
+
+**Lexend** (Bonnie Shaver-Troup, 2019). Open source. Designed to improve reading proficiency for readers with dyslexia and other reading challenges. Several width variants.
+
+**OpenDyslexic** (Abelardo Gonzalez). Open source. Specifically designed for dyslexic readers, with weighted bottoms to anchor letters. Some research evidence is mixed; users vary in preference.
+
+These typefaces should be considered for accessibility-focused products and as alternative font options users can switch to.
+
+## For specific cultural / language contexts
+
+**Noto** (Google, ongoing). Open source. The "no tofu" project covering essentially every script. Use for products supporting many languages.
+
+**Source Han Sans / Source Han Serif** (Adobe / Google, 2014–2017). Open source. CJK (Chinese, Japanese, Korean) typefaces.
+
+For Arabic, Hebrew, Thai, Devanagari, and other non-Latin scripts, look for typefaces designed by typographers familiar with the script. Don't apply Latin typeface design instincts blindly to other scripts.
+
+## Decision framework by product type
+
+**Consumer mobile app:** platform-native (SF Pro on iOS, Roboto on Android) for body and UI; custom for hero/marketing if budget allows.
+
+**Web SaaS product:** Inter for body and UI; Inter Display or a licensed display typeface for headlines; JetBrains Mono for code.
+
+**Editorial / content site:** a strong body serif (Charter, Source Serif, Mercury, or IBM Plex Serif) for sustained reading; a complementary sans-serif for UI; a display serif or sans for headlines.
+
+**Documentation site:** Inter or similar for body; JetBrains Mono for code; minimal display use.
+
+**Brand-driven consumer product:** custom or licensed display for hero/brand moments; Inter or system for body and UI.
+
+**Accessibility-focused product:** Atkinson Hyperlegible as the default body typeface; consider giving users a choice.
+
+**Internal enterprise tool:** system typefaces are fine; prioritize functional clarity over brand differentiation.
+
+## Pitfalls to avoid
+
+**Loading too many typefaces.** Each typeface load costs network bandwidth and render time. Two or three typefaces is plenty for almost any product.
+
+**Loading too many weights.** Each weight is its own font file. Stick to 2–4 weights per typeface (often Regular, Medium, Semibold, Bold is enough).
+
+**Not loading variable fonts when available.** Variable fonts (Inter, Recursive, Source Sans 3) ship multiple weights in a single file, dramatically more efficient than loading individual weight files.
+
+**Forgetting fallback stacks.** The user may not load your custom font (slow connection, font-loading error). Always specify a fallback that gives reasonable rendering: `font-family: 'Your Font', -apple-system, BlinkMacSystemFont, sans-serif;`
+
+**Ignoring font-display properties.** Use `font-display: swap` or `font-display: optional` to prevent invisible text during font loading.
+
+**Mixing typefaces from different categories.** A geometric sans (Inter) paired with a heavily decorative display typeface might clash. Look for typefaces designed to coexist (some foundries publish "pairing" suggestions).
+
+## Cross-reference
+
+For the parent principle on legibility, see `legibility`. For sustained-reading typography, see `readability`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: legibility
+description: 'Apply the principle of Legibility — the visual clarity of individual characters and short phrases, determined by typeface, size, weight, contrast, and spacing. Use when picking type for UI elements (buttons, labels, navigation), evaluating typography against rendering conditions (small sizes, low-contrast displays, distance viewing), choosing display vs. body type, or auditing accessibility. Legibility is the precondition for reading; if a user can''t quickly distinguish "I" from "1" or "O" from "0," everything downstream from text fails. Distinct from readability, which is about sustained reading of prose.'
+---
+
+# Legibility
+
+> **Definition.** Legibility is the visual clarity of individual characters and short text — the ease with which a reader can identify each letter, number, or symbol at a glance. It's determined by typeface design, size, weight, color contrast, and the spacing within and between characters. Legibility is the *prerequisite* for reading; without it, the rest of typography (hierarchy, voice, readability) is pointless because the user can't reliably identify what they're looking at.
+
+The classic test of legibility: can the reader distinguish similar characters quickly under the actual viewing conditions? "I" and "1" and "l" — three different characters that in many typefaces look nearly identical. "O" and "0." "rn" and "m." "5" and "S." "8" and "B." A typeface that makes these distinctions clear is legible; one that doesn't, isn't. The cost of poor legibility is paid every time the user has to look twice.
+
+Legibility is distinct from *readability*. Readability concerns the ease of reading sustained prose — line length, leading, paragraph rhythm. Legibility concerns the ease of identifying individual characters or short phrases. A poster billboard, a button label, a code listing, a phone number on a contact card — all are legibility problems. A long article is primarily a readability problem (though it requires legibility too).
+
+## Why legibility matters
+
+Most UI text is not prose. It's labels, button text, form-field values, error messages, navigation items, search results. These are read in glances, often in motion (scrolling), often in poor conditions (small screens, harsh sunlight, while doing something else). The user has fractions of a second to identify what each chunk of text says.
+
+Poor legibility costs the user every glance. They look, can't immediately resolve what the text says, look again, sometimes lean closer or zoom in. The cost is small per instance and large in aggregate.
+
+In specific high-stakes contexts the cost of misread characters is severe. A pilot misreading "1" as "I" in an altitude callout. A pharmacist misreading a dosage. A doctor misreading patient ID. A user typing a confirmation code wrong because the displayed code can't be distinguished. These are not abstract concerns — they're recurring sources of real-world error.
+
+## The five inputs to legibility
+
+Legibility is determined by:
+
+**Typeface design.** Some typefaces are designed for legibility at small sizes, distance viewing, or character disambiguation. Others are designed for display use, expressive personality, or branded identity, often at the cost of legibility. Roman, sans-serif, slab-serif, and humanist typefaces vary in their legibility characteristics.
+
+**Size.** Larger text is more legible up to the point where the eye can take it in at a glance. Below ~9px on screens, most typefaces lose distinguishability between characters. Below ~6px, most text becomes unreadable.
+
+**Weight.** Bold and very thin weights are both less legible at small sizes than regular weight. Hairline weights especially can become illegible at small sizes or low-contrast conditions. Bold weights can fill in detail and lose distinguishability.
+
+**Contrast.** Color contrast between text and background. Low contrast (gray text on white, dark blue on dark gray) reduces legibility. WCAG guidelines specify minimum contrast ratios (4.5:1 for normal text, 3:1 for large text) that are the floor for legibility.
+
+**Spacing (tracking and leading).** Too-tight tracking causes characters to merge into ambiguous shapes; too-loose tracking dissolves the word into separate letters. Tight leading (line height) causes ascenders and descenders to overlap.
+
+A typeface chosen for legibility may still be illegible if rendered too small, too thin, in low contrast, or with bad spacing. All five inputs need to be controlled.
+
+## Diagnosing legibility problems
+
+Symptoms of legibility problems include:
+
+**Users squint or lean closer to read.** They can't resolve the text from their natural viewing distance. Either the size is too small, the contrast is too low, or both.
+
+**Users frequently mistype confirmation codes, ID numbers, or other character strings.** The displayed characters are hard to distinguish. Common culprits: 0/O, 1/I/l, 2/Z, 5/S, 8/B.
+
+**Tooltip hover or zoom usage is unexpectedly high.** Users reach for tools that help them read because the text is too small.
+
+**Reading speed is measurably slow on UI text.** A first-time-user study where users take longer to identify menu options or button labels than expected. Legibility cost is measurable.
+
+**Accessibility audits flag text contrast.** Automated tools (axe, WAVE, Lighthouse) flag instances where text/background contrast is below WCAG thresholds.
+
+## Sub-skills in this cluster
+
+- **legibility-typeface-and-size** — Choosing typefaces and sizing them appropriately. The most fundamental legibility decisions; most other inputs are secondary to these.
+- **legibility-contrast-and-spacing** — The conditions under which a legible typeface is rendered: contrast ratio, tracking, leading, color choices.
+
+## Worked examples
+
+### A login form's legibility
+
+A login form has labels, input fields, helper text, error messages, and a primary button. Each is a legibility decision.
+
+- Field labels (Email, Password): regular weight, ~14–16px, dark text on light background. Comfortable to read at a glance.
+- Input field text (the user's typed input): regular weight, ~14–16px, dark text. Critical that the user can verify what they've typed.
+- Helper text ("Must include at least one symbol"): smaller (~12px), lighter weight or muted color. Legibility threshold: still readable at small size, but de-emphasized.
+- Error messages ("Password too short"): same size or slightly larger than helper text, in error color (typically red), with sufficient contrast. Critical that the user can read the error.
+- Primary button ("Sign In"): larger (~16–18px), heavier weight, high contrast (white on brand color). Legibility supports recognition at a glance.
+
+Each element's typography is calibrated to its role. Helper text can be smaller because it's secondary; error messages can't be too small because they're critical.
+
+### A confirmation code with a problematic typeface
+
+A user receives a 6-character confirmation code: "OL10IB". The displayed code is in a regular sans-serif typeface where O and 0, L and 1, I and 1, all look nearly identical. The user types "0L1OIB," "OL1OIB," or other variants. The code fails. They blame themselves.
+
+The fix: render confirmation codes in a typeface designed for character disambiguation (a slab-serif with strong distinction between 0 and O, like JetBrains Mono or Fira Code), or use only characters that can be unambiguously distinguished (omit 0, O, I, 1, L from the code alphabet).
+
+### Display type vs. body type
+
+A landing page uses a beautiful display typeface — thin, elegant, with high contrast between thick and thin strokes — for both the headline and the body copy. The headline reads beautifully (display type at large sizes is its purpose). The body copy is hard to read: the thin strokes disappear at small sizes, the high contrast makes some letters look like dots and lines rather than letterforms.
+
+The fix: use the display typeface for the headline only. Body copy needs a typeface designed for sustained reading at small sizes — typically a humanist or transitional serif, or a sans-serif designed for legibility (Inter, IBM Plex Sans, Source Sans, etc.).
+
+### Low-contrast button text
+
+A button has white text on a light-blue background. The contrast ratio is 2.8:1 — below the WCAG 4.5:1 minimum. Users with low vision can't read the button label; users in bright sunlight can't read it either. The button looks beautiful in the design tool but fails in production.
+
+The fix: darken the button background until contrast is at least 4.5:1, or change the text color (white on a darker blue, dark text on a light blue). The legibility cost of the original choice is too high.
+
+### Code listing with the wrong typeface
+
+A documentation site uses a proportional sans-serif for code examples. The proportional spacing makes it hard to align columns; the lack of distinction between l, I, and 1 makes the code ambiguous. Developers struggle to distinguish identifiers and copy code accurately.
+
+The fix: use a monospace typeface for code (every character occupies the same width), ideally one designed for code (programming ligatures, distinguishable 0/O and 1/I/l). Common choices: JetBrains Mono, Fira Code, Cascadia Code, IBM Plex Mono.
+
+## Anti-patterns
+
+**Display typefaces in body copy.** A typeface designed for headlines used at small sizes loses its distinguishing features and becomes hard to read.
+
+**Hairline weights at small sizes.** Ultra-thin typefaces look elegant at large sizes and disappear at small sizes — especially on lower-DPI displays or in glare conditions.
+
+**Light gray text on white.** Designers often reach for #999 or #BBB text for "secondary" content. The contrast is below WCAG threshold; users with low vision, older users, and users in bright environments struggle.
+
+**Typeface choices for branding that hurt legibility.** A custom display typeface used throughout the product because it's "on-brand," even at small UI sizes where it doesn't function. Branding shouldn't override functional legibility.
+
+**Inadequate testing on low-DPI or older displays.** Designers usually work on high-DPI displays where everything renders crisply. The same typography on lower-DPI displays may render with antialiasing artifacts that hurt legibility.
+
+**Rendering on bright/colorful backgrounds without adjustment.** Text legibility depends on its background. The same text that's legible on white may not be legible on a photo or gradient. Test against actual backgrounds.
+
+## Heuristic checklist
+
+Before shipping any text element, ask: **Is the typeface appropriate for the size and use?** Display type for headlines, body type for body, monospace for code. **Is the size large enough to be read at the intended viewing distance?** Test at actual size on actual devices. **Is the weight calibrated to the size?** Heavier weights for small sizes; lighter for large headlines. **Does the contrast meet WCAG?** Use a contrast checker; at minimum 4.5:1 for body text. **Is the spacing comfortable?** Tracking neither tight nor loose; leading at least 1.4× the font size for body text.
+
+## Related principles
+
+- **Readability** — the related principle for sustained-reading text (long prose); legibility is the per-character clarity.
+- **Color** — color choice affects contrast and therefore legibility.
+- **Signal-to-Noise Ratio** — well-chosen typography is signal; poorly chosen is noise.
+- **Accessibility** — legibility is the typography dimension of accessibility.
+- **Hierarchy** — legibility supports hierarchy; you can't have hierarchy if the text is illegible.
+- **Form Follows Function** — display type follows display function; body type follows body function; mixing them violates the principle.
+
+## See also
+
+- `references/lineage.md` — origins in typography research, signage standards, and HCI.
+- `legibility-typeface-and-size/` — sub-skill on the most fundamental legibility decisions.
+- `legibility-contrast-and-spacing/` — sub-skill on rendering conditions.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/legibility/references/lineage.md
@@ -1,0 +1,86 @@
+# Legibility — origins and research lineage
+
+## Roots in print typography
+
+Legibility as a principle predates digital design by centuries. Print typographers have studied the visual clarity of letterforms since the era of metal type. The 19th and 20th centuries produced an extensive body of research on what makes characters distinguishable: x-height, stroke contrast, aperture (the openness of letters like c and a), counter (the enclosed space inside letters like o and e), and terminal style.
+
+Key findings from print legibility research, much of which still applies in digital:
+
+- **Larger x-height improves legibility at small sizes.** Typefaces with tall lowercase letters (Helvetica, Verdana, Inter) are more legible at small sizes than typefaces with small lowercase letters (Times, Garamond) at the same point size.
+- **Open apertures aid distinction.** Letters with openly drawn apertures (the opening at the top or side of c, e, a, s) are more distinguishable from each other than letters with tight closed apertures.
+- **Distinct character shapes matter more than pretty ones.** A typeface that makes I/l/1 distinguishable, 0/O distinguishable, S/5 distinguishable is more legible than a more uniform-looking typeface.
+- **Contrast between thick and thin strokes affects readability at size.** High-contrast typefaces (Bodoni, Didot) are striking at large display sizes but lose their thin strokes at small sizes.
+
+## Signage and wayfinding research
+
+Public signage applications drove the most rigorous legibility research. Highway signs need to be readable at high speed from long distances; airport signs need to be readable across long sight lines; pharmaceutical labels need to be readable in low light by people with declining vision.
+
+Notable work:
+
+- **The Highway Gothic typeface** (used on US road signs since the 1940s) was designed for legibility at distance, with wide proportions and relatively low stroke contrast. Its 2004 successor, Clearview, was designed to improve legibility further but was eventually phased back out due to mixed evidence about its actual benefits.
+- **The DIN typeface family** (originally developed for German engineering signage) emphasizes character distinguishability at the cost of some aesthetic uniformity. The 1929 DIN 1451 standard remains influential.
+- **The transit-system typefaces** developed for the New York subway, the London Underground (Johnston, Gill Sans's predecessor), and the Paris Métro (Parisine) are case studies in legibility for high-speed scanning.
+- **The ANSI/IES standards** for industrial signage specify minimum size, contrast, and spacing for legibility at given distances. These standards are based on extensive psychophysical research.
+
+The signage research consistently finds: legibility is a property of typeface, size, and rendering conditions together — not of the typeface alone. A typeface that's legible at 30pt under good light may be illegible at 10pt under glare.
+
+## Digital typography era
+
+The arrival of computer screens introduced new legibility challenges:
+
+- **Pixel grid constraints.** Early displays had low resolution (72–96 DPI). Typefaces designed for print didn't render well at small sizes; the pixel grid forced compromises in letterform shape.
+- **Hinting.** A technique for adjusting typefaces to render well at small sizes by aligning strokes to pixel boundaries. Required for legibility on lower-DPI displays.
+- **Pixel-perfect typefaces.** Verdana (Matthew Carter, 1996) and Georgia (Carter, 1996) were designed specifically for screen rendering at small sizes — wider proportions, generous spacing, hinting baked in. They remain among the most legible typefaces for low-DPI conditions.
+
+The shift to high-DPI ("Retina" and equivalent) displays in the 2010s reduced some of these constraints. Modern typefaces can be more sophisticated because the rendering supports more detail. But the fundamental legibility properties (x-height, stroke contrast, character distinguishability) still matter.
+
+## Typefaces designed specifically for character disambiguation
+
+Several typefaces have been designed to maximize character distinguishability, especially for code, identification numbers, and other contexts where misreading matters:
+
+- **Inconsolata** (Raph Levien, 2006) — a monospace typeface with strongly distinguished I/l/1 and 0/O.
+- **Source Code Pro** (Adobe, 2012) — Adobe's open-source code typeface, with similar disambiguation features.
+- **Fira Mono / Fira Code** (Mozilla, 2014) — a monospace typeface with programming ligatures and clear character distinctions.
+- **JetBrains Mono** (JetBrains, 2020) — designed specifically for code reading, with explicit attention to ambiguous-character distinctions and OpenType features for ligatures.
+- **Atkinson Hyperlegible** (Braille Institute, 2020) — designed for low-vision readers, with maximally distinct character shapes.
+
+These typefaces demonstrate that character disambiguation is a deliberate design choice, not a happy accident. When ambiguity matters (code, IDs, codes), reach for typefaces designed for it.
+
+## Accessibility research
+
+Modern accessibility research, codified in WCAG (Web Content Accessibility Guidelines), extends legibility to specific quantitative criteria:
+
+- **Minimum contrast ratio:** 4.5:1 for normal text, 3:1 for large text (at least 18pt or 14pt bold).
+- **Resizable text:** users must be able to scale text up to 200% without loss of functionality.
+- **Avoid text-as-image** when text would suffice (so users can adjust the rendering).
+
+These criteria are floors, not ceilings. Better-than-WCAG contrast (7:1 or higher) substantially improves legibility for users with low vision, older users, and users in poor viewing conditions. Best practice is to design well above the floor.
+
+Atkinson Hyperlegible and similar typefaces specifically target users with low vision; their design principles (extreme distinguishability, generous apertures) translate to better legibility for all users in suboptimal conditions.
+
+## Empirical findings on legibility
+
+The literature converges on a few stable findings:
+
+- **Sans-serif typefaces are slightly more legible at small sizes on screens** than serif typefaces, due to less detail to lose at small sizes. The difference shrinks as DPI increases.
+- **Body text below 14px is harder to read for many users**, especially older readers. Most modern UI uses 14–16px as a body baseline.
+- **Line-length matters less for short UI text** than for long-form prose; for UI labels, focus on character clarity and rendering.
+- **Higher contrast generally improves legibility**, with diminishing returns above 7:1.
+- **Typeface and weight should be calibrated to size.** Light weights at small sizes; regular or medium for body; bold for emphasis or display.
+
+## Legibility in motion
+
+A subset of legibility worth mentioning: text that scrolls, animates, or appears briefly. The viewer has less time to read, so legibility requirements are higher. Captioning research (for film and television) suggests that caption text should be 30% larger than equivalent static text, with extra contrast and avoidance of ambiguous characters.
+
+Modern UI increasingly involves motion — toast notifications that appear and disappear, scrolling tickers, animated transitions. These should be designed to higher legibility standards than static UI.
+
+## Sources informing this principle
+
+- Tinker, M. A. (1963). *Legibility of Print*. (Foundational text on print legibility research.)
+- Carter, M. (Various, 1990s–present). Designer of Verdana, Georgia, and many other typefaces designed for screen legibility.
+- Lupton, E. (2010). *Thinking with Type*. (Comprehensive overview of typography for designers.)
+- Federal Highway Administration. (Various). Research on Highway Gothic and Clearview legibility.
+- Atkinson, B. (Braille Institute, 2020). Atkinson Hyperlegible typeface and design rationale.
+- WCAG 2.1 (2018). Web Content Accessibility Guidelines.
+- IES (Illuminating Engineering Society). Standards on signage legibility.
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/perception-router/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/perception-router/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: perception-router
+description: 'Use this skill whenever a design task involves visual perception, layout, hierarchy, grouping, scanning order, attention, color organization, or composition — regardless of framework, design system, or platform. Trigger when the user is laying out a screen, page, slide, poster, dashboard, mobile view, or print piece; choosing what to emphasize; deciding how things should group; picking type sizes, spacing, or color roles; reviewing why something "looks busy" or "feels empty"; or asking "where should the eye land first." Routes the model to the right perception principle in this plugin and surfaces the most-decisive ones for the surface in question. Framework-agnostic: applies to web, mobile, print, physical product, slide design, and information graphics alike.'
+---
+
+# Perception & hierarchy — router
+
+This plugin holds the principles that govern how the eye organizes a composition: what gets seen first, what groups with what, what reads as noise, what reads as quality. They are framework-agnostic; the same principle applies to a shadcn/ui card, a Material chip, a Figma slide, a poster, or a printed report.
+
+## How to route
+
+Read the task and identify the principles that decide it. Most non-trivial perception tasks are dominated by 3–6 principles. Read those principles' skills in full; treat the rest as background.
+
+## Principles in this plugin
+
+The list below is the full inventory of perception-related principles from *Universal Principles of Design* covered by this plugin. Each principle has its own skill (and where useful, sub-aspect skills) under `skills/`. Principles marked **[full]** have reference-grade skill files; the others are planned and will be added in subsequent passes.
+
+### Visual hierarchy and emphasis
+
+- **`hierarchy`** *[full]* — the ranking of importance among visible elements; size, weight, color, position.
+  - Sub-skills: `hierarchy-typographic`, `hierarchy-spatial`, `hierarchy-color-and-tone`.
+- **`alignment`** — elements share an invisible axis; misalignment reads as disorder.
+- **`area-alignment`** — alignment by visual mass rather than bounding box.
+- **`signal-to-noise-ratio`** *[full]* — the ratio of meaningful information to decoration.
+  - Sub-skills: `snr-densification`, `snr-decoration-removal`, `snr-emphasis-economy`.
+- **`highlighting`** — emphasis works only when sparing.
+- **`von-restorff-effect`** — the item that differs is remembered and noticed first.
+- **`red-effect`** — red attracts disproportionate attention; reserve for genuine urgency.
+- **`horror-vacui`** — the impulse to fill empty space; whitespace is a feature.
+- **`layering`** — distinct visual planes (z, elevation) reduce noise.
+- **`gutenberg-diagram`** — Z-pattern reading on uniform layouts.
+
+### Gestalt grouping
+
+- **`proximity`** *[full]* — nearby items are perceived as a group.
+  - Sub-skills: `proximity-form-fields`, `proximity-data-tables`, `proximity-navigation`.
+- **`similarity`** — items that look alike are perceived as related.
+- **`closure`** — the eye completes incomplete shapes.
+- **`common-fate`** — elements moving together are perceived as related.
+- **`figure-ground-relationship`** — every composition has a focused figure and a recessive ground.
+- **`good-continuation`** — aligned edges read as connected.
+- **`uniform-connectedness`** — a shared region binds elements more strongly than proximity alone.
+- **`law-of-pragnanz`** — the eye prefers the simplest valid interpretation.
+- **`contour-bias`** — sharp angles feel hostile; rounded corners feel friendly.
+
+### Proportion, rhythm, and depth
+
+- **`golden-ratio`** — 1:1.618; useful as a starting proportion for hero compositions.
+- **`fibonacci-sequence`** — successive Fibonacci ratios produce natural-feeling spacing scales.
+- **`rule-of-thirds`** — split a composition into thirds; place focal points on intersections.
+- **`symmetry`** — bilateral, radial, or translational; stable but can feel static.
+- **`self-similarity`** — fractal repetition at multiple scales creates coherence.
+- **`cathedral-effect`** — high "ceilings" (whitespace) invite expansive thinking; low ones invite focus.
+- **`three-dimensional-projection`** — subtle depth cues (shadow, scale) clarify layering.
+
+### Typography and color
+
+- **`legibility`** — character distinctness; a property of typeface and rendering.
+- **`readability`** — sustained reading speed; a property of layout (length, leading, contrast).
+- **`color`** — hue, saturation, value; cultural meaning; accessibility.
+- **`gloss-bias`** — glossy surfaces read as desirable.
+- **`top-down-lighting-bias`** — humans assume light from above; shadows below = raised, shadows above = recessed.
+
+### Attention quirks
+
+- **`inattentional-blindness`** — focused users don't see unexpected elements.
+- **`threat-detection`** — sharp angles, snake-like shapes, angry faces detected fast.
+- **`orientation-sensitivity`** — vertical and horizontal lines processed faster than oblique.
+
+## Heuristic for which to read first
+
+- **Designing a page or screen layout** → `hierarchy`, `alignment`, `proximity`, `signal-to-noise-ratio`.
+- **Reviewing a "busy" or "noisy" UI** → `signal-to-noise-ratio`, `highlighting`, `horror-vacui`.
+- **Form layout** → `proximity`, `alignment`, `good-continuation`, `gutenberg-diagram`.
+- **Data table or dashboard** → `hierarchy`, `signal-to-noise-ratio`, `legibility`, `gestalt similarity`.
+- **Marketing / hero surface** → `hierarchy`, `golden-ratio` or `rule-of-thirds`, `gloss-bias`, `cathedral-effect`.
+- **Empty / loading / error states** → `hierarchy`, `horror-vacui`, `figure-ground-relationship`.
+- **Brand / visual-identity decisions** → `contour-bias`, `color`, `symmetry`, `self-similarity`.
+- **Choosing color tokens** → `color`, `red-effect`, `top-down-lighting-bias`, plus accessibility checks (see `process-and-robustness-principles`).
+
+## Working method
+
+1. **Name the surface** in concrete terms: "B2B SaaS settings page with three sections," not "settings page."
+2. **Pick 3–6 decisive principles** from the list above. Most surfaces are dominated by Hierarchy, Proximity, Alignment, and Signal-to-Noise.
+3. **Read those skills.** Each principle skill includes a definition, when-to-apply guidance, anti-patterns, and worked examples.
+4. **Make the decision and name the trade-off.** Most principles trade against another.
+
+## Cross-plugin pointers
+
+- For *learnability* (mental models, complexity, defaults, recognition), see `cognition-and-learnability-principles`.
+- For *behavior* (affordance, feedback, errors, control), see `interaction-and-control-principles`.
+- For *brand and tone*, see `aesthetics-and-emotion-principles`.
+- For *accessibility and edge cases*, see `process-and-robustness-principles`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/perception-router/references/further-reading.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/perception-router/references/further-reading.md
@@ -1,0 +1,55 @@
+# Further reading: perception and hierarchy
+
+A curated list of external sources for going deeper into the perception-related principles in this plugin. Use these when a project needs more authority than the in-skill summaries provide.
+
+## Foundational
+
+- **Wertheimer, M.** (1923). "Untersuchungen zur Lehre von der Gestalt II." Translated as "Laws of Organization in Perceptual Forms." The original paper laying out the Gestalt grouping laws (proximity, similarity, closure, common fate, good continuation, figure-ground).
+- **Köhler, W.** (1947). *Gestalt Psychology*. Mentor. The book-length treatment that brought Gestalt theory to a broader audience.
+- **Koffka, K.** (1935). *Principles of Gestalt Psychology*. Harcourt, Brace.
+
+## Information design
+
+- **Tufte, E. R.** (1983). *The Visual Display of Quantitative Information*. Graphics Press. The canonical work on data-ink ratio, chartjunk, and visual integrity in information graphics.
+- **Tufte, E. R.** (1990). *Envisioning Information*. Graphics Press. Layering, separation, color, narrative.
+- **Bertin, J.** (1967). *Sémiologie graphique*. Translated as *Semiology of Graphics* (1983). The taxonomy of visual variables (position, size, value, texture, color, orientation, shape).
+- **Cleveland, W. S.** (1985). *The Elements of Graphing Data*. Hobart Press. Empirical work on what humans can decode from charts.
+
+## Visual perception research
+
+- **Treisman, A.** (1980). *Feature Integration Theory*. The foundational model of preattentive visual processing.
+- **Pelli, D. G., Tillman, K. A.** (2008). "The uncrowded window of object recognition." *Nature Neuroscience*. On crowding effects relevant to text legibility.
+- **Itti, L. & Koch, C.** (2001). "Computational modelling of visual attention." *Nature Reviews Neuroscience*. Saliency maps — what the eye is drawn to in a complex scene.
+
+## Web and UI applications
+
+- **Krug, S.** (2000, 2014). *Don't Make Me Think*. New Riders. The most-cited web usability book; written for designers, very practical.
+- **Nielsen, J.** Many writings at nngroup.com. Particularly useful: NN/g studies on F-pattern, banner blindness, and form perception.
+- **Schenkman, B. N. & Jönsson, F. U.** (2000). "Aesthetics and preferences of web pages." *Behaviour & Information Technology*. Empirical work linking visual properties to perceived quality.
+
+## Typography
+
+- **Bringhurst, R.** (2012, 4th ed.). *The Elements of Typographic Style*. Hartley & Marks. The reference work for typesetting.
+- **Lupton, E.** (2010). *Thinking with Type*. Princeton Architectural Press. Accessible introduction.
+- **Spiekermann, E. & Ginger, E. M.** (2003). *Stop Stealing Sheep & Find Out How Type Works*. Adobe Press.
+
+## Color
+
+- **Albers, J.** (1963). *Interaction of Color*. Yale University Press. The foundational treatment of perceptual color relationships.
+- **Itten, J.** (1961). *The Art of Color*. Color theory for designers.
+- **Stone, M.** (2003). *A Field Guide to Digital Color*. CRC Press. Practical color science for screens.
+
+## Online tools and references
+
+- **Material Design** (Google) — material.io/design. Although Material is a specific design system, its documentation includes useful general guidance on hierarchy, color, motion.
+- **Apple Human Interface Guidelines** — developer.apple.com/design. Same: specific to Apple platforms but generally applicable.
+- **WAI-ARIA Authoring Practices Guide** — w3.org/WAI/ARIA/apg. The canonical reference for accessible component patterns.
+- **Refactoring UI** (Steve Schoger, Adam Wathan). Practical book/site on UI design for engineers; many perception-grounded recommendations.
+
+## Going further
+
+For a working designer, the highest-leverage investments after this plugin are:
+
+1. Read Tufte's *Visual Display* — once. It changes how you see information graphics permanently.
+2. Build muscle memory with a type-and-color audit on every project for ~3 months. After that, the perception checks become automatic.
+3. Watch real users (not just designers) use your designs. The gap between what you intended and what they perceive is where the next round of learning lives.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-data-tables/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-data-tables/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: proximity-data-tables
+description: 'Use this skill when designing or fixing data tables and tabular layouts — row spacing, column spacing, header treatment, group separators, total rows, sticky headers, dense vs. comfortable variants. Trigger when the user is laying out a table, deciding density, debugging "rows that are hard to follow," picking when to add zebra striping, or arguing for/against borders. Sub-aspect of `proximity`; read that first if you haven''t already.'
+---
+
+# Proximity in data tables
+
+Tables stress proximity in two directions at once: rows should read as discrete records (vertical proximity binding cells of the same row, separating them from cells of neighbor rows), and columns should read as semantic groupings (horizontal proximity within a column header, between header and cells). Most table problems are proximity problems disguised as styling problems.
+
+## The two-axis proximity ladder
+
+In a table, you're managing two perpendicular spacing systems:
+
+```
+Vertical:
+  Inside a row (cell padding)        — ~12-16px
+  Between rows                       — ~0 (or thin border for separation)
+  Header to first row                — slightly more than between rows
+  Footer / total row                 — distinctly more than between rows
+
+Horizontal:
+  Within a cell (text to edge)       — ~12-16px
+  Between columns                    — ~0 (cell border or just padding)
+  Numeric columns: tabular-nums + right alignment for column-internal proximity
+```
+
+The classic mistake is uniform padding everywhere — every gap the same — so the eye can't tell rows from columns from groups.
+
+## Dense vs. comfortable variants
+
+Tables come in two density modes; pick deliberately:
+
+```
+Comfortable (default for most apps):
+  Cell padding:  py-3 px-4   (12px / 16px)
+  Row height:    ~48px
+  Best for:      moderate datasets, mixed user proficiency
+
+Dense (power-user / spreadsheet-like):
+  Cell padding:  py-1.5 px-3  (6px / 12px)
+  Row height:    ~32px
+  Best for:      high-frequency scanning, expert users, datasets >50 rows visible
+```
+
+Don't mix densities in the same table. Don't try to be "compact but readable" with mid-sized padding — it ends up neither dense enough for power users nor comfortable enough for casual ones.
+
+## Header proximity
+
+The header should bind to its column (vertically tight to the column it labels) but separate clearly from the data rows.
+
+```html
+<style>
+  .table { width: 100%; border-collapse: collapse; }
+  .table th, .table td { padding: 0.75rem 1rem; text-align: left; }
+  .table th {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: hsl(0 0% 35%);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border-bottom: 1px solid hsl(0 0% 88%);   /* separates header from data */
+    padding-bottom: 0.5rem;                    /* tighter to the underline */
+  }
+  .table td { border-bottom: 1px solid hsl(0 0% 95%); }   /* very subtle row separator */
+  .table tbody tr:hover { background: hsl(0 0% 98%); }
+</style>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Customer</th>
+      <th style="text-align: right;">Amount</th>
+      <th style="text-align: right;">Days late</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Acme Co.</td>
+      <td style="text-align: right; font-variant-numeric: tabular-nums;">$2,480.00</td>
+      <td style="text-align: right; font-variant-numeric: tabular-nums;">14</td>
+      <td><span class="badge badge-warning">Pending</span></td>
+    </tr>
+    <!-- … -->
+  </tbody>
+</table>
+```
+
+The header sits in its own row, visually distinct (smaller, uppercase, lower contrast, with a stronger underline). Data rows have a subtle hairline separator that suggests row boundaries without dominating.
+
+## Numeric column proximity
+
+Numbers in a column should align *within the column*, so the eye can scan vertically and compare magnitudes:
+
+- **Right-align** numeric columns. Left-aligned numbers don't compare.
+- **Tabular nums** (`font-variant-numeric: tabular-nums`) so digits occupy equal width. Without this, "1,000" and "9,999" don't align by digit position.
+- **Same number of decimals** in every cell of a column. "$2.5", "$10.00", "$1,200" don't align. Pick a precision and stick to it.
+
+```html
+<td style="text-align: right; font-variant-numeric: tabular-nums;">$2,480.00</td>
+<td style="text-align: right; font-variant-numeric: tabular-nums;">$10.00</td>
+<td style="text-align: right; font-variant-numeric: tabular-nums;">$98,001.50</td>
+```
+
+Now the eye can scan the column and see magnitude differences instantly.
+
+## Group separators
+
+When rows belong to logical groups (orders by month, projects by team, transactions by status), encode the grouping with a *visible gap* and an optional sub-header — not by adding a heavy border:
+
+```html
+<table class="table">
+  <thead>…</thead>
+  <tbody>
+    <tr class="group-header">
+      <td colspan="4">May 2026</td>
+    </tr>
+    <tr><td>…</td>…</tr>
+    <tr><td>…</td>…</tr>
+
+    <tr class="group-header">
+      <td colspan="4">April 2026</td>
+    </tr>
+    <tr><td>…</td>…</tr>
+    <tr><td>…</td>…</tr>
+  </tbody>
+</table>
+
+<style>
+  .group-header td {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: hsl(0 0% 35%);
+    background: hsl(0 0% 97%);
+    padding-top: 1rem;        /* extra space above this row separates groups */
+    padding-bottom: 0.5rem;
+  }
+</style>
+```
+
+The extra top padding on group headers creates a perceptual gap; the slight background tint reinforces it. The user reads months as groups, transactions as group members.
+
+## Total / summary rows
+
+Total rows should bind to the data they summarize (close vertically) and stand out from regular rows (heavier weight, possibly a top border):
+
+```html
+<tfoot>
+  <tr style="font-weight: 600; border-top: 2px solid hsl(0 0% 88%);">
+    <td>Total</td>
+    <td colspan="2" style="text-align: right; font-variant-numeric: tabular-nums;">$24,800.00</td>
+    <td></td>
+  </tr>
+</tfoot>
+```
+
+The 2px top border separates the summary from data rows. Bold weight signals "this is summary, not a regular row." Same column alignment as the data above.
+
+## Zebra striping (alternating row backgrounds)
+
+Use sparingly. Zebra striping helps the eye track across very wide rows (~7+ columns) but adds visual noise to compact tables.
+
+- **Use it**: wide tables, many columns, where the user must trace a single row across.
+- **Skip it**: 3–5 column tables where row tracking isn't a problem; a hover background is enough.
+- **Make it subtle**: `hsl(0 0% 98%)` against white — visible but not distracting. Anything stronger competes with the data.
+
+## Anti-patterns
+
+- **Heavy borders everywhere.** Every cell bordered, every row separated, every column ruled. The page becomes a grid prison; data drowns in chrome. Strip borders; let alignment and subtle separation do the work.
+- **Equal padding top and bottom on rows.** With no row separator and equal padding, rows blur into a wall of text. Add either a hairline separator or a slight row-zebra.
+- **Numeric and text columns aligned the same way.** Numbers left-aligned mean the eye can't compare magnitudes; text right-aligned means the eye can't follow words.
+- **Inconsistent decimal precision.** One column shows "$2", "$2.5", "$2.50", "$2.501" — eye scan fails. Pick a precision per column.
+- **Sticky header with no separator.** Sticky headers that float over scrolling data without a clear border merge into the data; users don't realize what's a header.
+
+## Heuristics
+
+1. **The single-finger trace.** Can you trace any row with one finger from left to right without losing your place? If not, row separation is too weak (or the row is too tall).
+2. **The numeric-column scan.** Look down a numeric column. Can you spot the largest value at a glance? If not, alignment or tabular-nums is missing.
+3. **Strip the chrome.** Mentally remove every border and background. Does the table still parse? If yes, your chrome is doing redundant work; trim it.
+
+## Related sub-skills
+
+- **`proximity`** (parent).
+- **`proximity-form-fields`** — same principle on input layouts.
+- **`hierarchy-typographic`** — header styling lives at the intersection of hierarchy and proximity.
+- **`signal-to-noise-ratio`** — tables are a primary case for SNR discipline.
+- **`legibility`** — tabular numerals and alignment are legibility decisions as much as proximity ones.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-data-tables/references/table-design-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-data-tables/references/table-design-patterns.md
@@ -1,0 +1,128 @@
+# Table design: patterns and references
+
+A reference complementing `proximity-data-tables` with deeper design patterns and historical context.
+
+## Tabular data design history
+
+The visual conventions for tabular data are remarkably old and remarkably stable:
+
+- **Accounting ledgers** (Italian double-entry bookkeeping, ~1494, codified by Pacioli) established columnar layout, right-alignment for numerics, totals at the bottom, headers at the top — the same conventions used in modern data tables.
+- **Census tables** (19th century onward) added subgrouping and hierarchical headers.
+- **Tufte's *Visual Display*** (1983) and *Envisioning Information* (1990) catalog the best-and-worst of statistical tables, with strong opinions about chartjunk and over-decoration.
+
+The web's table design briefly forgot these conventions in the 2010s (CSS-styled "card grids" replaced semantic tables for tabular data) and is now relearning them. `<table>` with semantic `<th>`, `<td>`, `<tfoot>` is once again the right element for tabular data.
+
+## Density patterns
+
+Three established densities, each with its use:
+
+| Density | Row height | Use case |
+|---|---|---|
+| Comfortable | 48–56 px | Default for general apps; mixed proficiency users |
+| Compact | 32–40 px | Power users, dense datasets, spreadsheet-like |
+| Hyperdense | 20–28 px | Specialized tools (trading, IDEs, monitoring); experts only |
+
+Don't mix densities in the same table. Don't try to be "compact but readable" with mid-sized padding — you'll please neither density mode.
+
+## Alignment conventions
+
+Strong conventions, broken at your peril:
+
+- **Text columns: left-align** in LTR scripts. Right-align text reads as decorative.
+- **Numeric columns: right-align** so digit positions stack.
+- **Date columns: left-align** if formatted as text ("May 2"), right-align if numeric/ISO ("2026-05-02").
+- **Action / status columns: center or left**, depending on density.
+- **Headers**: align to match the column data they label. Numeric column → right-aligned header.
+
+## Numeric formatting
+
+Tabular numbers benefit from `font-variant-numeric: tabular-nums` — equal-width digits so columns align by digit position. Without it, "1,000" and "9,999" don't align even though they have the same character count.
+
+Decimal precision should be consistent within a column. Don't show "$2", "$10.00", and "$1,200.50" in the same column — pick one precision.
+
+## Group separators
+
+When rows are grouped (by date, status, owner, etc.):
+
+- **Subtle row of slightly-darker background** carrying the group label (least obtrusive).
+- **Group label as a tinted band** with the group key (clearer; takes more space).
+- **Visible gap before the next group** (extra row padding).
+
+Don't use heavy borders to separate groups; the page becomes a grid prison.
+
+## Sticky headers
+
+For tables that scroll vertically (≥ 20 rows visible):
+
+```css
+thead { position: sticky; top: 0; z-index: 1; background: white; }
+thead th {
+  border-bottom: 1px solid hsl(0 0% 88%);
+  box-shadow: 0 1px 0 hsl(0 0% 88%);  /* slight shadow when scrolled */
+}
+```
+
+The shadow appears only when content is scrolled beneath the header, providing visual feedback that the header is "floating."
+
+## Sortable columns
+
+Sortable columns need a clear affordance:
+
+- Cursor pointer on header hover.
+- Sort direction indicator (↑ / ↓ / ↕) visible on hover; current-sort indicator persistent on the active column.
+- Click cycles ascending → descending → unsorted, or just toggles ascending/descending.
+
+Keyboard: enter to toggle sort on the focused header.
+
+## Selection and bulk actions
+
+For tables with row selection:
+
+- Checkbox column at the *left* (precedes data, doesn't disturb scanning).
+- "Select all" checkbox in the header cell, with indeterminate state when partial.
+- Bulk-action toolbar appears above the table when selection > 0 — contextually showing only relevant actions.
+
+## Cross-domain examples
+
+### Spreadsheet conventions
+
+Excel, Google Sheets, Airtable: cell selection, fill handles, formula bars. The grid is the universal interface for tabular data; web tables that pretend to be cards reinvent something users already know how to use.
+
+### Train and flight schedules
+
+Mass-transit timetables maximize information per square inch. Times are right-aligned (compare departure times across destinations). Service notes (holiday-only, late-night) are footnoted with superscript markers. Header cells are color-coded by service category.
+
+These conventions evolved over a century of riders learning to scan; software tables can borrow heavily.
+
+### Stock-market tables
+
+Newspaper stock tables (largely extinct) packed 6–8 columns per ticker (last, high, low, change, volume, P/E, dividend, yield) at maybe 6pt type. They worked because the layout was so consistent that frequent users developed spatial memory; new users struggled.
+
+The pattern: dense data with consistent layout earns power-user efficiency at the cost of new-user friction. Choose deliberately.
+
+## Edge cases
+
+### Responsive tables
+
+A wide table on a 375px screen is unusable. Patterns:
+
+- **Horizontal scroll** within the table region — preserves table structure, costs scrolling.
+- **Stacked rows** at mobile — each "row" becomes a card with field/value pairs. Loses cross-row scanning.
+- **Priority columns** — show only the 2–3 most important columns on mobile; expand to detail view on tap.
+
+Each pattern has trade-offs; pick based on the user's primary task.
+
+### Tables with mixed cell types
+
+When some cells are numbers, some are dates, some are status badges, some are images — alignment becomes fraught. Default to:
+
+- Each cell aligned per its type (number right, text left, etc.).
+- Header alignment matches its cell type.
+- Status cells with badges — center the badge in the cell, or left-align if cells are wide.
+
+## Resources
+
+- **Tufte, E. R.** (1983, 1990, 1997). The full *Envisioning Information* / *VDQI* / *Visual Explanations* trilogy.
+- **Few, S.** *Show Me the Numbers* (2004) — practical statistical-table design.
+- **Material Design Tables docs** — material.io.
+- **Adam Silver** — "Designing Data Tables" series on adamsilver.io.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-form-fields/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-form-fields/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: proximity-form-fields
+description: 'Use this skill when laying out a form, fixing a confusing form, or building a form layout convention for a design system. Forms are where proximity failures are most visible: ambiguous label-input pairing, sections that bleed into each other, help text that orphans from its field. Trigger when designing sign-up, sign-in, settings, profile, billing, checkout, multi-step, or any structured-input surface. Sub-aspect of `proximity`; read that first if you haven''t already.'
+---
+
+# Proximity in form layout
+
+Forms are the canonical proximity case. A form with poor proximity produces ambiguous label-input pairings, orphaned help text, sections that don't read as sections, and a general feeling that the user must "decode" the layout before they can fill it in. A form with good proximity reads as a structured set of pairs and groups; the user fills it in without thought.
+
+## The form proximity ladder
+
+Use four nested levels of spacing — each level visibly tighter than the level above it:
+
+```
+Level 1: gap-1   (4px)    inside a label-input pair
+Level 2: gap-3   (12px)   between fields in a group
+Level 3: gap-6   (24px)   between groups within a section
+Level 4: gap-10  (40px)   between sections
+```
+
+Each level should be at least 2× the level inside it. Don't use `gap-2` and `gap-3` for different roles — they look identical.
+
+## The label-input pair
+
+The single most important proximity decision in a form: the **label belongs with the input it labels**. Every other proximity issue cascades from this.
+
+### Top-aligned labels (default for vertical forms)
+
+```html
+<style>
+  .form { display: grid; gap: 1.5rem; max-width: 400px; }     /* Level 3 between groups */
+  .field { display: grid; gap: 0.25rem; }                      /* Level 1 inside pair */
+  .field-help { font-size: 0.8rem; color: hsl(0 0% 45%); }     /* tone reduction for tertiary */
+</style>
+
+<form class="form">
+  <div class="field">
+    <label for="email">Email address</label>
+    <input id="email" type="email" required />
+    <p class="field-help">We'll send a verification link.</p>
+  </div>
+  <div class="field">
+    <label for="password">Password</label>
+    <input id="password" type="password" required />
+  </div>
+  <button type="submit">Sign up</button>
+</form>
+```
+
+The label, input, and help text are bound by tight (4px) spacing. The fields are separated by loose (24px) spacing. Pairing reads instantly.
+
+### Inline labels (left-aligned, common in admin and settings)
+
+```html
+<style>
+  .form-grid {
+    display: grid;
+    grid-template-columns: 10rem 1fr;          /* fixed label column */
+    gap: 0.75rem 1rem;                          /* row gap, column gap */
+    max-width: 600px;
+  }
+  .form-grid label { padding-top: 0.5rem; text-align: right; }
+  .form-grid .field-help { grid-column: 2; font-size: 0.8rem; color: hsl(0 0% 45%); }
+</style>
+
+<form class="form-grid">
+  <label for="display-name">Display name</label>
+  <input id="display-name" />
+
+  <label for="email">Email</label>
+  <input id="email" type="email" />
+  <p class="field-help">Used for login and notifications.</p>
+
+  <label for="role">Role</label>
+  <select id="role">…</select>
+</form>
+```
+
+Note how the help text appears in the right column under its input — proximity binds it to the field, not to the label across the row.
+
+### Section grouping
+
+When a form spans more than ~5 fields, group them. Sections get **distinctly larger** spacing than between fields, plus a heading.
+
+```html
+<form style="display: grid; gap: 2.5rem; max-width: 480px;">
+  <section style="display: grid; gap: 1rem;">
+    <h2 style="margin-bottom: 0.25rem;">Profile</h2>
+    <div class="field"><label>Display name</label><input /></div>
+    <div class="field"><label>Bio</label><textarea></textarea></div>
+  </section>
+
+  <section style="display: grid; gap: 1rem;">
+    <h2 style="margin-bottom: 0.25rem;">Notifications</h2>
+    <div class="field"><label>Email frequency</label><select>…</select></div>
+    <div class="field"><label>Quiet hours</label><input /></div>
+  </section>
+
+  <section style="display: grid; gap: 1rem;">
+    <h2 style="margin-bottom: 0.25rem;">Security</h2>
+    <div class="field"><label>Two-factor</label><div>…toggle…</div></div>
+  </section>
+</form>
+```
+
+Three ranks of spacing (1rem within a section, 2.5rem between sections, plus the tight 0.25rem inside each field). The heading is *slightly* closer to its first field (0.25rem) than to neighbors (1rem) so it groups with what it labels.
+
+### Required indicators
+
+A common proximity question: where does the asterisk go? Right next to the label text, with no space:
+
+```html
+<label>Email <span class="required" aria-hidden>*</span></label>
+```
+
+Not:
+
+```html
+<label>Email</label> <span class="required">*</span>     <!-- detached, looks like body content -->
+```
+
+The asterisk is part of the label, not a separate element. Proximity confirms.
+
+### Inline error messages
+
+Errors should appear *below* the field they reference, with tight spacing:
+
+```html
+<div class="field" data-state="error">
+  <label for="email">Email</label>
+  <input id="email" type="email" aria-invalid="true" aria-describedby="email-error" />
+  <p id="email-error" class="field-error">Please enter a valid email.</p>
+</div>
+
+<style>
+  .field-error {
+    font-size: 0.8rem;
+    color: hsl(0 75% 35%);
+    margin-top: 0.25rem;     /* same as label-input gap */
+  }
+</style>
+```
+
+The error sits inside the field group's tight cluster, so the user reads it as part of the field, not as page-level content.
+
+## Multi-column forms
+
+Sometimes density requires placing fields side-by-side (first name / last name; city / state / zip). Proximity-friendly multi-column layout:
+
+```html
+<style>
+  .field { display: grid; gap: 0.25rem; }
+  .row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }   /* same as field gap */
+</style>
+
+<form style="display: grid; gap: 1rem; max-width: 480px;">
+  <div class="row">
+    <div class="field"><label>First name</label><input /></div>
+    <div class="field"><label>Last name</label><input /></div>
+  </div>
+  <div class="row" style="grid-template-columns: 1fr auto auto;">
+    <div class="field"><label>City</label><input /></div>
+    <div class="field"><label>State</label><select>…</select></div>
+    <div class="field"><label>ZIP</label><input style="width: 6rem;" /></div>
+  </div>
+</form>
+```
+
+The horizontal gap (`gap: 1rem`) within a row matches the vertical gap between rows. Each field is a tight pair internally. The user reads "first name + last name as a paired row," distinct from the row above.
+
+## Anti-patterns
+
+- **Equal vertical spacing.** Label, input, label, input all separated by the same gap. Pairing is ambiguous; users read carefully.
+- **Help text outside the pair.** Help text in a sidebar or above the section heading. The user has to look elsewhere to understand the field. Place help text under its input, tightly bound.
+- **Section heading equally spaced above and below.** The heading should be tighter to its own section than to the previous section.
+- **Border-as-section.** Wrapping each section in a card with a 1px border because the spacing isn't doing the work. First fix the spacing; the borders may not be needed.
+- **Mobile mush.** A form that's nicely grouped on desktop collapses on mobile because the responsive layout reduced all gaps to one value. Maintain the proportional ladder at every breakpoint.
+
+## Heuristics
+
+1. **Cover and pair.** Cover all but two adjacent elements. Can you tell if they're a pair or two separate items? If not, the gap is wrong.
+2. **The 'gap audit'.** List every distinct gap value used in the form. There should be 3–5, each visibly different. Many distinct gaps near each other (8px, 10px, 12px, 14px) signal accidental spacing.
+3. **Mobile line-up test.** At 320px viewport, the form should still read as discrete groups. If it becomes a single column of evenly-spaced rows, proximity has collapsed.
+
+## Related sub-skills
+
+- **`proximity`** (parent) — the principle in full.
+- **`proximity-data-tables`** — applying the same idea to tabular data.
+- **`hierarchy-spatial`** — spatial hierarchy *between* groups; complementary to proximity *within* groups.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-form-fields/references/form-design-research.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-form-fields/references/form-design-research.md
@@ -1,0 +1,85 @@
+# Form-design research and patterns
+
+A reference complementing `proximity-form-fields` SKILL.md with research findings and patterns from the broader form-design literature.
+
+## Empirical findings
+
+The most-cited form-design research:
+
+- **Caroline Jarrett & Gerry Gaffney**, *Forms that Work* (2008). The reference work for form usability. Key finding: label-input *association* (proximity, alignment, semantic clarity) accounts for the majority of form usability differences across designs.
+- **Luke Wroblewski**, *Web Form Design: Filling in the Blanks* (2008). Compiles empirical studies on label position, alignment, error placement, and other form decisions.
+- **NN/g studies on form completion** (multiple) — consistently show that top-aligned labels outperform left-aligned for completion speed when the form is single-column; left-aligned labels outperform when fields are extensively scanned (e.g., a profile review).
+
+Key empirical results worth remembering:
+
+- **Top labels are 50% faster to complete on average** than left-aligned labels (Penzo, 2006), because the eye moves vertically without scanning sideways.
+- **Right-aligned labels** (label flush right against input flush left) are tied for speed with top-aligned but read as less friendly.
+- **Inline labels (placeholder-only)** test 30%+ slower than visible labels and have highest error rates, especially after the user starts typing and the placeholder vanishes.
+- **Required-field markings as `*` are widely understood** but should be paired with text for accessibility ("required").
+
+## Form-layout patterns by use case
+
+### Sign-up / sign-in (fast completion priority)
+
+Single column, top labels, generous gaps between fields, primary CTA at bottom-right or full-width.
+
+### Long settings (scanning priority)
+
+Two-column with right-aligned labels — the eye scans the left column for the setting it wants, then values are aligned in a second column for quick review.
+
+### Multi-step wizard (progress priority)
+
+Single column per step. Stepper at top showing progress. Each step is short (≤ 5 fields). Primary CTA progresses; secondary CTA returns.
+
+### Edit-in-place (proximity to context priority)
+
+Inline editing where each field is bound to the data it represents (no labels needed; the data itself is the label). Hover or focus reveals editing affordance.
+
+### Conversational form (one-question-at-a-time priority)
+
+Each field on its own screen with a question and an input. Reduces Hick's Law pressure but multiplies clicks.
+
+## Cross-domain examples
+
+### Government forms
+
+Government forms (tax returns, immigration, benefits) are the bottom of the form-design barrel and the highest-stakes. They violate proximity routinely (labels and inputs separated by half-pages of instructions), and the cost is measurable in failed applications and call-center burden.
+
+A few governments have invested in form modernization (UK GOV.UK, US 18F) and seen large completion-rate gains from applying basic proximity, single-column layout, and progressive disclosure.
+
+### Paper forms
+
+Paper forms have proximity built in by physical reality — there's a line for "Name" right next to the empty space to write it. Translating these to digital and *losing* the proximity is the failure mode.
+
+### Survey research
+
+Academic survey design (Couper, Tourangeau) studies how question grouping affects responses. Questions grouped together by topic show more correlated answers (acquiescence bias); spreading them out reduces that bias. Proximity changes the *answers*, not just the speed.
+
+## Edge cases
+
+### Mobile two-column layouts
+
+Two-column layouts collapse on mobile. The same form needs to read sensibly at 375px wide and 1280px wide. Practical pattern:
+
+- Default to single column.
+- Use two columns only for paired fields where the pairing is genuinely tight (first/last name, city/state).
+- At mobile breakpoint, collapse paired columns to single column.
+
+### Conditional fields
+
+Fields that appear/disappear based on prior input (e.g., "Are you a US citizen?" → "Visa type") need proximity that *remains* clear when the conditional fields appear. Insert them in place; don't reflow the whole form.
+
+### Multi-language forms
+
+Label length varies wildly across languages (German labels are often 2× English; Chinese can be 0.5×). Form layouts that work in English break in German. Test at multiple languages.
+
+## Resources
+
+- **Jarrett, C. & Gaffney, G.** (2008). *Forms that Work*.
+- **Wroblewski, L.** (2008). *Web Form Design: Filling in the Blanks*.
+- **GOV.UK Design System** (gov.uk/design-system) — form patterns for high-stakes government use.
+- **WCAG 1.3.1, 3.3.1, 3.3.2** — relevant success criteria for form accessibility.
+
+## Closing
+
+Form design is one of the most-studied corners of UX, and the findings consistently elevate proximity above other variables. If a form is failing, the first thing to audit is the spacing and pairing — long before the wording or the visual style.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-navigation/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-navigation/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: proximity-navigation
+description: 'Use this skill when designing or fixing navigation — sidebars, top nav, footer nav, mobile menus, breadcrumbs, tab bars, command palette groupings. Trigger when grouping related links, deciding when to add section dividers, fixing a sidebar where every link feels like a separate item, or designing a mobile bottom-nav with multiple action groups. Sub-aspect of `proximity`; read that first if you haven''t already.'
+---
+
+# Proximity in navigation
+
+Navigation is a sequence of links where some belong to the same group and others to different groups. Proximity is the cheapest way to communicate the structure — far cheaper and lighter than dividers, sub-headers, or color shifts.
+
+## The navigation proximity ladder
+
+```
+Inside a section: gap-1   (4px) between adjacent links
+Between sections: gap-6   (24px) — visibly larger
+Section heading:  closer to its first link than to the previous section
+```
+
+Keep the inside-section gap tight. Aggressive whitespace inside a sidebar wastes vertical space and makes the eye treat each link as its own region.
+
+## Sidebar with grouped sections
+
+```html
+<nav style="display: grid; gap: 1.5rem; padding: 1rem;">
+  <div style="display: grid; gap: 0.125rem;">
+    <p class="nav-heading">Workspace</p>
+    <a class="nav-link" href="/dashboard">Dashboard</a>
+    <a class="nav-link" href="/projects">Projects</a>
+    <a class="nav-link active" href="/team">Team</a>
+  </div>
+
+  <div style="display: grid; gap: 0.125rem;">
+    <p class="nav-heading">Personal</p>
+    <a class="nav-link" href="/profile">Profile</a>
+    <a class="nav-link" href="/notifications">Notifications</a>
+  </div>
+
+  <div style="display: grid; gap: 0.125rem;">
+    <p class="nav-heading">Account</p>
+    <a class="nav-link" href="/billing">Billing</a>
+    <a class="nav-link" href="/security">Security</a>
+  </div>
+</nav>
+
+<style>
+  .nav-heading {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: hsl(0 0% 50%);
+    padding: 0 0.5rem;
+    margin-bottom: 0.25rem;       /* slightly closer to its first link */
+  }
+  .nav-link {
+    padding: 0.375rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
+    color: hsl(0 0% 25%);
+    text-decoration: none;
+  }
+  .nav-link:hover { background: hsl(0 0% 96%); }
+  .nav-link.active { background: hsl(0 0% 92%); font-weight: 500; }
+</style>
+```
+
+Three sections, no dividers. The 24px gap between sections is unmistakably looser than the 2px gap between links. Section headings recede in tone (uppercase + small + grey) so they don't compete with the links.
+
+## When to add a divider
+
+If sections need *more* separation than proximity alone provides — typically when:
+
+- Sections are conceptually very different (workspace links vs. account/sign-out).
+- The sidebar is short (3–4 sections) and you want a strong visual rhythm.
+- A sub-section of links is visually similar enough to its parent that proximity alone won't differentiate.
+
+Use the lightest divider that does the job:
+
+```html
+<hr style="border: 0; border-top: 1px solid hsl(0 0% 90%); margin: 0;" />
+```
+
+Resist heavy dividers (2px, dark colors) — they read as walls.
+
+## Mobile bottom nav
+
+Bottom nav with 3–5 primary destinations should bind tightly horizontally:
+
+```html
+<nav class="bottom-nav">
+  <a href="/feed"><HomeIcon /><span>Home</span></a>
+  <a href="/search"><SearchIcon /><span>Search</span></a>
+  <a href="/post"><PlusIcon /><span>New</span></a>
+  <a href="/inbox"><InboxIcon /><span>Inbox</span></a>
+  <a href="/me"><UserIcon /><span>You</span></a>
+</nav>
+
+<style>
+  .bottom-nav {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    display: grid; grid-template-columns: repeat(5, 1fr);
+    border-top: 1px solid hsl(0 0% 88%);
+    background: white;
+    padding: 0.5rem 0 calc(0.5rem + env(safe-area-inset-bottom));
+  }
+  .bottom-nav a {
+    display: grid; gap: 0.125rem; justify-items: center;
+    font-size: 0.625rem;
+    color: hsl(0 0% 40%);
+  }
+  .bottom-nav a[aria-current="page"] { color: hsl(220 90% 50%); font-weight: 500; }
+</style>
+```
+
+The icon and label are tightly bound (2px gap). The five items distribute equal space across the bar. No dividers; the equal distribution is the proximity signal that they're a peer group.
+
+## Breadcrumbs
+
+Breadcrumbs are a rare case where proximity is more uniform — each segment is a separate jump, but they're conceptually a continuous path:
+
+```html
+<nav aria-label="Breadcrumb">
+  <ol style="display: flex; gap: 0.5rem; align-items: center; list-style: none; padding: 0;">
+    <li><a href="/projects">Projects</a></li>
+    <li aria-hidden style="color: hsl(0 0% 60%);">/</li>
+    <li><a href="/projects/acme">Acme</a></li>
+    <li aria-hidden style="color: hsl(0 0% 60%);">/</li>
+    <li aria-current="page">Settings</li>
+  </ol>
+</nav>
+```
+
+Equal gaps between segments. Separators (`/`) live in the gap, recessed in tone. The current page is unlinked and slightly heavier — the only proximity *break* is the recessive separator.
+
+## Command palette groupings
+
+A `cmd-K` palette typically shows actions grouped by category. Proximity holds groups together:
+
+```
+Recent
+  Create invoice
+  Open settings
+
+Actions
+  Search
+  Invite teammate
+  Export workspace
+
+Navigation
+  Go to dashboard
+  Go to projects
+```
+
+Each group has a lightly-styled heading (small, uppercase, low contrast). Within each group, items are tightly stacked. Between groups, looser spacing. No dividers needed.
+
+## Anti-patterns
+
+- **Equal-spaced sections.** Sidebar with sections at the same gap as items inside sections. The eye reads it as one long list, not multiple groups.
+- **Heavy dividers between every section.** A sidebar with `<hr>` between every group looks like a form. Use space first; dividers only when space alone is insufficient.
+- **Section headings as items.** A sidebar where the section heading is styled like a link. Users try to click it. Style headings distinctly (smaller, uppercase, lower contrast, non-clickable cursor) so they read as labels.
+- **Nested-tree creep.** Every link nested under a parent, with indentation creating proximity confusion. Flat structure beats deep nesting in nav.
+
+## Heuristics
+
+1. **Read groups aloud.** "Workspace: Dashboard, Projects, Team." If you can hear the pause between groups, proximity is working.
+2. **Compress test.** Reduce the section gap to half. If the structure becomes unclear, you needed that gap. If it's still clear, your sections were over-spaced.
+3. **No-divider test.** Remove all dividers. If structure collapses, proximity wasn't doing the work and you were over-relying on chrome.
+
+## Related sub-skills
+
+- **`proximity`** (parent).
+- **`proximity-form-fields`** and **`proximity-data-tables`** — same principle in different layouts.
+- **`hicks-law`** (cognition plugin) — reducing the count of nav items matters more than how they're grouped; pair this skill with that one.
+- **`signal-to-noise-ratio`** — nav is a primary case for SNR discipline; keep chrome minimal.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-navigation/references/navigation-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity-navigation/references/navigation-patterns.md
@@ -1,0 +1,152 @@
+# Navigation patterns: cross-platform reference
+
+A reference complementing `proximity-navigation` SKILL.md with deeper patterns and platform-specific conventions.
+
+## Established navigation patterns
+
+### Top navigation bar
+
+Convention: 5–7 items at top, brand mark left, account/utility menu right. Used by virtually every web app. Works because:
+
+- Users are habituated.
+- Top edge has Fitts's Law advantage.
+- Width permits text labels at typical viewports.
+
+Limit: text labels become uncomfortable past 7 items at 1024px.
+
+### Sidebar (left, persistent)
+
+Convention: vertical stack of links/groups, often with icons. Used by web apps with deep IA (admin tools, productivity software, dashboards).
+
+Trade-offs: takes 200–280px of horizontal space; provides "you are here" context; supports more items than top nav (groups + scroll).
+
+Variations: collapsible (toggles between icon-only and icon+label) for power users who want screen space.
+
+### Sidebar (right, contextual)
+
+Used for properties panes, detail views, secondary navigation related to current selection. Different role from primary nav.
+
+### Hamburger / drawer
+
+Convention on mobile: hidden behind a menu icon (typically top-left), opens a sheet. Used because mobile screens can't fit persistent nav.
+
+Trade-offs: hides navigation; users must remember it exists. Good for low-frequency nav items; bad for primary navigation. Hence the rise of bottom-nav for primary mobile destinations.
+
+### Bottom tab bar (mobile)
+
+Convention: 3–5 items at the bottom of mobile screens, primary navigation. Apple HIG and Material both endorse for primary destinations.
+
+Trade-offs: limited to ~5 items (thumb reach + label width); always visible; combines edge advantage and thumb-reach advantage.
+
+### Breadcrumbs
+
+Used for hierarchical navigation showing the user's location and offering up-tree navigation. Best for deep IA (file systems, e-commerce categories, settings).
+
+Pattern: small, low-contrast, separated by `/` or `›`. Current page is unlinked.
+
+### Mega menu
+
+A wide drop-down panel with grouped links, used for content-rich sites (e-commerce, news). Trades simplicity for breadth — accommodates many sections without forcing tab-by-tab navigation.
+
+Risks: high cognitive load; only works when groups are clearly labeled and visually distinct.
+
+### Command palette
+
+`Cmd-K` invocation; type to filter; press Enter to execute. Originated in editors (Sublime, VSCode), now widespread in modern web apps (Linear, Notion, GitHub, Slack).
+
+Doesn't replace navigation; complements it for power users who want fast keyboard access.
+
+## Cross-domain examples
+
+### Wayfinding signage (physical)
+
+Airport, hospital, museum signage all use proximity to group destinations:
+
+- Departures, Arrivals, Baggage Claim — three columns or three sections, with clear gaps.
+- "This level" vs. "Other levels" sections.
+- Line-color coding for transit transfers.
+
+Software navigation can borrow: clear group labels, generous gaps, color coding for categorical distinction.
+
+### Restaurant menus
+
+A restaurant menu is hierarchical navigation: Appetizers, Mains, Desserts, Drinks. Within each: subgroups (Salads, Soups). Each item has a description and price.
+
+Typical menu proximity ladder: tight pair (item name + description); medium gap (between items); large gap (between sections, often with section header).
+
+Software nav follows the same structure: tight gap (link to nav-meta), medium gap (between links in a section), large gap (between sections).
+
+### Book table of contents
+
+A book's TOC is a navigation index. Structure:
+
+- Part / Section (largest type, generous space above).
+- Chapter (medium type, medium gap).
+- Section within chapter (smaller, tighter gap, often indented).
+- Page numbers right-aligned.
+
+Software docs sites mirror this — collapsible TOC sidebars descend from book TOC conventions.
+
+## Platform conventions
+
+### iOS
+
+- Tab bar at bottom for ≤ 5 primary destinations.
+- Top navigation bar with title and back button (large title pattern in iOS 11+).
+- Hamburger menus discouraged for primary nav.
+
+### Android (Material)
+
+- Bottom navigation for top-level destinations (3–5 items).
+- Navigation drawer (left swipe) for many destinations.
+- Top app bar.
+
+### Desktop OS
+
+- Menu bar at top of screen (macOS) or top of window (Windows).
+- Toolbars beneath menu bar.
+- Sidebar in many apps for navigation within document/project.
+
+### Web
+
+- No platform convention; many patterns coexist.
+- Sticky top nav is the most common modern default for SaaS.
+- Sidebar nav for app shells (Notion, Linear, Slack).
+
+## Heuristics for choosing nav style
+
+Pick based on:
+
+1. **Number of primary destinations.**
+   - ≤ 5 → top nav or bottom tabs (mobile).
+   - 5–12 → top nav with sub-menus, or sidebar.
+   - 12+ → sidebar with groups, or sidebar + command palette.
+
+2. **Depth of IA.**
+   - Flat (1 level) → top nav.
+   - Hierarchical → sidebar with collapsible sections, or breadcrumb-driven.
+   - Deeply hierarchical → tree view in sidebar.
+
+3. **User proficiency.**
+   - Casual / one-time → simpler, more visible nav.
+   - Power users → command palette for everything; minimal visible nav.
+
+4. **Form factor.**
+   - Mobile → bottom tabs or hamburger.
+   - Tablet → sidebar that collapses on rotation.
+   - Desktop → persistent sidebar or sticky top.
+
+## Anti-patterns
+
+- **Mega menus on mobile.** They don't fit; they don't work touch-friendly.
+- **Hamburger menus for primary nav on desktop.** Hides things that don't need hiding.
+- **More than ~7 top-nav items.** Hick's Law cost stops being worth the visibility.
+- **Inconsistent nav across sub-sections.** A section with custom navigation patterns disorients users.
+- **Hidden nav with no escape hatch.** A drawer with no obvious close affordance.
+
+## Resources
+
+- **Material Design Navigation docs** — material.io.
+- **Apple HIG: Navigation** — developer.apple.com/design.
+- **NN/g: navigation patterns** — nngroup.com (multiple articles).
+- **Refactoring UI** — ch. on navigation.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: proximity
+description: 'Use this skill whenever the question is how to make a composition feel organized — what belongs with what, where groups end, how related items can be visually bound without resorting to borders or boxes. Trigger when laying out forms, tables, navigation, lists, cards, dashboards, or any composition with multiple distinguishable groups of content. Trigger when a layout "feels disorganized," when users are confused which label goes with which input, when grouping is being attempted with borders that look heavy, or when a designer is reaching for color to encode grouping. Proximity is the cheapest, most powerful grouping tool in design; this skill teaches how to use spacing as the primary grouping mechanism, with sub-aspect skills for forms, tables, and navigation.'
+---
+
+# Proximity
+
+Proximity is one of the original Gestalt grouping laws: **elements close together are perceived as belonging together; elements farther apart are perceived as separate.** It is the cheapest grouping mechanism in the designer's toolkit — it requires no ink, no color, no chrome, only the deliberate distribution of space. Used well, proximity makes most other grouping tools (borders, backgrounds, dividers) unnecessary.
+
+## Definition (in our own words)
+
+When the human visual system encounters a set of similar elements, it organizes them into groups based on relative spatial distance. Items that share a small gap are perceived as a unit; items separated by a larger gap are perceived as belonging to different units. This perceptual grouping happens preattentively — before conscious thought, before reading. It is one of the most reliable findings in perception research, observed in infants, across cultures, and across animal species.
+
+## Origins and research lineage
+
+- **Gestalt psychology** (Wertheimer, 1923) formalized the laws of perceptual grouping, of which Proximity (*Gesetz der Nähe*) is the most basic. Wertheimer's original demonstrations used dots arranged at varying distances; the perceived groupings shifted dramatically with small spacing changes.
+- **Treisman's feature integration theory** (1980s) and the broader preattentive-processing literature established that grouping by spacing happens within the first ~200ms of viewing — before the user has consciously "looked" at anything.
+- **Information design** (Tufte; Krug, *Don't Make Me Think*, 2000) translated proximity from perception research into web/UI practice, particularly in the design of forms and information dense surfaces.
+- **Web usability research** (Nielsen Norman Group studies on form perception, label-input pairing) repeatedly shows that label-input ambiguity — usually a proximity failure — is among the top usability issues in form design.
+
+## Why proximity matters
+
+Every layout makes implicit proximity claims. If a label is equidistant from the input above and the input below, the user must read carefully to figure out which it labels. If two cards are visually identical to two surrounding cards, they read as one group of four — even when conceptually they're two pairs.
+
+Proximity failures are silent: users don't report "this label is ambiguous"; they just take longer, make more mistakes, and feel a low-grade frustration they can't articulate. This is why proximity is one of the highest-leverage things to get right in dense interfaces — small spacing decisions determine whether the page feels organized or chaotic.
+
+## When to apply
+
+- **Forms** — every label-input pair, every section, every fieldset. Proximity is the dominant principle in form layout.
+- **Lists and tables** — row spacing, column spacing, group separators.
+- **Navigation** — clusters of related links, dividers between sections.
+- **Cards** — internal layout (title, metadata, body, action) and external layout (cards-in-a-grid).
+- **Dashboards** — grouping of related KPIs.
+- **Settings pages** — sections, sub-sections, grouped controls.
+
+In short: anywhere you have ≥3 elements and need to communicate which belong together.
+
+## When NOT to apply (or when to be careful)
+
+- **When everything genuinely has equal status.** A list of 100 search results doesn't want sub-grouping; the user is scanning sequentially. Adding proximity-based grouping where there is no real grouping is noise.
+- **When grouping must survive responsive reflow.** If your nice 3-column grid wraps to 1 column on mobile, the proximity grouping that worked horizontally may collapse vertically. Plan for both.
+- **When proximity conflicts with continuity.** Sometimes elements that share a baseline or column should read as a row, even with internal gaps. Then alignment beats proximity (see Good Continuation).
+
+## How to encode grouping with proximity
+
+The trick is creating a **spacing hierarchy**: gaps inside a group should be smaller than gaps between groups, and the difference should be perceptually obvious. A 4px gap looks roughly like a 6px gap; the eye can't tell. A 4px gap is unmistakably tighter than a 16px gap.
+
+A useful spacing scale (most design systems land somewhere near this):
+
+```
+gap-1   = 0.25rem (4px)    inside a tight pair (label/input)
+gap-2   = 0.5rem  (8px)    inside a closely related set
+gap-3   = 0.75rem (12px)   between fields in a section
+gap-4   = 1rem    (16px)   between minor groups
+gap-6   = 1.5rem  (24px)   between sections
+gap-8   = 2rem    (32px)   between major regions
+gap-12  = 3rem    (48px)   between page-level zones
+```
+
+Adjacent values in the scale should differ by at least 1.5× — preferably 2× — for the eye to register them as different ranks of grouping. Don't use both `gap-3` and `gap-4` in the same composition for *different* grouping levels; they look identical.
+
+## Worked examples
+
+### Example 1: a label-input pair (the canonical case)
+
+**Anti-pattern (ambiguous):**
+
+```html
+<form>
+  <label>Email</label>
+  <input type="email" />
+  <label>Password</label>
+  <input type="password" />
+</form>
+```
+
+With default browser margins, each label sits roughly equidistant from the input above and the input below. The user has to read to figure out the pairing.
+
+**Right (proximity binds the pair):**
+
+```html
+<form style="display: grid; gap: 1rem;">                  <!-- gap-4 between fields -->
+  <div style="display: grid; gap: 0.25rem;">              <!-- gap-1 between label and input -->
+    <label for="email">Email</label>
+    <input id="email" type="email" />
+  </div>
+  <div style="display: grid; gap: 0.25rem;">
+    <label for="password">Password</label>
+    <input id="password" type="password" />
+  </div>
+</form>
+```
+
+Now the gap inside each pair (4px) is unmistakably tighter than the gap between pairs (16px). Pairing reads instantly without any reading.
+
+### Example 2: a settings page with three sections
+
+```html
+<style>
+  .settings { display: grid; gap: 3rem; }       /* gap-12 between sections */
+  .section  { display: grid; gap: 1rem; }       /* gap-4 between fields */
+  .section h2 { margin-bottom: 0.5rem; }        /* heading slightly closer to its fields */
+  .field { display: grid; gap: 0.25rem; }       /* gap-1 inside label/input pair */
+</style>
+
+<form class="settings">
+  <section class="section">
+    <h2>Profile</h2>
+    <div class="field"><label>Name</label><input /></div>
+    <div class="field"><label>Email</label><input /></div>
+  </section>
+  <section class="section">
+    <h2>Notifications</h2>
+    <div class="field"><label>Frequency</label><select>...</select></div>
+    <div class="field"><label>Channels</label><input /></div>
+  </section>
+  <section class="section">
+    <h2>Security</h2>
+    <div class="field"><label>Password</label><input type="password" /></div>
+  </section>
+</form>
+```
+
+Three nested ranks of proximity (4px / 16px / 48px) carry the entire grouping. No borders, no boxes, no dividers, no color — just space.
+
+### Example 3: a card with title, metadata, body, and action
+
+```html
+<style>
+  .card { display: grid; gap: 1rem; padding: 1.5rem; }
+  .card-header { display: grid; gap: 0.25rem; }     /* title + metadata are paired */
+  .card-actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
+</style>
+
+<article class="card">
+  <header class="card-header">
+    <h3>Q4 financial review</h3>
+    <p class="meta">Updated 3 minutes ago · Owner: Maria</p>
+  </header>
+  <p>This quarter shows record revenue across the SMB segment...</p>
+  <div class="card-actions">
+    <button>Open</button>
+    <button>Share</button>
+  </div>
+</article>
+```
+
+Three groupings: title-metadata (tight pair), body (its own paragraph), actions (their own row). Each cluster reads independently; together they form the card.
+
+### Example 4: a navigation menu with sections
+
+```html
+<nav style="display: grid; gap: 1.5rem;">                <!-- gap between sections -->
+  <div style="display: grid; gap: 0.25rem;">             <!-- tight gap between links -->
+    <a href="/dashboard">Dashboard</a>
+    <a href="/projects">Projects</a>
+    <a href="/team">Team</a>
+  </div>
+  <div style="display: grid; gap: 0.25rem;">
+    <a href="/settings">Settings</a>
+    <a href="/billing">Billing</a>
+    <a href="/logout">Sign out</a>
+  </div>
+</nav>
+```
+
+Two clear sections, no dividers needed. The eye reads the gap between them as a section break.
+
+## Anti-patterns
+
+- **The four-equidistant trap.** Label, input, label, input — all spaced the same. Common in browser-default form rendering. Always tighter inside the pair, looser between pairs.
+- **Borders as grouping.** Reaching for `border: 1px solid grey` around every group adds visual weight without doing what proximity already does for free. Borders are a fallback for when proximity isn't enough.
+- **Inconsistent gaps for the same role.** Three sections on a page, each separated by a different gap. The eye reads inconsistency as accident; settle on one section gap and use it everywhere.
+- **Equal gaps top-to-bottom in a card.** Header, body, footer all separated by the same gap. The user has to read to figure out the structure. Vary gaps to encode role.
+- **Whitespace orphans.** A heading close to its content, but with so much space below the content that the next heading attaches to the *previous* content rather than its own. Always: heading-tighter-to-its-content; sections-looser-than-fields.
+
+## Heuristics
+
+1. **Squint test for grouping.** Squint until detail blurs. Each visual cluster should be obvious as a cluster, with clear gaps between clusters. If the page is one continuous mass, proximity is too uniform.
+2. **Read the cards aloud.** "Title, then metadata, then body, then actions." If you can hear the pauses between groups, proximity is working. If everything runs together, the gaps are equal.
+3. **Two-finger test.** With two fingers, can you point at a single group and feel that the boundaries are clear? If your finger keeps drifting into the next group, the boundary is too ambiguous.
+4. **Strip the borders.** Remove every border on the page (mentally or actually). If structure collapses, you were leaning on borders to do proximity's job.
+
+## Related principles
+
+- **`uniform-connectedness`** — when proximity isn't enough, a shared background or container creates a stronger group; proximity tried first.
+- **`similarity`** — items that look alike are also grouped; combines with proximity.
+- **`good-continuation`** — items aligned on an axis read as a row, even with internal spacing.
+- **`hierarchy`** — proximity establishes *grouping*, hierarchy establishes *ranking* between groups.
+- **`signal-to-noise-ratio`** — proximity reduces noise by replacing chrome (borders, backgrounds) with negative space.
+- **`horror-vacui`** — proximity *requires* whitespace; resist filling it.
+
+## Sub-aspect skills
+
+- **`proximity-form-fields`** — applying proximity to form layouts, label-input pairs, sections.
+- **`proximity-data-tables`** — row spacing, column spacing, total rows, group separators.
+- **`proximity-navigation`** — sidebar groups, top-nav clusters, mobile menus.
+
+## Final note
+
+Proximity is the principle most likely to be invisible when working and noisy when failing. The reward for getting it right is that the page feels organized in a way no one can quite pinpoint — they just don't get confused.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity/references/gestalt-and-grouping-research.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/proximity/references/gestalt-and-grouping-research.md
@@ -1,0 +1,82 @@
+# Proximity: Gestalt research and cross-domain examples
+
+A reference complementing the `proximity` SKILL.md with deeper grounding in Gestalt psychology and examples from beyond software UI.
+
+## The Gestalt research lineage
+
+The Gestalt school of psychology (Berlin, c. 1910s–1930s) was founded on the observation that perception organizes wholes from parts in lawful, predictable ways. Max Wertheimer's 1923 paper *Untersuchungen zur Lehre von der Gestalt II* laid out the grouping laws — proximity, similarity, closure, common fate, good continuation, figure-ground — most of which still appear in modern textbooks unchanged.
+
+The Gestalt psychologists weren't just cataloging illusions; they were arguing against the prevailing view that perception is built up atom-by-atom from elementary sensations. Their evidence: the same set of dots produces different perceived groupings depending only on spacing. Spacing is not a sensation; it's a relationship. Therefore perception operates on relationships, not just elements.
+
+This was a foundational shift in psychology and propagated outward into design through art-school education in the mid-20th century (Bauhaus, Black Mountain College, Yale's design program under Albers).
+
+## Why proximity is the strongest grouping cue
+
+Of the Gestalt grouping laws, proximity is the one that survives the most other competing cues. If two items are close in space, they read as grouped *even when they differ in color, shape, and orientation*. Similarity, by contrast, is overridden by proximity in most cases — items that look alike but are spatially distant read as separate; items that look different but are close read as a pair.
+
+This was tested empirically by Stephen Palmer (1992), among others, and the proximity-dominates-similarity finding has held up.
+
+The practical implication: when designing for grouping, *spend space first*. Color, borders, and similarity treatments are secondary tools.
+
+## Cross-domain examples
+
+### Print page layout
+
+A print spread groups content by spacing alone, almost without exception:
+
+- Headline, deck, body — tightly stacked, then a generous gutter to the next article.
+- Image plus caption — caption sits in the small space below the image, visibly closer to the image than to surrounding body.
+- Footnotes — separated from body by a horizontal rule and a clear gap, but the rule is doing structural work; the gap does the grouping.
+
+Newspaper designers in the early 20th century could group dozens of articles on one front page using only proximity, vertical rules (when needed), and consistent column widths. Card-layout web pages could learn from this.
+
+### Wayfinding signage
+
+Airport and metro signs cluster destinations by line/direction, separated by white space. The London Underground's "Way Out" signs group exits on one side, in-station services on the other, transfer lines in a third cluster — all with no boxes or borders, only spacing.
+
+### Music notation
+
+A single note belongs to a chord because it's vertically aligned with other notes in the same beat (proximity-along-time). Chords belong to a bar because they're horizontally proximate. Bars belong to a phrase because of a slight extra space at the phrase boundary.
+
+A composer who wrote everything at uniform spacing would produce music readable only with great effort.
+
+### Architecture and urban planning
+
+Urban-design researchers (Christopher Alexander, *A Pattern Language*, 1977) document proximity-grouping at the scale of buildings and neighborhoods: cafes "belong with" plazas through nearness; residential blocks read as units when consistently spaced; public squares fail when buildings around them are too disparate in setback.
+
+## Edge cases and quirks
+
+### Proximity vs. continuation
+
+When elements are arranged on a strong axis (a row or column), continuation can dominate proximity. A row of 5 cells reads as one row even with internal gaps, *if* the gaps are small relative to the row's continuity.
+
+Practical implication: in tabular data, row continuation is the dominant grouping cue, not within-cell proximity. Make sure your row structure is unmistakable.
+
+### Proximity in dense charts
+
+A scatter plot shows clusters by proximity — points near each other read as a group. This is the basis for cluster-detection algorithms (k-means, DBSCAN) and human visual data exploration.
+
+When designing data visualizations, leverage natural clustering: scatter plots reveal proximity clusters that bar charts of the same data hide.
+
+### Proximity in audio
+
+In sound design, "proximity" maps to time. Two sounds played within ~100ms register as a single percussive event; spaced further, as separate. This is the basis for drum patterns, musical rhythm, and interaction sounds.
+
+The UI implication: feedback sounds within ~100ms of an action read as part of the action ("the click made the sound"); delayed beyond ~300ms, they read as system response separate from the click.
+
+## Quantitative findings
+
+- **Bruce, Green & Georgeson** (*Visual Perception*, 2003) summarize the experimental literature: proximity grouping is detected within ~100ms of fixation, before conscious awareness of the elements.
+- **Quinlan & Wilton** (1998), perceptual grouping studies — proximity grouping survives across age, language, and most clinical impairments. It's about as universal as visual perception gets.
+- **Form-design studies (Wroblewski, Jarrett, others)** consistently find that label-input proximity is the single most decisive layout decision for form usability. Good proximity halves task error rates compared to ambiguous proximity.
+
+## Resources
+
+- **Wertheimer, M.** (1923). *Untersuchungen zur Lehre von der Gestalt II*. Translated as "Laws of Organization in Perceptual Forms" in Ellis (1938) *A Source Book of Gestalt Psychology*.
+- **Wagemans, J. et al.** (2012). "A century of Gestalt psychology in visual perception." *Psychological Bulletin*. A modern synthesis of the research.
+- **Alexander, C., Ishikawa, S., Silverstein, M.** (1977). *A Pattern Language*. Architecture and urban-design proximity examples.
+- **Wroblewski, L.** (2008). *Web Form Design: Filling in the Blanks*. Practical proximity-driven form patterns.
+
+## Closing thought
+
+Proximity is invisible when it works. The reward isn't that users say "what good proximity!" — it's that users move through your interface without confusion, and you can't quite point at why. That's the principle doing its job.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability-line-length/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability-line-length/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: readability-line-length
+description: 'Set line length (measure) for prose — capping the maximum width of body text so lines stay in the 45–75 character range that supports comfortable sustained reading. Use when designing article layouts, documentation, email templates, dashboard copy, or any container that holds paragraphs of prose. Line length is the most fundamental readability decision because it directly affects the reader''s eye movement; lines that are too long or too short both cost reading comfort.'
+---
+
+# Readability — line length (measure)
+
+Line length, also called *measure* in typography, is the number of characters per line. It's the most fundamental readability decision because it directly affects the reader's eye movement: at the end of each line, the eye must jump back and find the start of the next line, and the difficulty of that jump scales with line length.
+
+The recommended range, established by centuries of book typography research and confirmed by modern reading studies: **45 to 75 characters per line for body prose**, with 60–66 as the sweet spot for most use cases.
+
+## Why line length matters
+
+Two failure modes bracket the comfortable range.
+
+**Too long (>75 characters per line).** The eye must travel a long distance between line ends. The reader can lose their place — find the wrong line on the way back, or read the same line twice. Reading slows. Fatigue accumulates faster.
+
+**Too short (<45 characters per line).** The eye has to jump too frequently. Each line break interrupts the cognitive thread. Words at the line ends are often hyphenated awkwardly. Reading feels stuttering rather than flowing.
+
+The 45–75 range is wide enough to accommodate different design contexts; specific products can land at different points based on their typeface, audience, and content.
+
+## How line length is set
+
+Line length is determined by:
+
+**Container width.** A text container (`<article>`, `<main>`, a content column) has a width in pixels.
+
+**Font size.** The number of characters per line depends on how many character-widths fit in the container.
+
+**Typeface character width.** Different typefaces have different average character widths at the same point size. A condensed typeface fits more characters per line than a wide one.
+
+**Letter spacing.** Looser letter spacing means fewer characters per line.
+
+In practice: pick a target line length in characters (say, 65), and calculate the container width that produces that line length at your body size. For 16px Inter, this is roughly 600–700px container width. For 18px Georgia, it's about 650–750px. The exact number depends on the typeface.
+
+The CSS approach: use `max-width` on text containers, with a value calibrated to your target line length. Or use `ch` units (which are based on character width): `max-width: 65ch;` produces approximately 65 characters per line in most typefaces.
+
+## Line length on responsive layouts
+
+The biggest line-length challenge is responsive layouts that need to work across screen widths.
+
+**At wide desktop:** without `max-width`, body text fills the entire viewport width, often producing 130+ character lines that fail readability.
+
+**At narrow mobile:** the same text reflows to the narrow width, producing 30–40 character lines. With smaller font sizes, this can be acceptable, but the text feels cramped.
+
+The fix: cap `max-width` on text containers (so lines don't get too long at wide widths), and consider scaling font size down on narrow widths (so lines don't get too short).
+
+A practical pattern:
+
+```css
+.prose {
+  max-width: 65ch;
+  font-size: 16px;
+}
+
+@media (min-width: 1024px) {
+  .prose {
+    font-size: 18px;
+  }
+}
+```
+
+This gives ~65 characters per line at all widths, with slightly larger text on larger screens.
+
+## Worked examples
+
+### A blog post layout
+
+A blog post container with `max-width: 65ch` and 16px body text. On any screen wider than ~700px, the article reads at a comfortable line length. On screens narrower than ~400px (mobile portrait), the text reflows to fill the available width, producing 30–50 character lines depending on typeface.
+
+The mobile case is suboptimal but acceptable. Consider bumping the body size to 18px on mobile to get back into the 45–55 character range.
+
+### A dashboard with embedded prose
+
+A dashboard widget shows a paragraph of explanatory text inside a card. The card is 800px wide. Without intervention, the text fills the card and runs ~140 characters per line. Users skip the explanation because the long lines are visually intimidating.
+
+The fix: cap the explanatory text's max-width at 65ch (about 600px at the dashboard's body size). The text now reads at a comfortable line length, even though the card is wider.
+
+### Email layout
+
+An email template designed at 600px column width with 14px body text produces roughly 75–80 characters per line — at the upper edge of the comfortable range. On mobile (read in narrow portrait), the email may reflow to 320px, producing 40 character lines (just below the comfortable minimum, but acceptable).
+
+The compromise of email design: you can't perfectly satisfy all clients and screen sizes. Pick a target (often 600px column at 14–16px text) and accept that some clients will render slightly wider or narrower.
+
+### A wide-screen documentation site
+
+A documentation site renders on a large monitor. Without max-width, body prose fills 1500px+ at 16px — well over 200 characters per line. Users zoom out, lean closer, or invoke reader mode.
+
+The fix: cap content max-width at 65ch (~600px at this body size). The wide screen has plenty of room for sidebar navigation, table of contents, and other supporting elements alongside the centered prose.
+
+### A code-and-prose documentation page
+
+A documentation page with prose explaining concepts and code blocks demonstrating them. The prose follows readability rules (max-width: 65ch). Code blocks can extend wider — code lines often need 80–120 characters before wrapping, and wrapping code mid-line can break syntax highlighting and indentation.
+
+The pattern: prose blocks at 65ch max-width; code blocks at a wider max-width (90–120ch) or full width within the article column. Use horizontal scroll if code lines exceed the available width rather than wrapping.
+
+## Anti-patterns
+
+**Letting body text fill the container width.** The default behavior on most layouts. Long lines are uncomfortable, and the longer the screen, the worse it gets.
+
+**Setting `max-width` in pixels and forgetting to test on different displays.** A 700px max-width designed for a 14px font may produce different line lengths if a user has zoomed the page or if the system font is different.
+
+**Two-column layouts with too-narrow columns.** Splitting a content area into two columns can produce columns of 30–40 characters each — too narrow. Either widen the columns or use a single column.
+
+**Prose-and-image layouts where the prose is squeezed.** When a sidebar image takes 40% of the width and prose takes the remaining 60%, the prose may end up at narrower-than-comfortable line length. Either reflow on narrower screens or reconsider the layout.
+
+**Justified text at narrow widths.** Justified text (left and right edges aligned) needs sufficient line length to distribute spacing without producing rivers of white space. At narrow widths, justified text becomes spotty. Use left-aligned (ragged-right) instead.
+
+**Forgetting subheadings and other interruptions.** A 65ch column of pure prose for thousands of words is a wall, even at the right line length. Combine line-length capping with paragraph and section structure.
+
+## Heuristic checklist
+
+Before shipping a long-form layout, ask: **What's the line length of body text at the rendering widths my users will see?** Measure, don't estimate. **Is it in the 45–75 character range?** If wider, add max-width; if narrower, consider larger font or wider container. **Does the line length hold up across mobile, tablet, and wide desktop?** Test all breakpoints. **Are code blocks and other special content handled separately?** They often need different rules.
+
+## Related sub-skills
+
+- `readability` — parent principle on sustained-reading ease.
+- `readability-rhythm-and-prose` — sibling skill on paragraph spacing and rhythm.
+- `legibility-typeface-and-size` — typeface and size choices that interact with line length.
+- `chunking` — paragraph breaks chunk prose into readable units, complementing line-length control.
+
+## See also
+
+- `references/measure-by-context.md` — line-length recommendations for specific contexts (book, web, email, documentation).

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability-line-length/references/measure-by-context.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability-line-length/references/measure-by-context.md
@@ -1,0 +1,119 @@
+# Line length — measure by context
+
+Specific line-length recommendations for different content types, contexts, and audiences.
+
+## Book typography (print)
+
+**Body prose:** 60–66 characters per line. The classic book measure, refined over centuries. A typical paperback page has a text block ~10–12 cm wide at 9–11pt body type, producing this range.
+
+**Children's books:** 30–50 characters per line. Younger readers benefit from shorter lines that reduce the cost of finding the next line.
+
+**Reference books / textbooks:** 60–75 characters. Slightly wider than narrative prose; readers are often scanning rather than continuously reading.
+
+**Two-column books (newspapers, journals):** 35–50 characters per column. The narrower columns are necessary for the multi-column layout; readers adapt.
+
+## Web (single-column body content)
+
+**Articles and long-form posts:** 60–70 characters per line. The web's default contexts. Use `max-width: 65ch` or similar.
+
+**Blog posts and newsletters:** 60–70 characters per line. Same as articles.
+
+**Documentation:** 60–80 characters per line. Slightly more permissive because users often scan rather than read continuously, and code examples sometimes need wider lines.
+
+**Product descriptions:** 50–70 characters per line. Often shorter because they're embedded in product cards or galleries.
+
+**Marketing copy:** 50–70 characters per line. Marketing prose is read more carefully than UI text and benefits from comfortable measure.
+
+## Web (UI text)
+
+**UI labels and short text:** measure mostly doesn't apply (these are too short for line-length to matter). Focus on legibility.
+
+**Helper text and longer UI explanations:** 60–80 characters per line. Treat like compressed body prose.
+
+**Modal and dialog content:** 50–70 characters per line. Modals are usually narrower than the main content, so this is often automatic.
+
+**Toast notifications:** 40–60 characters. Shorter because users often glance at toasts rather than read them carefully.
+
+## Email
+
+**Plain-text email:** 65–75 characters per line. Many email clients still wrap at 72 or 80 characters; design within this constraint.
+
+**HTML email body:** 600px column width is the conventional desktop standard, producing roughly 70–80 characters per line at 14–16px text. On mobile this reflows to whatever width the client renders.
+
+**Newsletter:** 600–700px column width with 16–18px body text gives 60–70 characters per line at desktop. Test across major email clients.
+
+## Mobile
+
+**Mobile body prose:** mobile screen widths (320–430px depending on device) constrain line length to roughly 30–50 characters at 16px text. This is just below the comfortable minimum, but mobile readers are accustomed to it.
+
+**To get back into the comfortable range on mobile:** reduce font size slightly (to 15px), increase typeface character density, or accept the cramped feel.
+
+**Mobile-first design:** start with the mobile constraint and ensure the line length grows comfortably as the screen widens (use `max-width` capped at 65ch).
+
+## E-readers
+
+**E-reader default:** typically 50–65 characters per line. Users can adjust font size and column width independently.
+
+**The takeaway from e-readers:** they default to comfortable line lengths and let users tune. Web design that gives users this control (or sets sensible defaults) treats them with similar respect.
+
+## Code
+
+**Inline code (in prose):** follows the prose's line length.
+
+**Code blocks (multi-line code):** 80–120 characters per line is typical. Code conventions in many languages (PEP 8 for Python, various ESLint rules for JavaScript) recommend 80 or 100 characters per line.
+
+**Reason for wider:** code needs to maintain alignment and indentation. Wrapping mid-line breaks readability more than long lines do.
+
+**For code blocks:** use horizontal scroll when lines exceed the available width, rather than wrapping. Provide a visible scroll cue.
+
+## Tables and data
+
+**Cell text within tables:** measure mostly doesn't apply for short cell values. For cells containing prose (descriptions, comments), consider capping width.
+
+**Wide tables:** if individual cells contain more than ~50 characters of prose, consider whether the data should be in a different layout (a card view, a detail panel) rather than a table.
+
+## Captions and footnotes
+
+**Captions under images:** 30–50 characters per line typical. Captions are short and embedded; line length matters less than legibility and proximity to the image.
+
+**Footnotes:** 60–80 characters per line. Similar to body prose.
+
+## Forms
+
+**Field labels and helper text:** measure mostly doesn't apply (these are too short).
+
+**Long-form text fields (textarea):** the field's width is its measure. Aim for 60–80 characters per line in the input area for comfortable composition.
+
+**Long-form previews:** if the form is generating content (a comment, a post), preview the text at the line length it will be displayed at, not the line length it's being typed at.
+
+## Dashboards and analytics
+
+**Numeric data:** measure mostly doesn't apply.
+
+**Commentary and explanations:** treat like compressed body prose. 60–75 characters per line if the explanation is more than a sentence.
+
+**Dashboard descriptions:** often appear in side panels or expanded detail views. 50–70 characters per line.
+
+## Specialty contexts
+
+**Subtitles / captions on video:** 32–42 characters per line is the broadcasting convention. Two lines max per subtitle. Designed for fast reading at video pace.
+
+**Marquee / scrolling text:** measure doesn't apply (one continuous line, but read as it scrolls). Pace and contrast matter more.
+
+**Augmented reality / heads-up displays:** very short measure (20–30 characters per line) because users are also processing the real-world view.
+
+## Anti-patterns
+
+**Designing only for desktop and shipping to mobile.** Desktop-comfortable measure becomes mobile-cramped without intervention. Verify both.
+
+**Wide-screen layouts without max-width.** Modern monitors are wide; without a cap, body text gets very long. Always set max-width on prose containers.
+
+**Justified text at narrow widths.** Justified text needs comfortable line length to distribute spacing well. At narrow widths, justification produces uneven spacing. Use left-aligned.
+
+**Forgetting that ch units depend on the typeface.** `max-width: 65ch` produces different actual widths in different typefaces. Test the actual rendered line length.
+
+**Two-column layouts at desktop that produce too-narrow columns.** A 1024px page split into two columns of 30–40 characters each is harder to read than a single column at 65 characters.
+
+## Cross-reference
+
+For paragraph rhythm and breathing room, see `readability-rhythm-and-prose`. For the parent principle, see `readability`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability-rhythm-and-prose/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability-rhythm-and-prose/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: readability-rhythm-and-prose
+description: 'Apply paragraph rhythm and prose-level readability — calibrating leading, paragraph spacing, subheading frequency, and visual breathing room so that long-form text reads smoothly without fatigue. Use when designing article layouts, documentation, reports, transcripts, or any context with sustained prose. Beyond line length and legibility, the rhythm of prose layout — the rest points provided by paragraph breaks, the hierarchy provided by subheadings, the breathing room provided by margins — determines whether readers stay engaged with long content.'
+---
+
+# Readability — rhythm and prose
+
+Beyond line length, readability is determined by the rhythm of prose layout: the spacing between lines, the spacing between paragraphs, the frequency of subheadings, the visual breathing room around the text. Together these create a reading experience that either flows or stutters, that either invites continued reading or discourages it.
+
+The right rhythm makes long content feel approachable. The wrong rhythm makes the same content feel like a wall.
+
+## Leading (line height) for prose
+
+Leading is the vertical space between baselines of consecutive lines. For body prose:
+
+**1.5× to 1.7×** the font size is the comfortable range. So 16px text needs 24–28px line height; 18px text needs 27–31px line height.
+
+Why this range:
+
+- Tighter than 1.4× makes ascenders and descenders crowd, the eye drift to adjacent lines, and reading slow.
+- Looser than 1.8× makes lines feel disconnected from each other; the prose breaks into discrete strips rather than flowing.
+- The comfortable range balances visual flow (lines connected enough) and visual separation (lines distinct enough).
+
+For UI and dense text (tables, captions, helper text), tighter leading (1.3–1.4×) is often appropriate because the text is shorter and scanned rather than read continuously.
+
+For display sizes (headlines, hero text), tighter leading (1.0–1.2×) keeps the headline feeling unified.
+
+## Paragraph spacing
+
+The space between paragraphs creates the rest points that prose depends on. For body prose:
+
+**0.75em to 1em** of vertical space between paragraphs (in addition to the line-height of the last line of the previous paragraph). So 16px text typically has 12–16px of space between paragraphs.
+
+This makes paragraph breaks visible from a distance — the reader can see paragraph structure even when scanning. Without enough space, paragraphs blur together visually.
+
+The alternative pattern (used in print books) is first-line indent: each new paragraph starts with a small indent (typically 1em) and there's no extra space between paragraphs. This is appropriate for traditional book layouts but rare on the web; block paragraphs with space between are the modern web convention.
+
+## Subheading frequency
+
+Long content needs structural breaks beyond paragraphs. Subheadings provide:
+
+**Structural navigation.** The reader can scan the subheadings to understand the article's structure and find the section they want.
+
+**Visual rest.** A subheading creates a break point that gives the eye a moment to recover before continuing.
+
+**Cognitive chunking.** Each section under a subheading is a discrete unit that the reader can process and set aside.
+
+Frequency: **every 3–5 paragraphs is a comfortable rhythm** for most prose. Articles longer than ~500 words benefit from at least one subheading. Articles longer than ~1500 words need multiple levels of hierarchy (h2 sections, possibly h3 subsections).
+
+## Visual breathing room
+
+The space around the text block matters too:
+
+**Margins.** Body prose should have visible margins on all sides, not just left and right. Padding above and below the article, not just within paragraphs.
+
+**Container structure.** Article layouts work best when the prose has a clear single-column structure with little visual competition. Sidebars, ads, and pop-ups all reduce reading focus.
+
+**Section breaks.** Major sections within an article can have additional vertical space, decorative dividers, or other visual signals that mark a transition.
+
+## Other rhythm considerations
+
+**Sentence length variety.** Not strictly typography, but related to perceived rhythm: prose that varies sentence length feels more readable than prose with all-similar sentences. (This is the writer's job, not the designer's, but layout can support it by not breaking sentences awkwardly with hard line breaks.)
+
+**Word and character spacing in prose.** Use the typeface's defaults; don't tweak letter or word spacing for body prose unless you have a specific reason. The typeface designer has already calibrated these.
+
+**Drop caps and pull quotes.** Editorial conventions that can punctuate long prose, but use sparingly. Heavy use feels overdesigned; light use can mark the start of a major section or highlight a key passage.
+
+## Diagnosing rhythm problems
+
+Symptoms of prose-rhythm issues:
+
+**The page feels intimidating before reading starts.** A wall of text without visible structure. Add subheadings, more paragraph breaks, or more vertical breathing room.
+
+**Reading time drops sharply over content length.** Readers fatigue earlier than the content warrants. Likely too-tight leading, too-long paragraphs, or insufficient subheadings.
+
+**Readers complain that the content "feels long" even when it isn't.** A 1000-word article that feels like 3000 words. Often a rhythm problem; the content is fine but the layout doesn't break it up enough.
+
+**Users reach for reader mode.** They're invoking the browser's tool for the reading experience your design failed to provide.
+
+## Worked examples
+
+### A blog post layout
+
+A blog post container: 18px Georgia body type with 1.6 line height (29px), 65ch max-width, 0.8em paragraph spacing (~14px), subheadings (h2 in 24px) every 3–5 paragraphs, generous vertical margin around the article (4em above and below).
+
+The reader can scan the subheadings to see the article's structure. Within each section, paragraphs are 3–5 sentences with comfortable spacing. The eye flows down the page without effort.
+
+### An article with poor rhythm
+
+A 2000-word article: 16px text with 1.2 line height (default browser), no max-width (full container width), single paragraphs of 10+ sentences with no spacing between, no subheadings. The page is one continuous block of text.
+
+Readers open the article, see the wall, and leave. Even those who try to read tire quickly. The content may be excellent; the rhythm has destroyed it.
+
+The fix: bump line-height to 1.6, cap max-width to 65ch, break paragraphs into 3-5 sentences each with visible spacing, add subheadings every 3–5 paragraphs.
+
+### A documentation page
+
+Documentation typically has more interruptions than article prose: code blocks, callouts, lists, tables. The rhythm needs to accommodate these.
+
+A pattern that works:
+
+- Body prose at 16px / 1.6 leading / 0.8em paragraph spacing / 65ch max-width.
+- Code blocks at 90ch max-width with 1em vertical space above and below.
+- Callouts (info, warning) with their own background tinting and 1em margins.
+- Subheadings (h2, h3) with extra space before to create clear section breaks.
+
+The result is a page that flows through prose, pauses for code or callouts, and resumes prose with clear visual boundaries.
+
+### A FAQ layout
+
+A FAQ page is structurally a sequence of question-answer pairs. Treat each Q+A as a distinct chunk:
+
+- Question: 16px medium weight, with 1em margin below to attach answer.
+- Answer: 16px regular weight, 1.5 line height, indented or visually distinct.
+- Between Q+A pairs: 2em vertical space.
+
+The rhythm makes the page scannable (jumping between questions) and readable within each answer.
+
+## Anti-patterns
+
+**Tight leading on body prose.** Browser default (~1.2) is too tight for sustained reading. Set explicit line-height for prose containers.
+
+**No paragraph spacing.** Paragraphs visually merging together is one of the fastest ways to make prose feel impenetrable.
+
+**No subheadings in long content.** Long articles without structural breaks are walls of text. Add hierarchy.
+
+**Paragraphs that are too long.** A 12-sentence paragraph is intimidating regardless of layout. Shorter paragraphs (3–5 sentences) feel more approachable. (Writer's job, but designers can encourage by leaving room.)
+
+**Text crammed into the available container.** No margin around the article, no space between sections. The text feels claustrophobic.
+
+**Animation or interaction during reading.** Sticky headers, scroll-triggered animations, pop-ups during reading all interrupt rhythm. Long-form reading deserves a quiet layout.
+
+**Justified text without proper hyphenation.** Justified text without good hyphenation produces uneven word spacing — "rivers" of white space that disrupt reading rhythm.
+
+**Lists of bullet points used as a substitute for prose.** Bullet points break rhythm; they're lists, not prose. Use them when the content is genuinely a list, not as a way to avoid writing connected prose.
+
+## Heuristic checklist
+
+Before shipping long-form content, ask: **Is the leading at least 1.5× the font size for body prose?** Tighter is uncomfortable. **Is paragraph spacing visible from a distance?** It should clearly mark paragraph breaks. **Are there subheadings every 3–5 paragraphs?** Long content needs structural breaks. **Does the article have visible breathing room around it?** Cramped layouts cost reading comfort. **Does the page have any interruptions during reading?** Sticky headers, animations, pop-ups all disrupt rhythm; minimize during reading flow.
+
+## Related sub-skills
+
+- `readability` — parent principle on sustained-reading ease.
+- `readability-line-length` — sibling skill on measure (line length).
+- `chunking` — paragraphs and subheadings chunk content into readable units.
+- `hierarchy` — subheadings express structural hierarchy.
+- `signal-to-noise` — clean prose layouts maximize signal.
+
+## See also
+
+- `references/prose-layout-patterns.md` — patterns for specific kinds of long-form content.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability-rhythm-and-prose/references/prose-layout-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability-rhythm-and-prose/references/prose-layout-patterns.md
@@ -1,0 +1,195 @@
+# Prose layout patterns
+
+Patterns for laying out specific kinds of long-form content, with notes on the rhythm choices that work for each.
+
+## Pattern: long-form article
+
+A 1500–5000-word article on a content site.
+
+**Body type:** 17–20px serif or humanist sans-serif. Slightly larger than UI body text because the reader is committing to sustained reading.
+
+**Line height:** 1.5–1.7×.
+
+**Line length:** 60–70 characters (use `max-width: 65ch` or similar).
+
+**Paragraph spacing:** 0.8–1em between paragraphs (visible breaks).
+
+**Subheading frequency:** every 3–5 paragraphs. Use h2 for major sections, h3 for sub-sections within them.
+
+**Structure:** single column, centered in the page, with significant whitespace on the sides.
+
+**Interruptions:** minimize. Pull-quotes and inline images are fine; sticky banners and pop-ups disrupt reading.
+
+## Pattern: documentation page
+
+Technical documentation with prose, code blocks, and supporting content.
+
+**Body type:** 15–17px sans-serif. Slightly smaller than article prose because the reader is often scanning for specific information rather than reading continuously.
+
+**Line height:** 1.5–1.6×.
+
+**Line length:** 60–80 characters for prose. Code blocks can extend wider (90–120ch).
+
+**Subheading frequency:** every 2–4 paragraphs. Documentation is often heavily structured; subheadings double as in-page navigation targets.
+
+**Code blocks:** use monospace, slight background tint, generous leading (1.5–1.6×). Add padding around code blocks (1em vertical space above/below).
+
+**Callouts:** info, warning, tip boxes. Use sparingly; too many disrupt rhythm.
+
+**Sidebar navigation:** common in documentation, with table of contents. Keep the body column centered or slightly left-of-center to maintain reading focus.
+
+## Pattern: blog post
+
+A 500–2000-word post on a personal or company blog.
+
+**Body type:** 18–20px serif (for personal/editorial feel) or sans-serif (for company/product feel).
+
+**Line height:** 1.5–1.7×.
+
+**Line length:** 60–70 characters.
+
+**Paragraph spacing:** 1em between paragraphs.
+
+**Subheading frequency:** less critical than for long articles; can be optional for shorter posts. For posts over 1000 words, use h2 every 3–5 paragraphs.
+
+**Author / date metadata:** subtle, not competing with the content. Smaller font, muted color, well above or below the prose.
+
+## Pattern: email body
+
+An email read in client UIs of varying widths and conventions.
+
+**Body type:** 14–16px sans-serif. (Serif can render poorly in some email clients.)
+
+**Line height:** 1.5×.
+
+**Column width:** 600px is the conventional desktop standard. Mobile clients reflow to whatever width they render at.
+
+**Paragraph spacing:** clear visible breaks (about 1em between paragraphs).
+
+**Constraints:** email clients render CSS inconsistently. Use inline styles, simple layouts, and test in major clients (Gmail, Apple Mail, Outlook).
+
+**No reliance on CSS-only effects:** background images, custom fonts, and complex layouts often fail. Design for the most conservative client and progressively enhance.
+
+## Pattern: report or whitepaper
+
+A long-form formal document, often viewed on desktop and printed.
+
+**Body type:** 11–12pt serif (for print) or 16px serif (for web). Choose based on primary medium.
+
+**Line height:** 1.4–1.5× (slightly tighter than blog prose; reports are often more formal).
+
+**Line length:** 60–75 characters.
+
+**Subheading frequency:** every 3–6 paragraphs. Reports often have rich hierarchy (chapters, sections, sub-sections).
+
+**Footnotes and citations:** common; use a smaller size (10–12pt) and clear visual separation from body.
+
+**Tables and figures:** common; ensure they're integrated with the prose layout, not floating awkwardly.
+
+## Pattern: newsletter
+
+A periodic email or web post combining multiple short pieces.
+
+**Body type:** 14–16px.
+
+**Line height:** 1.5×.
+
+**Line length:** 60–70 characters per piece.
+
+**Structure:** distinct sections per piece, with clear visual separation (subheadings, dividers, or extra spacing).
+
+**Skimmability:** newsletter readers often scan more than read. Clear subheadings, brief introductions, and prominent links to "read more" support scanning.
+
+## Pattern: transcript or chat log
+
+Long-form conversational content.
+
+**Body type:** 14–16px sans-serif.
+
+**Line height:** 1.5×.
+
+**Speaker attribution:** clear visual distinction (name in bold, in a colored badge, or aligned to one side).
+
+**Paragraph spacing:** clear breaks between speaker turns.
+
+**Time stamps:** subtle, not competing with the content.
+
+**Reading rhythm:** transcripts often have a different rhythm than article prose — short turns, frequent speaker changes, sometimes pauses or interruptions noted. Layout should accommodate this naturally.
+
+## Pattern: book / e-book
+
+Long-form sustained reading.
+
+**Body type:** 16–20px serif (print convention transferred to digital).
+
+**Line height:** 1.5–1.7×.
+
+**Line length:** 50–65 characters.
+
+**Paragraph spacing:** can use first-line indents (book convention) or block paragraphs with space (web convention).
+
+**Margins:** generous on all sides; the text block should feel framed by white space.
+
+**Chapter structure:** clear chapter breaks with visual emphasis (page break in print; significant vertical space online).
+
+**User control:** allow users to adjust font size, line height, and column width. Different readers want different settings.
+
+## Pattern: dashboard with explanatory text
+
+A data dashboard that includes paragraphs of context or commentary.
+
+**Body type:** 14–15px sans-serif (matches UI text).
+
+**Line height:** 1.5×.
+
+**Line length:** 60–80 characters; cap with max-width even if the container is wider.
+
+**Position:** explanatory text should be near the data it explains, not in a separate panel.
+
+**Length:** keep prose short; dashboards are scanned, not read. Long explanations should be expandable ("read more") rather than always-visible.
+
+## Pattern: terms of service / legal document
+
+Long-form formal content that users sometimes need to actually read.
+
+**Body type:** 14–16px sans-serif.
+
+**Line height:** 1.5×.
+
+**Line length:** 65–75 characters.
+
+**Hierarchy:** rich. Numbered sections, sub-sections, sub-sub-sections. Each level visually distinguished.
+
+**Tables of contents:** essential. Users navigate to specific sections; provide jump links.
+
+**Subheadings:** every few paragraphs at minimum. Long unbroken sections of legal prose are notoriously bad to read.
+
+**Plain-language summary at top:** supports reading by giving users the gist before they decide to read the details.
+
+## Pattern: FAQ
+
+Question-and-answer pairs.
+
+**Question:** 16px medium weight, slightly larger than the answer.
+
+**Answer:** 15–16px regular weight, 1.5 line height.
+
+**Spacing:** 0.5em between question and answer; 2em between Q+A pairs.
+
+**Structure:** consider grouping questions by topic with subheadings, especially for FAQ pages with more than 10 questions.
+
+**Search or filter:** for FAQ pages with many questions, provide a search or category filter.
+
+## Anti-patterns
+
+**Reusing UI text settings for long prose.** UI text is calibrated for short, scannable text. Long prose needs different settings (larger size, more leading, more breathing room).
+
+**Reusing print typography for digital.** Print uses tighter leading and smaller text than digital reading can support comfortably. Calibrate for the medium.
+
+**Forgetting mobile.** Long-form layouts often look great on desktop and break on mobile. Test reading experience at all the widths your users will use.
+
+**Burying the article in chrome.** Sticky headers, sidebars, ads, and pop-ups all reduce reading focus. Long-form deserves a clean reading experience.
+
+## Cross-reference
+
+For line length specifically, see `readability-line-length`. For the parent principle, see `readability`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: readability
+description: 'Apply the principle of Readability — the ease with which sustained prose can be read, determined by line length, line height, paragraph rhythm, font choice for prose, and visual breathing room. Use when designing long-form content (articles, documentation, books, transcripts), writing email or report layouts, evaluating whether users can comfortably read paragraphs of text. Distinct from legibility (per-character clarity); readability is about the experience of reading sustained prose without fatigue. The two principles compose: readability requires legibility and adds prose-specific constraints.'
+---
+
+# Readability
+
+> **Definition.** Readability is the ease with which sustained text can be read — paragraphs, articles, documentation, long-form content. It depends on the legibility of individual characters (necessary precondition) plus a set of prose-specific factors: line length, line height, paragraph spacing, typeface suited for sustained reading, and visual breathing room. A readable design lets the reader move smoothly through the text without fatigue or visual jumping.
+
+Readability is distinct from *legibility*. Legibility is per-character clarity — can the user identify each letter at a glance. Readability is sustained-reading ease — can the user read paragraphs of prose comfortably without tiring.
+
+A typeface can be highly legible (every character distinguishable) but poorly readable (uncomfortable for long-form reading) — many display typefaces are this way. A typeface can be highly readable (comfortable for sustained reading) but only moderately legible (some characters look similar) — many traditional book typefaces have minor character-distinction issues that don't matter for prose.
+
+## Why readability matters
+
+Most UI text is short — labels, buttons, helper text. Legibility usually dominates these contexts. But many products also serve long-form text: documentation, articles, emails, transcripts, reports, books, news, dashboards with substantial commentary. For these, readability matters as much as or more than legibility.
+
+Poor readability costs the user real effort: they tire faster, lose their place more often, miss content, and abandon longer pieces. The cost is not in any single moment but in the cumulative fatigue of reading.
+
+## The five inputs to readability
+
+Readability is determined by:
+
+**Line length (measure).** The number of characters per line. The classic recommendation is 45–75 characters per line for body prose, with ~66 as the sweet spot. Lines that are too long cause the eye to lose track between the end of one line and the start of the next; lines that are too short force frequent line breaks that interrupt reading flow.
+
+**Line height (leading).** The vertical space between lines. Generous leading aids reading by giving the eye clear separation between adjacent lines. Tight leading causes ascenders and descenders to overlap, slowing reading.
+
+**Paragraph spacing.** The space between paragraphs. Adequate spacing creates clear paragraph breaks that aid scanning and chunking. Tight paragraph spacing turns prose into a wall of text.
+
+**Typeface choice for prose.** Some typefaces are designed for sustained reading (humanist serifs, transitional serifs, humanist sans-serifs); others are designed for short use (display, signage). Sustained reading typefaces have proportions and details that reduce eye fatigue.
+
+**Visual breathing room.** Margins around text, vertical space between sections, page-level rhythm. Cramped layouts cost reading comfort even when individual elements are well-designed.
+
+## Diagnosing readability problems
+
+Symptoms of readability issues:
+
+**Users skim or abandon long content.** They open an article, scan the first paragraph, and leave. Often the problem is not the content but the readability of the layout.
+
+**Users complain about "tiring" or "hard-to-read" pages.** Difficult to articulate, but a reliable signal of readability issues.
+
+**Reading-time analytics drop sharply over content length.** Time-on-page falls faster than content length predicts; users are tiring faster than the content warrants.
+
+**Reflow on different screen sizes produces dramatically different layouts.** A page that's readable at desktop width may be unreadable at a different width if the text doesn't reflow well.
+
+**Users zoom in or use reader mode.** When users invoke browser reader mode or zoom in, your readability has failed; the browser is doing what your design should have done.
+
+## Sub-skills in this cluster
+
+- **readability-line-length** — Setting line length (measure) and how it interacts with screen width, font size, and reading context. The most fundamental readability decision.
+- **readability-rhythm-and-prose** — Paragraph rhythm, leading, vertical spacing, and the prose-level readability that goes beyond line-by-line.
+
+## Worked examples
+
+### A readable article layout
+
+A long-form article on a content site: 18px serif body type at 1.6 line height, line length capped at 70 characters, paragraph spacing of about 0.8em above each paragraph, generous margins on the article, no other elements competing in the central column. Subheadings break up sections every 3–5 paragraphs.
+
+The reader can move smoothly through the article without conscious effort. The line length is short enough that the eye easily finds the next line, the leading is comfortable, and the paragraph rhythm provides natural rest points.
+
+### A documentation page
+
+Documentation often combines prose and code. The prose follows similar readability principles (15–17px body text, 1.6 line height, 60–70 character line length) and code blocks are differentiated visually (monospace, slightly tinted background, generous leading).
+
+The combination requires careful design: code blocks shouldn't disrupt prose flow; prose shouldn't blur into code. Vertical rhythm between paragraphs and code blocks should be consistent.
+
+### A wall of text that fails
+
+A FAQ page with no structural breaks: 16px text running 120 characters per line, 1.2 line height, single paragraphs of 10–15 sentences each, no subheadings. Users open it, see the wall, and leave without reading.
+
+The fix: shorter paragraphs, subheadings every few paragraphs, line length capped at 70 characters, line height bumped to 1.5+, more vertical space between paragraphs. The content is the same; the readability transforms.
+
+### A dashboard with too-long lines
+
+A dashboard widget shows a paragraph of explanatory text that runs the full width of the dashboard column — about 130 characters per line. Users read the first few lines and skip the rest because the long lines tire the eye.
+
+The fix: cap the explanation's max-width at 70 characters. The dashboard column can be wider, but the text within it shouldn't run the full width.
+
+### Email that's hard to read on mobile
+
+An email designed at desktop width (600px column with 12pt text) is read on a mobile phone. The text reflows to the narrower screen width but the font size doesn't scale up; lines are now very short (15–20 characters) and the user pinches to zoom or switches to a different reader.
+
+The fix: design email for mobile-first, with larger base font sizes (16–18px) and narrower max-widths that still read well at desktop width.
+
+## Anti-patterns
+
+**Lines that run the full container width.** Default web behavior is to fill the available width with text, which often produces lines too long for comfortable reading. Cap your max-width.
+
+**Tight leading on body prose.** Browser default leading (about 1.2) is too tight for sustained reading. Bump to 1.5 or higher for body content.
+
+**No paragraph breaks.** Long paragraphs that don't break up are visually intimidating and cognitively dense. Most prose benefits from 3–5 sentence paragraphs.
+
+**No subheadings in long content.** A 2000-word article without subheadings is a wall. Subheadings every 3–5 paragraphs provide visual rest and structural navigation.
+
+**Dense layouts that compete with the prose.** Sidebars, ads, callouts, and pop-ups that surround the prose all reduce reading focus. Long-form content benefits from cleared layouts that prioritize the reading experience.
+
+**Display typefaces in body prose.** A typeface chosen for headlines used at body sizes for prose. Reading fatigue accelerates rapidly.
+
+**Justified text without proper hyphenation.** Justified text (left and right edges aligned) without good hyphenation produces uneven word spacing — "rivers" of white space running through the prose. Most digital contexts should use left-aligned (ragged-right) text instead.
+
+**Text overlaid on busy backgrounds.** Text on a photo or pattern fights for attention with the background. Use a solid background for body text.
+
+## Heuristic checklist
+
+Before shipping any long-form content, ask: **Is the line length capped at 45–75 characters?** Wider needs justification. **Is the leading at least 1.5× the font size?** Tighter is uncomfortable. **Is there adequate paragraph spacing?** Visible breaks between paragraphs. **Are there subheadings every 3–5 paragraphs?** Long content needs structural navigation. **Is the typeface designed for sustained reading?** Display type doesn't survive at body sizes. **Have I tested at all the screen sizes my users will use?** Especially mobile.
+
+## Related principles
+
+- **Legibility** — the per-character clarity that readability builds on.
+- **Hierarchy** — readability is supported by clear structural hierarchy.
+- **Chunking** — paragraphs and subheadings chunk prose into readable pieces.
+- **Signal-to-Noise Ratio** — readable layouts maximize signal (the prose) and minimize noise (everything else).
+- **Form Follows Function** — long-form reading layouts should be different from UI layouts because their function is different.
+- **Accessibility** — readable typography helps users with reading differences.
+
+## See also
+
+- `references/lineage.md` — origins in book typography, web typography, and reading research.
+- `readability-line-length/` — sub-skill on line length (measure).
+- `readability-rhythm-and-prose/` — sub-skill on paragraph rhythm and breathing room.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/readability/references/lineage.md
@@ -1,0 +1,90 @@
+# Readability — origins and research lineage
+
+## Roots in book typography
+
+Readability has been the central concern of book typography for centuries. Long-form reading is the canonical use case for typography, and book designers have refined the principles through trial and error since the era of moveable type.
+
+Key historical findings, much of which carries to digital:
+
+- **Line length should be limited.** Book typographers have aimed for 60–75 characters per line for centuries. The constraint is rooted in the saccadic structure of reading: at the end of a line, the eye must jump back and find the start of the next. Lines that are too long cause the eye to lose its place; lines that are too short cause too-frequent jumps.
+- **Leading should be generous for body prose.** A typical book sets body text at 10–11pt with 13–14pt leading (roughly 1.3× to 1.4×). Web tends to use slightly more generous leading (1.5–1.6×) because screen reading is harder than paper reading.
+- **Justified text needs hyphenation.** Justifying body text (aligning both edges) requires hyphenation breaks to prevent uneven word spacing. Without good hyphenation, justified text produces "rivers" of white space that disrupt reading.
+- **Margins frame the text.** A book page is mostly margin, with the text block in the center. The margins serve readability by providing breathing room and reducing competition for attention.
+
+## Web typography research
+
+The arrival of long-form reading on the web introduced new variables. Notable findings from web typography research, especially the work of Robert Bringhurst (*The Elements of Typographic Style*, 1992 onward), Oliver Reichenstein (founder of iA, who argued passionately for typography-first web design in the 2000s), and various practitioners:
+
+- **Web reading is harder than print reading.** Lower DPI, screen glare, distraction, scrolling all contribute. This pushes toward more generous typography (larger sizes, more leading, shorter line lengths) than print.
+- **Screen reading benefits from slightly larger body sizes.** 16px is a comfortable web body baseline; 18px is comfortable for content-focused sites. Many older sites used 12–14px and felt cramped.
+- **Line length on responsive sites is the hardest variable.** A site that's readable at desktop width may have 130-character lines that fail at large desktop widths. CSS `max-width` on text content blocks is essential.
+
+## Modern reading research
+
+The literature on reading itself — saccades, fixations, comprehension — gives us several stable findings:
+
+- **Reading is not continuous.** The eye makes ~3–4 fixations per second, jumping (saccading) between them. Each fixation takes in about 7–9 characters of text on average.
+- **Comprehension lags fixation.** The brain processes text behind the eye's actual position. This makes longer line lengths cognitively costly: the reader must hold the in-progress line in working memory.
+- **Skimming is different from reading.** When users scan rather than read, line length matters less and visual structure matters more. Subheadings, bold pull-out text, and bullet points all support skimming.
+- **Reading speed declines with reading time.** Sustained reading produces measurable fatigue. Designs that reduce per-line cognitive load extend the reader's stamina.
+
+## Bringhurst's principles
+
+Robert Bringhurst's *The Elements of Typographic Style* codifies many readability principles into specific recommendations:
+
+- **Choose a comfortable measure.** "Anything from 45 to 75 characters is widely regarded as a satisfactory length of line for a single-column page set in a serifed text face. The 66-character line (counting both letters and spaces) is widely regarded as ideal."
+- **Set leading proportional to type size.** "For body text in books, leading is typically 1 to 4 points more than the type size."
+- **Use a sufficient text-block width.** Wide enough that the typography doesn't feel cramped; narrow enough that line length stays in the comfortable range.
+- **Choose typefaces sympathetic to the language and content.** A serif typeface with humanist warmth for casual reading; a more austere typeface for technical content.
+
+These recommendations were written for print but transfer well to digital. Most have been adopted by reader-mode browsers, e-reader apps, and content-focused web design.
+
+## Reader mode and the design lesson
+
+Browser "reader mode" (Safari Reader, Firefox Reader View, Chrome Reading Mode) strips away the page design and presents the article in a clean, readable layout: large body text, generous leading, capped line length, simple typography, white background. The design choices are deliberately conservative — they prioritize readability above all.
+
+That reader mode exists at all is a critical lesson: many designed pages fail at the very thing they're supposed to do (let users read the article), and users have been driven to a tool that bypasses the design.
+
+The design implication: long-form content layouts should not require reader mode to be readable. If your article requires users to invoke reader mode, your design has failed.
+
+## Mobile reading
+
+Mobile reading has its own constraints. Phone screens are narrow (300–400px effective text width) and held closer than monitors. The implications:
+
+- **Smaller fixed line lengths.** A column that holds ~70 characters at 16px on desktop will hold ~30 characters at 16px on mobile. To get back to ~50–70 characters per line on mobile, body text often needs to drop to 14–16px (or the column to expand).
+- **Vertical scrolling dominates.** Mobile reading is inherently scrolling-heavy; the line height and paragraph spacing should be calibrated for that.
+- **Font weight and color matter more.** Mobile reading often happens in suboptimal conditions (sun, dim rooms, motion); typography needs to be robust against those conditions.
+
+## E-readers
+
+Dedicated e-readers (Kindle, Kobo) give us a useful benchmark for what readers actually want when given control:
+
+- Large body text (often 16–18px equivalent, with user-adjustable scaling).
+- Generous leading (~1.5×).
+- Comfortable margins.
+- Choice of serif (default for many devices) or sans-serif typefaces.
+- Limited typography (no display flourishes; consistent body type).
+- E-ink rendering that approximates paper.
+
+E-reader UI is consistently praised for reading comfort. The design lessons transfer to any long-form digital reading context: prioritize readability, give the user control, don't over-design.
+
+## Empirical findings worth remembering
+
+The literature converges on:
+
+- **Body text size 16–18px** for comfortable web reading; below 14 is cramped for long content.
+- **Line length 45–75 characters** for body prose; outside this range is measurably harder to read.
+- **Leading 1.5–1.7×** the font size for body prose; tighter is uncomfortable.
+- **Paragraph spacing** that's clearly larger than line spacing — visible breaks aid scanning.
+- **Generous margins** that provide breathing room around the text block.
+- **Serif vs. sans-serif** matters less than other factors. Both can be readable when designed for body text.
+
+## Sources informing this principle
+
+- Bringhurst, R. (1992). *The Elements of Typographic Style*. (The canonical modern text on typography.)
+- Tinker, M. A. (1963). *Legibility of Print*.
+- Lupton, E. (2010). *Thinking with Type*.
+- Reichenstein, O. (Various). iA's writing on web typography, especially "Web Design is 95% Typography" (2006).
+- Various reader-mode designs (Safari, Firefox, Chrome) as examples of readability-first design.
+- E-reader interface designs (Kindle, Kobo, Apple Books) as examples of long-form reading design.
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/signal-to-noise-ratio/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/signal-to-noise-ratio/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: signal-to-noise-ratio
+description: 'Use this skill whenever a design has too much or too little visual content competing for attention — when a screen "feels noisy," "looks busy," "feels cluttered," "feels empty," or when the user can''t find the meaningful information amid decoration. Trigger when reviewing dashboards, data tables, settings pages, marketing surfaces, or any layout under critique. Trigger when designing chart axes/legends/grids, when picking icon density, when deciding whether to add a divider/border/illustration, or when a design "passes" the requirements but doesn''t feel right. Signal-to-Noise Ratio is the discipline of subtraction; this skill teaches what counts as signal vs. noise, how to audit and reduce noise, and the trade-offs of overcorrecting.'
+---
+
+# Signal-to-Noise Ratio
+
+Signal-to-Noise Ratio (SNR) is the proportion of meaningful information to irrelevant or decorative content in a composition. The principle, borrowed from communications engineering, asserts that comprehension and aesthetic quality both improve as SNR rises — every visible element that doesn't carry meaning competes with the elements that do.
+
+## Definition (in our own words)
+
+In a design, *signal* is anything that helps the viewer accomplish their task or understand the content: data, labels, controls, focal imagery, navigation paths, and the typographic and spatial structure that makes them legible. *Noise* is anything else: decorative borders that don't separate meaningful groups, illustrations unrelated to the content, repeated branding marks, gratuitous gradients, drop shadows on cards that don't elevate, status icons next to fields that have no status, hover effects on non-interactive elements. A high-SNR design strips away noise so the signal can land. A low-SNR design buries the signal in chrome.
+
+## Origins and research lineage
+
+- **Information theory** (Shannon, 1948) gave us the SNR ratio as a measurable property of communication channels. The more noise on a channel, the more redundancy required to transmit a message reliably.
+- **Edward Tufte's *data-ink ratio*** (*The Visual Display of Quantitative Information*, 1983) translated this into design vocabulary: maximize the ratio of ink that conveys information to total ink on the page; "erase non-data-ink, within reason."
+- **Modern minimalist design movements** (Swiss design, Dieter Rams' "Less, but better") have applied the same discipline to product design at large.
+- **Cognitive load theory** explains why low SNR is costly: every visible element is processed, however briefly, by the viewer's perceptual system. Noise consumes attention even when consciously ignored.
+
+## Why SNR matters
+
+A composition with high SNR feels effortless — the viewer reads it without working. A composition with low SNR feels exhausting in ways the viewer often can't articulate. They report it as "busy" or "overwhelming" or "cluttered," but the underlying mechanism is preattentive: the eye is constantly evaluating elements, and unproductive elements steal effort that could go to signal.
+
+Low SNR also degrades the meaningful elements. A status badge is informative when it's the only colored element in a row; the same badge in a row of three other colored chips and an illustration becomes part of the visual texture and stops registering.
+
+## When to apply
+
+- **Always**, as a final pass: after a draft is functionally complete, audit for noise.
+- **Particularly on dashboards, data tables, settings, and admin UIs** — surfaces where users return repeatedly and noise compounds.
+- **When the design "feels right" in a mockup but cluttered in production** — usually because real data is messier than sample data, and accumulated chrome was tolerable in the mockup but isn't in use.
+- **When users describe the UI as "overwhelming" or "I don't know where to look"** — these are SNR diagnoses.
+
+## When NOT to apply (or when to be careful)
+
+- **Marketing and brand surfaces** sometimes need elements that aren't strictly informational — atmosphere, character, illustration. Low SNR is sometimes the *point* (a luxury hero image isn't supposed to read as "data"). Apply SNR within the goals of the surface, not as a universal subtraction rule.
+- **Empty states** can use illustration to set tone; an absolutely empty empty-state may read as broken.
+- **Complete sterility** can also be a failure mode — a UI so stripped that it loses character or warmth. SNR is not minimalism for minimalism's sake.
+
+## What counts as signal vs. noise
+
+The distinction is **always relative to the user's task**. The same element can be signal on one surface and noise on another.
+
+| Element | Signal when… | Noise when… |
+|---|---|---|
+| Border on a card | The card needs to be distinguished from surrounding content | Proximity already does the grouping work |
+| Drop shadow | The element actually floats above context (popover, modal) | Applied to inert content (a card sitting on the page) |
+| Illustration | It teaches, illustrates, or sets emotional tone for the moment | It fills space because the page felt empty |
+| Status icon | Status varies and matters | Status is always the same or rarely changes |
+| Background gradient | It separates a region or sets atmosphere | It's "polish" with no role |
+| Divider | The two regions need stronger separation than spacing alone provides | Spacing already does the work |
+| Color swatch | It encodes meaning the user must recognize | Brand decoration |
+| Animated transition | It signals state change (open/close, success) | Eye-candy that interrupts focus |
+
+The audit question is always: *if I removed this, would the user lose information they need?* If no, it's noise.
+
+## How to raise SNR
+
+A practical four-step audit:
+
+### 1. Strip every border, then put back only the borders that serve
+
+Most UIs have too many borders. Lines around cards, lines between rows, lines around inputs, lines around containers of inputs. Many of these are redundant — proximity, alignment, and background tint already group the content.
+
+Procedure: in your CSS, set `* { border: 0 !important; }` temporarily. Look at the page. What broke? Anywhere structure collapsed, you needed the border. Restore those. Anywhere the page is fine without it, leave the border off.
+
+### 2. Strip every shadow and gradient, then put back only the ones that earn
+
+Shadows are particularly easy to overuse. Default `shadow-sm` on every card, `shadow-md` on every popover, `shadow-2xl` on every dialog. A sea of shadowed elements feels like a toy box.
+
+Reserve shadows for genuine elevation: a popover floating above content, a sticky header that needs to recess content under it, a dragged item that lifts.
+
+### 3. Strip every icon that isn't load-bearing
+
+Icons should make ambiguity disappear or save text space. An icon next to "Save" doesn't reduce ambiguity (the word is unambiguous) and doesn't save space (the button has the word too). Strip it.
+
+Icons earn their pixels when:
+
+- They replace text in space-constrained chrome (toolbar, tab bar, mobile nav).
+- They disambiguate (a sparkle on "AI suggest" tells you the action is AI-assisted, which "Suggest" alone wouldn't).
+- They encode status (a check, a warning triangle) where the user scans for state.
+
+### 4. Strip every duplicate signal
+
+If status is encoded in color, icon, *and* text, you have redundancy. Sometimes redundancy is correct (accessibility — color-blind users need a non-color signal). But if all three signals are firing for a low-stakes piece of metadata, you're spending three signals where one would do.
+
+## Worked examples
+
+### Example 1: a dashboard tile (before / after)
+
+**Low SNR (before):**
+
+```html
+<div class="kpi-tile" style="
+  border: 1px solid hsl(0 0% 88%);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  background: linear-gradient(180deg, hsl(0 0% 99%), hsl(0 0% 96%));
+  box-shadow: 0 4px 12px rgba(0,0,0,0.04);
+">
+  <div style="display: flex; align-items: center; gap: 0.5rem;">
+    <div style="background: hsl(220 90% 95%); padding: 0.5rem; border-radius: 0.5rem;">
+      <DollarIcon style="color: hsl(220 90% 50%);" />
+    </div>
+    <p style="font-size: 0.875rem; color: hsl(0 0% 35%); font-weight: 500;">
+      MONTHLY REVENUE
+    </p>
+  </div>
+  <p style="font-size: 2.5rem; font-weight: 600; margin-top: 1rem;">$48,200</p>
+  <div style="display: flex; align-items: center; gap: 0.25rem; margin-top: 0.5rem;">
+    <ChevronUpIcon style="color: hsl(142 70% 35%);" />
+    <p style="color: hsl(142 70% 35%); font-size: 0.875rem;">12% vs last month</p>
+  </div>
+  <hr style="margin: 1rem 0;" />
+  <p style="font-size: 0.75rem; color: hsl(0 0% 60%);">Last updated 3 minutes ago</p>
+</div>
+```
+
+Audit: gradient (noise), shadow on inert card (noise), icon-in-tinted-square next to label (decoration, not load-bearing), divider before metadata (proximity does this for free).
+
+**High SNR (after):**
+
+```html
+<div class="kpi-tile" style="border: 1px solid hsl(0 0% 92%); border-radius: 0.5rem; padding: 1.5rem;">
+  <p style="font-size: 0.8rem; color: hsl(0 0% 45%);">Monthly revenue</p>
+  <p style="font-size: 2.5rem; font-weight: 600; margin-top: 0.25rem; font-variant-numeric: tabular-nums;">$48,200</p>
+  <p style="color: hsl(142 70% 30%); font-size: 0.875rem; margin-top: 0.25rem;">↑ 12% vs last month</p>
+  <p style="font-size: 0.75rem; color: hsl(0 0% 60%); margin-top: 1rem;">Last updated 3 minutes ago</p>
+</div>
+```
+
+Same information, half the visual weight. The number — the actual signal — dominates.
+
+### Example 2: a chart (Tufte-style data-ink discipline)
+
+**Low SNR:** chart with thick axis lines, every gridline labeled, 3D bars, drop shadows, gradient bar fills, legend repeated in tooltip, axis title in 18px bold.
+
+**High SNR:** thin axis lines (or none), gridlines only at major intervals (light grey), flat bars, single-color fills, axis title in 12px lowercase, label values directly on bars when there are <8 of them.
+
+```html
+<svg viewBox="0 0 320 200">
+  <!-- subtle baseline only -->
+  <line x1="40" y1="180" x2="310" y2="180" stroke="hsl(0 0% 80%)" stroke-width="1" />
+  <!-- bars, flat fill -->
+  <rect x="50" y="80" width="30" height="100" fill="hsl(220 70% 50%)" />
+  <rect x="100" y="60" width="30" height="120" fill="hsl(220 70% 50%)" />
+  <rect x="150" y="100" width="30" height="80" fill="hsl(220 70% 50%)" />
+  <rect x="200" y="40" width="30" height="140" fill="hsl(220 70% 50%)" />
+  <!-- value labels above bars (replace the y-axis entirely) -->
+  <text x="65" y="72" font-size="10" text-anchor="middle">42</text>
+  <text x="115" y="52" font-size="10" text-anchor="middle">58</text>
+  <text x="165" y="92" font-size="10" text-anchor="middle">31</text>
+  <text x="215" y="32" font-size="10" text-anchor="middle">71</text>
+  <!-- x labels -->
+  <text x="65" y="195" font-size="10" text-anchor="middle" fill="hsl(0 0% 45%)">Q1</text>
+  <text x="115" y="195" font-size="10" text-anchor="middle" fill="hsl(0 0% 45%)">Q2</text>
+  <text x="165" y="195" font-size="10" text-anchor="middle" fill="hsl(0 0% 45%)">Q3</text>
+  <text x="215" y="195" font-size="10" text-anchor="middle" fill="hsl(0 0% 45%)">Q4</text>
+</svg>
+```
+
+The signal here is four numbers (Q1–Q4 values) and their relative magnitudes. Everything else is at the bare minimum needed to read them.
+
+### Example 3: a settings page
+
+A common low-SNR pattern: every setting wrapped in its own card, every section heading colored in brand, every help text in a tinted callout box, "save" buttons under every section.
+
+A high-SNR settings page uses one or two `Card` containers per section (proximity does the rest), section headings in normal text weight at the top of each section, help text in dim grey under the field it concerns, and a single "Save changes" button at the bottom (or auto-save with toast confirmation).
+
+## Anti-patterns
+
+- **The brand-everywhere page.** Every available surface tinted with the brand color, every separator in brand. The brand becomes background noise; users tune it out.
+- **The "polish" pass.** A late-stage designer adds shadows, gradients, hover effects, and micro-illustrations to "make it feel more designed." The new chrome reduces SNR; the page loses clarity.
+- **The empty-state mascot.** A 400px-tall illustration of a sad cat under three lines of empty-state copy. The illustration is the signal; the actual instruction recedes.
+- **The data table with everything bordered.** Cells, rows, columns, and table border all 1px solid. The data is now jail.
+- **Decorative redundancy.** A "Bell" icon next to a label that says "Notifications" next to another bell icon next to a section heading "Notification preferences." Pick one.
+
+## Heuristics
+
+1. **The squint test (again).** Squint at the page. Is one thing dominant? If the page is uniformly busy, SNR is low.
+2. **The screenshot reduction.** Take a screenshot, scale to 25%. If you can still tell what the page is for and where the actions are, SNR is good. If it looks like noise pixels, low.
+3. **The "delete and see" test.** Delete a candidate noise element. Does the page feel diminished? If yes, it was signal. If no, you've improved the page.
+4. **The data-ink ratio.** For information graphics specifically: estimate the proportion of ink that conveys data versus chrome. Tufte's heuristic was to push toward 100%; in practice 70%+ is healthy.
+
+## Related principles
+
+- **`hierarchy`** — strong hierarchy raises SNR by making one element carry the message.
+- **`proximity`** — proximity reduces the need for borders and dividers (which are often noise).
+- **`horror-vacui`** — the impulse to fill empty space, which directly lowers SNR.
+- **`highlighting`** — emphasis only works in low-noise environments.
+- **`form-follows-function`** (aesthetics) — every form choice should derive from a function; SNR is the operational version.
+- **`ockhams-razor`** (cognition / process) — among solutions that work, prefer the simplest.
+
+## Sub-aspect skills
+
+- **`snr-densification`** — when SNR is *too* high (sterile, sparse), how to add signal density without adding noise.
+- **`snr-decoration-removal`** — a structured audit method for removing decorative chrome.
+- **`snr-emphasis-economy`** — how to spend emphasis (color, weight, size) sparingly so each instance lands.
+
+## Final note
+
+SNR is a discipline of subtraction. The pull toward addition is constant — every stakeholder wants their feature on the dashboard, every designer wants polish, every product manager wants a callout for the new thing. The job of the SNR-aware designer is to keep saying *no* — and *yes* only to the few things that earn their pixels.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/signal-to-noise-ratio/references/data-ink-and-information-design.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/signal-to-noise-ratio/references/data-ink-and-information-design.md
@@ -1,0 +1,81 @@
+# Data-ink, chartjunk, and information-design history
+
+A reference complementing `signal-to-noise-ratio` with the information-design literature that grounds the principle.
+
+## Tufte's data-ink ratio
+
+Edward Tufte's *The Visual Display of Quantitative Information* (1983) is the canonical source. His *data-ink ratio*:
+
+```
+Data-ink ratio = (data-ink) / (total ink used to print the graphic)
+```
+
+Tufte's prescription: maximize this ratio. "Erase non-data-ink, within reason. Erase redundant data-ink, within reason. Revise and edit." The five principles he lists:
+
+1. Above all else, show the data.
+2. Maximize the data-ink ratio.
+3. Erase non-data-ink.
+4. Erase redundant data-ink.
+5. Revise and edit.
+
+The "within reason" qualifier matters — minimalism for its own sake destroys context. The point is not zero non-data-ink, it's the *highest defensible* ratio.
+
+## Chartjunk
+
+Tufte coined "chartjunk" for visual elements that distract from data: drop shadows on bars, 3D effects on pie charts, decorative backgrounds, ornamental gridlines, irrelevant illustrations.
+
+The cost of chartjunk isn't only aesthetic; it's perceptual. The eye must filter out the junk to see the data, and the cognitive cost compounds across glances. For a chart someone looks at twice (rare), the cost is small. For a dashboard tile someone glances at every morning for a year, the cost is real.
+
+## Information design lineage
+
+- **Otto Neurath** and the **Isotype** system (1920s–40s). Pictograms designed for at-a-glance comprehension; an early formal study of what to include and exclude in info-graphics.
+- **Jacques Bertin**, *Sémiologie graphique* (1967). The visual variables (position, size, value, texture, color, orientation, shape) and their suitability for different data types (categorical, ordinal, quantitative).
+- **William Cleveland**, *The Elements of Graphing Data* (1985). Empirical studies on which chart types support accurate magnitude judgments. Position-on-scale (bar charts) outperforms angle-judgment (pie charts) consistently.
+- **Stephen Few**, *Show Me the Numbers* (2004). Practical SNR-driven advice for business graphics.
+
+## Cross-domain examples
+
+### Newspaper charts vs. infographic charts
+
+A newspaper data chart prioritizes data-ink: thin axes, no gridlines, label-on-bar. An infographic from a content-marketing agency typically loads up on chartjunk — illustrative icons, gradients, patterns — to look "designed." Both serve audiences; the news chart serves comprehension, the infographic serves engagement.
+
+Software dashboards usually want news-chart restraint, not infographic flair. Most dashboards are read repeatedly by the same users; clarity wins.
+
+### Print vs. screen density
+
+Print can sustain higher information density than screens because print is high-resolution, perfectly stable, and viewable at multiple distances. Screens have:
+
+- Lower resolution (subpixel rendering helps but doesn't equal print).
+- Brightness that fatigues the eye over long reading.
+- Variable viewing distance.
+
+Translation: dense print layouts often look cluttered when copied 1:1 to screen. Increase the SNR for screen — fewer marks, more space, larger type, less ornament.
+
+### Industrial control panels
+
+Aircraft cockpits, power-plant control rooms, and other "high-stakes glance" interfaces are extreme SNR exercises. Every control is labeled briefly; emphasis is reserved for warnings; non-load-bearing graphics are absent. The cost of misreading a 737 throttle is high enough that designers ruthlessly subtract.
+
+A useful comparison: any modern web dashboard that displays "live" data should aspire to cockpit-grade clarity for the load-bearing information, even if surrounding chrome is more relaxed.
+
+### Wayfinding signage
+
+Highway signs are SNR exercises at scale: destinations and routes only; minimal decoration; consistent typeface; high contrast. Compare to retail signage in a busy mall (low SNR — every shop competing) — the cognitive feel difference is exactly what SNR predicts.
+
+## Quantitative findings
+
+- Cleveland & McGill's accuracy hierarchy of perceptual tasks (1984): position on a common scale is judged most accurately; angle and area are judged least accurately. SNR-conscious chart design picks chart types where viewers' perceptual accuracy is highest.
+- Ware's *Information Visualization* (2004) and Munzner's *Visualization Analysis & Design* (2014) both summarize the research on which visual encodings produce reliable magnitude judgments.
+
+## Edge cases
+
+- **Marketing surfaces.** A landing page's job isn't only to inform; it's to set tone, build affect, persuade. Pure SNR-discipline produces a documentary-grade landing page that converts poorly. Marketing accepts more "noise" because the noise carries brand and emotion. Don't over-apply SNR here.
+- **Empty states.** A truly minimal empty state can read as broken. A small illustration plus a clear CTA — slightly more "noise" than zero — earns its space.
+- **Onboarding tours.** Walking the user through features needs annotation, arrows, callouts — temporarily lower SNR is the right trade for the moment.
+
+## Resources
+
+- **Tufte, E. R.** *The Visual Display of Quantitative Information* (1983); *Envisioning Information* (1990); *Visual Explanations* (1997); *Beautiful Evidence* (2006). The full quartet.
+- **Few, S.** *Show Me the Numbers* (2004); *Information Dashboard Design* (2006).
+- **Cleveland, W. S.** *The Elements of Graphing Data* (1985).
+- **Ware, C.** *Information Visualization: Perception for Design* (2004).
+- **Munzner, T.** *Visualization Analysis & Design* (2014).

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/similarity-and-contrast/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/similarity-and-contrast/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: similarity-and-contrast
+description: 'Apply deliberate dissimilarity (contrast) to distinguish elements that need to be perceived as different — primary vs. secondary actions, normal vs. error states, foreground vs. background, the one important thing vs. the rest. Use when you want to emphasize a single element, distinguish roles, or break up a too-uniform layout. Contrast is similarity''s complement: similarity groups, contrast separates. The skill is calibrating contrast so it communicates what matters without creating visual chaos.'
+---
+
+# Similarity and contrast
+
+If similarity makes things feel like they go together, contrast makes things feel different. Used together, they let you communicate "these belong, those don't" through pure visual treatment. Used separately, similarity alone produces a uniform layout where nothing stands out, and contrast alone produces visual chaos where nothing is grouped.
+
+The skill is calibrating both: enough similarity that related items group, enough contrast that distinct things distinguish. Most design problems are calibration problems on this axis.
+
+## When to introduce contrast
+
+Contrast deliberately introduces difference where similarity would be misleading or insufficient. Specifically:
+
+**Primary vs. secondary actions.** A submit button must be distinguishable from a cancel button. The two should not look the same — that misleads users about which is the primary action. Contrast in color, weight, or size separates them.
+
+**Normal vs. exceptional states.** A normal status item should look different from an error item. The exceptional state needs to stand out so users notice it.
+
+**Important vs. supporting content.** A page title should look different from body text. The hero card should look different from secondary cards. Without contrast, the user has no visual hierarchy to rely on.
+
+**Foreground vs. background.** The active workspace should be visually dominant; the chrome (sidebars, headers, footers) should recede. Without contrast, foreground and background compete for attention.
+
+**Now vs. later.** The current step in a flow should look different from completed and upcoming steps. Without contrast, the user can't tell where they are.
+
+## Calibrating contrast
+
+Contrast can be too subtle or too aggressive. The right level depends on what you're communicating.
+
+**Too subtle.** Two button styles that differ only by 10% opacity. The dissimilarity isn't visible; users don't perceive distinct categories. Either increase the contrast or remove the styling difference (it's not communicating).
+
+**Too aggressive.** A primary button rendered in such a different style from secondary buttons that it doesn't even feel like the same component family. The contrast is so high it severs the relationship.
+
+**Just right.** Primary and secondary buttons share a recognizable component shape (same padding, same rounding, same height) but differ clearly in color and weight. They're recognizably the same kind of thing (similarity at the structural level) with one clearly more emphasized than the other (contrast at the styling level).
+
+The pattern: contrast within a family is more useful than contrast between families. Both are buttons; they share button-ness. One is emphasized.
+
+## The most useful contrasts
+
+Some contrast types do more work than others.
+
+**Color contrast.** Bright/saturated colors stand out against muted/desaturated. The brand color is reserved for primary actions; secondary actions use neutral colors. Status colors stand against neutral backgrounds.
+
+**Weight contrast.** Bold against regular against light. Useful for typographic hierarchy without changing colors.
+
+**Size contrast.** Large against small. Headlines vs. body. Hero card vs. supporting cards.
+
+**Color-light vs. color-dark.** Within a single color, dark vs. light. Useful in monochrome or restrained color systems.
+
+**Filled vs. outlined.** A filled button vs. an outlined button. Visually distinguishable; primary vs. secondary.
+
+**Position contrast.** A floating action button (FAB) is positioned differently from in-line buttons; that position contrast emphasizes it.
+
+**Density contrast.** A spacious section against a dense section. The spacious one feels emphasized.
+
+## The one-thing-emphasized rule
+
+Hierarchy works when one element is clearly emphasized at each level. Pages have a single primary action; sections have a single primary headline; cards have a single primary image or value.
+
+The corollary: emphasis loses its meaning when too many things are emphasized. A page with five "primary" buttons has no primary; users don't know which is the most important. A page with three different highlight colors has no clear emphasis.
+
+The discipline is restraint. Pick the one or two things that warrant emphasis. Let the rest read as supporting.
+
+## Worked examples
+
+### Form with primary and secondary buttons
+
+A form has a "Submit" primary action and a "Cancel" secondary action. Both are buttons; both share the same height, padding, and rounding (similarity at the structural level). They differ in:
+
+- Color: Submit uses the brand color background with white text; Cancel uses a neutral background with dark text.
+- Weight: Submit's text is medium weight; Cancel's is regular.
+- Possibly size: Submit slightly larger to add emphasis.
+
+Users see the family ("buttons") and the hierarchy (one is primary). The contrast is calibrated to be visible without severing the family relationship.
+
+### Dashboard with one featured metric
+
+A dashboard has 8 metrics. One is critical (today's revenue); seven are supporting. The critical metric is rendered in a hero card with larger size, bolder weight, and a slightly emphasized background. The seven supporting metrics are in smaller, more uniform cards.
+
+The contrast establishes hierarchy at first glance. Users see the featured metric immediately; the supporting metrics are available but don't compete.
+
+If all 8 metrics had been styled the same (heavy similarity, no contrast), users would have to read each label to find revenue. The contrast does the work of hierarchy.
+
+### A long article with subtle contrast
+
+A long-form article uses similarity heavily for the body prose (consistent body type, consistent line spacing) and introduces contrast for structural breaks: subheadings in larger weight, pull-quotes in italic and a different color, code blocks with a different typeface and tinted background.
+
+The contrasts are subtle but clearly distinguish each kind of element. The reader can scan the article structure (subheadings stand out) and quickly identify special content (pull-quotes, code).
+
+### Primary/secondary that fail to distinguish
+
+A form's submit and cancel buttons are both rendered in the brand color (the designer thought "brand consistency"), with only a subtle 5% saturation difference. Users can't tell which is primary; they often click cancel by mistake.
+
+The fix: use the brand color only for the primary; use a neutral color for the cancel. The contrast between brand and neutral is the signal.
+
+### Five-color highlights that lose meaning
+
+A documentation site uses red, blue, green, yellow, and purple highlights for different categories. With five categories competing for attention, the highlights stop reading as emphasis and start reading as noise. Users don't pay attention to any of them.
+
+The fix: reduce to 1–2 highlight types. If more categories are needed, encode them with subtler cues (small icons, badges) that don't compete for attention.
+
+## Anti-patterns
+
+**Contrast for contrast's sake.** Adding visual variety without communicating anything. Decoration disguised as design.
+
+**Universal emphasis.** Making everything bold, everything large, everything colored. Nothing stands out because everything stands out.
+
+**Subtle differences that don't communicate.** A 5% opacity change between two states. Users don't perceive the difference; the styling doesn't do its job.
+
+**Contrast that contradicts hierarchy.** A "back" button styled larger and bolder than the "next" button. Users get confused about which is the forward action.
+
+**High contrast on everything.** Drop shadows on every card, brand color on every button, large size on every heading. The contrasts compound and create visual chaos.
+
+**Contrast inconsistent across surfaces.** Primary buttons styled one way on the home screen, another way on the settings screen. Users can't form a stable expectation.
+
+## Heuristic checklist
+
+Before settling on visual treatment, ask: **What needs to be distinguished, and what should look the same?** Plan similarity and contrast deliberately. **Is contrast doing distinguishing work, or just adding visual variety?** If the latter, remove. **Is each level of hierarchy clearly one-thing-emphasized?** Multiple "primary" elements at the same level dilute emphasis. **Is contrast strong enough to be perceived?** Subtle differences may not communicate.
+
+## Related sub-skills
+
+- `gestalt-similarity` — parent principle on similarity perception.
+- `similarity-grouping` — sibling skill on grouping by similarity.
+- `hierarchy` — contrast is a primary mechanism for expressing hierarchy.
+- `signal-to-noise` — disciplined contrast is signal; undisciplined is noise.
+- `color` — color contrast is the most powerful kind.
+
+## See also
+
+- `references/contrast-patterns.md` — patterns for specific contrast situations.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/similarity-and-contrast/references/contrast-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/similarity-and-contrast/references/contrast-patterns.md
@@ -1,0 +1,121 @@
+# Similarity and contrast — patterns
+
+Specific contrast patterns for common UI situations.
+
+## Pattern: primary vs. secondary actions
+
+Primary: brand color background, white text, medium weight, full opacity. Sometimes slightly larger or with a subtle shadow.
+
+Secondary: neutral background or transparent background with border, dark text on neutral, regular weight.
+
+Tertiary (text-only links): brand color text on transparent, no border, medium weight.
+
+The hierarchy clearly visible: primary > secondary > tertiary in visual weight.
+
+## Pattern: hero element vs. supporting
+
+Hero: large size, bold weight, brand or accent color, often a distinct background or container, optional shadow or elevation.
+
+Supporting: standard size, regular weight, neutral colors, plain containers.
+
+The hero immediately draws attention; supporting elements are scannable but don't compete.
+
+## Pattern: featured card in a grid
+
+Among a grid of similarly-styled cards, one card receives differential treatment: larger size, accent color, prominent badge, distinct shape, or a combination. The featured card stands out clearly.
+
+This pattern works when used sparingly. Two featured cards in the same grid weakens the emphasis; three or more eliminates it.
+
+## Pattern: error or warning states
+
+Normal items: neutral colors, standard styling.
+
+Error items: red/danger color (background tint, border, icon), bold weight on the error message, possibly shake animation on appearance.
+
+The contrast must be strong enough that error states are immediately noticed in a list or feed of normal items.
+
+## Pattern: current step in a flow
+
+Past steps (completed): muted color, possibly with a checkmark.
+
+Current step: brand color, full saturation, possibly larger or bolder.
+
+Future steps: gray, deemphasized.
+
+The contrast tells users where they are in the flow at a glance.
+
+## Pattern: active vs. inactive navigation
+
+Active nav item: brand color background or text, bold weight, possibly an indicator (left bar, underline).
+
+Inactive items: neutral text, regular weight, no background.
+
+When users navigate, the active item is immediately distinguishable.
+
+## Pattern: emphasized text within prose
+
+Body text: regular weight, body color.
+
+Emphasized text (bold, italic, underlined link): clearly distinct treatment.
+
+Code (inline): monospace typeface, slight tinted background, slight color shift.
+
+Each kind of emphasis is visually distinct from the body and from the other kinds of emphasis.
+
+## Pattern: foreground vs. background panels
+
+Active workspace: full color, full saturation, primary content treatment.
+
+Chrome (sidebar, header, footer): muted color, lower contrast, secondary treatment.
+
+Modals or overlays over the main content: shadow or scrim behind the modal pulls focus.
+
+The visual hierarchy moves attention to the right thing.
+
+## Pattern: emphasized rows in a table
+
+Standard rows: alternating subtle backgrounds (or no alternation).
+
+Emphasized rows (selected, hovered, important): distinct background color and possibly border.
+
+Headers: bold weight, slight background tint.
+
+The contrast lets users track which row they're interacting with and which rows are categorically different.
+
+## Pattern: badge or tag emphasis
+
+Standard items: no badge.
+
+Categorized items: small badge in category color (e.g., "New," "Beta," "Premium").
+
+Critical items: large badge or prominent visual treatment.
+
+Badges are highly visible by design; reserve them for items that warrant the attention.
+
+## Pattern: progressive emphasis in a sequence
+
+In a multi-step or progressive-disclosure context:
+
+Step 1 emphasized; later steps muted.
+
+After completing step 1, step 2 emphasized; step 1 fades to "completed"; step 3 still muted.
+
+The contrast moves with the user's progress.
+
+## Anti-patterns
+
+**Multiple "primary" elements at the same level.** Two brand-color buttons next to each other, both labeled "Save". Users can't tell which is the actual primary.
+
+**Contrast that doesn't follow hierarchy.** Subtle visual choices that don't track to importance. Visually loud elements that aren't actually important; visually quiet elements that are critical.
+
+**Different contrast styles for the same purpose across the product.** Primary buttons one shade of blue on the home screen and a different shade on settings. Inconsistency.
+
+**Subtle differences read as accidental.** Two card styles that differ by 5% padding. Users can't tell whether the difference is intentional.
+
+**Contrast that's strong but invisible to a fraction of users.** Color-only contrast that fails for color-blind users. Always pair with shape or text.
+
+**Too many simultaneously emphasized elements.** A page with 8 things all visually emphasized. The emphasis cancels.
+
+## Cross-reference
+
+For grouping by similarity, see `similarity-grouping`. For the parent principle, see `gestalt-similarity`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/similarity-grouping/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/similarity-grouping/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: similarity-grouping
+description: 'Use visual similarity to create perceptual groups — making related items look alike so users perceive them as a set. Use when designing lists with categorized items, navigation systems, status displays, dashboards with multiple data series, or any layout where you want users to see "these things go together" at a glance. The strongest grouping cues, in order, are color, size, shape, and orientation; combine multiple cues for the strongest grouping.'
+---
+
+# Similarity — grouping
+
+When you want users to perceive a set of items as belonging together — as a category, as related, as the same kind of thing — visual similarity is the most direct way to communicate it. Two items styled the same way are perceived as a pair; ten items styled the same way are perceived as a set; an entire list styled consistently is perceived as a category.
+
+## Core grouping techniques
+
+**Same color.** The strongest grouping cue. All "active" items in one color; all "inactive" items in another. All items in a category share a color tag or background tint.
+
+**Same size.** Items at the same visual scale group. All section headings at the same size; all body text at the same size; all icons at the same size.
+
+**Same shape.** Items in the same shape group. All cards have the same proportions; all buttons have the same corner radius; all icons share a stroke style.
+
+**Same icon or symbol.** Items marked with the same icon group. All "important" items get a star; all "deletable" items get a trash icon visible on hover.
+
+**Same typographic treatment.** Bold weight, italic, color shift — applied consistently — makes a class of words read as a group (every link, every keyword, every status name).
+
+Combine multiple cues for stronger grouping. A "selected" item with both a colored background AND a colored border AND a checkmark icon is grouped much more strongly than an item with just one of those cues.
+
+## When grouping by similarity is the right move
+
+**Related items spread across a layout.** If items aren't physically close (proximity grouping isn't available) but should be perceived as related, similarity carries the grouping. Selected items in a long list, for example.
+
+**Mixed categories in a single view.** A dashboard showing servers in different statuses, files of different types, projects in different stages. Similarity by category lets users scan and segment.
+
+**Repeating elements with shared role.** Buttons of the same priority; navigation items at the same level; cards of the same type. Consistent styling makes the role recognizable.
+
+**Status communication.** Active vs. inactive, healthy vs. failing, approved vs. pending. Different visual treatment for each status; consistent within each status.
+
+## Worked examples
+
+### A multi-status dashboard
+
+A monitoring dashboard shows 50 services. Each service can be in one of four states: healthy, degraded, down, unknown.
+
+- Healthy: green background tint + checkmark icon.
+- Degraded: yellow background tint + warning icon.
+- Down: red background tint + X icon.
+- Unknown: gray background tint + dash icon.
+
+The user can scan all 50 services and immediately see the distribution of states. Color does most of the grouping; icons reinforce.
+
+If only one cue had been used (only icons, no color), the perceptual grouping would be much weaker; users would have to focus on each item individually.
+
+### A document list with file-type grouping
+
+A file manager shows mixed file types. PDFs all have a red PDF icon; Word docs have a blue Word icon; images have a small thumbnail; folders have a folder icon. The visual similarity within each file type makes scanning easy: "show me all the PDFs" is just "find all the items with the red icon."
+
+If file types had been distinguished only by extension in the filename, scanning would be much harder.
+
+### A navigation hierarchy
+
+A sidebar nav has primary nav items (top level) and secondary nav items (children, indented). Primary items use a slightly larger size, bolder weight, and consistent icon treatment. Secondary items use smaller size, regular weight, indented position.
+
+Within each level, items group by similarity. The two levels are distinguished by their differences. Users see the hierarchy at a glance.
+
+### Selected items in a long list
+
+A list of 100 items. The user has selected 12 of them. Selected items have a colored background tint (the brand color at 15% opacity); unselected items have no background.
+
+Even though selected items are scattered through the list, the color similarity makes them visually group. The user can see how many are selected, and where they are, without scrolling carefully.
+
+If selection had been indicated with just a small checkmark in the corner, the selected items wouldn't group as strongly; the user would need to scan more carefully.
+
+### A pricing table
+
+A pricing table shows three plans (Basic, Pro, Enterprise). Each plan card has the same visual structure (price, features list, CTA button). Within each card, the features list uses the same typography, the same checkmark icon for included features, the same X icon for excluded features.
+
+The structural similarity across cards makes them comparable: the user can scan horizontally to compare features. The styling similarity within each card makes each card readable as a coherent unit.
+
+## Anti-patterns
+
+**Grouping cues that conflict.** A card with a colored background that says "Important" but a small subtle border that says "Inactive." The user gets contradictory grouping signals.
+
+**Inconsistent styling within a category.** Some items in the "important" category styled with a red border, others with a red background, others with just a red icon. The category fragments visually.
+
+**Subtle differences that don't communicate.** A 5% opacity change between two states. The visual similarity is so strong the dissimilarity goes unnoticed; users don't perceive distinct groups.
+
+**Overgrouping.** Trying to make every item in a long list look subtly different to encode many dimensions of metadata. Users can't process more than ~5 visual categories at a time without effort. Reduce the categories or use other mechanisms (filters, sort) for the rest.
+
+**Color used for grouping but accessible only by color.** Color-blind users can't perceive color-only grouping. Always pair color with shape or position.
+
+## Heuristic checklist
+
+When designing a layout with multiple item types, ask: **What are the categories of items?** Each category should have a consistent visual treatment. **Which similarity cues am I using to communicate each category?** Color is strongest; combine with shape or icon for accessibility. **Are items within each category styled consistently?** Inconsistency fragments the grouping. **Are different categories distinguished sufficiently?** Subtle differences may not be perceived.
+
+## Related sub-skills
+
+- `gestalt-similarity` — parent principle on similarity-based perception.
+- `similarity-and-contrast` — sibling skill on dissimilarity for distinction.
+- `proximity` — proximity grouping; complementary to similarity.
+- `color` — color is the strongest similarity cue.
+- `consistency` — consistency creates similarity within a product.
+
+## See also
+
+- `references/grouping-patterns.md` — patterns for specific grouping situations.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/similarity-grouping/references/grouping-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/similarity-grouping/references/grouping-patterns.md
@@ -1,0 +1,142 @@
+# Similarity grouping — patterns
+
+Specific patterns for using similarity to group items in common UI contexts.
+
+## Pattern: status-by-color
+
+Each status has a distinct color (often paired with an icon). Items in the same status share the visual treatment.
+
+Common status palette:
+- Healthy / success / active: green (#10B981 or similar)
+- Warning / pending: yellow or amber (#F59E0B)
+- Error / down / destructive: red (#EF4444)
+- Informational / in-progress: blue (#3B82F6)
+- Neutral / disabled / unknown: gray (#6B7280)
+
+Pair color with shape (icon) for accessibility. Avoid using ten different colors for ten different statuses; users can't track that many distinct categories.
+
+## Pattern: category-by-icon
+
+Each category gets a consistent icon. All items in the category display the icon. Users learn the icon-category mapping after a few exposures.
+
+Useful when:
+- The categories are fixed and limited (5–15 categories).
+- Users will encounter many items across categories.
+- The icons are visually distinct enough to be quickly identified.
+
+Less useful when:
+- Categories are too numerous.
+- Categories are user-defined (icons can't anticipate them).
+- The visual real estate doesn't accommodate icons.
+
+## Pattern: badge-or-tag
+
+A small visual element (badge, tag, label) attached to items in a particular state or category. The badges share visual treatment within a state but differ across states.
+
+Common uses:
+- "New" badge on recently added items.
+- "Pro" or "Premium" badge on paywalled features.
+- Status badges (e.g., "Draft," "Published," "Archived").
+- Tags on content (genres, topics, owners).
+
+Badges are highly visible and quick to scan. They can stack (an item can have multiple badges) but stacking too many becomes cluttered.
+
+## Pattern: row-style alternation
+
+In a long list or table, alternating background colors (zebra striping) helps users track horizontally without losing the row.
+
+Use carefully:
+- Subtle alternation (2–5% darker on alternate rows) is usually right.
+- Heavy alternation (high contrast) can be visually noisy.
+- For very long rows, alternation aids scanning; for short rows, it may not be needed.
+- Alternation doesn't communicate categorical information; it's purely a scan-aid.
+
+## Pattern: indented hierarchy
+
+Hierarchical lists (a tree, an outline, a nested file structure) use indentation to indicate parent-child relationships. Items at the same indentation level are siblings (peers); deeper indentation means children.
+
+Combined with similarity by typography (headings vs. body, parent vs. child styling), indentation creates clear hierarchy that users can scan.
+
+## Pattern: card-based list
+
+Items in a list each presented as a card with consistent internal structure (title, image, metadata, action). Each card looks the same; users scan a list of structurally identical cards.
+
+The card pattern is common because:
+- Cards have clear boundaries (visual chunking).
+- The internal structure can be elaborate while staying scannable.
+- Cards can be designed to work in both list and grid layouts.
+
+## Pattern: avatar/icon-led list
+
+Items in a list each prefaced with a small avatar or icon. The avatar/icon position is consistent (always left, same size).
+
+Common uses:
+- Contact lists (avatar + name).
+- Team member lists.
+- Comment threads (avatar + content).
+- Activity feeds.
+
+The visual rhythm of avatars helps users scan vertically and identify items by associated person/icon.
+
+## Pattern: priority-by-weight
+
+Important items styled with bold weight; less important items with regular or light weight. The weight similarity groups items at each priority level.
+
+Common uses:
+- Task lists with priority indication.
+- News feeds with featured/standard distinction.
+- Inbox lists with unread/read distinction (unread bold, read regular).
+
+The weight contrast is subtle but effective; it doesn't add visual noise the way color does.
+
+## Pattern: type-by-shape
+
+Different content types displayed with different shapes:
+- Square cards for one type.
+- Circle avatars for another.
+- Pill-shaped tags for another.
+
+The shape similarity within each type makes scanning by type easy. Use sparingly — too many shape types in a single layout becomes chaotic.
+
+## Pattern: interactive-by-style
+
+Interactive elements (buttons, links, controls) styled distinctly from non-interactive content. Within interactive, primary actions styled distinctly from secondary actions.
+
+Common implementation:
+- All buttons share a common style (rounded, with padding, with state changes).
+- All links share a common style (underlined or colored, with hover state).
+- All non-interactive text uses a standard body style.
+
+Users can scan the page and immediately identify what's clickable.
+
+## Pattern: data-series in charts
+
+In multi-series charts (line charts, bar charts), each series uses a distinct color consistently. The line for revenue is always blue across the dashboard; profit is always green; expenses are always red.
+
+This is similarity grouping across the whole product: a user looking at any chart can identify which line is which series by color, without needing to consult the legend each time.
+
+Cross-product semantic colors (revenue is always blue) deserve documentation in the design system so they're applied consistently.
+
+## Pattern: state-by-treatment
+
+Different interaction states (default, hover, active, focus, disabled) get distinct visual treatment, applied consistently across all interactive elements.
+
+A button's hover state is the same shift across all buttons (e.g., 10% darker background). A focus ring is the same color across all focusable elements. A disabled state is the same opacity across all disabled controls.
+
+Consistent state treatments make interactive behavior predictable and accessible.
+
+## Anti-patterns
+
+**Ad-hoc grouping treatments.** Each part of the product invents its own grouping cues. Users can't transfer their understanding between sections.
+
+**Color-only grouping.** Without shape or label reinforcement, color-blind users can't perceive the grouping.
+
+**Subtle differences that don't communicate.** A "selected" state that's barely distinguishable from "unselected." Users can't see what's grouped with what.
+
+**Cues that fight each other.** A red background that says "danger" combined with a checkmark that says "approved." Users don't know which signal to trust.
+
+**Overuse of all available cues.** A single item highlighted with color, bold weight, large size, distinct shape, badge, AND icon. The item screams; the rest of the layout falls away. Reserve heavy emphasis for moments that warrant it.
+
+## Cross-reference
+
+For dissimilarity used to distinguish, see `similarity-and-contrast`. For the parent principle, see `gestalt-similarity`.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-decoration-removal/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-decoration-removal/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: snr-decoration-removal
+description: 'Use this skill when the question is *what to delete* — running a structured audit of a UI to remove decorative elements that don''t earn their pixels. Trigger when reviewing an existing UI for noise reduction, when a stakeholder pushback says "this feels too busy" but you don''t know what specifically to cut, or when polishing a design pre-ship. This is the operational counterpart to `signal-to-noise-ratio`; it gives you a checklist and a procedure rather than a principle.'
+---
+
+# Decoration removal: an audit procedure
+
+A structured procedure for going through an existing UI and identifying chrome that adds visual weight without serving the user. Run this as a final pass before shipping, or when revising a design that "feels busy."
+
+## The audit
+
+Work through the UI element-by-element. For each candidate, ask: *if I removed this, would the user lose information they need?* If no, it's a candidate for deletion.
+
+### Borders
+
+For every border on the page, ask:
+
+1. Is it separating two regions that would otherwise blur together? *(e.g., a sticky header from the scrolling content beneath it)*
+2. Is it the only thing distinguishing an interactive element from non-interactive content? *(e.g., outlined buttons in a low-color UI)*
+3. Is it required by the component's role? *(e.g., the border of an input field)*
+
+If none of the above: delete the border. Most card borders, divider lines between sections, container borders around field groups are unnecessary — proximity already does the grouping work.
+
+### Backgrounds and tints
+
+For every tinted region (cards, panels, banners, callouts), ask:
+
+1. Is it grouping content that proximity alone can't?
+2. Is it a state (hover, selected, focused, disabled)?
+3. Is it semantic (success/warning/destructive)?
+
+If none of the above, the tint is decoration. Common offenders: brand-tinted hero panels with no informational role, "info" boxes that just hold normal content, colored sections that exist "for variety."
+
+### Shadows
+
+For every box-shadow, ask:
+
+1. Does this element actually float above its context (popover, tooltip, modal, dragged element)?
+2. Is it a hover-state cue that matters?
+
+If none of the above, drop the shadow. Most card shadows are unwarranted — cards sit *on* the page, not above it.
+
+### Gradients
+
+For every gradient (backgrounds, button fills, illustrations), ask:
+
+1. Does it reinforce a directional cue (e.g., a hero gradient suggesting depth, a button "lift" via subtle gradient)?
+2. Is it part of an illustrative element with content meaning?
+
+If neither, replace with a flat color. Decorative gradients age poorly and reduce SNR.
+
+### Icons
+
+For every icon, ask:
+
+1. Is it replacing text in a space-constrained context (toolbar, mobile nav, tab bar)?
+2. Does it disambiguate (e.g., sparkle = AI-assisted, lock = encrypted, warning triangle = destructive)?
+3. Is it carrying status information (e.g., success check, error X)?
+
+If none, delete the icon. The most common offender is decorative icons next to section headings — "Notifications" with a bell icon, "Account" with a user icon. The label already says what it is.
+
+### Repeated branding
+
+For every brand mark (logo, brand color block, brand pattern), ask: how many times does the brand appear on this screen? Once is right (header). Twice is fine if one is a footer mark. More than that, you're decorating with the logo and the user is tuning it out.
+
+### Animations and transitions
+
+For every animation, ask:
+
+1. Is it signaling a state change (open/close, success, drag)?
+2. Is it providing affordance (a button that elevates on hover)?
+3. Is it teaching causality (an item slides into a list to show it was added)?
+
+If none of the above, the animation is eye-candy. Particularly suspect: looping animations (drawing the eye repeatedly), entrance animations on every element on page load (delays time-to-content).
+
+### "Polish" effects
+
+The last pass of a design often adds:
+
+- Glassmorphism / backdrop-filter on elements that don't actually overlap content
+- Subtle inner shadows on inputs (they fight focus rings)
+- Micro-illustrations next to empty states that already have an icon and a sentence
+- Brand-color underlines on headings
+- Tinted "callout" boxes around quotes or tips
+
+Each of these has a defensible single use; together, on the same surface, they collapse to noise.
+
+## A worked audit
+
+Imagine the following as the visual chrome on a single dashboard tile:
+
+- 1px border + 8% brand-color tint background + 12px shadow + a 32x32 brand-color icon in a tinted square next to the label + a colored top accent stripe + a hover scale effect + a help-tooltip "i" icon that's never been clicked.
+
+Audit results:
+
+- **Border:** keeps the tile distinct from neighbors → keep, but lighten to `hsl(0 0% 92%)`.
+- **Background tint:** decorative, not grouping (proximity already separates tiles) → delete.
+- **Shadow:** the tile doesn't float; it sits → delete.
+- **Brand icon-in-square:** doesn't add information; "Monthly revenue" is unambiguous → delete.
+- **Top accent stripe:** decoration → delete.
+- **Hover scale:** the tile isn't a primary interaction; users don't expect cards to scale → delete.
+- **"i" tooltip:** if it's never been clicked, ask whether the metric needs explanation at all. If it does, surface that explanation in the dashboard's empty/onboarding state, not on every tile → delete.
+
+What remains: the border, the label, the number, the delta, the timestamp. The signal is intact; the chrome is gone. SNR up, perceived quality often up too — restraint reads as competence.
+
+## Common pitfalls in this audit
+
+- **Overcorrection.** Stripping too much produces sterility (see `snr-densification`). After this audit, look at the page again — has it become too sparse for the role?
+- **Saved by hover.** A border is fine *because* it appears on hover. Don't delete it.
+- **The stakeholder defense.** "But marketing wanted that callout box." If marketing's request didn't survive a signal audit, propose moving the request to a different surface (the marketing site, an onboarding tour) where decoration is appropriate.
+
+## Heuristics
+
+1. **The 25% screenshot test.** Reduce a screenshot to 25%. Things that vanish are probably noise (or weak signal); things that remain visible are likely signal-bearing.
+2. **The "after" walk-through.** After removing things, walk through the user's primary task. Did anything become harder? If yes, restore the deleted element.
+3. **Versions side-by-side.** Place the cluttered version next to the cleaned version. Most viewers prefer the cleaned one without being able to articulate why.
+
+## Related sub-skills
+
+- **`signal-to-noise-ratio`** (parent).
+- **`snr-densification`** — the opposite move; rebalances if you've over-stripped.
+- **`snr-emphasis-economy`** — what to do with emphasis once noise is gone.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-decoration-removal/references/audit-checklist.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-decoration-removal/references/audit-checklist.md
@@ -1,0 +1,87 @@
+# Decoration-removal: extended audit checklist
+
+A reference complementing `snr-decoration-removal` with a more granular audit method and patterns from teams that have run subtraction passes at scale.
+
+## The expanded audit
+
+For each visible element on a screen, run through:
+
+```
+1. PURPOSE
+   [ ] Does this element have a clearly statable purpose?
+   [ ] If purpose = "decoration," can I cut it?
+   [ ] If purpose = "branding," can it move to chrome (header/footer) instead?
+
+2. REDUNDANCY
+   [ ] Does this element duplicate information already shown nearby?
+   [ ] If it provides redundant signal for accessibility, keep it.
+   [ ] If it's redundant for emphasis, evaluate whether the emphasis is earning its space.
+
+3. DISCOVERABILITY (inverse check)
+   [ ] If I removed this, would users be unable to find a feature they need?
+   [ ] If the answer is "they'd find it via the menu / palette," cut it.
+   [ ] If "they'd never find it," keep it but consider whether it should be smaller.
+
+4. STATE-DEPENDENT
+   [ ] Is this element shown when its state is the default? If yes, why?
+     - Status icon for "active" when 99% of items are active = noise.
+     - Loading spinner that never appears = harmless dead code.
+     - Notification dot when count = 0 = noise; hide when zero.
+
+5. AESTHETIC INVESTMENT
+   [ ] Is this element here because the design "felt empty"?
+   [ ] If yes, reconsider — empty space is valid; gratuitous fill isn't.
+```
+
+## Subtraction patterns from real redesigns
+
+### Twitter's iconic-action redesign (2010s onward)
+
+Original interface: each tweet showed Reply / Retweet / Like / Share / More icons inline. Audit: are all 5 visible on every tweet? Yes. Cut decorations? Reduced icon visual weight, shifted to outline-only style, increased spacing. Same actions, less ink.
+
+### Apple Notes redesign (across versions)
+
+Early versions: linen-textured backgrounds, leather-bound legal-pad metaphor, decorative line ruling. Later versions: pure white background, no decoration. Same functionality, much higher SNR.
+
+### Linear's chrome reduction
+
+Linear's editor (2018+) systematically stripped chrome that competing project-management tools defaulted on: heavy borders, status badges everywhere, action icons on every row. Result: visually quieter than Jira/Asana while showing the same information.
+
+The pattern: subtraction is *easier in greenfield* than retrofitting. Existing products accumulate chrome over years; new products start with discipline.
+
+## What teams reliably resist subtracting
+
+Some categories survive most audits because subtraction is politically expensive:
+
+- **Brand marks.** Marketing protects brand visibility; subtracting any brand mark requires sponsorship.
+- **Stakeholder pet features.** A button placed there because someone in leadership wanted it; cutting it requires negotiation.
+- **Compliance footers.** Cookie banners, terms links, copyright. Genuinely required, but can usually be visually demoted (smaller, lower-contrast).
+- **A/B-tested additions.** Once an element shows even small lift in A/B test, removing it is hard. Aggregate decoration accumulates this way.
+
+A useful tool: a periodic "subtraction sprint" with senior support, treating subtraction as a positive feature rather than a removal of someone's work.
+
+## Subtraction in non-software contexts
+
+### Editorial design
+
+Magazines like *The Economist* and *Monocle* are notable for restraint: minimal kicker treatments, no rule overload, no callout boxes for every quote. The magazines that survived the print-decline era often did so by leaning into restraint as identity.
+
+### Industrial product design
+
+Dieter Rams' "Less, but better" and Apple's product-design lineage are both subtraction-as-discipline: every visible element earns its place; the rest is removed.
+
+### Architecture
+
+Mies van der Rohe's "Less is more" and the Modernist movement broadly applied subtraction to architecture. The cost: spaces that feel cold without decoration. The reward: clarity, durability, agelessness.
+
+The lesson: subtraction without warmth produces cold UIs. Combine subtraction with thoughtful detail (good typography, generous whitespace, occasional warm flourishes) for "less, but better."
+
+## Resources
+
+- **Maeda, J.** *The Laws of Simplicity* (2006). Ten laws of simplification, applicable beyond software.
+- **Krug, S.** *Don't Make Me Think* — practical web subtraction patterns.
+- **Refactoring UI** — many before/after examples of subtraction passes.
+
+## Closing
+
+A subtraction pass is the cheapest design improvement available: no new content to create, no engineering cost beyond the deletes. It's also the hardest to schedule, because it doesn't ship a "feature." The teams that allocate time for it consistently produce visibly better products.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-densification/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-densification/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: snr-densification
+description: 'Use this skill when a design has *too much* whitespace — when the SNR pendulum has swung from cluttered all the way to sparse, sterile, or "empty-feeling," and you need to add signal density without adding noise. Trigger when reviewing a UI that "feels thin," "feels under-built," or where users complain "I''m scrolling forever to get to anything." Also trigger when designing power-user surfaces (admin panels, IDEs, data tools) that need higher density than consumer defaults. Sub-aspect of `signal-to-noise-ratio`; read that first if you haven''t already.'
+---
+
+# Densification: adding signal without adding noise
+
+The opposite failure mode of "noisy UI" is "sterile UI" — a design so subtractively-edited that it loses the affordances and richness users actually need. SNR is a *ratio*; you can improve it either by removing noise or by adding signal. This skill covers the latter.
+
+## When sterility is the problem
+
+Symptoms:
+
+- Power users tell you they "miss" features that are present but tucked away.
+- The page contains 3 things on a 1440px screen and feels under-built.
+- Common workflows require navigating away and back; the current surface doesn't show enough.
+- The empty state doesn't feel empty — the *populated* state feels empty.
+- A/B testing shows users hesitating because there's not enough information to decide.
+
+## What signal-density looks like
+
+Densification means **more meaningful information per visible region**, with the meaning still clearly readable. Done well, it looks like a Bloomberg terminal in restraint mode: many numbers, but every number labeled, ranked, and scannable.
+
+Approaches:
+
+### 1. Replace navigation steps with adjacent context
+
+A common low-density mistake: a list view shows only names; the user clicks through to see details. Densify by showing critical detail inline.
+
+```html
+<!-- Sparse: name only, click for detail -->
+<li><a href="/projects/acme">Acme Q4 Refresh</a></li>
+
+<!-- Dense: name + status + owner + due date inline -->
+<li>
+  <a href="/projects/acme">Acme Q4 Refresh</a>
+  <span class="meta">In review · Maria · Due May 12</span>
+</li>
+```
+
+The signal-per-line jumped 4x with no added noise.
+
+### 2. Use compact data primitives
+
+Replace large cards with rows. Replace giant icons with small ones. Replace verbose labels with shorter conventional ones.
+
+```html
+<!-- Sparse: each KPI in a 200x200 card with icon and gradient -->
+<div class="card-grid">
+  <div class="card">…1 number…</div>
+  <div class="card">…1 number…</div>
+  <div class="card">…1 number…</div>
+</div>
+
+<!-- Dense: KPIs as a single row of stat blocks -->
+<dl class="stat-row">
+  <div><dt>Revenue</dt><dd>$48.2k <span class="delta-up">+12%</span></dd></div>
+  <div><dt>Users</dt><dd>12,481 <span class="delta-up">+3%</span></dd></div>
+  <div><dt>Churn</dt><dd>2.1% <span class="delta-down">-0.4%</span></dd></div>
+  <div><dt>NPS</dt><dd>42</dd></div>
+</dl>
+```
+
+### 3. Inline action affordances
+
+Don't make users open a row's menu to see what they can do. Show the actions inline (icon-buttons in the row).
+
+```html
+<tr>
+  <td>Acme Q4 Refresh</td>
+  <td>In review</td>
+  <td class="actions">
+    <button aria-label="Open"><EyeIcon /></button>
+    <button aria-label="Comment"><MessageIcon /></button>
+    <button aria-label="Archive"><ArchiveIcon /></button>
+  </td>
+</tr>
+```
+
+### 4. Smaller default sizes
+
+The default shadcn/Material density is calibrated for general use. Power surfaces benefit from `text-sm` body, `text-xs` metadata, `py-1.5` row padding instead of `py-3`. Just tune one notch denser, not five.
+
+### 5. Allow user-controlled density
+
+Offer a "Compact" mode in settings, or per-table density toggles, so users can pick their preferred ratio.
+
+## How densification differs from noise
+
+The line between dense and noisy is whether the additional content is **task-relevant**.
+
+- **Dense:** more numbers, more labels, more rows, more context — all serving the user's reason for being here.
+- **Noisy:** more borders, more shadows, more illustrations, more decoration — none of which advance the task.
+
+A correctly densified UI looks like more information; a noisy UI looks like more decoration around the same information.
+
+## Worked example: a sparse dashboard, densified
+
+**Before (sparse):**
+
+```html
+<main style="padding: 4rem; max-width: 800px; margin: 0 auto;">
+  <h1>Welcome back</h1>
+  <p>You have 3 things to review.</p>
+  <button>Go to inbox</button>
+</main>
+```
+
+A "welcome dashboard" of this kind feels like a placeholder. The user came to *do something*; they shouldn't have to click through.
+
+**After (densified):**
+
+```html
+<main style="padding: 1.5rem; max-width: 1200px; margin: 0 auto;">
+  <header style="display: flex; justify-content: space-between; align-items: end;">
+    <div>
+      <h1 style="font-size: 1.5rem;">Today</h1>
+      <p style="color: hsl(0 0% 45%); font-size: 0.875rem;">3 to review · 2 due this week</p>
+    </div>
+    <div style="display: flex; gap: 0.5rem;">
+      <button>Inbox</button>
+      <button class="primary">New</button>
+    </div>
+  </header>
+
+  <section style="margin-top: 2rem; display: grid; gap: 1rem; grid-template-columns: 2fr 1fr;">
+    <div>
+      <h2 style="font-size: 1rem; margin-bottom: 0.5rem;">To review</h2>
+      <ul class="dense-list">
+        <li><a href="/r/1">Acme Q4 contract</a> <span class="meta">Maria · 2h</span></li>
+        <li><a href="/r/2">Brand book v3</a> <span class="meta">Lin · yesterday</span></li>
+        <li><a href="/r/3">2026 hiring plan</a> <span class="meta">You · 3d</span></li>
+      </ul>
+    </div>
+    <aside>
+      <h2 style="font-size: 1rem; margin-bottom: 0.5rem;">This week</h2>
+      <dl class="stat-list">
+        <div><dt>Open tickets</dt><dd>14</dd></div>
+        <div><dt>Closed</dt><dd>52</dd></div>
+        <div><dt>Avg response</dt><dd>2h 14m</dd></div>
+      </dl>
+    </aside>
+  </section>
+</main>
+```
+
+Same page region, ~10× the actionable signal, no added noise.
+
+## Anti-patterns
+
+- **Densification by adding decoration.** "It feels empty, let me add a hero illustration." That's the opposite move; you've added noise, not signal.
+- **Densification by adding all features.** Every product feature gets a tile on the dashboard regardless of relevance. That's noise too — only the user's actually-needed features should be present.
+- **Density without alignment.** Cramming many elements without a strict grid produces clutter, not density. Strong alignment is what allows high density to remain readable.
+
+## Heuristics
+
+1. **Squint test in reverse.** Squint at the page. Is there *any* dominant content? If you see only mass background and a few dots, the page is empty.
+2. **The "What can I do here?" test.** Land on the page cold. Within 2 seconds, can you identify 3 actions you might take? If no, density is too low.
+3. **The information audit.** Count the distinct pieces of useful information visible without scrolling. Compare to similar surfaces in well-designed competitors. If you're at half their count and the page feels light, densify.
+
+## Related sub-skills
+
+- **`signal-to-noise-ratio`** (parent).
+- **`snr-decoration-removal`** — the *subtraction* side of SNR; complementary to this skill.
+- **`hierarchy-spatial`** — densification needs strong spatial hierarchy or it becomes visual mush.
+- **`propositional-density`** (cognition) — closely related: meaning per mark, signal per pixel.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-densification/references/density-research.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-densification/references/density-research.md
@@ -1,0 +1,76 @@
+# Densification: research and patterns
+
+A reference complementing `snr-densification` with research on optimal information density and case studies of density redesigns.
+
+## Research on density
+
+The density "right answer" depends entirely on the user's task and proficiency. A few findings worth knowing:
+
+- **Bloomberg terminal users** (high-frequency professional traders) consistently reject "simplified" redesigns. Density is feature, not bug — a single screen showing 200+ data points outperforms a clean dashboard for the use case.
+- **NN/g studies on dashboards** repeatedly find that under-dense dashboards force users to cross-reference multiple screens, increasing total task time even when each screen is faster to read.
+- **Hick & Hyman**: decision time grows with options *visible at the moment of choice*. Forcing the user to navigate to find the option introduces a different cost (recall + Fitts's distance) that often exceeds the Hick's tax of just showing more.
+
+The lesson: density isn't bad. *Disorganized* density is bad.
+
+## What earns density
+
+Densification works when:
+
+- **A consistent grid holds the layout together.** High density without alignment is chaos.
+- **Type and color reduce noise.** Smaller type, more neutrals, less ornament.
+- **Repetition aids scanning.** Same column structure across rows lets the eye find the third column instantly.
+- **Hierarchy ranks within the density.** Even a Bloomberg terminal has primary numbers and secondary metadata.
+
+## Cross-domain examples
+
+### Newspaper sports pages
+
+A sports section's box scores are extreme density: dozens of players, multiple stats per player, multiple games per page. They work because:
+
+- Strict columnar layout.
+- Tabular numerals.
+- Fixed type size, fixed row height.
+- Consistent abbreviations (BB, RBI, HR).
+
+Daily readers parse box scores in seconds. The density rewards practice.
+
+### Aircraft cockpits
+
+A 737 cockpit has hundreds of indicators. Pilots learn the layout as spatial memory; in an emergency they "fly to" the indicator without reading. The density is essential — separating the indicators across multiple screens would slow critical responses.
+
+### IDE / code editor density
+
+VS Code, JetBrains IDEs ship dense by default — file tree, editor, terminal, problems panel, debug panel — because expert users want it all visible. Casual users (Markdown editing, simple edits) often prefer a "Zen mode" — same software, lower density.
+
+## When users complain about density
+
+Two symptoms, two diagnoses:
+
+- **"It feels overwhelming."** Probably *poor structure*, not too much content. Reorganize before reducing.
+- **"I'm scrolling forever."** Probably *too sparse* — content is well-organized but spread out. Densify.
+
+The wrong fix is usually applied to the wrong symptom: people densify "overwhelming" pages (making them worse) and de-densify "scrolling forever" pages (making *them* worse).
+
+## Patterns
+
+### The Bloomberg / spreadsheet pattern
+
+Tabular layout, 16–24px row heights, tabular numerals, color-coded categories, sparse decoration. Use for: high-frequency power-user tools, monitoring dashboards.
+
+### The Linear / Notion pattern
+
+Single-column with strong hierarchy; modest density per screen but very fast inter-screen navigation. Use for: moderate-density apps where users move between objects more than they scan a single dense screen.
+
+### The Slack / chat pattern
+
+Vertical timeline with tight message spacing; sidebar for channels; many things visible at once. Use for: communication and stream apps.
+
+## Resources
+
+- **Few, S.** *Information Dashboard Design* (2006). Practical density-tuning for monitoring dashboards.
+- **Tognazzini, B.** "First Principles of Interaction Design" — discusses density tuning across user types.
+- **Refactoring UI** — chapter on density and breathability.
+
+## Closing
+
+Density is the only SNR move that adds rather than subtracts. The trick is to add *signal*, not chrome.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-emphasis-economy/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-emphasis-economy/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: snr-emphasis-economy
+description: 'Use this skill when deciding *how* to spend emphasis — color, weight, size, motion — across a design so that each instance lands. Trigger when picking the primary action among many CTAs, when status-color usage has multiplied across the app and lost meaning, when the brand color appears in too many places, or when a designer asks "should this also be highlighted?" and the answer is almost always no. Sub-aspect of `signal-to-noise-ratio`; read that first if you haven''t already.'
+---
+
+# Emphasis economy
+
+Emphasis is a finite resource. Every time you use color, bold, size, or motion to call attention to something, you're spending some of the user's *attentional bandwidth*. Spend too freely and the bank empties — emphasis stops registering. Spend deliberately and each instance lands.
+
+## The core idea
+
+Emphasis works through *contrast against a quieter background*. A red badge in a sea of white badges shouts; a red badge among twenty other red badges is invisible. The job of emphasis economy is to keep the background quiet so the emphasized things stand out.
+
+The rough budget per surface:
+
+- **One** primary action per visible region.
+- **One or two** instances of the brand-emphasis color (logo, primary CTA).
+- **One or two** instances of destructive color (an "overdue" badge, a delete button — never both on the same row).
+- **Zero or one** "new!" / highlight callouts.
+
+Above this, emphasis dilutes.
+
+## How emphasis dilutes
+
+A page starts with one bold word, one colored badge, one underlined link. The eye picks them out instantly. Add a second bold word — the eye now sweeps both. Add a third — they're a category, not emphasis. By the seventh bold word, "bold" no longer means "important"; it means "this UI uses bold a lot."
+
+The same dilution happens with:
+
+- **Color emphasis:** brand-color buttons everywhere → brand color stops registering.
+- **Status color:** every row marked "active" green → green stops meaning anything specific.
+- **Size emphasis:** every section heading at 24px → no section dominates.
+- **Motion:** loading spinners, animated badges, hover rotations on every card → page feels jittery and nothing reads as primary.
+
+## Practical rules
+
+### One primary action per region
+
+A region (toolbar, card, modal footer, page header) gets exactly one filled / colored / dominant button. Everything else is `outline`, `ghost`, or text-only.
+
+```html
+<!-- Right -->
+<div class="actions">
+  <button class="ghost">Cancel</button>
+  <button class="outline">Save draft</button>
+  <button class="primary">Publish</button>
+</div>
+
+<!-- Wrong: three primary buttons fight; user can't pick -->
+<div class="actions">
+  <button class="primary">Cancel</button>
+  <button class="primary">Save draft</button>
+  <button class="primary">Publish</button>
+</div>
+```
+
+If you genuinely have two equally-primary actions (rare), the layout should make the choice obvious through framing, not weight: "Continue without saving" / "Save and continue" — both visually equal, both labeled to clarify the consequence.
+
+### Reserve destructive color for actually destructive
+
+"Destructive red" should appear in a UI in proportion to how often the user faces a destructive action. On most surfaces, that's zero or one places. If your app has red on every row (because "delete" is in every row's menu), the destructive signal is now ambient and won't activate when it actually matters.
+
+Better: keep "delete" as a neutral menu item until the user *opens* the confirmation, then the dialog goes red. Stress saved for the moment.
+
+### Reserve status color for genuine status variation
+
+A list of items where every item is the same status doesn't need a color-coded badge — the column is constant. Use status color only when status varies meaningfully.
+
+### Reserve bold for one or two roles
+
+Pick what bold means in your design:
+
+- Headings (most common)
+- Primary numbers in tables / dashboards
+- "Now" or "live" markers
+
+Three bold roles is the maximum. If labels, values, headings, table headers, button text, and metadata are all bold somewhere, bold no longer encodes anything.
+
+### Reserve motion for state changes
+
+A button glows on hover (state). A toast slides in (state). A new item lifts into a list (state). These all earn their motion. A page-load fade-in cascade across every element is theater — restraint serves the user better.
+
+## How to spend emphasis well
+
+Once you've quieted the background, you have a budget to spend on the moments that matter.
+
+### The single hero moment
+
+A pricing page can have *one* "Recommended" tier highlighted. Not three "popular" tiers; not every tier with a color. One.
+
+```html
+<div class="pricing-grid">
+  <article class="plan">…Starter…</article>
+  <article class="plan featured">…Pro (highlighted)…</article>
+  <article class="plan">…Enterprise…</article>
+</div>
+```
+
+The featured plan gets: a slightly different background, a "Recommended" chip, a brighter border, a slightly lifted shadow. Stack the cues.
+
+### The single first-time moment
+
+A new feature gets a "New" badge for two weeks. Not forever. Not on every feature simultaneously. Spend the badge on the most important new thing, retire it after users have seen it.
+
+### The single high-stakes confirmation
+
+A destructive `AlertDialog` gets the full red + warning icon + type-to-confirm treatment because *this is the moment it earns those cues*. The button to open the dialog can stay neutral.
+
+## Worked example: a noisy toolbar, economized
+
+**Before (emphasis everywhere):**
+
+```html
+<header class="toolbar" style="background: hsl(220 90% 95%);">
+  <button class="primary">New</button>
+  <button class="primary" style="background: hsl(142 70% 35%);">Sync</button>
+  <button class="primary" style="background: hsl(38 90% 50%);">Reports</button>
+  <button class="primary" style="background: hsl(280 70% 50%);">AI</button>
+  <span class="badge new" style="background: hsl(0 80% 50%);">NEW</span>
+  <span class="badge new" style="background: hsl(0 80% 50%);">BETA</span>
+  <button class="primary danger">Delete all</button>
+</header>
+```
+
+Five colored buttons, two red badges, one tinted background. Eye finds nothing.
+
+**After (emphasis economized):**
+
+```html
+<header class="toolbar">
+  <button class="primary">New</button>
+  <button class="ghost">Sync</button>
+  <button class="ghost">Reports</button>
+  <button class="ghost"><SparklesIcon /> AI <span class="badge">New</span></button>
+  <div style="margin-left: auto;">
+    <button class="ghost danger" aria-label="Delete all"><TrashIcon /></button>
+  </div>
+</header>
+```
+
+One primary action. One "New" badge on the genuinely new feature. The destructive action is iconified and tucked at the right margin. The eye finds "New" instantly.
+
+## Anti-patterns
+
+- **Promotional creep.** Marketing wants every available feature to have a "callout"; over time everything's highlighted and nothing reads.
+- **Brand-color CTA inflation.** Every link, every action, every chip in brand color. Brand color now means "interactive in general," not "do this thing."
+- **Status-everywhere syndrome.** Every row has a colored status badge, every column has an icon, every value has a delta indicator. Real status changes get lost in the texture.
+- **Animation inflation.** Page loads with cascading entrance animation, scrolls trigger reveals, hovers spin, badges pulse. Total visual fidget; cognitive cost is high.
+
+## Heuristics
+
+1. **Count the highlights.** On any given screen, how many things are highlighted (colored, bold, badged, animated)? More than 3–4? Cut.
+2. **Cover-the-emphasis test.** Cover the most-emphasized element. Does anything *else* now read as primary? If yes, you have multiple primaries fighting.
+3. **The "what's new here?" test.** Glance at the page for 1 second. What's the first thing you noticed? If it was an accidental ornament rather than your intended primary, the economy is broken.
+
+## Related sub-skills
+
+- **`signal-to-noise-ratio`** (parent).
+- **`snr-decoration-removal`** — the audit method for stripping noise; clears space for emphasis to land.
+- **`snr-densification`** — the opposite move when over-pruned.
+- **`hierarchy`** — emphasis economy is the operational expression of hierarchy: the budget you spend to make the rank visible.
+- **`von-restorff-effect`** — the perceptual basis for why economized emphasis works.
+- **`red-effect`** — the specific case for the destructive color budget.

--- a/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-emphasis-economy/references/emphasis-budget-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/perception-and-hierarchy-principles/skills/snr-emphasis-economy/references/emphasis-budget-cases.md
@@ -1,0 +1,109 @@
+# Emphasis economy: case studies and budgets
+
+A reference complementing `snr-emphasis-economy` with concrete budget examples and case studies of well-spent and ill-spent emphasis.
+
+## Sample emphasis budgets per surface
+
+The numbers below are illustrative defaults; tune to your product. Each "instance" is a single use of the cue on the screen at a glance.
+
+### A working application screen (settings, dashboard, inbox)
+
+```
+Brand color (filled buttons / accents)        1 instance
+Brand color (links, icons, subtle accents)   ≤ 5 instances
+Destructive (red) color                       0–1 instances
+Success (green) color                         0–2 instances
+Warning (amber) color                         0–1 instances
+Bold text (display/heading roles only)        ≤ 5 instances
+"New" / "Beta" badges                         ≤ 1 active at a time
+Animated motion (looping)                      0
+Animated motion (state-change one-shot)        per-event
+```
+
+### A marketing landing page
+
+```
+Brand color (hero CTA)                        1 dominant instance
+Brand color (other surfaces, gradients)      ≤ 3 instances
+Saturated photography or illustration          1 hero, modest below
+Bold text                                      headlines + CTAs
+Animation (entrance / scroll-reveal)           1–2 events per fold
+```
+
+### A pricing page
+
+```
+Highlighted "Recommended" tier                 1
+Brand color CTA on each tier                   3 (one per tier, but only one filled)
+"Save N%" badges                              ≤ 1 (annual toggle)
+```
+
+### A checkout / payment flow
+
+```
+Primary action (Pay)                           1 dominant per step
+Secondary actions (back, skip)                 1–2 ghost-style
+Trust signals (lock icon, brand badges)        ≤ 3
+Error / validation                             only when active, then dominant
+```
+
+The pattern: as the page becomes more *task-focused*, the emphasis budget shrinks. Marketing tolerates more; payments tolerate less.
+
+## Case study: emphasis inflation
+
+A common pattern: a product launches with disciplined emphasis. Over years, every team adds a "small thing":
+
+- Marketing wants a "New!" callout for the new feature.
+- Sales wants a banner for the upcoming webinar.
+- Customer success wants a "complete your profile" prompt.
+- Product wants to highlight the analytics tab.
+- Engineering wants a "system status" indicator.
+
+Each addition individually justified, none audited against the others. Within 18 months: every screen has 3–5 active highlights, the user tunes them all out, and the next "important callout" needs to be even bigger to register.
+
+The fix is institutional: *one team owns the highlight budget across all screens*. Adding a highlight requires retiring another. Without this, inflation is inevitable.
+
+## Case study: red-color budget
+
+A SaaS product had:
+- Red as brand primary (all CTAs).
+- Red for "delete" buttons.
+- Red for error states.
+- Red for "overdue" status.
+- Red highlight color for new-feature callouts.
+
+Result: nothing red registered as urgent. The error state in particular failed user testing — users weren't reading the validation message because the page was already "covered in red."
+
+The fix: re-platform the brand to a non-red primary (royal blue), reserve red exclusively for destructive and error states. Validation suddenly worked again.
+
+## Cross-domain examples
+
+### Newspaper headlines
+
+A traditional newspaper front page has *one* dominant headline. Breaking news might warrant a cross-page banner (rare). The next-tier headline is visibly smaller. The eye reads the dominant first, the secondary second. Multiple front-page leads reads as a chaotic news day, not a normal one.
+
+### Theatrical lighting
+
+A stage with everything brightly lit has no focal point. Lighting designers reserve full intensity for the moment that matters; rest of the stage sits in fill light. The audience's eye follows the bright; multiple equally-bright actors fight.
+
+### Restaurant menu design
+
+A "Chef's Recommendation" or "Most popular" mark on a single dish exploits the same principle. Menus with too many "starred" items degrade the signal of any one star.
+
+## Heuristics for trimming
+
+When auditing emphasis on a busy surface:
+
+1. **List every emphasized element** (every colored, bold, badged, animated element).
+2. **Rank by genuine importance** to the user's task.
+3. **Demote everything below rank #3.**
+
+Demotion means: lose the color emphasis (back to neutral), lose the bold (back to regular weight), lose the badge (defer to a less prominent surface).
+
+Resistance is normal; stakeholders will object that "their" element is important. The compromise: a rotating spotlight (e.g., a "feature of the week" slot) where one promotional surface holds the emphasis, rotating across teams.
+
+## Resources
+
+- **Material Design Color** — material.io. Documents how Material's "primary color" is supposed to be used sparingly.
+- **Nielsen Norman Group** — multiple articles on banner blindness and the emphasis-inflation problem.
+- **Refactoring UI** — chapters on color and emphasis discipline.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/.claude-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/.claude-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json.schemastore.org/claude-plugin.json",
+  "name": "process-and-robustness-principles",
+  "displayName": "Process & Robustness Principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for design process, accessibility, iteration, and robustness against edge cases. Covers Accessibility, Iteration, Factor of Safety, Prototyping, Weakest Link, Scaling Fallacy, and Ockham's Razor. Drawn from the process-related entries of 'Universal Principles of Design' (Lidwell, Holden, Butler, 2003) and the broader engineering and inclusive-design literature (WCAG, Maeda, Cooper, Petroski).",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HDeibler/universal-design-principles.git",
+    "directory": "plugins/process-and-robustness-principles"
+  },
+  "category": "design",
+  "keywords": [
+    "design",
+    "ux",
+    "accessibility",
+    "wcag",
+    "iteration",
+    "prototyping",
+    "process",
+    "robustness",
+    "weakest-link",
+    "ockhams-razor",
+    "scaling",
+    "universal-design-principles"
+  ]
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/.codex-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "process-and-robustness-principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for design process, accessibility, iteration, and robustness against edge cases. Covers Accessibility, Iteration, Factor of Safety, Prototyping, Weakest Link, Scaling Fallacy, and Ockham's Razor.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": [
+    "design",
+    "ux",
+    "accessibility",
+    "wcag",
+    "iteration",
+    "prototyping",
+    "process",
+    "robustness"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Process & Robustness Principles",
+    "shortDescription": "Accessibility, iteration, prototyping, reliability, and pruning.",
+    "developerName": "Hunter D",
+    "category": "Design",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "longDescription": "Framework-agnostic design principles for design process, accessibility, iteration, and robustness against edge cases. Covers Accessibility, Iteration, Factor of Safety, Prototyping, Weakest Link, Scaling Fallacy, and Ockham's Razor.",
+    "websiteURL": "https://github.com/HDeibler/universal-design-principles"
+  }
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/.codexignore
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/.codexignore
@@ -1,0 +1,7 @@
+.git/
+.DS_Store
+**/.DS_Store
+tmp/
+temp/
+.cache/
+scratch/

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/.cursor-plugin/plugin.json
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/.cursor-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "process-and-robustness-principles",
+  "displayName": "Process & Robustness Principles",
+  "version": "1.0.0",
+  "description": "Framework-agnostic design principles for design process, accessibility, iteration, and robustness against edge cases. Covers Accessibility, Iteration, Factor of Safety, Prototyping, Weakest Link, Scaling Fallacy, and Ockham's Razor.",
+  "author": {
+    "name": "Hunter D",
+    "email": "hunterd107@gmail.com"
+  },
+  "homepage": "https://github.com/HDeibler/universal-design-principles",
+  "repository": "https://github.com/HDeibler/universal-design-principles",
+  "license": "MIT",
+  "keywords": ["design", "ux", "accessibility", "wcag", "iteration", "prototyping", "process", "robustness"],
+  "category": "design",
+  "tags": ["accessibility", "wcag", "iteration", "prototyping", "robustness", "reliability"],
+  "skills": "./skills/"
+}

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/LICENSE
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/LICENSE
@@ -1,0 +1,39 @@
+MIT License
+
+Copyright (c) 2026 Hunter D
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+# Notes on attribution
+
+This software is a derivative *working library* inspired by the principle
+taxonomy popularized in *Universal Principles of Design* (Lidwell, Holden, &
+Butler, Rockport Publishers, 2003). The principle names and high-level
+taxonomy are drawn from that source, used here as a research reference under
+fair use. All prose, examples, code, anti-patterns, and analyses in this
+repository are written in the authors' own words, drawing on the broader
+publicly available design and HCI research literature (Wertheimer, Hick,
+Fitts, Norman, Nielsen, Tufte, Lynch, WCAG, Lavie & Tractinsky, Csikszentmihalyi,
+Zajonc, and many others).
+
+This software is not affiliated with, endorsed by, or sponsored by Rockport
+Publishers, the Lidwell-Holden-Butler authors, or any other rightsholder of
+the original book. See `ATTRIBUTION.md` for a fuller breakdown of sources.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/README.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/README.md
@@ -1,0 +1,22 @@
+# process-and-robustness-principles
+
+Framework-agnostic design principles for design process, accessibility, iteration, and robustness against edge cases.
+
+## Status
+
+| Skill cluster | State |
+|---|---|
+| `process-router` | ✅ Complete |
+| **Accessibility** + `perceivable` + `operable` + `understandable` + `robust` | ✅ Complete (reference-grade) |
+| **Iteration** + `design-vs-development` + `prototype-fidelity` | ✅ Complete |
+| **Factor of Safety** + `content-stress` + `failure-margin` | ✅ Complete |
+| **Prototyping** + `concept-throwaway-evolutionary` + `when-and-what` | ✅ Complete |
+| **Weakest Link** + `weakest-link-identification` + `weakest-link-treatment` | ✅ Complete |
+| **Scaling Fallacy** + `scaling-load-assumptions` + `scaling-interaction-assumptions` | ✅ Complete |
+| **Ockham's Razor** + `ockhams-feature-pruning` + `ockhams-equivalent-designs` | ✅ Complete |
+
+24 skills, each with a `references/` deep-dive file.
+
+## Planned
+
+After this batch, priority next builds: `life-cycle`, `development-cycle`, `normal-distribution`, `structural-forms`, `uncertainty-principle`, `convergence`, `cost-benefit`, `garbage-in-garbage-out`.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/SECURITY.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Report security issues by opening a private security advisory on GitHub or by
+emailing hunterd107@gmail.com.
+
+This marketplace packages prompt-only agent skills. It does not bundle MCP
+servers, hooks, scripts, executable dependencies, credentials, or networked
+services.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-operable/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-operable/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: accessibility-operable
+description: 'Use this skill when the question is whether users can *operate* a UI — keyboard, switch device, voice, screen-reader gestures — not just by mouse or touch. Trigger when designing keyboard navigation, focus management for modals/menus/popovers, drag-and-drop with alternatives, motion-heavy interactions, or any flow that asks the user to do something. Covers WCAG Principle 2 (Operable). Sub-aspect of `accessibility`; read that first if you haven''t already.'
+---
+
+# Accessibility — Operable
+
+WCAG Principle 2: user-interface components and navigation must be operable.
+
+The five sub-criteria, simplified:
+
+1. **Keyboard accessible** — everything that works with mouse must work with keyboard.
+2. **Enough time** — timing-out interactions are warned and extendable.
+3. **Seizures and physical reactions** — no flashing content; respect motion preferences.
+4. **Navigable** — users can find content and know where they are.
+5. **Input modalities** — touch and other input methods supported with adequate target size.
+
+## 1. Keyboard accessible
+
+### Every interactive element is reachable via Tab
+
+The default `Tab` order follows DOM source order and only includes natively focusable elements: `<a href>`, `<button>`, `<input>`, `<select>`, `<textarea>`, `<summary>`, `<iframe>`, plus elements with `tabindex="0"`.
+
+- **Use semantic elements.** `<button>`, not `<div onclick>`.
+- **Use `tabindex="0"`** to add custom interactive elements to tab order.
+- **Use `tabindex="-1"`** to make an element programmatically focusable (e.g., for focus management) but not reachable via Tab.
+- **Avoid `tabindex` > 0.** Positive tabindex creates a custom tab order that's almost always worse than DOM order and bewilders screen readers.
+
+### Visible focus indicators
+
+The user must see where focus is. Browsers provide default focus rings; never `outline: none` without a replacement.
+
+```css
+/* Right: replace, don't remove */
+:focus { outline: none; }
+:focus-visible {
+  outline: 2px solid hsl(220 90% 50%);
+  outline-offset: 2px;
+  border-radius: 0.25rem;
+}
+
+/* Wrong: removes the only signal a keyboard user has */
+*:focus { outline: none; }
+```
+
+`:focus-visible` (rather than `:focus`) shows the ring only when focus arrived via keyboard (or non-pointer means), not on every mouse click. This addresses the historical "designers don't want focus rings on click" concern without sacrificing keyboard accessibility.
+
+### Standard keys for standard interactions
+
+Honor user expectations:
+
+| Key | Behavior |
+|---|---|
+| `Tab` | Focus next; `Shift+Tab` for previous |
+| `Enter` / `Space` | Activate button, follow link, toggle checkbox |
+| `Esc` | Close overlay (Dialog, Sheet, Popover, Combobox) |
+| Arrow keys | Move within radio groups, sliders, tabs, menus, comboboxes |
+| `Home` / `End` | First / last in a list or menu |
+| `Page Up` / `Down` | Scroll a region |
+| `/` | Often: focus search (de facto convention) |
+| `Cmd/Ctrl+K` | Often: open command palette (de facto convention) |
+
+ARIA Authoring Practices Guide documents canonical keyboard interactions for every common pattern.
+
+### No keyboard traps
+
+A keyboard trap is a region where focus enters and cannot leave via keyboard alone. Common offenders:
+
+- Custom datepickers without arrow-key escape.
+- Embedded iframes with their own focus management that don't release.
+- Modal dialogs without `Esc` to close.
+
+**Test:** keyboard-only walkthrough. If you ever get stuck and have to mouse to escape, you have a trap.
+
+### Focus management for overlays
+
+When a modal opens:
+
+1. Move focus into the modal (typically the first focusable element, or a "primary" focus target).
+2. Trap focus inside until the modal closes.
+3. Restore focus to the trigger element when the modal closes.
+
+```js
+// Pseudocode — in practice use a library that handles edge cases
+function openModal(modal, trigger) {
+  modal.dataset.previousFocus = trigger;
+  const focusables = modal.querySelectorAll('a, button, input, [tabindex="0"]');
+  focusables[0]?.focus();
+  // ... trap focus on Tab/Shift+Tab within `focusables` ...
+}
+
+function closeModal(modal) {
+  modal.previousFocus?.focus();
+}
+```
+
+Most accessible UI libraries (Radix UI, React Aria, headless component sets) do this automatically. Custom-built modals that skip focus management are inaccessible.
+
+### Skip links
+
+```html
+<a href="#main" class="skip-link">Skip to main content</a>
+<header><nav>... 50 nav items ...</nav></header>
+<main id="main">...</main>
+
+<style>
+  .skip-link {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+  }
+  .skip-link:focus {
+    position: fixed;
+    top: 8px; left: 8px;
+    padding: 8px 16px;
+    background: black; color: white;
+    z-index: 100;
+  }
+</style>
+```
+
+Keyboard users tab past nav to reach content quickly. Visible only on focus so it doesn't clutter sighted-mouse-user views.
+
+## 2. Enough time
+
+### Adjustable timing
+
+If the system has timeouts (session expiry, captcha re-verify, time-limited form), users must be able to:
+
+- Turn it off, OR
+- Extend it, OR
+- Adjust it (across a wide range, ≥ 10× default).
+
+Exceptions: real-time events (auctions), where time limit is essential.
+
+```html
+<!-- Right: warn before timeout, allow extension -->
+<dialog open>
+  <h2>Session about to expire</h2>
+  <p>You have 60 seconds before your session ends.</p>
+  <button onclick="extendSession()">Stay signed in</button>
+</dialog>
+```
+
+### No moving / blinking content (without controls)
+
+Content that auto-moves, blinks, or scrolls for more than 5 seconds must be pause-able / stop-able.
+
+This includes carousels, animated banners, news tickers, autoplaying video.
+
+## 3. Seizures and physical reactions
+
+### Three flashes or below
+
+WCAG 2.3.1: don't have content that flashes more than 3 times per second. Photosensitive epilepsy can be triggered by flashing in the 3–55 Hz range.
+
+In practice, this rules out: rapid strobe effects, blinking text (don't), high-contrast flashing animations.
+
+### Motion preferences
+
+WCAG 2.3.3: respect `prefers-reduced-motion`. Many users (vestibular disorders, migraine, motion sensitivity) have configured their OS to request reduced motion.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+For specific motion that's *meaningful* (a state change indicator), allow it but make it briefer / less dramatic in reduced-motion mode.
+
+## 4. Navigable
+
+### Page titles
+
+Every page has a unique, descriptive `<title>`:
+
+```html
+<title>Settings — Notifications — Acme</title>
+```
+
+Screen reader users hear the title on page load; tab labels show it; browser history relies on it. Generic "Acme" titles for every page are useless.
+
+### Focus order matches reading order
+
+When a user tabs through a page, focus should follow the visual / logical reading order. CSS-rearranged elements (Grid, Flex order) can break this — test.
+
+### Link purpose
+
+Links should be understandable from their text alone (or from text + immediately-adjacent context). Screen reader users navigate by listing all links.
+
+```html
+<!-- Wrong: "click here" tells the screen reader user nothing -->
+<p>To read more, <a href="/blog/post">click here</a>.</p>
+
+<!-- Right: link text describes destination -->
+<p>Read more in <a href="/blog/post">our annual review</a>.</p>
+```
+
+### Multiple ways to find content
+
+WCAG 2.4.5 (AA): provide more than one way to find a page (search, sitemap, navigation, related-content links). Helps users with cognitive impairments and users who navigate non-linearly.
+
+### Headings and labels are descriptive
+
+`<h2>Article</h2>` — useless. `<h2>Q4 sales recap</h2>` — useful.
+
+### Focus visible (covered above)
+
+### Location indicators
+
+Users need to know where they are. Breadcrumbs, current-page highlighting in nav, page titles all serve this.
+
+```html
+<nav>
+  <a href="/dashboard">Dashboard</a>
+  <a href="/projects" aria-current="page">Projects</a>
+  <a href="/team">Team</a>
+</nav>
+```
+
+`aria-current="page"` tells assistive tech which item is current; visual styling reinforces it.
+
+## 5. Input modalities
+
+### Target size (covered in `fitts-law-touch-targets`)
+
+WCAG 2.5.5 (AAA): targets ≥ 44×44 CSS px.
+WCAG 2.5.8 (AA, 2.2): targets ≥ 24×24 CSS px with adequate spacing.
+
+### Pointer gestures
+
+Multi-pointer or path-based gestures (pinch, swipe, drag) must have single-pointer alternatives:
+
+- Pinch-to-zoom → buttons / keyboard for zoom in/out.
+- Swipe-to-delete → swipe + always-visible action button.
+- Drag-and-drop → keyboard reorder (arrows + spacebar).
+
+### Pointer cancellation
+
+The user can cancel a pointer action by moving away before lifting. Don't trigger destructive actions on `mousedown`; trigger on `mouseup` or `click`.
+
+### Label in name
+
+The accessible name must include any visible label text. Pattern:
+
+```html
+<!-- Right: visible text matches accessible name -->
+<button>Save</button>
+
+<!-- Wrong: aria-label overrides visible text, voice control breaks -->
+<button aria-label="Submit">Save</button>
+<!-- Voice user says "click Save" — fails because the accessible name is "Submit" -->
+```
+
+### Motion actuation
+
+Functions triggered by device motion (shake, tilt) must have UI alternatives. Some users physically can't shake a device.
+
+## Worked example: an accessible dropdown menu
+
+```html
+<div class="dropdown">
+  <button id="menu-button"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-controls="actions-menu">
+    Actions
+  </button>
+  <ul id="actions-menu"
+      role="menu"
+      hidden
+      aria-labelledby="menu-button">
+    <li role="menuitem" tabindex="-1">Edit</li>
+    <li role="menuitem" tabindex="-1">Duplicate</li>
+    <li role="menuitem" tabindex="-1">Archive</li>
+    <li role="separator"></li>
+    <li role="menuitem" tabindex="-1" class="destructive">Delete</li>
+  </ul>
+</div>
+```
+
+JavaScript to handle:
+
+- `Enter`/`Space`/`ArrowDown` on the button: open menu, focus first item.
+- `ArrowUp`/`ArrowDown` in menu: move focus.
+- `Home`/`End`: first / last item.
+- `Esc`: close, return focus to button.
+- `Tab`: close, move to next focusable.
+- Click outside: close.
+
+Plus `aria-expanded` toggles between `"true"` and `"false"`.
+
+This is verbose because menus genuinely have a lot of expected behavior. Use Radix, React Aria, or another library that implements WAI-ARIA Menu pattern correctly — don't roll your own.
+
+## Anti-patterns
+
+- **`outline: none` without a replacement.** Single largest accessibility crime in modern web design.
+- **`<div onclick>`.** Not focusable, not keyboard-operable, not announced as a button. Use `<button>`.
+- **Mouse-only menus.** Hover-revealed menus that close on `mouseout` with no keyboard equivalent.
+- **Modal traps.** Modals that don't close on `Esc`, don't trap focus, don't restore focus on close.
+- **Custom date pickers without keyboard.** Date pickers are notoriously inaccessible; if you must build one, follow ARIA Authoring Practices.
+- **Drag-only reorder.** No keyboard alternative for sorting or reordering.
+- **Auto-advancing carousels.** Focus thrash on every slide change; no way for keyboard users to read content before it disappears.
+
+## Heuristics
+
+1. **Unplug your mouse.** Walk through every primary flow. Anything you can't do with keyboard alone is broken.
+2. **Tab around the page.** Focus indicators visible? Tab order logical? Any traps?
+3. **Try `Esc` everywhere.** Open every overlay; `Esc` should close it.
+4. **Test with `prefers-reduced-motion: reduce`.** macOS: System Settings → Accessibility → Display → Reduce Motion. Are critical animations still meaningful? Are decorative ones gone?
+5. **Voice-control test.** macOS Voice Control or Windows Speech Recognition. Say "click [visible text]." If the click works, label-in-name is correct.
+
+## Related skills
+
+- **`accessibility`** (parent).
+- **`accessibility-perceivable`** — what users see; complementary.
+- **`accessibility-understandable`** — what users comprehend.
+- **`accessibility-robust`** — markup that assistive tech can rely on.
+- **`fitts-law`** and **`fitts-law-touch-targets`** (interaction) — target size.
+- **`feedback-loop`** (interaction) — keyboard interactions need visible feedback too.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-operable/references/operable-deep-dive.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-operable/references/operable-deep-dive.md
@@ -1,0 +1,129 @@
+# Operable: standards and edge cases
+
+A reference complementing `accessibility-operable` SKILL.md with deeper detail on the WCAG 2.* criteria and harder cases.
+
+## WCAG 2.* criteria summary
+
+The Operable principle has five guidelines.
+
+### 2.1 Keyboard accessible
+
+- **2.1.1 Keyboard (A)** — all functionality available from a keyboard.
+- **2.1.2 No Keyboard Trap (A)** — focus can always leave a region.
+- **2.1.4 Character Key Shortcuts (A)** — single-character shortcuts are off by default or remappable.
+
+### 2.2 Enough time
+
+- **2.2.1 Timing Adjustable (A)** — time limits can be turned off, adjusted, or extended.
+- **2.2.2 Pause, Stop, Hide (A)** — auto-moving content can be paused.
+
+### 2.3 Seizures and physical reactions
+
+- **2.3.1 Three Flashes or Below (A)** — no content flashes more than 3 times per second.
+- **2.3.3 Animation from Interactions (AAA)** — motion triggered by interaction can be disabled.
+
+### 2.4 Navigable
+
+- **2.4.1 Bypass Blocks (A)** — skip links to main content.
+- **2.4.2 Page Titled (A)** — page has a descriptive title.
+- **2.4.3 Focus Order (A)** — focus follows a meaningful sequence.
+- **2.4.4 Link Purpose (A)** — link text is meaningful in context.
+- **2.4.5 Multiple Ways (AA)** — more than one way to find a page.
+- **2.4.6 Headings and Labels (AA)** — headings and labels are descriptive.
+- **2.4.7 Focus Visible (AA)** — the focused element is visually distinct.
+- **2.4.11 Focus Not Obscured (Minimum) (AA, 2.2)** — focused elements not entirely hidden by other content.
+
+### 2.5 Input modalities
+
+- **2.5.1 Pointer Gestures (A)** — multi-pointer or path-based gestures have single-pointer alternatives.
+- **2.5.2 Pointer Cancellation (A)** — pointer-down doesn't trigger destructive actions; users can cancel before pointer-up.
+- **2.5.3 Label in Name (A)** — accessible name includes visible label text.
+- **2.5.4 Motion Actuation (A)** — functions triggered by device motion have UI alternatives.
+- **2.5.5 Target Size (Enhanced) (AAA)** — targets 44×44 CSS px.
+- **2.5.7 Dragging Movements (AA, 2.2)** — dragging has a single-pointer alternative.
+- **2.5.8 Target Size (Minimum) (AA, 2.2)** — targets 24×24 CSS px with adequate spacing.
+
+## Hard cases
+
+### Custom focus management
+
+For modals, popovers, comboboxes, menus, the standard pattern:
+
+- Focus moves into the component on open (typically first focusable element).
+- Focus is trapped within the component while open.
+- Focus returns to the triggering element when the component closes.
+
+This is hard to implement correctly. Edge cases:
+
+- The trigger was inside another modal.
+- The trigger was removed from the DOM after the modal opened.
+- The user navigated away while the modal was open.
+- A nested modal opened.
+
+Most accessible UI libraries (Radix UI, React Aria, headless component libraries) handle these — strongly prefer them over building from scratch.
+
+### Skip links
+
+The classic implementation:
+
+```html
+<a href="#main" class="skip-link">Skip to main content</a>
+
+<style>
+  .skip-link {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+  .skip-link:focus {
+    position: fixed;
+    top: 8px; left: 8px;
+    width: auto; height: auto;
+    padding: 8px 16px;
+    background: black; color: white;
+    z-index: 10000;
+  }
+</style>
+```
+
+Some teams provide multiple skip links (skip to nav, skip to main, skip to footer) for power users.
+
+### Drag-and-drop with keyboard
+
+Drag is hard to map to keyboard. Patterns:
+
+- **Arrow keys + spacebar.** Spacebar to "pick up" an item; arrows to move; spacebar to drop. Used by sortable lists.
+- **Type-to-position.** Type a number to move an item to that position.
+- **Move to / dropdown.** A "Move to..." menu offering destination choices instead of physical drag.
+
+WCAG 2.5.7 (AA, 2.2) requires *some* single-pointer alternative; keyboard alternative is even better.
+
+### Animation and motion
+
+WCAG 2.3.3 (AAA) covers interaction-triggered animation. CSS:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+For motion that's *meaningful* (a state change), still allow a brief, subtle version even in reduced-motion mode — just avoid the elaborate or distracting variant.
+
+### Focus-not-obscured (WCAG 2.2)
+
+A new criterion in WCAG 2.2: when an element receives focus, it cannot be entirely hidden by other content (e.g., a sticky header). Test by tabbing through and checking that the focused element is fully visible at every step.
+
+Common failures: a sticky header covering inputs as they receive focus; a footer covering form fields when tabbing through.
+
+## Closing
+
+Operable accessibility intersects with general usability — keyboard support and focus management aren't only "for disabled users"; they're for power users, mobile users with bluetooth keyboards, anyone in a hurry. Build it once; it benefits everyone.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-perceivable/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-perceivable/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: accessibility-perceivable
+description: 'Use this skill when the question is whether users can *perceive* the content — see it, hear it, or feel it — regardless of impairment. Trigger when designing color systems, picking text sizes, building image-heavy surfaces, working with video/audio, designing for low-vision users, or running an accessibility audit. Covers WCAG Principle 1 (Perceivable). Sub-aspect of `accessibility`; read that first if you haven''t already.'
+---
+
+# Accessibility — Perceivable
+
+WCAG Principle 1: information and user-interface components must be presentable to users in ways they can perceive.
+
+The four sub-criteria, simplified:
+
+1. **Text alternatives** for non-text content.
+2. **Time-based media** (audio/video) has alternatives.
+3. **Adaptable** content can be presented in different ways without losing structure.
+4. **Distinguishable** — color contrast, audio control, text resizing.
+
+This skill covers each in practical detail.
+
+## 1. Text alternatives
+
+### Images
+
+Every image gets alternative text describing what's relevant about it. The right alt text depends on the image's role:
+
+```html
+<!-- Informative: describe what the user needs to know -->
+<img src="/dashboard-screenshot.png"
+     alt="Dashboard showing $48,200 monthly revenue, up 12% from last month." />
+
+<!-- Functional (image as link / button): describe the action -->
+<a href="/profile">
+  <img src="/avatar.png" alt="Open your profile" />
+</a>
+
+<!-- Decorative: empty alt so screen readers skip -->
+<img src="/decorative-pattern.svg" alt="" aria-hidden="true" />
+
+<!-- Complex (chart, infographic): brief alt + linked long description -->
+<figure>
+  <img src="/sales-chart.png"
+       alt="Quarterly sales chart, see description below."
+       aria-describedby="chart-desc" />
+  <figcaption id="chart-desc">
+    Sales rose from $12k in Q1 to $58k in Q4, with a dip to $31k in Q3 caused
+    by a supply chain interruption.
+  </figcaption>
+</figure>
+```
+
+**Common mistakes:**
+- `alt="image"` or `alt="photo of woman"` — describes the file type, not the meaning.
+- Decorative images with non-empty alt — screen reader users hear "decorative-pattern-3-svg" announced as content.
+- Long alt text on simple images — alt should be ≤ 125 characters; longer goes in `<figcaption>` or linked description.
+
+### Icons
+
+Icon-only buttons need an accessible name. Two patterns:
+
+```html
+<!-- Pattern A: aria-label on the button -->
+<button aria-label="Close">
+  <svg aria-hidden="true">...</svg>
+</button>
+
+<!-- Pattern B: visually-hidden text -->
+<button>
+  <svg aria-hidden="true">...</svg>
+  <span class="sr-only">Close</span>
+</button>
+```
+
+Either is fine; pattern B can be more reliable across screen readers. The `sr-only` class:
+
+```css
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+### Decorative SVG
+
+```html
+<svg aria-hidden="true" focusable="false">...</svg>
+```
+
+`aria-hidden` removes from accessibility tree; `focusable="false"` prevents keyboard focus on the SVG (some browsers focus SVGs by default).
+
+## 2. Time-based media
+
+### Video
+
+- **Captions** for all spoken content. Auto-generated captions are a starting point; review for accuracy.
+- **Audio descriptions** for visual content not conveyed by audio (a chart appearing on screen, a character action shown but not narrated).
+- **Transcripts** as text alternatives for anyone who can't watch.
+
+### Audio
+
+- **Transcripts** for podcasts, interviews, voicemails.
+- **Captions or transcripts** for any audio-only message in the UI.
+
+### Auto-playing media
+
+Don't autoplay video or audio with sound. WCAG 1.4.2 requires that audio playing for more than 3 seconds either:
+
+- Has a pause/stop control, or
+- Has a volume control independent of system volume.
+
+Better: don't autoplay sound at all. It's hostile to users with hearing aids, in public spaces, or sharing audio output.
+
+## 3. Adaptable
+
+### Semantic structure
+
+Use HTML elements for what they're for. Heading order matters; landmarks matter; lists matter.
+
+```html
+<!-- Right -->
+<main>
+  <h1>Dashboard</h1>
+  <section aria-labelledby="kpi-heading">
+    <h2 id="kpi-heading">This month</h2>
+    <ul>
+      <li>Revenue: $48k</li>
+      <li>Users: 12,481</li>
+    </ul>
+  </section>
+</main>
+
+<!-- Wrong: divs everywhere, no structure -->
+<div>
+  <div>Dashboard</div>
+  <div>This month</div>
+  <div>Revenue: $48k</div>
+  <div>Users: 12,481</div>
+</div>
+```
+
+Screen readers navigate by headings (`H` key in NVDA), landmarks (`R` key), lists, links. Without semantic structure, navigation falls apart.
+
+### Heading order
+
+Don't skip heading levels. Page structure:
+
+```
+<h1>Page title (one per page)
+  <h2>Section
+    <h3>Subsection
+      <h4>Sub-subsection
+```
+
+Going from `<h1>` to `<h3>` confuses assistive tech. If the visual size you want for an `<h2>` is too large, restyle the `<h2>` — don't reach for `<h3>` to get smaller text.
+
+### Reading order
+
+Source order in HTML should match visual reading order. CSS Grid and Flexbox can rearrange visually, but screen readers follow source order.
+
+```html
+<!-- Source order matches visual order: title, then summary, then details -->
+<article>
+  <h2>Article title</h2>
+  <p class="summary">Brief summary.</p>
+  <p>Detailed body...</p>
+</article>
+
+<!-- Wrong: visually rearranged but source order is now confusing -->
+<article style="display: flex; flex-direction: column-reverse;">
+  <p>Detailed body...</p>
+  <p>Summary.</p>
+  <h2>Title</h2>
+</article>
+```
+
+### Programmatic relationships
+
+Use `<label for>`, `aria-labelledby`, `aria-describedby` to expose visual relationships to assistive tech.
+
+```html
+<div>
+  <label for="email">Email</label>
+  <input id="email" aria-describedby="email-help" />
+  <p id="email-help">We'll never share this.</p>
+</div>
+```
+
+The label is associated; the help text is associated. A screen reader announces all three together.
+
+## 4. Distinguishable
+
+### Color contrast
+
+WCAG ratios:
+
+| Content | Level AA | Level AAA |
+|---|---|---|
+| Body text (< 18pt regular or < 14pt bold) | 4.5:1 | 7:1 |
+| Large text (≥ 18pt regular or ≥ 14pt bold) | 3:1 | 4.5:1 |
+| UI components and graphical objects | 3:1 | (no AAA) |
+| Disabled / inactive elements | (exempt) | (exempt) |
+
+Test every text-on-background combination. Common failures:
+
+- Light grey body text (`#999` on white = 2.85:1, fails AA).
+- Brand-color body links (`#1e90ff` on white = 3.4:1, fails AA for body text).
+- Placeholder text in inputs (often muted to look "less important," ends up unreadable).
+
+Tools: WebAIM Contrast Checker, Stark plugin, Chrome DevTools' contrast inspector.
+
+### Color not the only signal
+
+WCAG 1.4.1: don't use color alone to convey information. Pair with icon, text, pattern, or position.
+
+```html
+<!-- Wrong: red border = error, but if red isn't perceivable, no signal -->
+<input style="border: 2px solid red" />
+
+<!-- Right: red border + icon + descriptive text -->
+<div class="field" data-state="error">
+  <label for="email">Email</label>
+  <input id="email" aria-invalid="true" aria-describedby="email-error" />
+  <p id="email-error">
+    <AlertIcon aria-hidden="true" /> Please enter a valid email.
+  </p>
+</div>
+```
+
+### Text resize
+
+WCAG 1.4.4: text must be resizable up to 200% without loss of content or functionality. Test:
+
+- Browser zoom at 200% — does content reflow without horizontal scroll?
+- Text size only at 200% (Firefox supports text-only zoom) — does the layout survive?
+
+Use relative units (`rem`, `em`, `%`) for type sizes; avoid `px` for body text. Use `vw`/`vh` cautiously — they don't scale with text size.
+
+### Reflow
+
+WCAG 1.4.10 (Level AA): content reflows to a 320 CSS-pixel-wide viewport without requiring horizontal scrolling. Equivalent to 400% zoom on a 1280px viewport.
+
+Practical test: open the design in DevTools at 320px wide and 1280px wide. Anything that requires sideways scroll for primary content fails.
+
+### Images of text
+
+Avoid embedding text in images (which can't be resized, restyled, or read by screen readers). Render text as text wherever possible. SVG with `<text>` elements is OK because it scales and can be read; raster images of text aren't.
+
+### Non-color content
+
+Patterns, textures, position, shape — non-color signals carry meaning for color-blind users:
+
+```html
+<!-- Chart series with color + pattern -->
+<svg>
+  <rect fill="url(#solid-blue)" />     <!-- Series A: solid blue -->
+  <rect fill="url(#striped-blue)" />   <!-- Series B: striped blue -->
+  <rect fill="url(#dotted-blue)" />    <!-- Series C: dotted blue -->
+</svg>
+```
+
+Even users who can perceive color benefit from redundant signals.
+
+## Worked example: an accessible status badge system
+
+```html
+<style>
+  .badge { display: inline-flex; align-items: center; gap: 4px;
+           padding: 2px 8px; border-radius: 9999px;
+           font-size: 12px; font-weight: 500; }
+  .badge--success { background: hsl(142 70% 95%); color: hsl(142 70% 22%); }
+  .badge--warning { background: hsl(38 95% 95%); color: hsl(38 90% 25%); }
+  .badge--error   { background: hsl(0 80% 95%); color: hsl(0 75% 32%); }
+</style>
+
+<span class="badge badge--success">
+  <CheckIcon aria-hidden="true" /> Paid
+</span>
+<span class="badge badge--warning">
+  <ClockIcon aria-hidden="true" /> Pending
+</span>
+<span class="badge badge--error">
+  <AlertIcon aria-hidden="true" /> Overdue
+</span>
+```
+
+What's working:
+
+- Color + icon + text — three signals.
+- Contrast ratios above 7:1 for both color combinations (verified in a contrast checker).
+- Icons have `aria-hidden` since the text already conveys meaning.
+- Background color tinted, foreground darkened, both relative to a hue rather than using full saturation (preserves AA contrast).
+
+## Anti-patterns
+
+- **`alt="image"` or `alt=""` on informative images.** Screen reader users get nothing.
+- **Color-only error states.** A red border with no text or icon. Color-blind users perceive no error.
+- **Pale-grey body text for elegance.** Below 4.5:1 contrast — looks polished, fails AA, exhausts users with low vision.
+- **Auto-playing video with sound.** Hostile to users in shared spaces, with hearing aids, on subway commutes.
+- **Heading shenanigans.** Using `<h2>` for "I want this size" rather than for structural meaning. Leaves `<h1>` missing or `<h2>` skipped.
+
+## Heuristics
+
+1. **The contrast checker pass.** Every text-on-background pair, every UI-element-against-background pair. Body must clear 4.5:1; large text and UI 3:1.
+2. **The grayscale pass.** Take a screenshot, convert to grayscale. Do all status indicators still parse?
+3. **The 200% zoom test.** Browser zoom to 200%. Layout survives? Buttons still hittable? No content lost?
+4. **The screen-reader pass.** With VoiceOver / NVDA / TalkBack, walk a critical flow. Listen for unlabeled controls, announced as "blank," missing state.
+5. **The image audit.** Every `<img>`. Alt text describes what the user needs to know. Decorative images have empty alt.
+
+## Related skills
+
+- **`accessibility`** (parent).
+- **`accessibility-operable`** — keyboard reach and target size.
+- **`accessibility-understandable`** — labels, copy, predictability.
+- **`accessibility-robust`** — semantic markup and ARIA.
+- **`color`** and **`hierarchy-color-and-tone`** (perception) — color decisions that respect contrast.
+- **`legibility`** and **`readability`** (perception) — type decisions that aid perception.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-perceivable/references/perceivable-deep-dive.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-perceivable/references/perceivable-deep-dive.md
@@ -1,0 +1,97 @@
+# Perceivable: standards and edge cases
+
+A reference complementing `accessibility-perceivable` SKILL.md with deeper detail on the WCAG 1.* criteria and harder cases.
+
+## WCAG 1.* criteria summary
+
+The Perceivable principle has four guidelines, each with measurable success criteria.
+
+### 1.1 Text alternatives
+
+- **1.1.1 Non-text Content (Level A)** — every non-text element has an equivalent text alternative.
+
+### 1.2 Time-based media
+
+- **1.2.1 Audio-only and Video-only (A)** — alternatives provided.
+- **1.2.2 Captions (A)** — captions for prerecorded audio.
+- **1.2.3 Audio Description or Media Alternative (A)** — audio description or text alternative for video.
+- **1.2.4 Captions (Live) (AA)** — captions for live audio.
+- **1.2.5 Audio Description (AA)** — audio description for prerecorded video.
+
+### 1.3 Adaptable
+
+- **1.3.1 Info and Relationships (A)** — information and structure conveyed in presentation must be programmatically determinable.
+- **1.3.2 Meaningful Sequence (A)** — content order makes sense when linearized.
+- **1.3.3 Sensory Characteristics (A)** — instructions don't rely solely on shape, color, position.
+- **1.3.4 Orientation (AA)** — content works in both portrait and landscape.
+- **1.3.5 Identify Input Purpose (AA)** — common form fields use autocomplete attributes.
+
+### 1.4 Distinguishable
+
+- **1.4.1 Use of Color (A)** — color is not the only visual means of conveying information.
+- **1.4.2 Audio Control (A)** — auto-playing audio over 3 seconds has stop/pause.
+- **1.4.3 Contrast (Minimum) (AA)** — 4.5:1 body, 3:1 large.
+- **1.4.4 Resize Text (AA)** — text resizable to 200% without loss.
+- **1.4.5 Images of Text (AA)** — avoid images of text where text would do.
+- **1.4.10 Reflow (AA)** — content reflows to 320 px wide without horizontal scroll.
+- **1.4.11 Non-text Contrast (AA)** — UI components and graphical objects have 3:1 contrast.
+- **1.4.12 Text Spacing (AA)** — content adapts to user-set spacing.
+- **1.4.13 Content on Hover or Focus (AA)** — hover/focus revealed content is dismissable, hoverable, persistent.
+
+## Hard cases
+
+### Charts and infographics
+
+A chart is non-text content per 1.1.1, but a one-line alt won't convey the chart's data. Patterns:
+
+- **Brief alt + linked long description.** "Quarterly sales chart, see description below." Then a `<figcaption>` or separate page detailing the data.
+- **Data table alongside the chart.** The same data in `<table>` form for screen reader users; the chart for sighted users.
+- **`<svg>` with native semantics.** SVG charts can include `<title>` and `<desc>` elements that screen readers may read.
+
+For complex visualizations (interactive dashboards), text alternative is harder. Consider letting screen reader users access the underlying data directly rather than describing the visualization.
+
+### Decorative vs. functional images
+
+The line is sometimes blurry. Heuristics:
+
+- If removing the image would lose information, it's informative — needs alt.
+- If removing the image only loses style, it's decorative — `alt=""` and `aria-hidden="true"`.
+- If the image *is* the link/button, alt describes the action.
+- An image that adds *atmosphere* but no information (a hero photo behind a heading) is decorative.
+
+### CAPTCHA
+
+WCAG 1.1.1 requires text alternatives for non-text content, but CAPTCHA exists to defeat automated systems including assistive tech. The accommodation: provide alternative challenges (audio CAPTCHA, logic puzzles, reCAPTCHA's invisible methods). Single-modality visual CAPTCHA fails accessibility broadly.
+
+### Dynamic visual content (videos, animations)
+
+WCAG 1.2 series covers prerecorded media. For live or auto-generated visual content:
+
+- Provide pause / stop controls.
+- Don't auto-play with sound.
+- Honor `prefers-reduced-motion`.
+- For data visualizations that animate, give a static-state alternative.
+
+## Color contrast: nuances
+
+Contrast is calculated against the *visible* foreground and background. Some traps:
+
+- **Text over images.** The contrast varies by pixel. Fix by adding a semi-opaque scrim, a text-shadow, or a solid background panel.
+- **Text over gradients.** Same issue; pick the worst-case spot to measure.
+- **Anti-aliased text.** The actual edges of glyphs sub-pixel render and may have lower contrast than the text body. Ensure baseline body color/background pair meets the ratio.
+- **Disabled controls.** WCAG explicitly exempts disabled controls from contrast requirements — but the rationale is weak. Aim for at least 3:1 even on disabled, so users can read the disabled state.
+
+## Reflow at 320 px
+
+Test at the iPhone SE / smaller-Android width: 320 CSS pixels. At this width, no horizontal scroll for primary content. Tables and code blocks may scroll horizontally as exceptions.
+
+Common reflow failures:
+
+- Fixed-width containers (e.g., `width: 800px`).
+- Columns that don't collapse on narrow screens.
+- Tooltips that extend off-screen.
+- Modals with fixed pixel widths larger than 320.
+
+## Closing
+
+Perceivable accessibility is the most "checklistable" sub-principle — many of its criteria are programmatically testable. But the gap between passing the checklist and being genuinely perceivable is wide; manual testing with assistive tech catches what automated tools miss.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-robust/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-robust/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: accessibility-robust
+description: 'Use this skill when the question is whether assistive technologies — screen readers, voice control, switch devices, refreshable braille displays — can reliably interpret your UI. Trigger when picking between semantic HTML and a custom-built component, when reaching for ARIA, when designing live regions for dynamic content (toasts, validation, search results), or when reviewing a UI built largely from `<div>` elements. Covers WCAG Principle 4 (Robust). Sub-aspect of `accessibility`; read that first if you haven''t already.'
+---
+
+# Accessibility — Robust
+
+WCAG Principle 4: content must be robust enough to be interpreted reliably by a wide variety of user agents, including assistive technologies.
+
+The two sub-criteria, simplified:
+
+1. **Compatible** — markup is parsed correctly; name, role, and value are programmatically determinable for every UI component.
+2. **Status messages** — programmatically-conveyed status updates without focus shifts.
+
+Robustness is the layer most often broken by frameworks that abstract away HTML semantics. A `<div>`-based UI may be visually identical to a semantic one and entirely opaque to assistive tech.
+
+## 1. Compatible
+
+### Semantic HTML first
+
+Use the right HTML element for the job. Browsers and assistive tech understand semantic elements without further annotation.
+
+| Use this… | …not this |
+|---|---|
+| `<button>` | `<div>` with click handler |
+| `<a href>` | `<span>` with click handler |
+| `<input type="checkbox">` | `<div>` with custom toggle |
+| `<nav>` | `<div class="nav">` |
+| `<main>` | `<div class="main">` |
+| `<form>` | `<div>` with submit button |
+| `<label for="id">` | `<div>` next to an input |
+| `<table>` for tabular data | nested divs styled as a grid |
+
+The reason isn't aesthetic; semantic elements come with built-in:
+
+- Keyboard handling (`<button>` activates on Enter/Space).
+- Focus management (`<a href>` is in tab order).
+- Accessibility tree role (`<nav>` is announced as "navigation landmark").
+- Default styling that can be overridden but indicates affordance.
+- Form submission, validation, and serialization.
+
+A `<div role="button" tabindex="0" onclick onKeyDown>` is *almost* a button — and you've rebuilt 80% of what `<button>` provides for free, often imperfectly.
+
+### Name, Role, Value
+
+Every interactive component must have:
+
+- **Name** — what is it? ("Save," "Email field," "Open menu")
+- **Role** — what kind of thing is it? ("button," "textbox," "menu")
+- **Value** — what's its current state? ("checked," "expanded," "disabled," current text)
+
+Native HTML elements provide all three for free. For custom components, you provide them via ARIA.
+
+```html
+<!-- Native: name from text, role from <button>, value from disabled state -->
+<button disabled>Save</button>
+
+<!-- Custom: must declare all three -->
+<div role="button"
+     tabindex="0"
+     aria-disabled="true">
+  Save
+</div>
+```
+
+### When to use ARIA
+
+The first rule of ARIA: don't use ARIA. The second rule: don't use ARIA when a native element will do. The third rule: when you must use ARIA, use it correctly.
+
+**Use ARIA when:**
+
+- Building a custom component for which no native element exists (combobox, tablist, treegrid, slider) — use the appropriate WAI-ARIA pattern.
+- Adding state to a component that has no native attribute (`aria-expanded`, `aria-current`, `aria-pressed`, `aria-selected`).
+- Providing an accessible name when no visible label exists (`aria-label`, `aria-labelledby`).
+- Associating descriptions or errors with controls (`aria-describedby`).
+- Marking dynamic content for announcement (`aria-live`).
+
+**Don't use ARIA to:**
+
+- Reinvent native semantics (`role="button"` on `<button>`).
+- Override semantics that work (`role="presentation"` on a `<table>` of tabular data).
+- "Fix" inaccessible custom components without also adding keyboard support and state management.
+
+### ARIA roles, properties, states
+
+A few of the most-used:
+
+| Attribute | Purpose | Example |
+|---|---|---|
+| `role` | Declare what kind of widget | `role="dialog"` |
+| `aria-label` | Accessible name when no visible label | `<button aria-label="Close">×</button>` |
+| `aria-labelledby` | Accessible name from another element | `<dialog aria-labelledby="title">` |
+| `aria-describedby` | Description / error / hint | `<input aria-describedby="hint">` |
+| `aria-expanded` | Disclosure state | `<button aria-expanded="false">` |
+| `aria-current` | Current item in a set | `<a aria-current="page">` |
+| `aria-pressed` | Toggle button state | `<button aria-pressed="true">` |
+| `aria-checked` | Custom checkbox/radio state | `<div role="checkbox" aria-checked="true">` |
+| `aria-selected` | Selected item in a listbox | `<div role="option" aria-selected="true">` |
+| `aria-disabled` | Disabled (when `disabled` attr unavailable) | `<div aria-disabled="true">` |
+| `aria-invalid` | Error state | `<input aria-invalid="true">` |
+| `aria-required` | Required field | `<input aria-required="true">` |
+| `aria-hidden` | Hide from accessibility tree | `<svg aria-hidden="true">` |
+| `aria-live` | Announce changes | `<div aria-live="polite">` |
+| `role="alert"` | Important announcement | `<div role="alert">` |
+
+The WAI-ARIA Authoring Practices Guide documents complete patterns for: combobox, dialog, disclosure, feed, grid, listbox, menu, menubar, radiogroup, slider, tablist, treeview, and more. Reach for these patterns rather than inventing.
+
+### Don't break native semantics
+
+A common mistake: applying ARIA roles that *conflict* with the underlying element.
+
+```html
+<!-- Wrong: <a href> is already a link; role="button" overrides -->
+<a href="/save" role="button">Save</a>
+
+<!-- Wrong: <ul> already has list semantics; role="navigation" doesn't help -->
+<ul role="navigation">...</ul>
+
+<!-- Wrong: <table> for tabular data with role="presentation" strips semantics -->
+<table role="presentation">...</table>
+```
+
+If you must override semantics (rare), you almost always have the wrong base element.
+
+### Validate your HTML
+
+Invalid HTML can cascade in unpredictable ways through accessibility tree construction. Validate occasionally with the W3C HTML Validator.
+
+Common offenders:
+
+- Duplicate IDs (breaks `aria-labelledby` and `aria-describedby`).
+- Nested interactive elements (`<button>` inside `<a>`, `<a>` inside `<button>`).
+- `<button>` inside `<button>`.
+- Form controls not associated with `<label>`.
+
+## 2. Status messages
+
+Dynamic content updates that don't shift focus need to be announced to screen readers via live regions.
+
+### Live regions
+
+```html
+<!-- Polite: announce when convenient (after current speech) -->
+<div aria-live="polite" id="search-results-status"></div>
+
+<!-- Assertive: interrupt; for critical messages only -->
+<div aria-live="assertive" id="error-status"></div>
+```
+
+When you populate the live region, the screen reader reads the new content. The region must:
+
+- Be present in the DOM *before* content is added (live regions don't announce content present at page load).
+- Have only the new message inside it, replacing previous content.
+- Be visible to assistive tech (don't `display: none`; use `sr-only` if you don't want it visible).
+
+### `role="status"` and `role="alert"`
+
+Convenience roles with built-in `aria-live` settings:
+
+- `role="status"` ≈ `aria-live="polite"`. For non-critical updates ("Saved," "Loaded 24 results").
+- `role="alert"` ≈ `aria-live="assertive"` plus `aria-atomic="true"`. For urgent updates ("Connection lost," "Form has 3 errors").
+
+```html
+<!-- Toast notification (status) -->
+<div role="status">Changes saved</div>
+
+<!-- Form error summary (alert) -->
+<div role="alert">
+  Please fix the following: Email is invalid; Password is too short.
+</div>
+```
+
+Use `role="alert"` sparingly — it interrupts whatever the screen reader is doing. Reserve for genuine emergencies.
+
+### Common live-region patterns
+
+- **Toast notifications** — `role="status"` for success, info, warning; `role="alert"` for error.
+- **Search results count** — `<div role="status">Showing 24 results</div>` updates as the user filters.
+- **Form validation summary** — after a failed submit, populate `<div role="alert">` with the error count and let screen reader read it.
+- **Auto-saving indicator** — `<div role="status">Saving... Saved at 3:42 PM</div>` updates during background saves.
+- **Real-time data updates** — chat messages, stock prices: `aria-live="polite"` so the user hears them when convenient.
+
+### Don't overdo announcements
+
+Every announcement steals attention. Frequent live-region updates make the UI noisy for screen reader users. Rules of thumb:
+
+- Don't announce hover state changes.
+- Don't announce loading spinners (unless the load is unusually long).
+- Don't announce purely cosmetic transitions.
+- Aggregate where possible: instead of "Filter applied," "24 results loaded," "Filter applied," "12 results loaded" with each filter change, debounce and announce only the final state.
+
+### `aria-atomic` and `aria-relevant`
+
+Fine-tuning live region behavior:
+
+- `aria-atomic="true"` — read the entire region content when any part changes (default for `role="alert"`; useful for counts that should always be read in context: "24 results" changing to "12 results").
+- `aria-relevant` — control which mutation types announce (default is `additions text`). Rarely needed.
+
+## Worked examples
+
+### Example 1: a custom slider built right
+
+```html
+<label id="volume-label">Volume: <span id="volume-value">50</span>%</label>
+<div role="slider"
+     aria-labelledby="volume-label"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="50"
+     tabindex="0"
+     id="volume-slider"
+     class="slider-track">
+  <div class="slider-thumb" style="left: 50%;"></div>
+</div>
+```
+
+Plus JavaScript:
+
+- `ArrowLeft`/`ArrowRight` and `Home`/`End` adjust value.
+- On adjustment, update `aria-valuenow` *and* the visible text (`#volume-value`).
+
+The native `<input type="range">` does all of this automatically — strongly prefer that. Custom sliders are justified only when range can't meet your needs (multi-handle range, custom geometry, color picker).
+
+### Example 2: a search results announcement
+
+```html
+<form>
+  <label for="search">Search</label>
+  <input id="search" oninput="runSearch(this.value)" />
+</form>
+
+<div id="results">…rendered results…</div>
+<div id="results-status" class="sr-only" role="status"></div>
+
+<script>
+  function runSearch(q) {
+    const results = doSearch(q);
+    renderResults(results);
+    document.getElementById('results-status').textContent =
+      `${results.length} results for "${q}"`;
+  }
+</script>
+```
+
+Sighted users see results below the input; screen reader users hear "24 results for 'invoice'" without focus moving.
+
+### Example 3: a toast that announces
+
+```html
+<div id="toast-region" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+
+<script>
+  function showToast(message) {
+    const region = document.getElementById('toast-region');
+    region.textContent = message;
+    showVisualToast(message); // separate visible UI
+    setTimeout(() => region.textContent = '', 5000);
+  }
+</script>
+```
+
+The visible toast is rendered however your design library does it. The hidden live region is what assistive tech uses.
+
+## Anti-patterns
+
+- **`<div>` for everything.** A UI built without semantic elements is opaque to assistive tech and requires comprehensive ARIA to recover.
+- **`role="button"` on a `<button>`.** Redundant; sometimes interferes with native behavior.
+- **`aria-label` that contradicts visible text.** Voice control breaks; user says "click [visible text]" and nothing happens.
+- **Live regions added at announcement time.** `<div aria-live="polite">` must be in the DOM at page load to be reliably observed; adding it dynamically often misses the announcement.
+- **Aria-live on too much content.** Page-wide `aria-live` regions are constantly chattering. Scope to just the announcement element.
+- **Custom dropdowns missing keyboard.** ARIA roles applied to a div but no `Tab`, `Esc`, or arrow-key handlers. The screen reader hears "menu" but the user can't operate it.
+- **`role="presentation"` on tables of data.** Strips the semantics that make the table navigable. Reserve for genuinely-decorative table-shaped layouts.
+
+## Heuristics
+
+1. **The "is there a native element for this?" check.** Before reaching for ARIA, ask if HTML provides what you need. Almost always.
+2. **The accessibility tree audit.** Chrome DevTools → Accessibility tab. Inspect any custom component. Does it have a name, role, and (where applicable) value? If "name: empty" or "role: generic," the component is invisible to assistive tech.
+3. **The screen-reader walkthrough.** Open VoiceOver / NVDA / TalkBack and walk a critical flow. Listen for: unlabeled controls, components with no role, changes that aren't announced, "blank" or "press button to" without context.
+4. **The HTML validator.** Run your most-complex pages through validator.w3.org. Duplicate IDs, nested interactive elements, and missing labels often surface here first.
+
+## Related skills
+
+- **`accessibility`** (parent).
+- **`accessibility-perceivable`**, **`accessibility-operable`**, **`accessibility-understandable`** — siblings.
+- **`feedback-loop`** (interaction) — live regions are accessibility's version of feedback.
+- **`structural-forms`** (process) — semantic HTML is the structural-forms answer for accessibility.
+- **`affordance`** (interaction) — semantic elements come with default affordances.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-robust/references/robust-deep-dive.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-robust/references/robust-deep-dive.md
@@ -1,0 +1,152 @@
+# Robust: standards and edge cases
+
+A reference complementing `accessibility-robust` SKILL.md with deeper detail on the WCAG 4.* criteria and ARIA practice.
+
+## WCAG 4.* criteria summary
+
+The Robust principle has one guideline (4.1) with three success criteria (one of which was deprecated in 2.2).
+
+### 4.1 Compatible
+
+- **4.1.1 Parsing (A)** — *deprecated in WCAG 2.2.* Originally required valid HTML; modern browsers handle invalid HTML well enough that this criterion was removed.
+- **4.1.2 Name, Role, Value (A)** — every UI component has programmatically determinable name, role, and value (states/properties).
+- **4.1.3 Status Messages (AA)** — programmatically conveyed status messages without focus shifts.
+
+The framework here is the smallest of WCAG's four principles by criterion count, but it underlies most of the other principles' implementation: if your markup isn't robust, no amount of careful labeling rescues it.
+
+## The ARIA hierarchy
+
+ARIA (Accessible Rich Internet Applications) is a specification for adding semantic information to non-semantic markup. The relationship to native HTML:
+
+1. **Use a native HTML element if one fits.** `<button>`, `<a>`, `<input>`, `<nav>`, `<form>`, `<label>`, `<dialog>`, etc.
+2. **Use a native element with ARIA enhancement** when you need state native HTML doesn't express. `<button aria-pressed>`, `<a aria-current="page">`.
+3. **Build with ARIA on `<div>` / `<span>`** only when no native element fits. Custom comboboxes, tablists, treegrids, sliders.
+
+The first rule of ARIA: don't use ARIA. The second rule: use it when needed but use it correctly.
+
+## ARIA patterns from WAI-ARIA Authoring Practices
+
+The W3C's WAI-ARIA Authoring Practices Guide documents the canonical implementation of common interactive components. Patterns include:
+
+- Accordion
+- Alert / Alertdialog
+- Breadcrumb
+- Button
+- Carousel
+- Checkbox (custom)
+- Combobox
+- Dialog (modal)
+- Disclosure
+- Feed
+- Grid
+- Landmark regions
+- Link
+- Listbox
+- Menu / Menubar
+- Meter
+- Radiogroup
+- Slider
+- Spinbutton
+- Switch
+- Tabs
+- Toolbar
+- Tooltip
+- Tree / Treegrid
+
+Each pattern documents required ARIA roles, properties, states, keyboard interactions, and focus management. When building a custom component, find the matching pattern first; build to spec.
+
+## Live regions in depth
+
+`aria-live` regions notify assistive tech of dynamic content changes. Three priority levels:
+
+- `aria-live="off"` (default) — no announcement.
+- `aria-live="polite"` — announce when convenient (after current speech). Use for non-urgent updates: search results count, save confirmations.
+- `aria-live="assertive"` — interrupt and announce. Use sparingly, for genuinely urgent updates: critical errors, connection lost.
+
+Convenience roles with implicit `aria-live`:
+
+- `role="status"` ≈ `aria-live="polite"`.
+- `role="alert"` ≈ `aria-live="assertive"` plus `aria-atomic="true"`.
+- `role="log"` for chat-like sequential additions.
+- `role="timer"` for countdowns.
+- `role="progressbar"` for progress indicators.
+
+### Live region pitfalls
+
+- **The region must exist in the DOM at page load** for reliable announcement. Adding a live region just before populating it often misses the announcement.
+- **Each announcement should replace previous content**, not append (unless using `role="log"`).
+- **Don't announce every small change.** Aggregate updates; announce only when meaningful.
+- **Test on multiple screen readers.** Announcement behavior varies (NVDA, VoiceOver, JAWS, TalkBack).
+
+## Common semantic mistakes
+
+### `<div>` for everything
+
+A UI built without semantic elements is opaque to assistive tech and requires comprehensive ARIA to recover. The fix is structural: refactor to `<button>`, `<a>`, `<nav>`, `<main>`, `<form>`, `<label>`, `<table>` etc.
+
+### Conflicting ARIA roles
+
+Applying ARIA roles that contradict the underlying element:
+
+- `<a href="..." role="button">` — `<a>` is already a link; `role="button"` conflicts.
+- `<table role="presentation">` for actual tabular data — strips the semantics that make the table navigable.
+
+### `aria-label` overriding visible text
+
+```html
+<button aria-label="Submit">Save</button>
+```
+
+The accessible name is "Submit"; the visible text is "Save." Voice-control users say "click Save" and it doesn't work. Always: visible text matches accessible name.
+
+### Missing labels on form controls
+
+Every `<input>`, `<select>`, `<textarea>` needs a programmatically associated `<label>`. `aria-label` is acceptable; `aria-labelledby` referencing visible text is also acceptable. Placeholder-only is not acceptable.
+
+### Duplicate IDs
+
+`aria-labelledby` and `aria-describedby` rely on `id` attribute uniqueness. Duplicate IDs (common with reusable components) break these associations silently.
+
+## Testing for robustness
+
+### Inspect the accessibility tree
+
+Browser DevTools (Chrome, Firefox, Safari) all expose the accessibility tree — the structured representation that assistive tech sees. Key checks:
+
+- Does each interactive element have a non-empty `Name`?
+- Does each interactive element have a meaningful `Role`?
+- Does each stateful element have correct `State` (checked, expanded, pressed, etc.)?
+
+If "name: empty" or "role: generic" appears on an interactive element, the component is invisible to assistive tech.
+
+### Run a screen reader
+
+Test critical flows with VoiceOver (macOS/iOS), NVDA (Windows, free), or TalkBack (Android). Listen for:
+
+- Unlabeled buttons / inputs.
+- Components that don't announce their role.
+- State changes that aren't announced.
+- Garbled reading order.
+
+### Validate HTML
+
+W3C HTML Validator (validator.w3.org) catches:
+
+- Duplicate IDs.
+- Nested interactive elements.
+- Invalid attribute values.
+- Form controls without labels.
+
+These often correlate with accessibility issues.
+
+## Resources
+
+- **WAI-ARIA Authoring Practices Guide** — w3.org/WAI/ARIA/apg.
+- **ARIA in HTML spec** — w3.org/TR/html-aria.
+- **MDN ARIA reference** — developer.mozilla.org/Web/Accessibility/ARIA.
+- **A11y Project** — a11yproject.com.
+- **Inclusive Components** (Heydon Pickering) — inclusive-components.design.
+
+## Closing
+
+Robust accessibility is invisible when it works (assistive tech "just works") and devastating when it fails (the component is unusable). Lean on semantic HTML and well-tested component libraries; reach for raw ARIA only when you must.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-understandable/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-understandable/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: accessibility-understandable
+description: 'Use this skill when the question is whether users can *understand* the UI — predict its behavior, recover from errors, comprehend its labels and copy. Trigger when writing form labels and error messages, when designing flows with surprising state changes, when picking microcopy for the destructive moments, or when reviewing a UI that "works correctly but confuses people." Covers WCAG Principle 3 (Understandable). Sub-aspect of `accessibility`; read that first if you haven''t already.'
+---
+
+# Accessibility — Understandable
+
+WCAG Principle 3: information and the operation of the user interface must be understandable.
+
+The three sub-criteria, simplified:
+
+1. **Readable** — language is identified, jargon is explained, abbreviations are expanded.
+2. **Predictable** — the UI behaves consistently and changes context only when the user expects.
+3. **Input assistance** — labels, instructions, error messages, and prevention of mistakes.
+
+This sub-principle is where accessibility most overlaps with general usability — but the consequences fall hardest on users with cognitive impairments, learning disabilities, low literacy, or unfamiliarity with the language.
+
+## 1. Readable
+
+### Language identified
+
+Set the document language so screen readers pronounce correctly:
+
+```html
+<html lang="en">
+```
+
+For mixed-language content, mark the exception:
+
+```html
+<p>The French word for "dog" is <span lang="fr">chien</span>.</p>
+```
+
+A screen reader switches voice/pronunciation for the marked span.
+
+### Plain language
+
+Write at a reading level appropriate to your audience. For consumer products, that's typically grade 8 or below. Tools (Hemingway Editor, Readable, Microsoft Word's readability stats) measure this.
+
+Practices that improve readability:
+
+- Short sentences (<25 words).
+- Active voice ("Click Save" not "Save can be clicked").
+- Familiar words (use "buy" not "procure").
+- One idea per sentence.
+- Paragraphs ≤ 5 sentences.
+
+### Jargon and abbreviations
+
+If you must use jargon or abbreviations, expand them on first use:
+
+```html
+<p>
+  Single sign-on (<abbr title="Single Sign-On">SSO</abbr>) lets your team
+  use one login across all tools.
+</p>
+```
+
+Screen readers can announce the expansion via `<abbr title>`. Sighted users see the expansion on hover.
+
+For specialized terms, link to a definition or glossary the first time.
+
+### Pronunciation (rare but worth knowing)
+
+For content where pronunciation determines meaning (poetry, languages, certain proper nouns), provide pronunciation hints. Most apps don't need this; mention it for completeness.
+
+## 2. Predictable
+
+### Behavior on focus and input
+
+WCAG 3.2.1 and 3.2.2: changing the value of an input or moving focus to an element should NOT trigger an unexpected context change.
+
+Specifically:
+
+- A `<select>` should not auto-submit a form when a value changes.
+- Focusing an input should not open a popup or navigate.
+- Typing into a search field should not navigate to a result page on every keystroke.
+
+If a context change *is* the intended behavior (typeahead search, live filter), make it expected: label the field as "Search (results filter as you type)," show results below the input, don't yank focus.
+
+```html
+<!-- Wrong: select auto-submits on change -->
+<select onchange="this.form.submit()">
+  <option>Country A</option>
+  <option>Country B</option>
+</select>
+
+<!-- Right: select waits for explicit submit -->
+<select name="country">
+  <option>Country A</option>
+  <option>Country B</option>
+</select>
+<button type="submit">Continue</button>
+```
+
+### Consistent navigation
+
+Same navigation in the same place across pages. The "Help" link in the top-right on page A is in the top-right on page B too. Users (especially those with cognitive impairments or who navigate by spatial memory) rely on this.
+
+If a sub-section needs additional nav, place it in a consistent location (e.g., a left sidebar that always appears in left-sidebar slot).
+
+### Consistent identification
+
+Same component does the same thing across the app. A button labeled "Save" always saves; doesn't sometimes mean "save and close" and sometimes mean "save and continue." If two different actions are needed, two different labels: "Save" and "Save and continue."
+
+Same icon across the app should mean the same thing. A trash icon on one page meaning "delete," another page meaning "filter," is incoherent.
+
+## 3. Input assistance
+
+### Error identification
+
+WCAG 3.3.1: when an error is detected, identify the item in error and describe the error in text.
+
+```html
+<div class="field" data-state="error">
+  <label for="email">Email address</label>
+  <input id="email"
+         type="email"
+         aria-invalid="true"
+         aria-describedby="email-error" />
+  <p id="email-error" class="field-error">
+    <AlertIcon aria-hidden="true" />
+    Please enter a valid email address (e.g., name@example.com).
+  </p>
+</div>
+```
+
+Three things are happening:
+
+- `aria-invalid="true"` flags the input as in error (assistive tech may announce).
+- `aria-describedby` ties the message to the input (screen readers announce both).
+- The message text is specific (says what's wrong) and actionable (offers an example).
+
+### Labels and instructions
+
+Every input has a programmatically associated label. The label is descriptive (not just "Field 1"). If the input requires specific format, instructions are provided alongside.
+
+```html
+<!-- Right: label, format hint, and example -->
+<div class="field">
+  <label for="phone">Phone number</label>
+  <input id="phone"
+         type="tel"
+         aria-describedby="phone-help"
+         placeholder="555-123-4567" />
+  <p id="phone-help" class="field-help">
+    Format: 555-123-4567. We use this only for delivery questions.
+  </p>
+</div>
+```
+
+Notes:
+
+- `placeholder` is *not* a label — it disappears when the user starts typing. Use a real `<label>`.
+- Format hints belong in adjacent text (`aria-describedby`), not just placeholder.
+- Required fields should be marked both visually (asterisk) and programmatically (`required` attribute or `aria-required`).
+
+### Error suggestion
+
+WCAG 3.3.3 (Level AA): when the user makes an input error and the system can suggest a correction, do so.
+
+```html
+<!-- User typed "gmial.com" -->
+<p class="field-error">
+  Did you mean <button type="button" onclick="acceptSuggestion('gmail.com')">name@gmail.com</button>?
+</p>
+```
+
+Don't auto-correct silently — that's a context change without consent. Suggest, let the user accept.
+
+### Error prevention
+
+WCAG 3.3.4 (Level AA, for legal/financial/data submissions): the user must be able to:
+
+- **Reverse** the submission (a "Cancel my order" period), OR
+- **Check** the submission for errors before final commit (a confirmation page), OR
+- **Confirm** explicitly before final commit (a confirm dialog).
+
+For destructive irreversible actions in product UIs (delete account, transfer ownership), this is the strong reason for `AlertDialog` confirmation, type-to-confirm patterns, and 30-day "soft delete" recovery windows.
+
+### Help
+
+WCAG 3.3.5 (Level AAA): context-sensitive help is available. Tooltips, inline help, "What's this?" links.
+
+In product UIs, this lands in:
+
+- `<FieldDescription>` next to inputs that need explanation.
+- `?` icons next to settings whose function isn't obvious.
+- A persistent help link or chat in chrome.
+
+### Consistent help
+
+WCAG 3.2.6 (Level A, 2.2): if help mechanisms are present (contact info, FAQ link, chat widget), they appear in the same location across pages.
+
+## Worked examples
+
+### Example 1: a credit-card form with full input assistance
+
+```html
+<form>
+  <div class="field">
+    <label for="cc-number">Card number</label>
+    <input id="cc-number"
+           type="text"
+           inputmode="numeric"
+           autocomplete="cc-number"
+           aria-describedby="cc-help"
+           required
+           aria-required="true" />
+    <p id="cc-help" class="field-help">
+      16 digits, no spaces or dashes
+    </p>
+  </div>
+
+  <div class="field">
+    <label for="cc-exp">Expiration (MM/YY)</label>
+    <input id="cc-exp"
+           type="text"
+           inputmode="numeric"
+           autocomplete="cc-exp"
+           placeholder="MM/YY"
+           required
+           aria-required="true" />
+  </div>
+
+  <div class="field">
+    <label for="cc-cvc">CVC</label>
+    <input id="cc-cvc"
+           type="text"
+           inputmode="numeric"
+           autocomplete="cc-csc"
+           aria-describedby="cvc-help"
+           required
+           aria-required="true" />
+    <p id="cvc-help" class="field-help">
+      3-digit code on the back of your card (4 on Amex)
+    </p>
+  </div>
+
+  <button type="submit">Review order</button>
+</form>
+```
+
+What's happening:
+
+- Each field has a real label (associated via `for`/`id`).
+- `inputmode="numeric"` prompts the right keyboard on mobile.
+- `autocomplete` attributes let password managers and autofill help.
+- Help text is associated via `aria-describedby`.
+- Required is both visual (probably an asterisk from CSS) and programmatic (`required` + `aria-required`).
+- Submit goes to a "Review order" page (error prevention via review step).
+
+### Example 2: a destructive action with prevention layers
+
+```html
+<button onclick="openDeleteDialog()">Delete account</button>
+
+<!-- Dialog: -->
+<dialog open
+        role="dialog"
+        aria-labelledby="confirm-title"
+        aria-describedby="confirm-desc">
+  <h2 id="confirm-title">Delete your account?</h2>
+  <p id="confirm-desc">
+    This permanently removes your account, all your projects (12), and your
+    team's access (38 members). This cannot be undone.
+  </p>
+  <p>To confirm, type your account email below:</p>
+  <input type="text" placeholder="you@example.com" id="confirm-input" />
+  <button type="button">Cancel</button>
+  <button type="button"
+          class="destructive"
+          disabled
+          id="confirm-button">
+    Delete account permanently
+  </button>
+</dialog>
+```
+
+The user must:
+
+1. Click "Delete account" (intent).
+2. Read the dialog (consequences laid out).
+3. Type their email (active confirmation, error prevention).
+4. Click "Delete account permanently" (final commit).
+
+Each step is a deliberate barrier against accidental destruction.
+
+## Anti-patterns
+
+- **Placeholders as labels.** "Email" in placeholder text only — disappears on type, breaks for screen readers, fails on autofill.
+- **Generic error messages.** "Validation failed." Doesn't say which field, doesn't say what's wrong, doesn't say how to fix.
+- **Surprise context changes.** Selecting an option auto-navigates; typing in a field auto-submits. The user loses control.
+- **Inconsistent labels for the same action.** "Save" here, "Submit" there, "Confirm" elsewhere.
+- **No undo and no confirm for destructive actions.** Click-and-it's-gone with no recovery.
+- **Jargon without explanation.** "API token rotation period" with no hover or link to explain. The technical user knows; the casual user is lost.
+
+## Heuristics
+
+1. **The five-error test.** Trigger 5 different validation errors. Are all of them named, located near the field, and offered a fix?
+2. **The label audit.** Every form input has a `<label>` associated by `for`/`id`. No placeholder-as-label.
+3. **The unexpected-change test.** Walk through a form. Does any change of input value or focus trigger a navigation, popup, or auto-submit? Each is a violation.
+4. **The "stranger" test.** Show your form to someone unfamiliar with your product. Can they tell what each field wants without help text? If not, label or instruction is wrong.
+5. **The grade-level check.** Run your microcopy through a readability tool. Above grade 10 for consumer? Simplify.
+
+## Related skills
+
+- **`accessibility`** (parent).
+- **`accessibility-perceivable`**, **`accessibility-operable`**, **`accessibility-robust`** — siblings.
+- **`errors`** and **`forgiveness`** (interaction) — error UX is shared between accessibility and general interaction design.
+- **`feedback-loop`** (interaction) — feedback that the system received a change is part of predictability.
+- **`framing`** (cognition) — error copy framing affects whether the user feels blamed or helped.
+- **`mental-model`** (cognition) — predictable behavior aligns with the user's model.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-understandable/references/understandable-deep-dive.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility-understandable/references/understandable-deep-dive.md
@@ -1,0 +1,97 @@
+# Understandable: standards and edge cases
+
+A reference complementing `accessibility-understandable` SKILL.md with deeper detail on the WCAG 3.* criteria and harder cases.
+
+## WCAG 3.* criteria summary
+
+The Understandable principle has three guidelines.
+
+### 3.1 Readable
+
+- **3.1.1 Language of Page (A)** — `<html lang="...">`.
+- **3.1.2 Language of Parts (AA)** — language changes within a page marked.
+- **3.1.5 Reading Level (AAA)** — content at lower-secondary reading level or alternative provided.
+
+### 3.2 Predictable
+
+- **3.2.1 On Focus (A)** — receiving focus does not initiate context change.
+- **3.2.2 On Input (A)** — changing input value does not initiate context change.
+- **3.2.3 Consistent Navigation (AA)** — navigation in same order across pages.
+- **3.2.4 Consistent Identification (AA)** — same components identified consistently.
+- **3.2.6 Consistent Help (A, 2.2)** — help mechanisms in same location across pages.
+
+### 3.3 Input assistance
+
+- **3.3.1 Error Identification (A)** — errors identified in text, near the field.
+- **3.3.2 Labels or Instructions (A)** — labels or instructions provided for user input.
+- **3.3.3 Error Suggestion (AA)** — when system can suggest a correction, do so.
+- **3.3.4 Error Prevention (AA)** — for legal/financial/data submissions: reversible, checkable, or confirmed.
+- **3.3.7 Redundant Entry (A, 2.2)** — information user has already entered isn't asked again in the same session.
+- **3.3.8 Accessible Authentication (Minimum) (AA, 2.2)** — authentication doesn't depend on cognitive function tests (memory, transcription, math) without alternative.
+
+## Hard cases
+
+### Cognitive accessibility
+
+WCAG covers cognitive accessibility less comprehensively than visual or motor. Useful supplementary practices:
+
+- **Use plain language.** Aim for grade 8 or below for general consumer content.
+- **Front-load important information.** "Inverted pyramid" structure.
+- **Provide summaries** of long content.
+- **Use icons + text** for non-textual signals.
+- **Avoid jargon, idioms, abbreviations** without expansion.
+- **Predictable layout.** Same things in the same places.
+- **Forgiving interactions.** Undo, soft-delete, recovery from mistakes.
+
+The COGA (Cognitive and Learning Disabilities Accessibility Task Force) at W3C publishes more detailed guidance for cognitive accessibility.
+
+### Authentication
+
+WCAG 3.3.8 (added in 2.2) addresses a long-standing accessibility issue: many authentication mechanisms require cognitive function tests (remember a password, transcribe a code from email/SMS, solve CAPTCHA). These exclude users with cognitive impairments.
+
+Acceptable alternatives:
+
+- Password manager support (proper autocomplete attributes).
+- WebAuthn / passkeys.
+- Biometric authentication.
+- Hardware tokens.
+- Magic links (with care — they require email transcription if not click-through).
+
+Avoid: forced password complexity that requires user-generated mnemonic strategies; CAPTCHAs without alternative challenges; SMS codes that must be typed out.
+
+### Form labels and instructions
+
+WCAG 3.3.2 requires labels or instructions, but the *quality* of labels is largely uncovered by formal criteria. Best practices:
+
+- **Programmatically associate** every input with a label (`<label for="id">` or `aria-labelledby`).
+- **Visible labels** preferred over placeholder-only.
+- **Format expectations** stated near the field ("Phone: format 555-123-4567").
+- **Required marking** uses both visual asterisk and `required`/`aria-required`.
+
+### Error copy
+
+Error messages should be:
+
+- **Located** with the field they reference (`aria-describedby`).
+- **Specific** — say what's wrong, not just "invalid."
+- **Actionable** — say how to fix.
+- **Non-blaming** — frame as system limitation or user-action prompt, not user fault.
+
+Examples:
+
+- ❌ "Email is invalid."
+- ✅ "Please enter an email like name@example.com."
+
+### Predictability and surprise
+
+WCAG 3.2.1 and 3.2.2 prohibit context changes from focus or input change. Examples of violations:
+
+- Selecting a radio button auto-submits the form.
+- Tabbing into an input opens a popover.
+- Typing in a search field navigates to a results page on every keystroke.
+
+If context change *is* the desired behavior, label it ("Search results update as you type") and don't move focus.
+
+## Closing
+
+Understandable accessibility is the most usability-overlapping sub-principle — many of its requirements are good design generally. The accessibility framing makes them obligatory rather than nice-to-have, which is often what gets them prioritized.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: accessibility
+description: 'Use this skill on every design task that produces a user-facing surface. Trigger on every screen, component, prototype, or design review — accessibility isn''t a phase, it''s a property each surface either has or doesn''t. Trigger when the user mentions accessibility, a11y, WCAG, screen readers, keyboard navigation, contrast, motion sensitivity, ARIA, color blindness, "section 508," "EAA," or compliance. Also trigger when the user is *not* asking about accessibility — because most of the highest-impact accessibility decisions are made silently when no one was asking. Routes to sub-aspect skills for the four WCAG sub-principles: perceivable, operable, understandable, robust.'
+---
+
+# Accessibility
+
+Accessibility is the property of a design that lets it be used by the widest plausible range of people, including people with permanent, temporary, and situational impairments. It is not "compliance polish"; it is structural. A design that is bolted on top of an inaccessible foundation will always be partially accessible at best, and the cost to retrofit climbs quickly.
+
+## Definition (in our own words)
+
+A design is accessible to the extent that people can perceive its content, operate its controls, understand what it tells them, and rely on it across the assistive technologies they use. The four verbs — *perceive, operate, understand, robust* — are not arbitrary; they are the four sub-principles of the Web Content Accessibility Guidelines (WCAG), and they cover the full surface area of what can fail when a person who isn't a designer's idealized user encounters a design.
+
+## Origins and research lineage
+
+- **WCAG 1.0 (1999)** was the first formal web accessibility specification, published by the W3C's Web Accessibility Initiative (WAI).
+- **WCAG 2.0 (2008)** introduced the four-principle framework (Perceivable, Operable, Understandable, Robust) that grounds modern web accessibility practice.
+- **WCAG 2.1 (2018)** and **WCAG 2.2 (2023)** added criteria for mobile, low-vision, and cognitive disabilities.
+- **Section 508** (US, 1998 onward) and the **European Accessibility Act** (EAA, full effect 2025) make accessibility a legal requirement for many public-facing software products in their jurisdictions.
+- **Inclusive Design** (Microsoft Inclusive Design Toolkit; the work of Kat Holmes, Susan Goltsman, Annie Jean-Baptiste) reframes accessibility as designing for the spectrum of human diversity rather than for "users with disabilities" as a separate category.
+
+The takeaway: accessibility is a four-decade discipline with established principles, measurable criteria, and increasingly serious legal teeth.
+
+## Why accessibility matters
+
+The business case is often presented as either ethical ("it's the right thing to do") or compliance ("we'll get sued"). Both are real. But the deeper case is that accessibility is **good design that's been measured against the hardest cases**.
+
+The user with a screen reader is the user who needs your label-input pairing to be programmatically associated. *Every* user benefits when it is. The user with low vision is the user who needs your contrast ratio to clear 4.5:1. *Every* user benefits when contrast is good. The user with a motor impairment is the user who needs your hit targets to be 44×44. *Every* user — including users on a phone in motion, in glare, with a cracked screen, or one-handed — benefits.
+
+Accessibility raises the floor for everyone. The disabled user is the canary; if the design works for them, it works under the broader range of conditions everyone occasionally faces.
+
+The numbers in any modern audience:
+
+- ~15% of any population has a long-term disability (WHO).
+- ~8% of men have red-green color blindness; ~0.5% of women.
+- ~25% of adults over 65 have meaningful vision loss.
+- 100% of users will eventually be in some form of degraded condition (sun glare, motion, fatigue, distraction, broken finger).
+
+## When to apply
+
+- **Every design task.** Yes, every one.
+- **Most pointedly: at the start.** Bake accessibility into the design phase rather than retrofit at the end. Retrofitting is 2–10x the cost of building it in.
+- **At every design review.** Add an accessibility check to the review template.
+- **In component design (design system).** Get the primitives right and every consumer of them inherits the accessibility for free.
+
+## When NOT to apply
+
+There is no surface on which accessibility doesn't apply. The relative weight of different criteria varies (a marketing landing page is mostly Perceivable + Operable; a complex form is mostly Operable + Understandable), but no surface is exempt.
+
+## The four sub-principles (WCAG framework)
+
+WCAG organizes accessibility into four categories. Each gets its own sub-aspect skill in this plugin; this section is the overview.
+
+### Perceivable
+
+Users must be able to *perceive* the content via at least one of their senses. The system must not present information in a way that requires a sense the user doesn't have access to.
+
+Decisions in scope:
+
+- **Text alternatives** for images, icons, video, audio.
+- **Color and contrast** between text and background, between meaningful UI elements.
+- **Color is never the only signal** for meaningful information.
+- **Text scaling** without breaking the layout.
+- **Reflow** on small screens or zoomed displays.
+- **Captions and transcripts** for audio/video.
+
+### Operable
+
+Users must be able to *operate* the controls — including users who don't use a mouse or finger. Keyboards, switch devices, voice control, eye-tracking, and screen-reader gestures all need to work.
+
+Decisions in scope:
+
+- **Keyboard reachability** — every interactive element must be focusable and operable with `Tab`, `Enter`, `Space`, `Esc`, and arrow keys as appropriate.
+- **Visible focus indicators** so the user can see where they are.
+- **Skip links** so keyboard users don't tab through 50 nav items to reach content.
+- **No keyboard traps** — focus must always be able to leave a region.
+- **Motion sensitivity** — respect `prefers-reduced-motion`; provide pause/stop for any auto-moving content.
+- **Touch target size** — at least 24×24 px (WCAG 2.5.8 AA); 44×44 strongly preferred.
+- **No timing-out failures** without warning and extension.
+
+### Understandable
+
+Content and behavior should be predictable and recoverable. Error messages explain what went wrong and what to do. Labels describe what they label. Navigation is consistent across pages.
+
+Decisions in scope:
+
+- **Language** declared (`<html lang="en">`) so screen readers pronounce correctly.
+- **Predictable behavior** — components don't change context unexpectedly (e.g., selecting a `<select>` shouldn't auto-submit a form without warning).
+- **Error identification** — when an input is invalid, explain why in text, near the field, with `aria-describedby`.
+- **Labels and instructions** — every input has a label; complex inputs have clear instructions.
+- **Consistent navigation** — same nav in the same place across pages.
+
+### Robust
+
+The markup should work with current and future assistive technologies. Use semantic HTML where possible; use ARIA correctly when you need to extend semantics; never invent UI primitives that strip the accessibility from the underlying elements.
+
+Decisions in scope:
+
+- **Semantic HTML first** — `<button>`, `<a>`, `<nav>`, `<main>`, `<form>`, `<label>`. Use them for what they're for.
+- **ARIA second, only when needed** — `aria-label`, `aria-labelledby`, `aria-describedby`, `role`, `aria-expanded`, `aria-current`. Wrong ARIA is often worse than no ARIA.
+- **Status messages** — use `aria-live="polite"` (or `assertive`) for dynamic content that screen readers should announce (toasts, validation, search results).
+
+## A practical accessibility checklist (for any design)
+
+Run through this for every screen:
+
+```
+PERCEIVABLE
+  [ ] Every image has alt text (or alt="" if decorative).
+  [ ] Every icon-only button has aria-label.
+  [ ] Color contrast ≥ 4.5:1 for body text, ≥ 3:1 for large/UI elements.
+  [ ] Color is never the only signal for status, required fields, or meaning.
+  [ ] Layout survives 200% browser zoom without horizontal scroll.
+  [ ] Page has a single <h1>; heading levels are nested (h1 → h2 → h3), not skipped.
+
+OPERABLE
+  [ ] Every interactive element is keyboard-reachable via Tab.
+  [ ] Visible focus ring on every focusable element (don't outline:none without a replacement).
+  [ ] Esc closes any open overlay (Dialog, Sheet, Popover, Combobox).
+  [ ] Focus is trapped inside open modals; focus returns to the trigger when closed.
+  [ ] Skip-to-main link present, visible on focus.
+  [ ] Touch targets ≥ 44×44 (or ≥ 24×24 with adequate spacing).
+  [ ] prefers-reduced-motion is respected (no critical motion).
+
+UNDERSTANDABLE
+  [ ] Every input has a programmatically associated <label> (or aria-label / aria-labelledby).
+  [ ] Errors are inline, named, and offer a fix.
+  [ ] Form behavior doesn't change context unexpectedly on input change.
+  [ ] Required fields are marked with both a visual indicator and aria-required.
+  [ ] <html lang> is set.
+
+ROBUST
+  [ ] Use <button>, <a>, <input>, etc. for what they're for.
+  [ ] If you need a custom interactive element, give it the right role, tabindex, and keyboard handlers.
+  [ ] Live regions (aria-live) used for dynamic announcements (toast, validation, search).
+  [ ] Screen-reader test with NVDA / VoiceOver / TalkBack on critical flows.
+```
+
+## Worked examples
+
+### Example 1: an icon-only "search" button
+
+**Anti-pattern:**
+
+```html
+<div onclick="search()" style="cursor: pointer;">
+  <SearchIcon />
+</div>
+```
+
+Not focusable, no role, no label, not a button. Screen readers say nothing useful; keyboard users can't reach it.
+
+**Right:**
+
+```html
+<button onclick="search()" aria-label="Search">
+  <SearchIcon aria-hidden="true" />
+</button>
+```
+
+Native `<button>` (focusable, keyboard-operable, has button role). `aria-label` provides the accessible name. The icon is `aria-hidden` because the label already describes the action.
+
+### Example 2: an inline form error
+
+**Anti-pattern:**
+
+```html
+<input type="email" />
+<!-- after submit -->
+<p style="color: red;">Invalid</p>
+```
+
+The error isn't programmatically associated with the input. Screen readers announce the input without the error; sighted users with low vision may not see "Invalid" if it's small or low-contrast.
+
+**Right:**
+
+```html
+<div class="field">
+  <label for="email">Email</label>
+  <input
+    id="email"
+    type="email"
+    aria-invalid="true"
+    aria-describedby="email-error"
+  />
+  <p id="email-error" class="field-error">
+    Please enter a valid email address (e.g., name@example.com).
+  </p>
+</div>
+```
+
+`aria-invalid` flags the input as in error; `aria-describedby` ties the message to the input so screen readers announce both together. The message text is specific and offers a fix.
+
+### Example 3: a dialog (modal)
+
+**Anti-pattern:**
+
+```html
+<div class="modal">
+  <h2>Confirm</h2>
+  <button>OK</button>
+</div>
+```
+
+No role, no labelling, no focus management. Keyboard users can tab out into background content; screen readers don't know it's a dialog.
+
+**Right:**
+
+```html
+<div
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="dialog-title"
+  aria-describedby="dialog-description"
+>
+  <h2 id="dialog-title">Discard changes?</h2>
+  <p id="dialog-description">Your unsaved edits will be lost.</p>
+  <button>Discard</button>
+  <button>Cancel</button>
+</div>
+```
+
+Plus JavaScript that:
+
+- Moves focus into the dialog when it opens (typically the first focusable element, or a "primary" focus target).
+- Traps focus inside while open (Tab cycles through the dialog's focusable elements only).
+- Restores focus to the triggering element when closed.
+- Closes on `Esc`.
+
+Most accessible UI libraries (Radix UI, React Aria, headless component sets, shadcn) handle this automatically. If you build modals from scratch, you must do all of it yourself — this is why the strong recommendation is *don't*.
+
+### Example 4: respecting reduced motion
+
+```css
+.toast { transition: transform 200ms ease-out; }
+
+@media (prefers-reduced-motion: reduce) {
+  .toast { transition: none; }
+}
+```
+
+Or, more globally:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+Users with vestibular disorders, migraine triggers, or motion sensitivity have already told the OS they don't want motion. Honor it.
+
+### Example 5: a status badge that doesn't rely on color alone
+
+**Anti-pattern:**
+
+```html
+<span style="background: red; padding: 2px 6px;"></span>
+<span style="background: green; padding: 2px 6px;"></span>
+```
+
+Color is the only signal. Useless to color-blind users and to anyone in a screenshot or print.
+
+**Right:**
+
+```html
+<span class="badge badge-destructive">
+  <AlertIcon aria-hidden="true" /> Overdue
+</span>
+<span class="badge badge-success">
+  <CheckIcon aria-hidden="true" /> Paid
+</span>
+```
+
+Color, icon, and text together. Each user reads the channel that works for them.
+
+## Anti-patterns
+
+- **Outline-none on focus.** The most common accessibility crime. `:focus { outline: none; }` removes the only visual indicator keyboard users have. If you must restyle the focus ring, *replace* it with a custom one (`:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }`), don't remove it.
+- **Custom-built primitives that strip semantics.** A `<div onclick>` that "looks like a button" but isn't one. Use `<button>`. If you absolutely must use a div, add `role="button"`, `tabindex="0"`, and keyboard handlers — and you'll have rebuilt 80% of what `<button>` already does.
+- **ARIA misuse.** `role="button"` on something that's already a `<button>`. `aria-label` on a `<label>` element. Conflicting `aria-labelledby`. Wrong ARIA is worse than no ARIA — it can mislead screen readers actively.
+- **Color-only required indicators.** Red asterisk with no text "required" or `aria-required`. Color-blind users perceive nothing.
+- **Mouse-only interactions.** Drag-and-drop with no keyboard alternative. Hover-revealed menus with no focus equivalent. Right-click menus with no Shift+F10 access.
+- **The "we'll add accessibility later" plan.** Adding accessibility to a finished product is at best painful and at worst impossible. The right time is the first day of the project.
+- **Treating accessibility as a checklist instead of a property.** A WCAG-compliant page can still be confusing, slow, or hostile. Compliance is a floor, not the goal.
+
+## Heuristics and tools
+
+1. **Keyboard-only test.** Unplug your mouse. Navigate the entire flow. Anything you can't reach, anything you can't operate, anything where focus disappears is a bug.
+2. **Screen-reader test.** Use VoiceOver (macOS, iOS), NVDA (Windows), or TalkBack (Android) to walk a critical flow. Listen for: missing labels, announced as "blank" / "unlabeled," redundant announcements, important state not announced.
+3. **Contrast checker.** Browser DevTools, the WebAIM Contrast Checker, or Stark plugin. Body ≥ 4.5:1, large/UI ≥ 3:1.
+4. **Zoom to 200%.** Test the layout. Reflow on mobile-width breakpoints; no horizontal scroll for body content.
+5. **Color-blind simulators.** Chrome DevTools → Rendering → Emulate vision deficiencies. Or the Sim Daltonism / Color Oracle apps. Status systems that lean on red/green collapse here.
+6. **axe DevTools / WAVE / Lighthouse.** Automated audits catch ~30% of accessibility issues — useful as a floor, not a ceiling. Manual testing finds the rest.
+
+## Trade-offs and warnings
+
+- **Accessibility is not a substitute for usability.** A page can pass every WCAG criterion and still be confusing, slow, or hostile. Compliance is necessary; not sufficient.
+- **Aria-rich is not always better.** Excessive `aria-*` attributes can over-narrate the UI to screen reader users. Use the minimum needed; rely on semantic HTML when possible.
+- **Don't outsource accessibility to a single team.** Designers, engineers, content writers, QA — everyone owns part of it. A central "accessibility champion" can advise; a central "accessibility team" can review; but accountability has to be distributed.
+- **Test with real users.** Disabled users have lived experience that no checklist captures. Periodic testing with disabled participants — including diverse impairments — is the only way to find the issues automated tools miss.
+
+## Related principles
+
+- **`color`** (perception) — color decisions are accessibility decisions; build for both.
+- **`legibility`** and **`readability`** (perception) — typography choices that aid screen-reading also aid sighted users with low vision and cognitive impairments.
+- **`fitts-law`** (interaction) — target size for motor accessibility.
+- **`affordance`** (interaction) — affordance + ARIA = accessible affordance.
+- **`feedback-loop`** (interaction) — feedback loops must be perceivable in any modality.
+- **`error`** and **`forgiveness`** (interaction) — accessible error recovery means errors are *announceable* and *recoverable* by all users.
+
+## Sub-aspect skills
+
+- **`accessibility-perceivable`** — alt text, color/contrast, captions, text scaling.
+- **`accessibility-operable`** — keyboard, focus management, motion, target size.
+- **`accessibility-understandable`** — labels, error copy, predictable behavior.
+- **`accessibility-robust`** — semantic HTML, ARIA, screen-reader compatibility.
+
+## Final note
+
+Accessibility, more than any other principle in this plugin set, is one where doing it well is invisible and doing it badly is sometimes invisible too — until a real user encounters it and quietly leaves. The job of the accessibility-aware designer is to test the things you can't see *yourself* failing on, and to build the structural habits that make accessibility the default rather than the exception. The investment is repaid every day, by users you may never meet.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility/references/wcag-and-resources.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/accessibility/references/wcag-and-resources.md
@@ -1,0 +1,96 @@
+# Accessibility: WCAG, regulations, and resources
+
+A reference complementing the `accessibility` SKILL.md with the legal and standards landscape and a curated resource list.
+
+## The WCAG framework
+
+The Web Content Accessibility Guidelines (WCAG) are published by the W3C's Web Accessibility Initiative (WAI). Versions in active use:
+
+- **WCAG 2.0** (2008) — the foundational version still referenced in many legal contexts.
+- **WCAG 2.1** (2018) — adds mobile, low-vision, and cognitive criteria.
+- **WCAG 2.2** (2023) — adds focus appearance, dragging movements, target-size minimums, accessible authentication.
+- **WCAG 3** (W3C draft) — restructures the framework; not yet a formal recommendation.
+
+Each criterion has three conformance levels:
+
+- **Level A** — basic accessibility; failures here often affect substantial user populations.
+- **Level AA** — the practical legal target in most jurisdictions; most procurement and compliance refers to AA.
+- **Level AAA** — the highest level; not always achievable on every page (some criteria conflict with design needs).
+
+Most products aim for **WCAG 2.1 or 2.2 Level AA** as a practical target.
+
+## Legal landscape (as of writing)
+
+This is not legal advice. The landscape is evolving; consult counsel for specifics.
+
+### United States
+
+- **Americans with Disabilities Act (ADA)** — courts have increasingly held that web sites are "places of public accommodation" subject to ADA. WCAG 2.0/2.1 AA is the de facto standard cited in settlements.
+- **Section 508** (Rehabilitation Act) — applies to federal agencies and federal contractors. Updated to align with WCAG 2.0 AA in 2017.
+- **State laws** vary; California's Unruh Act and similar state statutes have been bases for accessibility lawsuits.
+
+### European Union
+
+- **European Accessibility Act (EAA)** — full effect June 2025. Applies to many consumer products and services. WCAG 2.1 AA is the harmonized standard.
+- **Web Accessibility Directive** — applies to public-sector websites and apps.
+
+### Other jurisdictions
+
+- **Canada** (Accessible Canada Act, AODA in Ontario), **Australia** (DDA), **UK** (Equality Act + PSBAR), **Israel** (IS 5568) — all have similar frameworks targeting WCAG 2.0/2.1 AA.
+
+The trend: more jurisdictions, lower thresholds for litigation, larger settlements. Building accessibly is increasingly a business risk-mitigation, not just an ethical position.
+
+## What automated tools catch
+
+Automated audits (axe-core, WAVE, Lighthouse) catch roughly 30% of accessibility issues — typically:
+
+- Missing alt text.
+- Color contrast failures.
+- Missing form labels.
+- Heading order issues.
+- Some ARIA misuse.
+
+Automated tools *don't* catch:
+
+- Whether alt text is meaningful (just whether it exists).
+- Whether keyboard navigation works for custom components.
+- Whether focus management is correct.
+- Whether copy is understandable.
+- Whether interactions match user mental models.
+- Most issues that come from *behavior*, not *markup*.
+
+Use automated tools as a baseline; manual testing is required for most actual conformance.
+
+## Manual testing
+
+The shortlist:
+
+1. **Keyboard-only walkthrough.** Unplug the mouse; complete every primary task. Find every trap, missing focus, hidden control.
+2. **Screen reader walkthrough.** VoiceOver (macOS/iOS), NVDA (Windows), TalkBack (Android). Listen for unlabeled controls, missing announcements, garbled reading order.
+3. **Zoom to 200% and 400%.** Reflow without horizontal scroll? Hit targets still hittable?
+4. **Color blindness simulation.** Chrome DevTools or OS-level filters.
+5. **High-contrast / dark mode.** Many users rely on these.
+6. **Reduced motion.** Settings → Accessibility → Reduce Motion.
+7. **Real disabled users.** No checklist substitutes for genuine usability testing with disabled participants.
+
+## Resources
+
+- **W3C WAI** — w3.org/WAI. Authoritative source for WCAG, ARIA, and methodology.
+- **WAI-ARIA Authoring Practices Guide** — w3.org/WAI/ARIA/apg. Canonical accessible-component patterns.
+- **WebAIM** — webaim.org. Practitioner-focused training, tools, and articles. Especially good: WAVE evaluator, contrast checker.
+- **The A11y Project** — a11yproject.com. Practical patterns and checklists.
+- **Inclusive Components** (Heydon Pickering) — inclusive-components.design. Component-by-component accessibility deep dives.
+- **Smashing Magazine accessibility section** — many practical articles.
+- **Deque axe** — deque.com/axe. Browser extension and CI tooling.
+- **MDN Web Docs: Accessibility** — developer.mozilla.org/Web/Accessibility. Reference material.
+- **GOV.UK Design System and Service Manual** — design-system.service.gov.uk. Government-grade accessibility patterns.
+
+## Books
+
+- **Horton, S. & Quesenbery, W.** *A Web for Everyone* (2013).
+- **Pickering, H.** *Inclusive Design Patterns* (2016).
+- **Holmes, K.** *Mismatch* (2018).
+
+## Closing
+
+WCAG is necessarily a checklist; accessibility is a practice. Treat WCAG as the floor and inclusive design as the ceiling. The investment in both is repaid in reach, in resilience, and increasingly in regulatory standing.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety-content-stress/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety-content-stress/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: factor-of-safety-content-stress
+description: 'Use this skill when designing UI to survive content extremes — long names, big numbers, multi-line addresses, missing images, internationalized strings, dense data. Trigger when reviewing a design against worst-case content, when bug reports show layouts breaking on real data, or when picking content limits and validation rules. Sub-aspect of `factor-of-safety`; read that first.'
+---
+
+# Designing for content stress
+
+Most designs are tested against ideal sample data: typical-length names, round numbers, well-cropped images, English. Real data is messier. Names span 1 to 100+ characters; numbers span tiny to enormous; images are missing, oversize, or wrong aspect; translations stretch UI strings 30%+. A design that handles only the typical breaks routinely on real users.
+
+## Common content-stress vectors
+
+### Name and identifier length
+
+- **English names**: typically 5–20 characters. Outliers: hyphenated, multi-word, titled — up to 60+.
+- **Other-script names**: Chinese names typically 2–4 characters; Spanish names with multiple surnames can exceed 50; Tamil names can be very long.
+- **Email addresses**: typically 15–35 characters. RFC max: 254.
+- **Account IDs / hashes**: 6–40 characters; users often need to read or copy them.
+
+Design for the worst plausible case; truncate gracefully with tooltips for very long values.
+
+### Numeric magnitudes
+
+- **Currency**: $0.01 to $999,999,999.99 — 13 visible characters at full extreme.
+- **Counts**: 1 to billions; consider abbreviation ("12.4M") for compact display.
+- **Percentages**: -100% to 100% (or beyond for compounded growth).
+- **Time durations**: seconds to years; consider unit-switching display.
+
+A column sized for "$5,000.00" breaks for "$1,234,567.89." Size for the worst case or use abbreviated formats.
+
+### Image content
+
+- **Missing**: image fails to load. Show a placeholder, not broken-image icon.
+- **Wrong aspect**: image doesn't match expected ratio. Crop, fit, or letterbox; choose deliberately.
+- **Oversize**: image is 4MB. Lazy-load, downsample, or progressively load.
+- **Mid-load**: brief moment with no image. Show skeleton or low-res preview.
+
+### Internationalization
+
+- **String length**: German strings are typically 30% longer than English; Russian and French similar; Chinese often 30% shorter.
+- **Bidirectional**: Arabic and Hebrew run right-to-left; mixed LTR/RTL content has its own complexities.
+- **Date / number format**: vary widely (covered in `chunking-numeric-and-otp`).
+- **Pluralization**: English has 2 forms (cat, cats); other languages have up to 6 (Polish, Russian, Welsh).
+
+Design with stretch room; test in worst-case languages (German for length, Arabic for direction).
+
+### Empty states
+
+- **Zero rows in a table**: don't show an empty grid; show an explanation.
+- **Zero items in a list**: show an empty state with guidance.
+- **First-run state**: no data yet; show onboarding.
+
+Empty states are often forgotten until QA. Design them deliberately.
+
+### Long-tail of edge cases
+
+- **Single character of content**: a one-character name or message.
+- **Whitespace-only content**: validate; reject or strip.
+- **Special characters**: Unicode emojis, combining characters, RTL marks; test rendering.
+- **HTML / SQL injection in user content**: sanitize at render time.
+
+## Worked examples
+
+### Example 1: a card layout that absorbs content variation
+
+```html
+<article class="user-card">
+  <div class="avatar">
+    <img src={avatarUrl} alt="" onerror="this.style.display='none'" />
+    <span class="avatar-fallback">{initials}</span>
+  </div>
+  <div class="user-info">
+    <h3 class="name">{name}</h3>
+    <p class="role">{role}</p>
+    <p class="email">{email}</p>
+  </div>
+</article>
+
+<style>
+  .user-card {
+    display: grid;
+    grid-template-columns: 48px 1fr;
+    gap: 12px;
+    padding: 16px;
+    min-height: 80px;       /* margin for multi-line names */
+  }
+  .avatar { position: relative; width: 48px; height: 48px; }
+  .avatar img { width: 100%; height: 100%; object-fit: cover; }
+  .avatar-fallback { /* shown when image fails */ }
+  .user-info { min-width: 0; }   /* allows truncation */
+  .name {
+    overflow-wrap: break-word;
+    hyphens: auto;
+  }
+  .email {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: hsl(0 0% 45%);
+  }
+</style>
+```
+
+The card handles:
+- Missing avatar (falls back to initials).
+- Long name (wraps to 2–3 lines; card grows).
+- Long email (truncates with ellipsis; full visible on hover).
+- Empty role (just doesn't render).
+
+### Example 2: a numeric column sized for the worst case
+
+```html
+<td class="amount">{currency(amount)}</td>
+
+<style>
+  .amount {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    width: 12ch;          /* fits "$9,999,999.99" */
+  }
+</style>
+```
+
+The column width accommodates the maximum-realistic value. Smaller values right-align within it.
+
+### Example 3: handling translation stretch
+
+```html
+<button class="cta">{t('signup.cta')}</button>
+
+<style>
+  .cta {
+    min-width: 120px;
+    padding: 12px 24px;
+    white-space: nowrap;     /* don't wrap; let it grow horizontally */
+  }
+  /* On narrow screens, allow wrap */
+  @media (max-width: 600px) {
+    .cta { white-space: normal; }
+  }
+</style>
+```
+
+The button accommodates German "Kostenlos anmelden" (longer than "Sign up free") without breaking the layout.
+
+### Example 4: empty state for a list
+
+```html
+{items.length > 0
+  ? <ItemList items={items} />
+  : <Empty
+      icon={<InboxIcon />}
+      title="Your inbox is empty"
+      description="When messages arrive, they'll appear here."
+      action={<Button>Compose new message</Button>}
+    />
+}
+```
+
+Designed deliberately, not just "the list happens to be empty."
+
+## Anti-patterns
+
+- **Sample data only.** Designing with "John Smith" and "$50.00." Real users break the layout.
+- **Fixed widths sized for typical.** A 200px name field that truncates 30% of users.
+- **No empty state.** A blank table with no explanation.
+- **No loading state.** A blank screen while data fetches.
+- **No error state.** A blank screen when data fetch fails.
+- **Translation testing only at release.** Translations expanded the UI; many surfaces need rework.
+- **Over-truncation.** Names truncated to 8 characters because "they look messy otherwise." Users can't identify themselves.
+
+## Heuristics
+
+1. **The "stress test page" approach.** Build a page that renders every component with maximum-length and minimum-length content. Screenshot regularly; fix what breaks.
+2. **The "real data" check.** Pull real samples (anonymized) from production and render them in the design. Most layouts surprise.
+3. **The "longest plausible content" estimate.** For each text field, ask: what's the worst case? Design for that.
+4. **The translation audit.** Render in German (long) and Arabic (RTL). What broke?
+
+## Related sub-skills
+
+- **`factor-of-safety`** (parent).
+- **`factor-of-safety-failure-margin`** — capacity and dependency margins.
+- **`chunking-numeric-and-otp`** — numeric formatting decisions.
+- **`accessibility-perceivable`** — content stress is also accessibility (long content for low-vision; missing images for blind users).

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety-content-stress/references/content-stress-test-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety-content-stress/references/content-stress-test-cases.md
@@ -1,0 +1,138 @@
+# Content stress: test-case reference
+
+A reference complementing `factor-of-safety-content-stress` with concrete test cases and worst-case content samples.
+
+## Sample worst-case test data
+
+A reusable test set for stress-testing layouts. Pull these into your test environment and render every component against them.
+
+### Names
+
+```
+Short:    Li
+Typical:  Maria Mendoza
+Long:     Pierre-Auguste Renoir III
+Very long: María-José Esperanza Sánchez de Bermúdez y Fernández
+Multi-script: 田中太郎 (Tanaka Tarō)
+With emoji: 🎉 Maya Chen
+RTL:      محمد عبد الرحمن
+```
+
+### Currency
+
+```
+$0.01
+$1.50
+$1,234.50
+$1,234,567.89
+$999,999,999.99
+-$1,234.50
+€1.234,50  (German format)
+¥1,234,567 (no decimals)
+```
+
+### Email addresses
+
+```
+a@b.co (5 chars)
+maria@acme.com (typical)
+maria.mendoza+filter@long-subdomain.example.com (long)
+verylonglocalpart-with-allowed-special.chars+filter@very.long.subdomain.example.com (near max)
+```
+
+### Multi-line content
+
+```
+Single word: Hello
+Single sentence: This is a typical short message.
+Paragraph: A longer paragraph that wraps to multiple lines and contains enough content
+to exercise text-wrapping behavior in the layout.
+Multi-paragraph: ...
+
+(Add 2-3 paragraphs of placeholder text)
+```
+
+### Numbers (counts and metrics)
+
+```
+0
+1
+12
+1,234
+1,234,567
+1,234,567,890
+12.5%
+-12.5%
++999.9%
+```
+
+### Dates
+
+```
+Today
+Yesterday
+2 hours ago
+Mar 5
+March 5, 2026
+2026-03-05
+2026-03-05 14:32:01 UTC
+```
+
+## Internationalization stress test
+
+Translate UI strings to:
+
+- **German** — typically 30% longer than English; tests horizontal expansion.
+- **Russian** — similar length; Cyrillic alphabet rendering.
+- **Chinese (Simplified)** — typically 30% shorter; vertical baseline differs.
+- **Arabic** — RTL direction; tests bidirectional layout.
+- **Hindi** — Devanagari script; line height is different.
+
+Render each and screenshot. Layouts that depended on English-length assumptions break visibly.
+
+## Image stress test
+
+Test image-handling with:
+
+- **Missing image** (404 / no src). Should fall back gracefully.
+- **Wrong aspect ratio** (a square image in a landscape slot). Crop, fit, or letterbox?
+- **Very large image** (8K resolution). Lazy-load and downsample.
+- **Tiny image** (16×16). Don't upscale unless deliberate.
+- **Animated GIF / video** in a static slot. Should still load.
+
+## Empty and edge states
+
+For every list, table, dashboard, or content area:
+
+- **Empty (zero items)**: deliberate empty-state design.
+- **Single item**: layout should still feel intentional.
+- **Maximum items**: pagination, virtualization, or scrolling kick in.
+- **Loading**: skeleton or spinner.
+- **Error**: explanation + recovery path.
+- **Stale data**: indication of staleness.
+
+## Accessibility stress test
+
+Test with:
+
+- **Browser zoom at 200% and 400%** — does layout reflow?
+- **Reduced motion** — do animations disable correctly?
+- **Forced colors mode** — do critical signals survive?
+- **Screen reader** — does the page narrate sensibly?
+- **Keyboard only** — can you reach everything?
+- **Touch only** — are targets ≥ 44×44?
+
+## Performance stress test
+
+- **Slow network throttling** — Chrome DevTools "Slow 3G."
+- **Slow CPU throttling** — DevTools "6x slowdown."
+- **Cold cache** — first-visit rendering.
+- **Many records** — lists with 1000, 10000 items.
+- **Heavy concurrent operations** — multiple panels loading.
+
+## Resources
+
+- **Storybook** — render every component against every state, including stress states.
+- **Playwright / Cypress** — automate visual regression on stress-test data.
+- **Percy / Chromatic** — visual-diff tools that catch unintended layout changes.
+- **Real user monitoring** — track real-world content distribution to inform what you should design for.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety-failure-margin/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety-failure-margin/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: factor-of-safety-failure-margin
+description: 'Use this skill when planning capacity, redundancy, graceful degradation, or recovery for systems that must keep working under stress — performance budgets, dependency failure handling, retry logic, error budgets, infrastructure capacity. Trigger when scoping infrastructure, designing error-handling architecture, planning for failure modes, or reviewing reliability incidents. Sub-aspect of `factor-of-safety`; read that first.'
+---
+
+# Failure margin: capacity, dependency, and graceful degradation
+
+The complement to content-stress safety: designing the system itself to absorb failures and load spikes without falling over. The discipline is anticipating which way the system might fail and building in margin or fallback.
+
+## Capacity margin
+
+A system designed to handle exactly its current peak load will fail when load grows. Sustainable systems run at meaningful headroom.
+
+### Sizing rule of thumb
+
+- **Steady-state load**: design capacity at 2–3x typical load.
+- **Anticipated peak**: design at 3–5x typical (covers daily/weekly spikes).
+- **Burst capacity**: have ability to scale to 5–10x for marketing, viral events.
+
+Cloud auto-scaling helps but isn't infinite — set explicit upper bounds and rate limits to prevent cost runaways during attacks.
+
+### Headroom warning thresholds
+
+Set monitoring at sub-capacity thresholds:
+
+```
+70% utilization → notify; investigate growth
+85% utilization → page on-call; immediate investigation
+95% utilization → critical; emergency response
+```
+
+Acting at 70% is far cheaper than acting at 100% (when the system has already started failing).
+
+## Dependency margin
+
+Most systems depend on external services: databases, third-party APIs, internal microservices. Each dependency is a potential failure point.
+
+### Strategies
+
+#### Timeouts everywhere
+
+Every external call should have a timeout. Without timeouts, a slow dependency can exhaust your connection pool or thread pool, cascading failure.
+
+```js
+const result = await Promise.race([
+  api.fetchUser(userId),
+  new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('timeout')), 2000)
+  )
+]);
+```
+
+#### Retries with backoff
+
+For transient failures, retry — but with exponential backoff to avoid hammering a struggling dependency.
+
+```js
+async function fetchWithRetry(fn, maxRetries = 3) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxRetries || !isRetryable(error)) throw error;
+      const delay = Math.min(1000 * 2 ** attempt, 10000) + Math.random() * 1000;
+      await sleep(delay);
+    }
+  }
+}
+```
+
+#### Circuit breakers
+
+When a dependency is failing repeatedly, stop trying for a while. Fail fast rather than waiting for timeouts.
+
+#### Caching as a fallback
+
+If the dependency is read-heavy, cache responses. When the dependency is down, serve stale data with a marker.
+
+## Graceful degradation
+
+A system that fails gracefully provides reduced functionality during failures rather than no functionality.
+
+Patterns:
+
+### Degraded UI states
+
+```jsx
+function UserProfile({ userId }) {
+  const { data, error } = useUser(userId);
+  if (error?.transient) {
+    return (
+      <UserProfileSkeleton>
+        <Banner type="warning">
+          Some information couldn't load. Reload to try again.
+        </Banner>
+      </UserProfileSkeleton>
+    );
+  }
+  return <UserProfileFull data={data} />;
+}
+```
+
+The page renders something useful even when the data fetch fails.
+
+### Feature degradation
+
+When the recommendation engine is down, show a generic feed instead of a personalized one. When the search index is down, show recent items instead of search results. The user gets *something*; the broken feature doesn't break the whole product.
+
+### Read vs. write degradation
+
+A common pattern: when the database is overloaded, accept reads but defer writes (queue them for later processing). Users can browse; new content arrives slightly delayed.
+
+## Error budgets (Google SRE)
+
+Service-level objectives (SLOs) define an explicit margin for failure. A 99.9% uptime SLO permits ~43 minutes of downtime per month — the "error budget."
+
+The discipline:
+
+- **When the budget has remaining capacity**: the team can take risks (deploy faster, run experiments, push boundaries).
+- **When the budget is consumed**: the team slows down (no risky deploys, focus on reliability).
+
+This formalizes the trade-off between feature velocity and reliability. Without explicit budgets, teams often default to either pushing too hard (frequent incidents) or being too cautious (slow innovation).
+
+## Worked example: an API call wrapped in three layers of margin
+
+```js
+async function getUserProfile(userId) {
+  // Layer 1: request with timeout and retry
+  const fetchFromAPI = () => withRetry(
+    () => apiClient.get(`/users/${userId}`, { timeout: 2000 }),
+    { maxRetries: 2, backoff: 'exponential' }
+  );
+
+  try {
+    const data = await fetchFromAPI();
+    cache.set(`user:${userId}`, data, { ttl: 60 });  // refresh cache
+    return data;
+  } catch (apiError) {
+    // Layer 2: fall back to cache
+    const cached = await cache.get(`user:${userId}`);
+    if (cached) {
+      logger.warn('API failed; serving cached data', { userId });
+      return { ...cached, _stale: true };
+    }
+    // Layer 3: serve placeholder
+    logger.error('API and cache failed; serving placeholder', { userId });
+    return { id: userId, name: 'Unknown', _placeholder: true };
+  }
+}
+```
+
+Three layers of margin: retry with backoff, cache fallback, placeholder. The user always gets *something*; the system never crashes hard.
+
+## Anti-patterns
+
+- **No timeouts.** A slow dependency exhausts resources; the whole system slows or hangs.
+- **Aggressive retries.** Retrying immediately and infinitely. The struggling dependency gets DDoS'd by your retries.
+- **No circuit breaker.** Continuing to call a dead dependency forever; resources tied up.
+- **All-or-nothing rendering.** If any data fetch fails, render nothing. Users see broken pages.
+- **Capacity at exactly current load.** No margin for growth; the next traffic spike crashes the service.
+- **Removing redundancy as "waste."** Until the redundancy was needed, it looked unused.
+
+## Heuristics
+
+1. **The dependency map.** List every external call. For each, ask: what's the failure mode? What's the user experience when it fails?
+2. **The capacity headroom audit.** What's current peak utilization? Less than 50% headroom is fragile.
+3. **The "what crashes the page?" check.** Disable each dependency in turn. What still renders? What breaks?
+4. **The error-budget review.** If you're using SLOs, regularly review error-budget consumption. Adjust velocity vs. reliability accordingly.
+
+## Related sub-skills
+
+- **`factor-of-safety`** (parent).
+- **`factor-of-safety-content-stress`** — UI margin for content edge cases.
+- **`weakest-link`** — finding the dependency that's most likely to fail.
+- **`forgiveness`** — user-side equivalent of system graceful degradation.
+- **`feedback-loop`** — letting users know when degraded mode is active.
+
+## Resources
+
+- **Google SRE Book** (sre.google) — comprehensive guide to error budgets, SLOs, and reliability practice.
+- **Petroski, H.** *To Engineer Is Human* — engineering perspective on safety factors.
+- **Reason, J.** *Human Error* — system-level failure analysis.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety-failure-margin/references/sre-and-reliability-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety-failure-margin/references/sre-and-reliability-patterns.md
@@ -1,0 +1,162 @@
+# SRE and reliability patterns reference
+
+A reference complementing `factor-of-safety-failure-margin` with the modern site-reliability-engineering vocabulary and patterns.
+
+## Site Reliability Engineering (SRE)
+
+Site Reliability Engineering, formalized at Google and codified in *Site Reliability Engineering* (O'Reilly, 2016), is the modern discipline of running production software at scale. Many of its practices are explicit factor-of-safety thinking applied to software:
+
+### Service-level objectives (SLOs)
+
+A formal target for system reliability:
+
+- **SLO**: 99.9% of requests succeed within 500ms over a rolling 30-day window.
+- **SLI** (indicator): the actual measurement of success/latency.
+- **SLA**: a contractual commitment, typically looser than the SLO, attached to consequences.
+
+The SLO is the safety target. Operating well above the SLO means there's margin for risk-taking; operating at or below the SLO means stop and stabilize.
+
+### Error budgets
+
+The complement of an SLO:
+
+- 99.9% SLO → 0.1% error budget.
+- Translates to ~43 minutes of permitted downtime per month, or ~26 seconds per day.
+
+The team can spend the error budget on risk: faster releases, infrastructure changes, experiments. When the budget is consumed, releases pause; teams focus on reliability work until the budget recovers.
+
+This is explicit safety-factor management: the budget is the margin; operating within it is sustainable; exceeding it triggers protective response.
+
+## Reliability patterns
+
+### Timeouts
+
+Every external call needs a timeout. Without one, a slow dependency can exhaust resources.
+
+```js
+// Good: explicit timeout
+const result = await fetch(url, { signal: AbortSignal.timeout(2000) });
+
+// Bad: no timeout (default may be unbounded)
+const result = await fetch(url);
+```
+
+### Retries with exponential backoff and jitter
+
+For transient failures, retry — but not aggressively. Exponential backoff prevents stampedes; jitter prevents synchronized retries.
+
+```js
+async function withRetry(fn, opts = {}) {
+  const { maxRetries = 3, initialDelay = 100, maxDelay = 10000 } = opts;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt === maxRetries) throw err;
+      const exp = initialDelay * 2 ** attempt;
+      const jitter = Math.random() * exp * 0.5;
+      await sleep(Math.min(exp + jitter, maxDelay));
+    }
+  }
+}
+```
+
+### Circuit breakers
+
+When a dependency is failing, stop calling it for a while. Two common states:
+
+- **Closed**: normal operation; requests pass through.
+- **Open**: dependency is failing; requests fail fast without trying the dependency.
+- **Half-open**: periodically try one request to see if the dependency has recovered.
+
+```js
+class CircuitBreaker {
+  constructor(threshold = 5, timeout = 30_000) {
+    this.failures = 0;
+    this.threshold = threshold;
+    this.timeout = timeout;
+    this.openedAt = null;
+  }
+
+  async call(fn) {
+    if (this.openedAt && Date.now() - this.openedAt < this.timeout) {
+      throw new Error('circuit open');
+    }
+    try {
+      const result = await fn();
+      this.failures = 0;
+      this.openedAt = null;
+      return result;
+    } catch (err) {
+      this.failures++;
+      if (this.failures >= this.threshold) {
+        this.openedAt = Date.now();
+      }
+      throw err;
+    }
+  }
+}
+```
+
+### Bulkheading
+
+Isolating resources so failure in one area doesn't cascade. For example, separate connection pools per dependency so a slow dependency doesn't exhaust the pool used by a fast one.
+
+### Graceful degradation
+
+When something fails, provide reduced functionality rather than no functionality:
+
+- Search service down → show recents.
+- Recommendation engine down → show generic feed.
+- Profile data fetch fails → show placeholder card.
+
+The user gets *something*; the broken feature doesn't break the whole product.
+
+### Canary releases
+
+Deploy a new version to a small percentage of traffic; monitor; expand gradually. Each percentage increase is a safety factor — issues are caught before full rollout.
+
+### Feature flags
+
+Ship code disabled; enable it at runtime per-cohort or per-percentage. Allows fast rollback without code redeploy.
+
+## Capacity planning
+
+### Headroom guidelines
+
+| Utilization | Status | Action |
+|---|---|---|
+| < 50% | Healthy | Normal operation |
+| 50–70% | Watch | Capacity-planning meeting; investigate growth |
+| 70–85% | Warning | Add capacity within days |
+| 85%+ | Critical | Page on-call; immediate capacity addition or load shedding |
+
+Acting at 70% is far cheaper than acting at 100% (when the system has already started failing).
+
+### Load shedding
+
+When the system can't handle the offered load, shed some load explicitly rather than letting everything degrade:
+
+- Reject some requests at the load balancer.
+- Disable heavy features (recommendations, exports).
+- Show a "we're busy, try in a minute" message.
+
+Better than slow degradation that affects all users equally.
+
+## Common failures of failure-margin design
+
+- **No timeouts.** A slow dependency exhausts thread pools or connection pools; the whole service slows or hangs.
+- **Aggressive retries.** Retrying immediately and infinitely. The struggling dependency gets DDoS'd by your retries.
+- **No circuit breaker.** Continuing to call a dead dependency forever; resources tied up.
+- **All-or-nothing rendering.** If any data fetch fails, render nothing. Users see broken pages.
+- **Capacity at exactly current load.** No margin for growth; the next traffic spike crashes.
+- **Removing redundancy as "waste."** Until needed, it looked unused. Then a single failure cascades.
+- **Optimizing without monitoring.** Cutting margin without instrumentation to detect when it was needed.
+
+## Resources
+
+- **Beyer, B. et al. (eds.)** *Site Reliability Engineering* (O'Reilly, 2016). Canonical SRE book.
+- **Beyer, B. et al. (eds.)** *The Site Reliability Workbook* (O'Reilly, 2018). Practical SRE patterns.
+- **Nygard, M.** *Release It!* (2007, 2nd ed. 2018). Reliability patterns for production software.
+- **Allspaw, J.** *The Art of Capacity Planning* (2008).
+- **Adam Shostack and Andy Ozment writings** on threat modeling and security margin.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: factor-of-safety
+description: 'Use this skill whenever the design will encounter conditions that can''t be fully predicted at design time — load spikes, edge-case content, real-world variability, hardware variation, third-party flakiness, or any "what if" scenario. Trigger when scoping performance budgets, designing for content extremes, picking infrastructure capacity, designing error-handling, or planning for the long tail of users with unusual setups. Factor of Safety is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) — also called "factor of ignorance" because the size of the safety factor is proportional to how much you *don''t* know.'
+---
+
+# Factor of Safety
+
+Factor of Safety is the engineering practice of designing systems with capacity exceeding what's strictly required, to absorb unknown variations and prevent failure. A bridge rated for 5,000 lbs is built to hold 25,000 — a safety factor of 5. The "extra" capacity isn't waste; it's insurance against the things you didn't predict: corrosion, fatigue, unusual load combinations, materials that didn't quite meet spec.
+
+For software design, the same logic applies: design with margin in performance, capacity, content handling, error tolerance, and edge cases. The unpredicted always shows up; the question is whether the system absorbs it gracefully or fails loudly.
+
+## Definition (in our own words)
+
+A factor of safety is the ratio of a system's actual capacity to the capacity it was designed to handle under normal use. The size of the factor depends on how much you don't know about the conditions the system will face — the more uncertainty, the larger the factor needs to be. The book's alternative name, "factor of ignorance," is illuminating: a well-understood, well-tested system can have a small safety factor; a novel system facing unknown conditions needs a large one.
+
+## Origins and research lineage
+
+- **Engineering safety practice** going back centuries. The Pyramids of Giza, by some analyses, were over-engineered with safety factors of 20+ — the builders couldn't predict load conditions over millennia, so they built radically conservatively.
+- **Henry Petroski**, *To Engineer Is Human: The Role of Failure in Successful Design* (St. Martin's Press, 1985) and *Design Paradigms: Case Histories of Error and Judgment in Engineering* (Cambridge University Press, 1994). Petroski's central thesis: engineering progresses by understanding past failures, and safety factors are the explicit acknowledgment that the next failure will look like something not yet seen.
+- **Lidwell, Holden & Butler** (2003) compactly stated the principle and noted the inverse relationship between safety-factor size and design knowledge. The book's central case: the Challenger O-rings, designed for a safety factor of 3 in past launches but well below 3 at low temperatures.
+- **Modern reliability engineering** (Jens Rasmussen, Charles Perrow's *Normal Accidents*, James Reason's work on system failure) extends the idea to complex systems where multiple small margins compound into total system safety.
+- **Software practice** — capacity planning, redundancy, error budgets (Google SRE), graceful degradation — all are factor-of-safety in software vocabulary.
+
+## Why factor of safety matters
+
+Every system designed at exactly its expected load will fail when it encounters more. Real systems always encounter more — through use you didn't predict, through growth, through abuse, through the long tail of edge cases. A system without margin fails loudly when conditions change; a system with margin absorbs the change gracefully and continues operating.
+
+The cost of insufficient margin is well-documented:
+
+- **Performance**: a system sized for 1,000 users that hits 1,500 users degrades or crashes.
+- **Content**: a layout sized for 50-character names breaks when a user has a 90-character name.
+- **Network**: an API designed assuming 99.9% uptime fails when its dependency drops to 98%.
+- **Hardware**: a UI designed for 1080p screens looks broken on 4K and on small mobile.
+- **Cognitive**: a tool designed for the typical user fails for the user with motor impairment, low vision, or unfamiliarity.
+
+The cost of *too much* margin is real too — over-engineering wastes resources, slows development, and can make systems harder to maintain. The discipline is calibrating margin to the actual uncertainty.
+
+## When to apply
+
+- **Performance and capacity planning.** Systems should run at meaningful headroom over typical load.
+- **Content handling.** Layouts must survive content that exceeds typical bounds — long names, big numbers, multi-line addresses, no images.
+- **Error tolerance.** Systems should fail gracefully on unexpected input rather than crashing.
+- **Network and dependency reliability.** Systems should degrade gracefully when dependencies are slow or down.
+- **Hardware variation.** UIs should work across device sizes, pixel densities, and input modalities.
+- **Accessibility.** Designs should accommodate users at the edges of typical capability ranges.
+- **Anywhere "we've never seen that before" is plausible.**
+
+## When NOT to over-apply
+
+- **Premature optimization.** Building 100x capacity when current load is 1x ties up resources better spent on other priorities.
+- **Speculative redundancy.** Multiple redundant systems for failure modes that have never occurred and aren't credible.
+- **Defensive code obscuring intent.** Wrapping every operation in try/catch with no error-handling strategy. Doesn't help; obscures.
+
+The right margin is enough to handle the credible unknown — not infinite.
+
+## How to size the safety factor
+
+The book's insight: the safety factor should track the level of *ignorance* about the design parameters.
+
+- **Well-understood, well-tested system**: safety factor of 1.5–2x typical load.
+- **Moderately understood, some unknowns**: 2–4x.
+- **Novel system, significant unknowns**: 4–10x or more.
+- **Catastrophic-failure systems with severe consequence**: even higher.
+
+Typical safety factors in different engineering domains:
+
+- Steel structures: 2–3x.
+- Wood structures: 4–6x (more variable material).
+- Aircraft: 1.5x (highly engineered, weight-constrained — but with extensive other safety mechanisms).
+- Software capacity: highly variable, often 2–5x of expected peak load.
+- UI content: typically design for 1.5–2x the typical content length.
+
+## Worked examples
+
+### Example 1: layout that survives content extremes
+
+A user-card layout designed only for short names breaks for the user named "María-José Esperanza Sánchez de Bermúdez."
+
+```css
+/* Without margin */
+.user-name {
+  width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+/* Long names disappear into ellipsis silently */
+
+/* With margin */
+.user-name {
+  max-width: 100%;
+  overflow-wrap: break-word;
+  hyphens: auto;
+}
+.user-card {
+  min-height: 80px;  /* accommodates 1-3 lines */
+}
+```
+
+The "with margin" version handles names from 5 to 90 characters; the layout grows gracefully.
+
+### Example 2: API capacity planning
+
+An API expected to handle 100 requests/second is designed with capacity for 500 rps. Reasoning:
+
+- Marketing campaigns, viral growth, or app launches can spike traffic 5–10x.
+- Slow database queries can multiply effective load.
+- One client misbehaving can saturate the API for everyone.
+
+The 5x margin handles common spikes; auto-scaling handles sustained growth beyond.
+
+### Example 3: graceful degradation when a dependency fails
+
+```js
+async function fetchUserData(userId) {
+  try {
+    return await api.fetchUser(userId, { timeout: 2000 });
+  } catch (error) {
+    // Graceful degradation: return cached data if available
+    const cached = await cache.get(`user:${userId}`);
+    if (cached) {
+      logger.warn('Using cached user data due to API failure', { userId, error });
+      return { ...cached, _stale: true };
+    }
+    // Last resort: return minimal data so UI can render something
+    return { id: userId, name: 'Unknown', _placeholder: true };
+  }
+}
+```
+
+Three levels of margin: try the API; fall back to cache; fall back to placeholder. The UI never gets a hard crash from a transient failure.
+
+### Example 4: form input that handles edge cases
+
+```html
+<input
+  type="email"
+  name="email"
+  maxlength="254"      <!-- RFC 5321 maximum email length -->
+  autocomplete="email"
+  spellcheck="false"
+  inputmode="email"
+/>
+```
+
+```js
+// Validate beyond max-length
+function isValidEmail(value) {
+  if (!value || value.length > 254) return false;
+  if (!value.includes('@')) return false;
+  // ... more validation
+  return true;
+}
+```
+
+The `maxlength="254"` is a margin: most emails are < 30 characters, but the RFC allows up to 254. Designing for 254 absorbs the long tail without breaking.
+
+### Example 5: error budgets (Google SRE)
+
+Google's Site Reliability Engineering practice formalizes safety factors as "error budgets":
+
+- Service-level objective (SLO): 99.9% availability.
+- Error budget: 0.1% — about 43 minutes of downtime per month.
+- Engineering teams can spend the budget on risk: faster releases, infrastructure changes, experimental features.
+
+The error budget is an explicit margin against perfection — and explicit guidance about when to slow down (budget consumed) and when to take risks (budget remaining).
+
+## Cross-domain examples
+
+### Bridges and structures
+
+Civil engineering's canonical safety-factor application. Bridges are designed for loads multiple times what they're rated to carry. Materials, weather, seismic events, and unanticipated use (heavy trucks, large crowds) are absorbed by the margin.
+
+### Aircraft
+
+Aircraft use lower safety factors than buildings (1.5x rather than 5x) because weight matters and materials are highly engineered. The trade-off: extensive testing, redundant systems, and rigorous maintenance compensate for the slimmer margin.
+
+### Medical devices
+
+Pharmaceutical dosing has built-in safety margins: the lethal dose of a drug is typically 10x or more of the therapeutic dose. The "ignorance" factor here is patient variation, drug interactions, and unusual conditions.
+
+### Disaster preparedness
+
+FEMA recommends households maintain 3 days of supplies (food, water, medicine). The 3-day window is a safety factor against typical disaster duration; communities maintain larger margins for less-typical disasters.
+
+### The Challenger disaster (the book's case)
+
+The space shuttle Challenger O-rings were designed with a safety factor of 3 — meaning they could handle 3x the expected stress. In past launches, the actual safety factor (under varying temperatures) had eroded toward 1. On the cold morning of January 28, 1986, the O-rings failed at a temperature where the safety factor was estimated below 1. The decision to launch despite engineering objections cost seven lives.
+
+The case illustrates a common pattern: when systems perform reliably over time, confidence rises and pressure to reduce safety factors (cost, schedule) accumulates. Lowering safety factors based on past success ignores that the past success was *partly* because of the safety factors.
+
+## Anti-patterns
+
+- **Optimizing without margin.** A system tuned to exactly its current load capacity. Any growth or spike crashes.
+- **Removing redundancy as "waste."** Until the redundancy was needed, it looked unused. Then a single failure cascades.
+- **Designing for the typical case only.** Edge cases are encountered routinely; designing only for typical means routinely failing.
+- **Confidence eroding safety factors over time.** Systems that worked reliably get optimized for cost; the safety factor erodes; an unusual event causes failure.
+- **No graceful degradation.** Systems that crash hard on dependency failure, instead of degrading to limited functionality.
+- **Content limits that match typical content.** A name field allowing 30 characters works for most users; the user with a 35-character name has a broken account.
+
+## Heuristics
+
+1. **The "what's the worst case?" audit.** For each design decision, name the worst plausible case (longest content, highest load, lowest device capability). Does the design handle it?
+2. **The "if this dependency fails" check.** For each external dependency, ask: how does the system behave if this dependency fails? If the answer is "the user sees a broken page," add margin.
+3. **The capacity headroom check.** What's the system's actual capacity vs. current peak load? Less than 2x is fragile; 5x+ is comfortable.
+4. **The "we've never seen that before" history.** Look at past incidents. Each one was probably "unprecedented" before it happened. New unprecedented things will happen.
+
+## Related principles
+
+- **`weakest-link`** — safety factors strengthen the chain; finding the weakest link is the first step.
+- **`scaling-fallacy`** — what works at small scale needs more margin at large scale.
+- **`structural-forms`** — the engineering analog: load-bearing patterns that distribute stress.
+- **`forgiveness`** — the user-side complement: designs that absorb user errors, not just system failures.
+- **`iteration`** — iterative testing helps identify where margin is needed.
+- **`uncertainty-principle`** — measurement itself introduces variability that the safety factor must absorb.
+
+## Sub-aspect skills
+
+- **`factor-of-safety-content-stress`** — designing UI to survive content extremes.
+- **`factor-of-safety-failure-margin`** — capacity planning, graceful degradation, redundancy.
+
+## Closing
+
+Factor of Safety is the engineering discipline that acknowledges what designers and builders try to forget: the unknown will arrive. Designs without margin fail loudly when it does; designs with margin absorb it. The cost of the margin is paid up front; the benefit pays out across the system's lifetime, especially in the moments no one anticipated.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety/references/petroski-and-engineering-history.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/factor-of-safety/references/petroski-and-engineering-history.md
@@ -1,0 +1,90 @@
+# Factor of Safety: engineering history and case reference
+
+A reference complementing the `factor-of-safety` SKILL.md with deeper engineering history and case studies.
+
+## Petroski's lineage of failure
+
+Henry Petroski's *To Engineer Is Human* (1985), *Design Paradigms* (1994), and *The Evolution of Useful Things* (1992) form the canonical contemporary reference on engineering failure. Central thesis: every successful engineering design is informed by the failures that preceded it. Safety factors are the explicit acknowledgment that the next failure will look like something not yet seen.
+
+A few of Petroski's case studies, summarized:
+
+### The Tacoma Narrows Bridge (1940)
+
+A suspension bridge that collapsed in moderate winds. Engineers hadn't accounted for aeroelastic flutter — the way wind interacts with a flexible structure. After the collapse, all subsequent suspension bridges incorporated extensive wind-tunnel testing and stiffer designs. The safety factor was effectively *increased* by adding a new dimension (wind dynamics) that hadn't been in the original analysis.
+
+### The Hyatt Regency walkway (1981)
+
+The hotel's suspended walkway collapsed during a tea dance, killing 114 people. The design change during construction (a single rod replaced with two rods) doubled the load on a single connection point — the safety factor was unintentionally cut from ~2 to ~1. Even a "well-engineered" design failed because a structural detail's safety factor was misunderstood by the field engineers who modified it.
+
+### The Challenger O-rings (1986)
+
+The book's central case. The O-rings were rated for a safety factor of 3 in past launches. At low temperatures, that factor eroded toward 1. Engineers warned about the cold morning launch; management overrode the warnings, citing the past safety factor without accounting for the temperature dependence. The shuttle exploded 73 seconds after launch.
+
+The pattern: when systems perform reliably over time, organizational memory loses track of *why* they worked. The safety factor erodes through optimization or modification; the next unusual condition exposes the erosion.
+
+## Safety factors in different engineering domains
+
+| Domain | Typical safety factor | Reasoning |
+|---|---|---|
+| Steel buildings | 2–3 | Well-understood material, predictable loads |
+| Wood structures | 4–6 | Variable material; moisture / insect / fire risk |
+| Aircraft | 1.5 | Weight matters; compensated by extensive testing and redundancy |
+| Pressure vessels | 4 | Catastrophic failure mode |
+| Elevators | 8–12 | Heavily regulated; severe failure consequence |
+| Climbing equipment | 5–10 | Personal safety; impossible to test in field |
+| Software systems | varies; often 2–5x current load | Less regulated; safety factor often informal |
+
+The pattern: higher consequence + more uncertainty → higher safety factor.
+
+## The "factor of ignorance" framing
+
+The book notes that "factor of safety" is sometimes called "factor of ignorance." This framing is illuminating because it reorients the question:
+
+- **"How safe should this be?"** is a values question without a clear answer.
+- **"How much don't we know about this?"** has a defensible answer based on testing, history, and analysis.
+
+The size of the safety factor should track the size of the ignorance. The more you know about how the system will be used, the smaller the factor can be. The more novel or untested the system, the larger.
+
+## Software examples of safety factors
+
+### Performance budgets
+
+Modern web-performance practice sets explicit performance budgets — page load < 2s, FCP < 1s, LCP < 2.5s, etc. These are factors of safety against:
+- Slow networks (rural, mobile, throttled).
+- Slow devices (older hardware, low-end Android).
+- Heavy contemporaneous load on the server.
+
+Designing to the budget at fast/light conditions ensures the user on slow conditions still has acceptable experience.
+
+### Capacity planning
+
+A SaaS app expected to handle 10K concurrent users is provisioned for 30K. Reasoning:
+- Marketing campaigns can spike load.
+- Single client misbehaviors can saturate.
+- Auto-scaling has lag.
+
+The 3x margin handles common spikes; auto-scaling handles sustained growth.
+
+### Error budgets (SRE)
+
+Google's Site Reliability Engineering practice defines explicit allowable downtime (e.g., 0.1% = 43 min/month). This is a safety factor on perfection — explicit acknowledgment that systems will fail and a budget for that failure.
+
+### Code complexity and maintenance
+
+A subtler safety factor: writing code that's easier than necessary so future engineers can modify it without errors. The "extra" simplicity is margin against future ignorance — the engineer modifying the code in two years won't have the original author's context.
+
+## When safety factors get cut
+
+A common pattern across domains: when a system performs reliably for a long time, pressure mounts to reduce its cost. The "wasted" capacity, redundancy, or polish gets trimmed. Each individual cut is justified — the system worked fine without it before. The cumulative effect: the safety factor that protected the system from the unprecedented is gone.
+
+The next unusual event then causes failure — and the post-mortem inevitably recommends restoring the safety factor that had been cut. Until the cycle starts again.
+
+The discipline: explicit documentation of why each safety factor exists, so future cost-cutters understand what they're trading off.
+
+## Resources
+
+- **Petroski, H.** *To Engineer Is Human* (1985); *Design Paradigms* (1994); *The Evolution of Useful Things* (1992).
+- **Perrow, C.** *Normal Accidents: Living with High-Risk Technologies* (1984).
+- **Reason, J.** *Human Error* (1990).
+- **Vaughan, D.** *The Challenger Launch Decision* (1996) — detailed analysis of the Challenger case.
+- **Google SRE Book** (sre.google) — modern software safety-factor practice.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration-design-vs-development/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration-design-vs-development/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: iteration-design-vs-development
+description: 'Use this skill when reviewing where in the project lifecycle iteration is happening — desirable iteration during design vs. costly rework during development. Trigger when a project keeps slipping due to "design changes during build," when scoping how much design work to do before engineering begins, or when retrospectives reveal that issues were caught too late. Sub-aspect of `iteration`; read that first.'
+---
+
+# Design iteration vs. development iteration
+
+The book makes a useful distinction: *design iteration* is the planned cycles that happen during the design phase; *development iteration* is the unplanned rework during build that means design wasn't iterated enough up front. The first is healthy; the second is expensive.
+
+## Why the distinction matters
+
+Cost per iteration cycle rises sharply as the project moves from design to development to deployment:
+
+```
+Sketch / wireframe       1x cost
+Interactive prototype    3-5x
+Coded MVP                10-30x
+Production-shipped       50-200x
+Production-deployed-to-customers  200-1000x
+```
+
+A change discovered during sketch costs a few hours; the same change discovered after deployment to customers can cost weeks of engineering, customer-trust damage, and emergency response.
+
+The principle: do as much iteration as possible at the cheapest fidelities. By the time the design moves to engineering, the fundamental questions should be answered.
+
+## Healthy design iteration
+
+Cycles measured in days to weeks; outputs include:
+
+- Sketches and wireframes
+- Interactive prototypes (Figma, Framer, code prototypes)
+- User interviews and usability tests
+- Design critiques
+- Stakeholder reviews
+- Refined specifications
+
+Each cycle has explicit purpose and known criteria for completion.
+
+## Costly development iteration
+
+Symptoms:
+
+- "We need to refactor that whole module — turns out the design didn't work."
+- "Engineering says they can't build it as designed."
+- "We discovered a fundamental issue in QA."
+- "We shipped, users complained, we're rolling back."
+
+Each is evidence that design iteration didn't catch what it should have.
+
+## Causes of excess development iteration
+
+- **Insufficient design iteration.** Skipping prototyping; rushing past user testing.
+- **Engineering-design isolation.** Designers and engineers don't talk during design; engineering discovers issues during build.
+- **Untested assumptions.** "I think users will want X" untested until users encounter X in production.
+- **Premature high fidelity.** Polishing pixels before structure is right. The pixels then have to be re-done.
+- **Spec-and-throw.** Designers spec without engineering input; engineering builds; result doesn't match the spec's intent.
+
+## Reducing development iteration
+
+### Bring engineering into design earlier
+
+Pair designers with engineers during early design phases. Engineers see implementation issues that designers miss; designers see UX issues that engineers miss. Catching either early is cheap.
+
+### Prototype with the same primitives as production
+
+A Figma prototype is fast but doesn't reveal performance issues, accessibility issues, or implementation complexity. A code prototype using your actual component library reveals those issues at the design phase, when they're cheap.
+
+### Test with users at low fidelity
+
+Paper prototypes and clickable wireframes catch most fundamental issues. The fancier the prototype, the more users react to the prototype's polish rather than its structure.
+
+### Define "done with design" criteria
+
+Don't move to development until specific questions are answered. "Users can complete the core task in the prototype" is a clearer gate than "design looks good."
+
+### Maintain feedback channels during build
+
+Engineers building the design should be able to flag issues quickly to designers. Async tools (Slack, design-review channels, weekly syncs) preserve this without slowing engineering.
+
+## When development iteration is unavoidable
+
+Some projects unavoidably need development iteration:
+
+- **Performance-discovered issues** (the design is correct but real data revealed scale problems).
+- **Cross-browser bugs** (the design is correct but rendering differs).
+- **Accessibility findings during audit.**
+- **Stakeholder feedback after seeing the build.**
+
+For these, the goal isn't zero development iteration; it's *minimizing* it. A well-designed project has few surprises during build.
+
+## Worked example: a feature that went well
+
+A team designs a new dashboard:
+
+- **Week 1**: sketches, structural review.
+- **Week 2**: clickable Figma prototype, 5 user interviews. Surfaces that one widget is misunderstood; redesign.
+- **Week 3**: refined prototype, engineering pairing session. Engineers identify a data-fetching constraint; design adapts.
+- **Week 4**: design handoff with documented edge cases.
+- **Week 5–6**: engineering build. Two minor design tweaks during build (acceptable rework).
+- **Week 7**: ship. Beta cohort happy.
+
+The 4 weeks of design iteration prevented what would have been 4–8 weeks of development rework if the team had skipped to engineering.
+
+## Worked example: a project that went poorly
+
+The same team rushes a feature:
+
+- **Week 1**: high-fidelity Figma mockup of the "final design."
+- **Week 2–4**: engineering build.
+- **Week 5**: QA finds the user can't complete the core task. Major redesign.
+- **Week 6–10**: rebuild. Ships.
+- **Week 11**: users report it's confusing. Patch ships.
+- **Week 12+**: ongoing churn.
+
+The "saved" 3 weeks of design iteration cost 8+ weeks of development iteration plus user-trust damage.
+
+## Heuristics
+
+1. **The "where did we discover this issue?" retrospective.** After each project, list the issues that were discovered. For each, ask where it could have been caught cheaply. Patterns emerge.
+2. **The fidelity-vs-question check.** For each design decision, ask: what's the cheapest prototype that answers this? Use that.
+3. **The engineering-pairing audit.** Across recent projects, was engineering involved during design? Projects where they weren't usually had more development iteration.
+
+## Related sub-skills
+
+- **`iteration`** (parent).
+- **`iteration-prototype-fidelity`** — picking the right fidelity for each cycle.
+- **`prototyping`** — the technique that enables design iteration.
+- **`weakest-link`** — early iteration finds the weakest link cheaply.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration-design-vs-development/references/cost-of-late-change.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration-design-vs-development/references/cost-of-late-change.md
@@ -1,0 +1,56 @@
+# The cost of late change: reference
+
+A reference complementing `iteration-design-vs-development` with the empirical basis for "shift left" thinking.
+
+## Boehm's cost-of-change curve
+
+Barry Boehm's research (1981, refined since) showed that the cost to fix a defect rises by orders of magnitude across the project lifecycle:
+
+| Phase | Relative cost |
+|---|---|
+| Requirements | 1x |
+| Design | 5x |
+| Coding | 10x |
+| Testing | 50x |
+| Production | 100–500x+ |
+
+The numbers vary across studies but the shape is consistent: defects discovered early are dramatically cheaper to fix than defects discovered late.
+
+The implication: invest in early activities (requirements, design, prototyping, review) to push defects "left" on the curve.
+
+## Why early defects are cheaper
+
+- **Less work depends on the defective decision.** A change in requirements affects no code; a change in design affects the spec but no code; a change in code affects only that module; a change after deployment affects users and dependent systems.
+- **The team's mental model is fresh.** Refactoring code you wrote last week is easier than refactoring code you wrote two years ago.
+- **Fewer external dependencies.** Once an API is exposed, partners depend on it; changes have ripple effects.
+- **Lower stakes.** A prototype's "bug" is an exploratory finding; a production bug affects revenue and trust.
+
+## Modern variations
+
+The shift-left philosophy has produced specific practices:
+
+- **Test-driven development** — write tests before code; defects in test design surface before defects in code.
+- **Property-based testing** — generate random inputs to find edge cases at the test phase.
+- **Static analysis / linting** — catch defects at edit time, before commit.
+- **Code review** — catch defects before merge.
+- **Pre-deployment canary releases** — catch defects in a small percentage of production before full rollout.
+
+Each shifts defect discovery earlier on the curve.
+
+## When development iteration is unavoidable
+
+Some defects can only be found after real-world deployment:
+
+- **Performance issues at scale.**
+- **Cross-browser / cross-device rendering bugs.**
+- **Race conditions and timing issues.**
+- **User behaviors no one predicted.**
+
+The goal isn't zero late-stage defects; it's *minimizing* them. A well-designed project has few surprises during build because design iteration was thorough.
+
+## Resources
+
+- **Boehm, B.** *Software Engineering Economics* (1981).
+- **McConnell, S.** *Code Complete* (1993, 2nd ed. 2004).
+- **Brooks, F. P.** *The Mythical Man-Month* (1975, 1995).
+- **Atlassian / GitHub engineering blogs** — modern shift-left practices in CI/CD.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration-prototype-fidelity/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration-prototype-fidelity/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: iteration-prototype-fidelity
+description: 'Use this skill when picking the appropriate prototype fidelity for an iteration cycle — sketches vs. wireframes vs. clickable Figma vs. code prototypes vs. production beta. Trigger when planning a research session, when a project is over- or under-investing in prototypes, or when the prototype fidelity is mismatched to the question being asked. Sub-aspect of `iteration`; read that first.'
+---
+
+# Picking the right prototype fidelity
+
+Each prototype fidelity is a tool with a cost and a use. Sketches are nearly free but answer only structural questions. Code prototypes cost more but answer performance and behavior questions. The discipline is matching fidelity to the question being asked — not always going lowest, not always going highest.
+
+## The fidelity ladder
+
+From cheapest to most expensive:
+
+### 1. Paper sketches
+
+A pen and paper. Cost: 5–30 minutes per option. Answers:
+
+- Does this layout structure make sense?
+- Are the right elements present?
+- What's the rough information architecture?
+
+Doesn't answer:
+
+- How does it feel to interact with this?
+- Does the typography work?
+- Are colors right?
+
+When to stop here: structural questions only; very early discovery.
+
+### 2. Wireframes (low-fidelity digital)
+
+Boxy, monochrome, no real content. Cost: 1–4 hours per screen. Answers:
+
+- Layout proportions on screen.
+- Reading order and hierarchy.
+- Information grouping.
+
+Doesn't answer:
+
+- Visual style.
+- Interaction feel.
+- Real-content edge cases.
+
+When to stop here: when structure is the question; before visual design begins.
+
+### 3. Mockups (high-fidelity static)
+
+Real fonts, colors, content; static image. Cost: 4–16 hours per screen. Answers:
+
+- Visual style.
+- Polish and brand fit.
+- Stakeholder alignment ("does this look right?").
+
+Doesn't answer:
+
+- Interaction.
+- Edge cases.
+- Performance.
+
+Common misuse: building high-fidelity mockups before structure is settled. The mockups become anchors that prevent structural changes.
+
+### 4. Clickable prototypes (Figma, Framer, ProtoPie)
+
+Mockups linked together with click-throughs. Cost: 1–3 days per major flow. Answers:
+
+- Does the interaction sequence make sense?
+- Where do users get confused?
+- Are the affordances clear?
+
+Doesn't answer:
+
+- Real-content edge cases.
+- Performance.
+- Cross-device behavior.
+
+Sweet spot for most user research; cheap enough to revise, real enough to test.
+
+### 5. Code prototypes
+
+Working code with real or seeded data, but not production-ready. Cost: 1–3 weeks. Answers:
+
+- Performance.
+- Cross-device behavior.
+- Real-data edge cases.
+- Implementation complexity.
+
+Doesn't answer:
+
+- Long-term scale issues.
+- Production reliability.
+
+Useful when implementation has unknowns or when performance is a concern.
+
+### 6. Production beta
+
+Shipped to a small percentage of real users. Cost: high (full implementation). Answers:
+
+- Real usage at scale.
+- Bug rates.
+- Long-term retention.
+- Real edge cases.
+
+Doesn't answer (well):
+
+- Counterfactual: would users have liked the alternative more?
+
+When to use: late-stage validation; gradual rollout.
+
+## Picking the right fidelity for each question
+
+A useful rule: pick the **cheapest fidelity that answers the question**.
+
+| Question | Recommended fidelity |
+|---|---|
+| Does the IA make sense? | Sketches or wireframes |
+| Is the visual style right? | High-fidelity mockup |
+| Does the flow work for users? | Clickable prototype + 5 interviews |
+| Will the load time be acceptable? | Code prototype with seeded data |
+| Will users adopt it? | Production beta with measurement |
+
+Going higher than needed wastes time. Going lower means you don't get the answer.
+
+## When to stay low fidelity longer
+
+Counterintuitively, low fidelity is often better for user research:
+
+- **Users critique the prototype's polish, not its structure.** A high-fidelity mockup gets feedback like "I don't love this blue" instead of "I don't understand what this page is for." The polish distracts.
+- **Low fidelity invites criticism.** Users feel comfortable suggesting changes to a sketch; they hesitate to challenge a polished mockup.
+- **Low fidelity is faster to revise.** You can make 5 sketch variations in the time it takes to make 1 mockup variation.
+
+For early-stage user research, sketches and wireframes often outperform high-fidelity prototypes despite "feeling unprofessional."
+
+## When to go high fidelity earlier
+
+A few cases where polish matters:
+
+- **Stakeholder buy-in.** Some stakeholders only react meaningfully to high-fidelity mockups. Build them for those reviews.
+- **Brand-perception research.** Testing whether a design feels like the brand requires polish.
+- **Competitive comparison.** Comparing your design's appeal to a competitor's polished product needs comparable polish.
+
+## Anti-patterns
+
+- **Pixel-perfect early.** Polishing visual details before structure is settled. The pixels then have to be redone.
+- **Test with the prototype that was easy to build.** Using a Figma prototype to test load-time performance, or a code prototype to test layout structure. Wrong fidelity for the question.
+- **Skip prototyping entirely.** "We're agile, we'll just build it." Then iterate expensively in production.
+- **Production-quality prototypes.** Building prototypes to production code quality. Defeats the cost advantage of prototyping.
+- **Treating prototypes as products.** Shipping a prototype as the product because it "works." Usually missing edge cases, accessibility, performance.
+
+## Worked example: layered prototyping for a new feature
+
+A team designs a new collaboration feature.
+
+- **Week 1**: paper sketches; internal review. Decide structural concept.
+- **Week 2**: wireframes; design crit. Refine information architecture.
+- **Week 3**: clickable Figma prototype; 5 user interviews. Discover one critical flow is confusing; redesign.
+- **Week 4**: refined Figma prototype; 5 more interviews. Confirm the redesign works.
+- **Week 5–6**: code prototype with real data. Surface a performance issue; design adapts.
+- **Week 7–10**: production build. Ship to 10% beta.
+- **Week 11–12**: full release.
+
+Each cycle uses the cheapest fidelity that answers the cycle's question.
+
+## Heuristics
+
+1. **The "what question is this prototype answering?" check.** Before building the prototype, name the question. Pick the fidelity that answers it.
+2. **The "could a sketch have caught this?" retrospective.** When issues are discovered late, ask whether earlier prototyping at lower fidelity would have caught them.
+3. **The user-reaction signal.** If users critique your prototype's visual polish, you're at too high fidelity for the question. Drop down.
+
+## Related sub-skills
+
+- **`iteration`** (parent).
+- **`iteration-design-vs-development`** — moving up the fidelity ladder is part of moving from design to development.
+- **`prototyping`** — the broader technique.
+- **`factor-of-safety`** — prototypes are a form of designing-with-margin.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration-prototype-fidelity/references/prototyping-tools-and-research.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration-prototype-fidelity/references/prototyping-tools-and-research.md
@@ -1,0 +1,73 @@
+# Prototyping tools and research findings
+
+A reference complementing `iteration-prototype-fidelity` with practical tools and research on prototype effectiveness.
+
+## Prototyping tools by fidelity
+
+### Paper / sketching
+
+- **Paper, pencil, sticky notes** — the original. Cheap, infinitely revisable.
+- **Whiteboards** — collaborative; great for early co-design.
+
+### Wireframes (low-fidelity digital)
+
+- **Balsamiq** — explicitly low-fidelity look; discourages detail polish.
+- **Figma / Sketch / Adobe XD** — can do low-fi; risk is creep toward higher fidelity.
+
+### Mockups (high-fidelity static)
+
+- **Figma** — current industry standard.
+- **Sketch** — Mac-only; declining share but still used.
+- **Adobe XD** — Adobe's tool; less popular than Figma.
+
+### Clickable prototypes
+
+- **Figma prototyping** — built-in.
+- **Framer** — more sophisticated interactions and animations.
+- **ProtoPie** — high-fidelity interactions including device sensors.
+- **InVision** — declining but still in use at large enterprises.
+
+### Code prototypes
+
+- **HTML / CSS / JS** with sample data — closest to production.
+- **React / Vue / Svelte** — with the actual component library.
+- **Vercel / Netlify** — quick deploy of prototypes for sharing.
+- **Storybook** — component-level prototyping.
+
+## Research on prototype-fidelity effects
+
+Multiple studies (Wong 1992; Walker, Takayama, Landay 2002) have compared user-research outcomes across prototype fidelities:
+
+- **Low-fidelity prototypes** elicit more structural and functional feedback ("I don't see how to do X") and less surface feedback.
+- **High-fidelity prototypes** elicit more surface feedback ("I don't like the color") and less structural challenge.
+- **Mixed-fidelity** can be the worst: users react to the polished parts as polished and the rough parts as unfinished.
+
+The practical implication: pick a consistent fidelity per study; if you want structural feedback, stay low.
+
+## Common prototype-fidelity mistakes
+
+- **Polishing too early.** Spending hours on visual design before structure is settled. The polish has to be redone.
+- **Pretending production prototypes are throwaway.** Building something at production fidelity, calling it a prototype. Eventually it becomes the actual product despite never being designed for production reliability.
+- **Skipping clickable prototypes.** Going straight from static mockup to code. Misses the interaction-feel feedback that clickables provide.
+- **Over-investing in interaction fidelity.** Spending a week perfecting micro-animations in a prototype that will be redone in code. The animations should be specced separately.
+
+## Worked example: an effective prototype escalation
+
+A team designs a new chat feature.
+
+1. **Day 1**: paper sketches; team agrees on structure.
+2. **Day 2**: Balsamiq wireframes; design crit.
+3. **Day 3-4**: Figma mockup of one critical screen; visual style review.
+4. **Week 2**: Figma clickable prototype of full flow; 5 user interviews.
+5. **Week 3**: refined prototype; 5 more interviews.
+6. **Week 4-5**: code prototype with real backend; performance check.
+7. **Week 6+**: production build.
+
+Each stage uses the cheapest fidelity that answers the cycle's question. The final code build is informed by 5 weeks of iteration but only requires production-quality work for the last 2 weeks.
+
+## Resources
+
+- **Walker, M., Takayama, L., Landay, J.** "High-Fidelity or Low-Fidelity, Paper or Computer?" (2002).
+- **Snyder, C.** *Paper Prototyping* (2003).
+- **Warfel, T.** *Prototyping: A Practitioner's Guide* (2009).
+- **NN/g** — articles on prototyping methodology.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: iteration
+description: 'Use this skill whenever the question is *how* to develop a design — through one big push or through repeated cycles of build, test, learn, refine. Trigger when planning a design process, scoping an MVP, deciding between waterfall and iterative delivery, planning research cadence, or reviewing why a project drifted from its original vision. Iteration is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) — and one of the most-violated by teams that try to ship "perfect" first versions.'
+---
+
+# Iteration
+
+Iteration is the practice of repeatedly cycling through design, build, test, and refine — using each cycle's output to inform the next. The core insight: design problems rarely yield to single passes of careful planning. They yield to cycles, where each pass uncovers issues invisible to the prior pass. The teams that internalize iteration consistently outperform those that try to plan the perfect solution up front.
+
+## Definition (in our own words)
+
+A design that emerges through iteration is built by repeating a small set of operations: design something; build a version of it; test it (with users, with data, with a critical eye); learn what worked and what didn't; refine; design the next version. Each cycle reveals problems that couldn't be predicted from the inside of the previous cycle. The total work to reach a good design through iteration is usually less than the work to reach the same quality through up-front planning, because iteration converges on what users actually need rather than what you predicted they would need.
+
+## Origins and research lineage
+
+- **Lidwell, Holden & Butler** (2003) distinguished two types of iteration: *design iteration* (the planned, expected refinement during the design phase) and *development iteration* (the unplanned, costly rework during build that indicates inadequate design). The first is good; the second is a failure of the first.
+- **Henry Petroski**, *The Evolution of Useful Things* (Knopf, 1992) and *To Engineer Is Human* (St. Martin's, 1985). Petroski's central thesis: useful objects evolve through accumulated failure and refinement, not through a single brilliant design moment. Successful designs encode many cycles of iteration.
+- **Eric Ries**, *The Lean Startup* (Crown Business, 2011). Translated iteration into product-management vocabulary: minimum viable product, build-measure-learn loop, validated learning. Influential across software product design.
+- **Tom Kelley & David Kelley** at IDEO, *Creative Confidence* (Crown Business, 2013) and earlier IDEO publications. Codified design thinking as an iterative discovery process: empathize → define → ideate → prototype → test → repeat.
+- **Boyd's OODA loop** (military strategy, applied to design) — observe, orient, decide, act, then repeat. The faster the loop, the better the outcomes.
+- **Modern agile / continuous-delivery practice** — Scrum, Kanban, XP, DevOps all encode iteration as a structural commitment. Releases shrink; feedback cycles tighten.
+
+## Why iteration matters
+
+A first design is built on assumptions. Some assumptions are right; some are wrong. The wrong ones can only be discovered by exposing the design to reality — to users, to use cases, to edge cases the designer didn't anticipate. The longer the design avoids contact with reality, the more wrong assumptions accumulate; the bigger and more painful the eventual correction.
+
+Iteration shortens the gap between assumption and verification. Each cycle exposes a few wrong assumptions; the next cycle corrects them. After several cycles, the design is largely correct because the assumptions have been replaced by observations. Without iteration, the design is shipped on assumptions still mostly untested.
+
+The cost of iteration vs. up-front planning:
+
+- **Up-front planning** is cheap to start (no implementation cost) but expensive to revise (entrenched specifications, sunk cost, political resistance).
+- **Iteration** is expensive to start (each cycle requires building) but cheap to revise (each cycle is small).
+
+For complex products with significant unknowns, iteration usually wins.
+
+## Design iteration vs. development iteration
+
+The book's distinction matters in practice:
+
+### Design iteration
+
+Planned cycles during the design phase — sketching, prototyping, testing, refining. Each cycle is intentional and produces learnings.
+
+Healthy design iteration:
+
+- Cycles measured in days to weeks.
+- Low-fidelity prototypes early, higher-fidelity later.
+- User feedback at each cycle.
+- Explicit criteria for "done with this cycle."
+
+### Development iteration
+
+Unplanned rework during the build phase, usually because the design wasn't iterated enough during design. The team builds something, discovers it doesn't work, partially rebuilds, discovers the rebuild has its own problems, etc.
+
+Development iteration is costly because building is more expensive than designing. Reduce it by iterating more thoroughly during design.
+
+The principle: spend cheap iteration cycles (design, prototype) to avoid expensive iteration cycles (build, rebuild).
+
+## When to apply
+
+- **Whenever the design has significant unknowns.** New product categories, new user segments, new technologies — anything where you can't predict the right answer.
+- **In MVP design.** The MVP is a vehicle for iteration; it ships not because it's "done" but because shipping enables the next iteration.
+- **In any project where the cost of wrong assumptions is high.** Iteration tests assumptions cheaply.
+- **When stakeholders disagree.** Iteration replaces argument with evidence.
+
+## When NOT to over-apply
+
+- **In safety-critical systems.** The cost of "iterating" on aircraft control software is human lives. Use iteration during design and prototype; lock down before deployment.
+- **For decisions with high switching cost.** Some decisions (database schema, API design that external partners depend on) are expensive to revise. Iterate intensely during design; commit deliberately.
+- **When the ground truth is well-known.** A standard CRUD form for a familiar use case may not need many cycles. Iteration is investment in discovery; if you already know the answer, skip the discovery.
+
+## The iteration cycle
+
+A workable cycle:
+
+### 1. Define the question
+
+What are you trying to learn or decide in this cycle? "How do users discover the new feature?" or "Which onboarding flow has higher completion?" Specific questions yield specific answers.
+
+### 2. Build the cheapest thing that answers the question
+
+The MVP for *this cycle*. A sketch, a clickable prototype, a coded version, an A/B test — whichever is cheapest and still answers the question.
+
+### 3. Expose it to reality
+
+Users (research session, beta cohort), data (analytics on a partial release), or a critical reviewer (design critique, code review). The design must encounter something outside the design team.
+
+### 4. Observe and learn
+
+What happened? What surprised you? What confirmed assumptions; what disconfirmed?
+
+### 5. Decide the next cycle
+
+Based on learnings, what's the next question? Refine, replace, or keep.
+
+The full cycle should take days to weeks for most software design — fast enough that learnings stay fresh; slow enough that real building can happen.
+
+## Worked examples
+
+### Example 1: a new feature on an existing product
+
+A team wants to add a new analytics dashboard. Iteration cycle:
+
+- **Cycle 1**: paper sketches, internal review. Cheap; surfaces obvious structural questions.
+- **Cycle 2**: clickable Figma prototype, 5 user interviews. Reveals which widgets users find valuable; which they ignore.
+- **Cycle 3**: coded version, beta with 10% of users. Reveals real-world performance issues; surfaces edge cases.
+- **Cycle 4**: refined version, full release with feature flag and monitoring. The dashboard is now mostly correct.
+
+Each cycle costs more than the last; each replaces more assumptions with evidence.
+
+### Example 2: a complete product redesign
+
+A team redesigns a product. Without iteration: 18 months of design and rebuild; ship; users hate it; emergency rollback or "v2" project.
+
+With iteration:
+
+- **Phase 1** (3 months): redesign one critical flow. Ship behind a feature flag; A/B test. Refine based on data.
+- **Phase 2** (3 months): redesign the next critical flow. Repeat.
+- **Phase 3** (3 months): adopt the new design system across surfaces that haven't been redesigned. Cosmetic-only.
+
+Total: 9 months, with each phase de-risked by data. Far better outcome than the 18-month bang.
+
+### Example 3: API design
+
+An API exposed to external developers can't be casually iterated — each version becomes a contract. But internal iteration before exposure can be intense:
+
+- **Cycle 1**: design the API on paper; review with 3 internal teams.
+- **Cycle 2**: implement a prototype; integrate from 1 internal client.
+- **Cycle 3**: expose to 3 internal clients; gather feedback.
+- **Cycle 4**: refine; release as `v1` to external partners.
+
+The pre-release cycles are cheap; the post-release iteration is expensive.
+
+### Example 4: an onboarding flow
+
+The team wants to improve sign-up completion. Iteration:
+
+- **Cycle 1**: instrument current flow; identify drop-off step. (Discovery.)
+- **Cycle 2**: hypothesize fix; build A/B test variant. Run for 2 weeks.
+- **Cycle 3**: analyze; ship winner; identify next drop-off step.
+- **Cycle 4**: repeat.
+
+Each cycle is data-driven and cheap. The cumulative improvement after 6–12 cycles often exceeds what any single redesign could achieve.
+
+## Cross-domain examples
+
+### Industrial product design
+
+The development of any complex industrial product (a new car, an appliance, a medical device) involves dozens of prototype iterations — clay models, foam mockups, 3D-printed parts, working prototypes, pilot production. Each iteration reveals issues invisible at the previous fidelity.
+
+### Architecture
+
+Frank Lloyd Wright's process: many sketches, sometimes hundreds, before settling on a design. The Guggenheim went through years of iterative revision before construction.
+
+### Software open-source
+
+Open-source projects iterate continuously through patches, pull requests, and releases. Linux, the modern web stack, and every major open-source product evolved through tens of thousands of iteration cycles.
+
+### Manufacturing (Toyota Production System)
+
+Toyota's "kaizen" — continuous small improvements — is iteration applied to manufacturing process. Each shift makes small changes; over decades, the cumulative improvement is enormous.
+
+### Scientific method
+
+Science *is* iteration: hypothesize, experiment, observe, refine. The same loop applied to design produces similar accumulating quality.
+
+## Anti-patterns
+
+- **The big-bang ship.** A design developed in isolation for months, shipped without iteration, fails on contact with reality.
+- **No iteration criteria.** Cycles without explicit "what are we trying to learn?" go on indefinitely without converging.
+- **Cycles too long.** Quarterly cycles in a product that should be iterating weekly or daily. Learnings stale; the team forgets the previous cycle's context.
+- **Cycles too short.** Daily redesigns that don't give the previous version time to be evaluated. Whiplash, no learning.
+- **Iteration without measurement.** Cycles that produce changes but no evidence of whether the changes helped. Pure motion, no progress.
+- **Skipping the "expose to reality" step.** Design cycles that stay inside the design team. Useful for some questions; useless for "does this work for users?"
+- **Confusing prototypes with products.** A prototype is an iteration vehicle; a product is what survives multiple iterations. Treating prototypes as products produces brittle, unfinished work.
+
+## Heuristics
+
+1. **The "what would surprise us?" check.** Before each cycle, predict what will happen. After, compare. Surprises are the value of iteration.
+2. **The cycle-time metric.** How long from "we have an idea" to "we have evidence about the idea"? Shorter is usually better.
+3. **The fidelity ladder.** Are you using the cheapest fidelity that answers the question? Don't build a coded prototype when a sketch would do.
+4. **The "stop iterating" criteria.** Define explicitly when iteration ends and shipping begins. Otherwise iteration can become procrastination.
+
+## Related principles
+
+- **`prototyping`** — the technique iteration relies on.
+- **`development-cycle`** — the larger-scale iteration of requirement → design → develop → test.
+- **`life-cycle`** — products iterate at the version-release cadence as well as within designs.
+- **`factor-of-safety`** — both principles acknowledge the inevitability of unknowns.
+- **`weakest-link`** — iteration finds the weakest link by exposing the design to stress.
+- **`uncertainty-principle`** — observation changes the observed; iteration's instrumentation has its own effects.
+
+## Sub-aspect skills
+
+- **`iteration-design-vs-development`** — distinguishing healthy design iteration from costly development rework.
+- **`iteration-prototype-fidelity`** — picking the right fidelity for each cycle's question.
+
+## Closing
+
+Iteration is the principle that separates teams who ship good products from teams who ship the products they planned. The teams that internalize "we will be wrong about something; let's find out which something cheaply" consistently outperform teams that try to be right the first time. Build the next cycle into every project plan.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration/references/research-and-method.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/iteration/references/research-and-method.md
@@ -1,0 +1,83 @@
+# Iteration: research, history, and method reference
+
+A reference complementing the `iteration` SKILL.md with deeper context on iterative methods.
+
+## Research lineage
+
+- **Henry Petroski**, *The Evolution of Useful Things* (1992) and *To Engineer Is Human* (1985). Central thesis: useful designs evolve through accumulated failure and refinement. The forks, paperclips, and bridges we use today exist in their current form because of generations of iteration.
+- **Eric Ries**, *The Lean Startup* (2011). Translated iteration into product-management vocabulary: minimum viable product, build-measure-learn loop, validated learning, pivot vs. persevere.
+- **Tom Kelley & David Kelley**, *Creative Confidence* (2013). IDEO's design-thinking process: empathize, define, ideate, prototype, test, repeat.
+- **Jeff Sutherland & Ken Schwaber**, *Scrum* (1995 onward). Time-boxed iterations with retrospectives.
+- **Boyd's OODA loop** (military strategy, 1960s onward) — observe, orient, decide, act, repeat. Faster cycle wins.
+- **Continuous delivery / DevOps** (Humble & Farley, *Continuous Delivery*, 2010). Iteration shrunk to the smallest reliable increment.
+
+## Iteration cycle frequencies
+
+Cycles in different contexts:
+
+| Context | Cycle length |
+|---|---|
+| Hardware product (cars, appliances) | Months to years |
+| Industrial software | Quarters |
+| Consumer software | Weeks |
+| Startup MVP | Days to weeks |
+| Continuous delivery | Hours to minutes |
+| User research | Days to weeks |
+
+Faster cycles enable more learning per unit time but demand more discipline (each cycle must produce value).
+
+## The "build-measure-learn" loop (Lean Startup)
+
+Three steps:
+
+1. **Build** the smallest thing that tests a hypothesis.
+2. **Measure** the result quantitatively (metrics, data).
+3. **Learn** from the measurement — confirm or reject the hypothesis.
+
+Then either persevere (the hypothesis is right; iterate further) or pivot (the hypothesis is wrong; try a different direction).
+
+The trap: building something *without* a clear hypothesis to test. The build wastes time; the measurement isn't meaningful; the learning is post-hoc rationalization.
+
+## Sutherland's "Spiral" model (1986)
+
+Predates Scrum; describes iterative development with each loop:
+
+1. Determine objectives.
+2. Identify and resolve risks.
+3. Develop and test.
+4. Plan the next iteration.
+
+The risk-driven framing — early iterations focus on the highest-risk unknowns — is enduringly useful.
+
+## Common iteration anti-patterns from research
+
+- **The waterfall trap**: gathering all requirements up front; designing fully; building fully; testing only at the end. Catches issues too late.
+- **The "iterate forever" trap**: cycles that never converge because there's no clear end criterion.
+- **The "iteration without measurement" trap**: cycles that produce changes but no evidence of whether the changes helped.
+- **The "iteration without learning" trap**: cycles that make changes but don't update the team's mental model of what works.
+
+## Cross-domain examples
+
+### Manufacturing: Toyota's kaizen
+
+Continuous incremental improvement. Each shift makes small changes; over decades, the cumulative improvement is enormous. Toyota's quality and efficiency advantages derive from kaizen as much as from any specific innovation.
+
+### Open-source software
+
+Linux, Wikipedia, the modern web stack: all built through tens of thousands of small iterations by many contributors. The aggregate quality far exceeds what any single team could produce.
+
+### Scientific method
+
+Science *is* iteration: hypothesize, experiment, observe, refine. The accumulated knowledge of human civilization is the output of millions of cycles.
+
+### Architecture and urban design
+
+Frank Lloyd Wright sketched dozens of revisions before committing to a building. Cities themselves iterate over generations — neighborhoods adapt, streets repurpose, buildings replace.
+
+## Resources
+
+- **Petroski, H.** *To Engineer Is Human* (1985); *The Evolution of Useful Things* (1992).
+- **Ries, E.** *The Lean Startup* (2011).
+- **Humble, J. & Farley, D.** *Continuous Delivery* (2010).
+- **Beck, K.** *Test-Driven Development by Example* (2002) — iteration at the code level.
+- **Knapp, J.** *Sprint* (2016) — five-day design-sprint method.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-equivalent-designs/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-equivalent-designs/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: ockhams-equivalent-designs
+description: 'Identify when two design options are functionally equivalent so the razor can be applied. Use when comparing design alternatives, evaluating whether two implementations of a feature actually produce the same outcome, or recognizing that a complex solution doesn''t earn its place against a simpler one. Most design debates involve actual tradeoffs; the razor only cuts when the alternatives genuinely produce equivalent results. The skill is identifying equivalence honestly rather than rationalizing complexity.'
+---
+
+# Ockham's Razor — equivalent designs
+
+The razor cuts when alternatives are functionally equivalent. The skill is recognizing when alternatives actually are equivalent — versus when a more complex alternative serves a real need that the simpler one doesn't.
+
+Designers and engineers often defend complexity by imagining benefits the complex solution provides. Sometimes those benefits are real; sometimes they're rationalization. The discipline is honest evaluation of whether the complexity earns its place.
+
+## Defining functional equivalence
+
+Two designs are functionally equivalent when they produce the same outcome for users. Specifically:
+
+**Same goal achieved.** The user can accomplish what they're trying to accomplish.
+
+**Same quality of outcome.** The result is equally good (correct, complete, accurate).
+
+**Same cost to user.** The user pays roughly the same in time, attention, learning.
+
+**Same edge case handling.** Both work for the cases users actually encounter.
+
+**Same downstream effects.** Both leave the system in the same state for subsequent interactions.
+
+If these are equal, the designs are equivalent for the user, and the razor cuts toward simpler.
+
+## When designs that look equivalent aren't
+
+Designs may look equivalent on the surface but actually differ in important ways:
+
+**Edge case behavior.** One design handles unusual cases gracefully; the other fails. The behavior in the typical case is the same; the long tail differs.
+
+**Performance.** One design is fast at small scale; the other scales better at large scale. Both work today; the difference matters tomorrow.
+
+**Error recovery.** One design recovers from failures elegantly; the other doesn't. Most of the time, neither fails; in the failure cases, they differ sharply.
+
+**Discoverability.** Two designs achieve the same task, but one is more discoverable. Users find one and not the other.
+
+**Accessibility.** Two designs work for typical users; one fails for users with disabilities.
+
+**Internationalization.** Two designs work in English; one fails in non-English contexts.
+
+**Future flexibility.** Two designs do the same thing today; one is easier to evolve.
+
+When evaluating equivalence, check these dimensions, not just the happy path.
+
+## When complexity actually earns its place
+
+A more complex design earns its place when it:
+
+**Solves a real problem the simpler doesn't.** Not a hypothetical problem; an actual user pain point with evidence.
+
+**Serves an important audience the simpler doesn't.** Even if the audience is small, if it's strategically important, the complexity may be justified.
+
+**Enables future capabilities.** Architectural complexity that supports planned future work, not speculative future work.
+
+**Improves reliability or performance materially.** Not in theory; in measurement.
+
+**Reduces other complexity.** Sometimes adding one component eliminates several others. The net change is simplification.
+
+If none of these apply, the complexity doesn't earn its place.
+
+## Evaluating equivalence honestly
+
+Engineers and designers tend to defend their preferred designs. Honest equivalence evaluation requires:
+
+**Defining "the user's goal" specifically.** Vague goals make any solution look reasonable. Precise goals make tradeoffs visible.
+
+**Listing the actual differences.** What does design A do that B doesn't? What does B do that A doesn't? Be specific.
+
+**Quantifying the differences.** Not "A is faster" — "A handles 1000 req/sec, B handles 5000." Numbers force honesty.
+
+**Identifying who pays for the differences.** Often complexity benefits some users (or the team) and costs others. Be explicit.
+
+**Time-shifting the comparison.** Today, the simpler design may be sufficient. In two years, the more complex one may be necessary. Make the time horizon explicit.
+
+## Worked examples
+
+### Two API designs that look equivalent
+
+**Option A:** A single endpoint that takes a complex JSON body specifying everything.
+
+**Option B:** Multiple endpoints, each with simpler parameters.
+
+At first they look equivalent — both expose the same functionality. But:
+
+- Option A is harder to document (the complex body has many fields).
+- Option B has more endpoints to maintain.
+- Option A has more validation logic for the body.
+- Option B is easier for clients to understand piecemeal.
+- Option A allows transactional behavior (one call); Option B doesn't.
+
+If transactional behavior matters, A wins. If documentation and approachability matter more, B wins. They're not equivalent; pick based on what matters.
+
+### Two feature implementations that are equivalent
+
+**Option A:** A wizard with 3 steps to configure a new resource.
+
+**Option B:** A single page with the same fields shown all at once.
+
+Both produce the same configured resource. The user experience differs (wizard vs. single page) but the outcome is the same.
+
+For a complex configuration with many interdependent decisions, the wizard helps the user; A is preferred. For a simple configuration with few fields, the single page is faster; B is preferred.
+
+If the configuration is genuinely simple, A's complexity doesn't earn its place. The razor cuts toward B.
+
+### Two architecture choices
+
+**Option A:** A microservices architecture with 12 services.
+
+**Option B:** A monolithic architecture in a single codebase.
+
+If the team is small and the throughput modest, A's complexity (network, deployment, monitoring) doesn't earn its place against B's simplicity. The razor cuts toward B.
+
+If the team is large with many independent groups, A's complexity may be justified by the parallelization it enables. The razor doesn't cut — they're not equivalent for this team.
+
+The right call depends on context. The discipline is to honestly evaluate the context, not to default to either.
+
+### Two visual treatments
+
+**Option A:** Detailed icons with multiple colors and gradients.
+
+**Option B:** Simple line icons in a single color.
+
+Both can communicate the same information. Option A may have aesthetic appeal but doesn't communicate more. Option B is faster to render, easier to maintain (consistent stroke weights), more flexible (color from currentColor), and more accessible (high contrast).
+
+The razor cuts toward B unless A's aesthetic is genuinely strategic to the brand. Even then, A should earn its place against the costs.
+
+### A complex feature defended on hypotheticals
+
+Engineering team proposes a complex configuration system: "Users will want to customize this in the future." Current users don't ask for it; no design pressure for it; speculative future need.
+
+The razor cuts: don't build it now. If future need materializes, build it then. YAGNI (You Aren't Gonna Need It). Premature flexibility is a common form of accumulated complexity.
+
+## Anti-patterns
+
+**Defending complexity with hypotheticals.** "We might need this someday." Without evidence, the complexity isn't earning its place.
+
+**Equivalence claims without checking edge cases.** Two designs equivalent on the happy path may differ sharply on the long tail.
+
+**Dismissing simpler options because they "feel less professional."** Aesthetic preference for complexity doesn't earn complexity's place.
+
+**Failing to time-shift the evaluation.** Today's equivalence may not be tomorrow's. Long-lived systems deserve longer-horizon evaluation.
+
+**Confusing "more features" with "better."** Complexity isn't quality. A focused product can be better than a sprawling one.
+
+**Comparing designs that aren't actually equivalent.** Apples and oranges. Pick designs that achieve the same goal, then evaluate the differences.
+
+## Heuristic checklist
+
+When considering two designs, ask: **What's the specific user goal each design serves?** Be precise. **Are they actually equivalent on the goal?** Not just the happy path; check edge cases, accessibility, scaling. **What are the differences?** List specifically. **What does the complexity earn?** Should be a real, measurable benefit. **What does the complexity cost?** Cognitive, maintenance, evolution. **If equivalent, choose simpler. If not, the razor doesn't apply.**
+
+## Related sub-skills
+
+- `ockhams-razor` — parent principle on preferring simpler designs.
+- `ockhams-feature-pruning` — sibling skill on removing accumulated complexity.
+- `form-follows-function` — closely related; both ask whether each design element earns its place.
+- `iteration` — equivalence evaluation evolves over time as you learn more about user needs.
+
+## See also
+
+- `references/comparison-template.md` — a template for honest design comparison.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-equivalent-designs/references/comparison-template.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-equivalent-designs/references/comparison-template.md
@@ -1,0 +1,147 @@
+# Honest design comparison — template
+
+A template for comparing design options to identify whether the razor applies.
+
+## Step 1: define the user goal precisely
+
+Vague goal: "users can manage their notifications."
+
+Precise goal: "users can change which kinds of events trigger emails (5 categories), and how frequently those emails are bundled (instant, hourly, daily)."
+
+The precise goal makes tradeoffs visible. The vague goal makes any solution look reasonable.
+
+## Step 2: list the candidate designs
+
+Be specific about each. Diagrams or sketches help.
+
+```
+Option A: [description]
+- How it works:
+- Key components:
+- User interaction:
+
+Option B: [description]
+- How it works:
+- Key components:
+- User interaction:
+```
+
+## Step 3: evaluate functional equivalence
+
+Check each dimension:
+
+```
+Dimension          | Option A   | Option B   | Equivalent?
+-------------------|------------|------------|------------
+Goal achieved?     | yes        | yes        | yes
+Quality of outcome | [details]  | [details]  | [yes/no]
+Cost to user       | [time, attention] | [time, attention] | [yes/no]
+Edge cases         | [handled?] | [handled?] | [yes/no]
+Downstream effects | [details]  | [details]  | [yes/no]
+Scaling            | [behavior] | [behavior] | [yes/no]
+Accessibility      | [conforms?]| [conforms?]| [yes/no]
+Internationalization | [works?] | [works?]   | [yes/no]
+Future flexibility | [easy?]    | [easy?]    | [yes/no]
+```
+
+If all "Equivalent?" cells are yes, the designs are functionally equivalent and the razor cuts toward simpler.
+
+If some cells are no, identify which differences matter.
+
+## Step 4: identify and weigh the differences
+
+For each non-equivalent dimension, ask:
+
+**How much does this matter?** Quantify if possible.
+
+**Who benefits, who pays?** Different audiences are affected differently.
+
+**When does this matter?** Now, near future, distant future?
+
+```
+Difference 1: [name]
+- A's behavior: [details]
+- B's behavior: [details]
+- Importance: [scale]
+- Who benefits / pays: [details]
+- Time horizon: [now / near / distant]
+```
+
+## Step 5: weigh the costs of complexity
+
+For each design, list the costs:
+
+```
+Option A costs:
+- Engineering complexity:
+- Maintenance burden:
+- Cognitive load on users:
+- Performance impact:
+- Reliability impact:
+- Onboarding cost:
+
+Option B costs:
+- [same dimensions]
+```
+
+Be explicit about each. Don't lump them together.
+
+## Step 6: make the decision
+
+If functionally equivalent: choose simpler (the razor cuts).
+
+If not equivalent: weigh the differences against the costs.
+
+```
+Decision: [chosen option]
+Rationale: [why, citing specific differences]
+Tradeoffs accepted: [what we're giving up]
+Conditions for revisiting: [what would change the decision]
+```
+
+## Common evaluation pitfalls
+
+**Comparing designs at different levels of detail.** Apples to oranges. Make the comparison fair.
+
+**Counting only the benefits of complexity.** Engineers tend to list what complex designs enable; honest comparison includes the costs.
+
+**Discounting future complexity costs.** Today's complexity is tomorrow's maintenance. Time-horizon-shift the evaluation.
+
+**Defending sunk-cost designs.** A design already partially built may not be the right answer; willingness to switch is essential to honest evaluation.
+
+**Ignoring context-specific constraints.** "All else equal" is rare; context matters. Make the relevant context explicit.
+
+**Equivalence claims that don't survive scrutiny.** A genuine equivalence check should hold up; if it doesn't, the designs aren't actually equivalent.
+
+## A worked example
+
+Goal: "let users set how often they receive notification emails."
+
+**Option A:** A single dropdown with 4 options (Never / Daily / Weekly / Instant).
+
+**Option B:** A detailed configuration page with separate settings per notification type, each with its own frequency dropdown.
+
+Functional equivalence check:
+
+| Dimension | A | B | Equivalent? |
+|---|---|---|---|
+| Goal achieved | Yes | Yes | Equivalent |
+| Quality of outcome | Set frequency for all notifications | Set frequency per type | Different |
+| Cost to user | One choice | Many choices | Different |
+| Edge cases | Coarse, may not match user needs precisely | Fine-grained | Different |
+
+Not equivalent. Difference: granularity of control.
+
+Weigh: who needs the granularity? If most users want the same frequency for all notifications, A is enough. If many users have specific patterns (instant for critical, daily for the rest), B serves them.
+
+Costs:
+- A: trivial to build, easy to use, easy to maintain.
+- B: substantial to build, more cognitive load, more maintenance.
+
+Decision: depends on whether the granularity matters. If we can get away with A, the razor cuts toward A. If users genuinely need B's granularity, B's cost is justified.
+
+In practice: ship A first. Watch for evidence that users want B. If the evidence appears, build B. If it doesn't, A is the answer.
+
+## Cross-reference
+
+For pruning accumulated complexity, see `ockhams-feature-pruning`. For the parent principle, see `ockhams-razor`.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-feature-pruning/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-feature-pruning/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: ockhams-feature-pruning
+description: 'Prune accumulated complexity from a product — features, options, settings, code paths that no longer earn their place. Use when auditing a mature product, reducing surface area, simplifying complex workflows, or evaluating whether to remove low-usage features. Pruning is harder than adding because users (often a small but vocal minority) resist removal even when usage data justifies it. The skill is identifying what to prune, deciding how, and managing the transition.'
+---
+
+# Ockham's Razor — feature pruning
+
+Feature pruning is the discipline of removing things that no longer earn their place. Most products accumulate features, options, and complexity over time; periodic pruning is necessary to prevent the product from becoming unusable through accumulated weight.
+
+Pruning is hard. Users (often a small but loud minority) resist removal even when most users don't use the feature. Engineers may have spent significant effort building it. Marketing has highlighted it. The cost of removal feels concrete; the benefit (freedom from maintenance, simpler product, easier evolution) is diffuse.
+
+But pruning, done well, is one of the highest-leverage product activities. A clean product evolves faster, costs less to maintain, is easier for new users to learn, and tends to keep its core users happier.
+
+## What's a candidate for pruning
+
+A feature, option, or piece of UI is a pruning candidate when one or more of:
+
+**Low usage.** Below 1% of users (often below 5%) without clear strategic justification.
+
+**High maintenance cost.** Bugs, support tickets, broken integrations.
+
+**Dependency liability.** Depends on third-party services, deprecated APIs, or aging infrastructure.
+
+**Confused with other features.** Users don't know which to use; designers can't articulate the difference.
+
+**Originally built for a use case that's no longer relevant.** The customer who requested it no longer exists; the workflow it supported has changed.
+
+**Functionality covered by other features.** Redundant with newer, better-designed capabilities.
+
+**Cognitive overhead disproportionate to value.** A setting that adds choice but most users don't engage with.
+
+**Holds back evolution.** Removing it would unlock significant simplification or new capability.
+
+## What's not a candidate for pruning
+
+Even if usage is low, don't prune when:
+
+**Critical for a small but high-value audience.** The 1% who use the feature might be your most valuable customers.
+
+**Required for compliance, legal, or accessibility.** The feature may serve a small audience but be essential for some context.
+
+**Required for a workflow that doesn't have an alternative.** Even rare workflows shouldn't be eliminated unless an alternative exists.
+
+**Strategic for future direction.** Some features are bets on a future use case; usage may grow.
+
+**Underutilized due to discoverability, not lack of value.** Sometimes a low-usage feature is one users don't know exists; promotion may be a better answer than pruning.
+
+## The pruning process
+
+A disciplined pruning process:
+
+**1. Audit.** List candidates based on usage data, support patterns, and engineering input.
+
+**2. Investigate each candidate.** For each: who uses it, why, what would they do without it? Talk to representative users if possible.
+
+**3. Categorize:**
+- Prune outright (low usage, no important users dependent).
+- Prune with migration (low usage but some users dependent; provide alternatives).
+- Defer (currently rare but strategically important).
+- Keep (justified despite low usage).
+
+**4. Plan the migration for "prune with migration" candidates.** What's the alternative for affected users? How will you communicate? What's the timeline?
+
+**5. Execute.** Announce, deprecate, remove. Each step has its own timeline.
+
+**6. Measure.** After pruning, did the predicted benefits materialize? Are affected users staying or churning?
+
+## Pruning patterns
+
+**Soft removal.** Remove from default UI but keep accessible (e.g., behind a "legacy" menu). Lower cost; users who depend can still find it.
+
+**Hard removal.** Remove entirely. Higher cost but cleaner result.
+
+**Replacement.** Remove the old feature; provide a better alternative. Requires the alternative to actually serve the use case.
+
+**Deprecation announcement.** Announce removal date in advance; let users prepare or migrate.
+
+**Sunset migration.** Active outreach to users of the feature, helping them migrate.
+
+The right pattern depends on usage volume, importance to users, and how cleanly the alternative covers the use case.
+
+## Worked examples
+
+### A feature with declining usage
+
+A productivity tool has a "smart suggestions" feature that auto-recommends actions. Initially popular; over time, usage has declined as the product has evolved. Audit shows: 2% of users use it weekly; mostly long-term users; the suggestions are often ignored.
+
+Decision: prune. Announce removal in 60 days. Email the 2% explaining the change and offering alternatives. Remove the feature; gain the maintenance time back.
+
+Result: minimal churn; the product is simpler; the engineering team has more capacity for other work.
+
+### A configuration setting that no one understands
+
+A settings panel has a checkbox: "Enable advanced mode." When enabled, it changes some keyboard shortcuts. Audit shows: 0.3% of users have enabled it; support sometimes gets questions about it; documentation is unclear.
+
+Decision: prune. Remove the setting; pick the better default for both modes; eliminate the divergent code paths. Communicate the change to the small affected audience.
+
+Result: simpler settings, simpler code, easier to support.
+
+### A feature dependent on a deprecated API
+
+The product integrates with a third-party service via an API the third party is deprecating. Investigation reveals: the integration is used by 1% of users; building on the new API would take months; the use case is partially served by other integrations.
+
+Decision: deprecate the integration; remove it when the old API shuts down. Communicate to affected users; recommend alternative integrations.
+
+Result: avoided months of engineering work; users have alternatives.
+
+### A "kept" decision
+
+A product has a feature for converting documents to a niche format. Usage: 0.5%. But investigation reveals that the niche format is required by some government agencies; users who depend on it are mission-critical (legal, government, healthcare).
+
+Decision: keep, despite low usage. Document the strategic reason. Plan to maintain it; budget for ongoing support.
+
+Result: low usage but real importance; pruning would harm critical users.
+
+### A redundant pair of features
+
+A product has two ways to accomplish the same task: an older "import" workflow and a newer "drag to upload" feature. Both exist in the UI. Users sometimes use both; sometimes use only one.
+
+Decision: prune the older "import" workflow. Verify the newer "drag to upload" handles all the cases. Communicate to users who used the older flow. Remove the older flow once migration is complete.
+
+Result: cleaner UI, less code, less confusion.
+
+## Anti-patterns
+
+**Pruning what users actually need.** Removing a feature without verifying who depends on it. The 1% may be your best customers.
+
+**Mass deprecation without migration paths.** Announcing many removals at once with no clear alternatives. Users feel abandoned.
+
+**Soft removal that lingers forever.** Moving a feature to a "legacy" menu but never actually removing it. Maintenance cost continues; the simplification benefit is partial.
+
+**Pruning on a whim.** Removing things because someone subjectively thinks they're not needed, without data. Often removes things that are actually used.
+
+**No communication.** Pruning silently. Users discover the change when their workflow breaks. Trust is damaged.
+
+**Pruning during major rebuilds.** Major rebuilds (often called "v2") that strip many features. Almost always less successful than incremental pruning.
+
+**Reflexive feature-cutting.** Treating "shipped fewer features" as a virtue independent of context. Sometimes adding features is correct; sometimes pruning is. Be evidence-based.
+
+## Heuristic checklist
+
+When considering pruning, ask: **What's the actual usage of this feature?** Get data before deciding. **Who uses it, and why?** Talk to affected users. **What's the maintenance cost?** Engineering time, support load, complexity. **What's the alternative for users who depend?** Don't leave them stranded. **Is there a migration plan?** Don't just delete and walk away. **How will you communicate?** Surprise removal damages trust.
+
+## Related sub-skills
+
+- `ockhams-razor` — parent principle on preferring simpler designs.
+- `ockhams-equivalent-designs` — sibling skill on identifying when designs are functionally equivalent.
+- `80-20-rule` — most use is concentrated in a few features; the long tail is often pruning candidates.
+- `iteration` — pruning is part of the iterative process of product evolution.
+- `weakest-link` — sometimes the weakest link is a feature that should be removed.
+
+## See also
+
+- `references/pruning-process.md` — step-by-step process for pruning decisions.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-feature-pruning/references/pruning-process.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-feature-pruning/references/pruning-process.md
@@ -1,0 +1,192 @@
+# Feature pruning — step-by-step process
+
+A practical workflow for pruning features, settings, and complexity from a product.
+
+## Phase 1: identify candidates
+
+Run a quarterly or semi-annual audit. Look for:
+
+**Usage data signals:**
+- Features used by less than 5% of active users (worth investigating; may be ok if strategic).
+- Features used by less than 1% (strong pruning candidates).
+- Features used by 0% (definite pruning candidates, unless clearly strategic).
+- Features whose usage is declining over time.
+
+**Engineering signals:**
+- Features with disproportionate bug rates.
+- Features dependent on deprecated APIs or aging infrastructure.
+- Features whose code is complex or untouched for years.
+- Features that block other improvements.
+
+**Support signals:**
+- Features that generate support tickets out of proportion to usage.
+- Features users frequently misunderstand.
+- Features that users ask about before discovering them.
+
+**Design signals:**
+- Settings whose purpose is unclear.
+- Multiple features that overlap in function.
+- Features that haven't been updated as the product evolved.
+
+## Phase 2: investigate each candidate
+
+For each candidate, gather:
+
+**Quantitative:**
+- Daily / weekly / monthly active users.
+- Trend over 6 / 12 / 24 months.
+- Usage by user segment (free, paid, enterprise).
+
+**Qualitative:**
+- Why do users who use it use it?
+- What would they do without it?
+- Are there alternatives that serve the same need?
+
+**Cost data:**
+- Engineering maintenance time per quarter.
+- Support tickets per quarter.
+- Infrastructure cost.
+- Documentation maintenance burden.
+
+**Strategic context:**
+- Was this a recent strategic addition that hasn't had time to grow?
+- Does it support a small but high-value audience?
+- Does it serve a use case that competitors don't cover?
+
+## Phase 3: categorize
+
+For each candidate:
+
+**Prune outright.** Low usage; no important users dependent; alternatives exist; strategic value low.
+
+**Prune with migration.** Low usage; some users dependent; alternatives exist or can be built; strategic value low.
+
+**Defer pruning.** Currently low usage but strategic value high (recent feature, important segment).
+
+**Keep.** Low usage but high importance (regulatory, accessibility, key segment).
+
+**Investigate further.** Unclear; need more data or user interviews.
+
+## Phase 4: plan migration
+
+For "prune with migration" candidates:
+
+**Identify affected users.** Get a list (or representative sample) of users who depend on the feature.
+
+**Define the alternative.** What will affected users do instead? Make sure the alternative actually works for their use case.
+
+**Communication plan:**
+- When will you announce removal?
+- How will you reach affected users (email, in-product banner, blog post)?
+- What support will you provide during migration?
+
+**Migration timeline:**
+- Announcement.
+- Deprecation period (feature still works, but warns of removal).
+- Removal date.
+
+A typical timeline: announce 60–90 days before removal. Show in-product warnings 30 days before. Remove on the announced date.
+
+## Phase 5: execute
+
+**Communicate.** Send announcements through all relevant channels. Be honest about the change and the rationale.
+
+**Provide migration help.** Documentation, video tutorials, support during the transition.
+
+**Monitor for issues.** Watch for spikes in support tickets, churn from affected users, or unanticipated workflow breaks.
+
+**Remove on schedule.** Don't keep pushing the date back; that signals the deadline isn't real and users won't migrate.
+
+## Phase 6: post-pruning measurement
+
+After removal:
+
+**Verify benefits materialized:**
+- Engineering time freed up?
+- Support tickets reduced?
+- Product simpler to onboard new users?
+
+**Check for damage:**
+- User churn from affected segment?
+- New support categories arising from removal?
+- Workflows that broke unexpectedly?
+
+**Document the decision.** Record what was removed, why, and what the impact was. This builds organizational memory and helps future pruning decisions.
+
+## Templates
+
+### Candidate evaluation template
+
+```
+Feature/setting: [name]
+Description: [what it does]
+Usage data:
+  - DAU: [number]
+  - % of active users: [percentage]
+  - Trend: [up / flat / down]
+Engineering cost:
+  - Maintenance hours/quarter: [estimate]
+  - Open bugs: [number]
+  - Tech debt: [low / med / high]
+Support cost:
+  - Tickets/quarter: [number]
+  - % of total tickets: [percentage]
+User research:
+  - Who uses it: [segments]
+  - Why they use it: [reasons]
+  - Alternatives if removed: [yes/no, what]
+Strategic value: [low / medium / high]
+Recommendation: [prune / migrate / defer / keep / investigate]
+Notes: [any context for the decision]
+```
+
+### Migration plan template
+
+```
+Feature being removed: [name]
+Removal date: [date]
+Affected users: [count, segment]
+Alternative: [what users should use instead]
+Communication:
+  - Announce: [date, channel]
+  - Reminder: [date, channel]
+  - Final warning: [date, channel]
+Documentation:
+  - Migration guide: [link or to-do]
+  - Updated help: [link or to-do]
+Support plan:
+  - Monitoring: [who, how]
+  - Escalation: [for issues]
+Success criteria:
+  - [measurable indicators]
+```
+
+## Common pruning failures
+
+**Pruning without communication.** Users discover removal when their workflow breaks. Trust damaged.
+
+**Over-promising on alternatives.** Claiming "the new feature does everything the old one did" when it doesn't. Users find the gaps and feel betrayed.
+
+**Pushing back the deadline indefinitely.** "We'll remove it next quarter" repeated for years. Users learn that deadlines aren't real.
+
+**Pruning without measurement.** Removing things and not tracking impact. Can't tell if pruning was successful or harmful.
+
+**Mass pruning during a redesign.** "v2" projects that strip many features at once. High user resistance; often partially reversed.
+
+**Not learning from past pruning.** Each pruning decision is treated independently; no organizational memory.
+
+## A sustainable pruning cadence
+
+Quarterly or semi-annual reviews are reasonable. The reviews should:
+
+- Identify a small number (3–10) of candidates.
+- Investigate them.
+- Make decisions.
+- Schedule executions.
+- Track outcomes.
+
+Don't try to prune everything at once; that creates user fatigue. Steady, deliberate pruning over time produces a healthier product than infrequent aggressive cuts.
+
+## Cross-reference
+
+For identifying when designs are functionally equivalent (and one can be pruned), see `ockhams-equivalent-designs`. For the parent principle, see `ockhams-razor`.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-razor/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-razor/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: ockhams-razor
+description: 'Apply Ockham''s Razor — given a choice between functionally equivalent designs, prefer the simplest. Use when comparing design approaches, evaluating whether a feature is necessary, deciding between elaborate and minimal solutions, auditing a product for accumulated complexity, or pruning features that no longer earn their place. The principle is not "always make things simpler" — it''s "when two designs do the same thing, pick the simpler one." Most design problems involve actual tradeoffs; the razor cuts only when functionality is truly equivalent.'
+---
+
+# Ockham's Razor
+
+> **Definition.** Given a choice between two designs that perform the same function equally well, prefer the simpler. Simplicity reduces cognitive load, eases maintenance, lowers cost, improves performance, and reduces failure modes. Complexity should be added only when it earns its place by serving a real need. The principle is named for the medieval philosopher William of Ockham, who argued that "entities should not be multiplied beyond necessity" — the simplest explanation that fits the evidence is preferred.
+
+In design, the razor cuts when comparing functionally equivalent options. If two designs serve the user's need equally well, pick the simpler one. The simpler design will be easier to learn, easier to maintain, less expensive to build, less likely to break, and easier to evolve.
+
+The principle is widely cited and widely misapplied. It does not mean "always strip features" or "minimum viable everywhere." It means: don't add complexity that doesn't earn its place. When two equally-good options exist, choose simpler. When a more complex option is genuinely better, choose it; just verify that the complexity is actually paying its way.
+
+## Why the razor matters
+
+Complexity has costs that often go uncounted at the moment of decision:
+
+**Cognitive cost.** Every feature, every option, every visual element costs the user attention and learning. A product with 50 features is harder to learn than one with 10, even if all 50 are individually useful.
+
+**Maintenance cost.** Every line of code, every component, every dependency needs to be maintained. A simpler system has fewer places to update, fewer interactions to debug, fewer surprises.
+
+**Reliability cost.** Each component is a potential failure point. A simpler system has fewer components, fewer interactions, fewer edge cases. Reliability tends to improve with simplicity.
+
+**Performance cost.** Complex systems are harder to make fast. Simpler systems are usually faster by default.
+
+**Evolution cost.** Adding a new feature to a simple system is easier than adding it to a complex one. Complexity compounds.
+
+**Documentation cost.** Complex systems need more documentation, which itself becomes a maintenance burden.
+
+These costs are paid continuously, often invisibly. Complexity feels free at the moment of addition; it becomes expensive over time.
+
+## When the razor cuts
+
+**When comparing two designs that produce the same outcome.** The simpler one is preferred.
+
+**When evaluating whether to add a feature.** Does the feature earn its place? Could the user accomplish the same goal without it? If yes, the absence is simpler.
+
+**When pruning an existing product.** Features, options, settings that don't serve the user well should be candidates for removal.
+
+**When choosing technical architecture.** A simpler architecture (fewer services, fewer abstractions, fewer technologies) is easier to maintain.
+
+**When picking between visual treatments.** A cleaner design that communicates the same information is preferred over an elaborate one.
+
+## When the razor doesn't apply
+
+**When the more complex option is genuinely better.** The razor cuts only when alternatives are equivalent. If the complex option serves users substantially better, choose it.
+
+**When simplification destroys necessary capability.** A medical interface that simplifies away critical information is too simple. The right level of complexity depends on what the system needs to do.
+
+**When the simpler option doesn't actually work.** A simple solution that doesn't solve the problem isn't simpler in any meaningful sense — it's just incomplete.
+
+**When the complexity is in the underlying problem.** Some problems are genuinely complex. Trying to make the solution radically simpler than the problem usually fails.
+
+The razor is a tiebreaker, not a mandate. Its work is to prevent unnecessary complexity, not to force inappropriate simplicity.
+
+## Diagnosing accumulated complexity
+
+Products tend to accumulate complexity over time, often invisibly. Symptoms:
+
+**Settings that no one understands.** A settings panel with dozens of options whose meanings have been forgotten.
+
+**Features that no one uses.** Features added for some specific need years ago that are now used by 0.1% of users.
+
+**Workflows with branches.** A flow that has 8 different paths through it, each handling a slightly different case.
+
+**Documentation that's longer than the code.** A sign that the design has accumulated complexity that's hard to explain.
+
+**Onboarding that takes longer.** New users need more time to understand the product than they used to.
+
+**Engineers afraid to touch certain code.** Code so complex that no one understands it; changes are risky.
+
+**Many "exception" handlers.** A codebase with many special cases for specific situations.
+
+These are all signs that the razor might be useful. Look for things that can be removed, simplified, or consolidated.
+
+## Sub-skills in this cluster
+
+- **ockhams-feature-pruning** — Removing features, options, and complexity that no longer earn their place. The discipline of cutting back what's accumulated.
+- **ockhams-equivalent-designs** — Identifying when two designs are functionally equivalent and applying the razor. The skill of recognizing when simpler is just as good.
+
+## Worked examples
+
+### Two equivalent designs for a setting
+
+A team is debating two designs for a "default sort order" setting:
+
+**Option A:** A dropdown with 5 options, each clearly named.
+
+**Option B:** A wizard that asks the user 3 questions and infers the right sort.
+
+Both produce the same result (the right default sort). Option A is simpler — fewer interactions, less code, less explanation needed. Option B is more elaborate but doesn't produce a better outcome.
+
+The razor cuts: choose A.
+
+### Feature that doesn't earn its place
+
+A product has a "share via fax" feature added 5 years ago when one customer asked for it. Usage data shows: 0.001% of users have ever used it. The code requires ongoing maintenance and occasionally breaks.
+
+The razor cuts: remove the feature. The few users who depend on it can be contacted; the maintenance burden goes away; the product becomes simpler.
+
+### Architecture choice
+
+A team is building a new microservice. Two options:
+
+**Option A:** A simple service that handles the responsibility, in the team's primary language and tech stack.
+
+**Option B:** A more elaborate service using a different language and framework chosen for theoretical performance benefits.
+
+If Option A meets the requirements, the razor cuts toward it. The team knows the language, the tech stack is supported, the maintenance burden is lower. The theoretical performance of Option B doesn't earn its place if the simpler option is fast enough.
+
+### Prune accumulated settings
+
+A product's settings page has 50 options accumulated over years. Audit reveals: 15 options are used by less than 1% of users; 8 options are obsolete (the underlying feature was removed); 5 are duplicates of each other; 10 should be defaults rather than settings.
+
+After pruning: 12 settings remain, each clearly justified. The settings page is dramatically simpler. The few users who depended on removed settings can be addressed individually.
+
+### A more complex design that earns its place
+
+A team is debating two designs for an editor:
+
+**Option A:** A simple text-only editor.
+
+**Option B:** A WYSIWYG editor with formatting, embeds, mentions, and inline collaboration.
+
+The functions aren't equivalent — Option B does substantially more. If users need the additional capabilities, the complexity is justified. The razor doesn't say "always simpler"; it says "simpler when equivalent."
+
+The complexity of Option B is acceptable because it earns its place by serving real needs that A can't.
+
+## Anti-patterns
+
+**Mistaking simplicity for value.** Stripping a product to "MVP" and shipping something that doesn't actually do useful work. Simplicity that fails to serve isn't simpler; it's incomplete.
+
+**Adding complexity reflexively.** Every problem solved with a new feature, a new option, a new toggle. The product accumulates complexity that's never pruned.
+
+**"Just one more option."** The temptation to add a configuration setting for every edge case. Each setting individually seems harmless; the accumulation becomes paralyzing.
+
+**Applying the razor to the wrong things.** Stripping features that users depend on; simplifying interfaces past the point of usability; cutting maintenance work that's actually needed.
+
+**Confusing minimal with simple.** A minimal-looking interface that requires deep navigation to find anything is not actually simple — it's hidden complexity. True simplicity means easy to use, not just visually sparse.
+
+**Reflexive simplification.** Cutting things just because cutting feels virtuous. Verify that what's cut actually wasn't earning its place.
+
+## Heuristic checklist
+
+When considering a design choice, ask: **Are the alternatives functionally equivalent?** If yes, the razor cuts toward simpler. **What does the complexity earn?** If little, prefer simpler. **What does the complexity cost?** Cognitive, maintenance, reliability, performance, evolution. **Will this complexity be paid for over its lifetime?** If not, choose simpler. **Have I confused minimalism with simplicity?** True simplicity is ease of use, not just visual reduction.
+
+## Related principles
+
+- **Form Follows Function** — the razor and form-follows-function are closely related; both ask whether each element earns its place.
+- **80/20 Rule** — most use is concentrated in a few features; the razor justifies pruning the long tail.
+- **Signal-to-Noise Ratio** — simpler designs have higher signal-to-noise.
+- **Mapping** — simpler mappings are easier to understand.
+- **Hick's Law** — fewer options means faster decisions.
+- **Iteration** — simplification is often an iterative process; what wasn't ready to remove last year may be ready now.
+
+## See also
+
+- `references/lineage.md` — origins in medieval philosophy and modern engineering.
+- `ockhams-feature-pruning/` — sub-skill on pruning accumulated complexity.
+- `ockhams-equivalent-designs/` — sub-skill on identifying functionally equivalent options.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-razor/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/ockhams-razor/references/lineage.md
@@ -1,0 +1,87 @@
+# Ockham's Razor — origins and research lineage
+
+## Medieval philosophy
+
+The principle is named for William of Ockham (c. 1287–1347), an English Franciscan friar and philosopher. Ockham articulated several versions of the principle that "entities should not be multiplied beyond necessity" (Latin: *Entia non sunt multiplicanda praeter necessitatem*). The principle was a methodological tool in medieval philosophical and theological argument: when explaining a phenomenon, the simplest explanation that fits the evidence is preferred.
+
+Ockham didn't invent the idea — earlier philosophers (Aristotle, Aquinas, Duns Scotus) had articulated similar principles — but his name is attached to it through historical tradition.
+
+The original use was epistemological: when constructing explanations of natural or theological phenomena, don't posit unnecessary entities. If two theories explain the same phenomenon equally well, the one with fewer assumed entities is preferred.
+
+## In modern science
+
+The razor became a methodological touchstone in modern science. Newton's third "rule of reasoning" in *Principia Mathematica* (1687): "We are to admit no more causes of natural things than such as are both true and sufficient to explain their appearances." Einstein's variant: "Everything should be made as simple as possible, but no simpler."
+
+In scientific practice, the razor functions as a tiebreaker. Among theories that fit the data equally well, the simpler one is preferred. This isn't because nature is "simple" but because simpler theories are easier to test, falsify, and build upon.
+
+The razor doesn't claim that simpler theories are *true* — it claims they're a better starting point. Complex theories may turn out to be correct (general relativity is more complex than Newtonian mechanics), but they need to earn their place by explaining things the simpler theory can't.
+
+## In engineering and design
+
+Engineering has independently arrived at similar principles through painful experience with complexity:
+
+- **KISS (Keep It Simple, Stupid).** Lockheed engineer Kelly Johnson's principle for designing aircraft.
+- **YAGNI (You Aren't Gonna Need It).** Extreme Programming principle: don't build features until they're actually needed.
+- **DRY (Don't Repeat Yourself).** A different kind of simplicity — eliminating redundancy.
+- **Worse is better.** Richard Gabriel's controversial 1989 essay arguing that simpler systems often beat more elaborate ones in real-world adoption.
+
+These all express variations of the razor adapted to engineering contexts: complexity is expensive; eliminate what you can.
+
+## In product design
+
+In product design, the razor cuts in a few specific contexts:
+
+**Feature decisions.** Should we add this feature? The razor asks: does it earn its place? Could users accomplish the goal without it?
+
+**Architectural decisions.** Should we use this technology / framework / dependency? The razor asks: is the simpler alternative sufficient?
+
+**Visual decisions.** Should the design include this element? The razor asks: does it serve the user, or is it decoration?
+
+**Interaction decisions.** Should this be a setting, a default, or something the system decides? The razor asks: is the user's choice valuable, or is it just complexity?
+
+The discipline is to be willing to say no to additions, even attractive ones, when they don't earn their place.
+
+## The razor and its critics
+
+The razor is widely cited but also widely contested. Critics make several points:
+
+**Complexity is sometimes essential.** Some problems are genuinely complex; oversimplifying solutions to them produces failures.
+
+**"Simpler" is in the eye of the beholder.** What counts as simpler often depends on assumptions and context. A design that's simpler in code may be more complex to use, or vice versa.
+
+**Premature simplification is its own failure.** Stripping things before understanding their purpose can be worse than including them.
+
+**The razor is a heuristic, not a law.** It works as a tiebreaker, not a rule that overrides other considerations.
+
+These critiques don't undermine the razor — they refine its application. The razor is most useful as a discipline against unnecessary complexity, not a mandate for minimum complexity.
+
+## Empirical patterns worth remembering
+
+The literature on complexity in design and engineering converges on:
+
+- **Complexity has compounding costs.** Each addition is small; the accumulated cost is substantial.
+- **Removal is harder than addition.** Once a feature exists, removing it generates user resistance even if usage is low.
+- **The right time to simplify is at the moment of decision.** Adding restraint at decision time prevents accumulation.
+- **Simple systems evolve more easily than complex ones.** A simple system can become complex; a complex system rarely becomes simple without major rework.
+- **Documentation length is a proxy for complexity.** When the user manual gets longer, the design has gotten more complex.
+
+## Modern relevance: AI and complexity
+
+The current generation of AI tools introduces a new variant of the razor question. AI capabilities tempt designers to add intelligence everywhere — every input gets autocomplete, every action gets a recommendation, every workflow gets an AI assistant.
+
+The razor question: does each AI capability earn its place? Or is it adding complexity that the user has to evaluate and trust without proportional benefit?
+
+Some AI features genuinely earn their place (search relevance, spam detection, transcription). Others are complexity in disguise (an AI suggestion that's wrong as often as right; a chat interface for tasks that have a clearer non-chat solution).
+
+The razor still cuts: even powerful capabilities should be added only when they're better than the simpler alternative.
+
+## Sources informing this principle
+
+- William of Ockham (14th century). Various philosophical writings.
+- Newton, I. (1687). *Principia Mathematica*. (Rules of reasoning.)
+- Einstein, A. (Various).
+- Gabriel, R. (1989). "The Rise of Worse is Better." (On the trade-offs in software engineering.)
+- Lockheed engineering tradition (KISS principle).
+- Beck, K., et al. (2000s). Extreme Programming literature (YAGNI principle).
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*.
+- Various essays on minimalist design (Dieter Rams, John Maeda's *The Laws of Simplicity*).

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/process-router/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/process-router/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: process-router
+description: 'Use this skill whenever the question is *how* to design well over time or *how* to make a design that doesn''t break — accessibility, prototyping cadence, MVP scoping, edge cases, performance budget, error handling at scale, design system governance, or any architectural-design question. Trigger on accessibility questions, "is this ready to ship," "what about the edge case where," design reviews, MVP scoping, "we have too many opinions on this." Framework-agnostic. Routes the model to the right process or robustness principle in this plugin.'
+---
+
+# Process & robustness — router
+
+This plugin holds the principles that govern *how design happens* and *how it survives contact with reality* — accessibility, iteration loops, edge cases, design-team dynamics, robustness against scale.
+
+## Principles in this plugin
+
+Each principle has its own skill (with sub-aspect skills where useful). Principles marked **[full]** have reference-grade skill files; the rest are planned and will be added in subsequent passes.
+
+### Inclusion
+
+- **`accessibility`** *[full]* — usable by people with the widest possible range of abilities.
+  - Sub-skills: `accessibility-perceivable`, `accessibility-operable`, `accessibility-understandable`, `accessibility-robust`.
+
+### Process and iteration
+
+- **`iteration`** — design is a loop, not a waterfall.
+- **`prototyping`** — making something concrete reveals what specs cannot.
+- **`development-cycle`** — projects move through requirements, design, develop, test phases.
+- **`life-cycle`** — products age; design for the whole arc, not just launch.
+- **`design-by-committee`** — group consensus produces averaged designs; beware.
+- **`not-invented-here`** — reflexive rejection of external solutions costs time and quality.
+- **`ockhams-razor`** *(also in cognition)* — among solutions that work, prefer the simplest.
+
+### Robustness and edge cases
+
+- **`factor-of-safety`** — design with margin so normal operation isn't at the edge of failure.
+- **`weakest-link`** — chains break at the weakest link; find and reinforce it.
+- **`normal-distribution`** — most users cluster around the mean; design for the bulk, accommodate the tails.
+- **`scaling-fallacy`** — what works at small scale doesn't necessarily scale.
+- **`uncertainty-principle`** — observation changes the observed; instrumentation distorts behavior.
+- **`structural-forms`** — load-bearing patterns that distribute stress (mass, frame, shell).
+
+## Heuristic for which to read first
+
+- **Every design task** → `accessibility`. Read it, run the checklist.
+- **MVP scoping** → `iteration`, `ockhams-razor`, `factor-of-safety`.
+- **"Is this ready to ship?"** → `weakest-link`, `factor-of-safety`, `accessibility`.
+- **Design system governance** → `consistency` (cognition), `modularity` (cognition), `life-cycle`.
+- **Reviewing scale** → `scaling-fallacy`, `normal-distribution`.
+- **Stuck in committee** → `design-by-committee`, `not-invented-here`, `ockhams-razor`.
+- **Performance / latency** → `weakest-link`, `factor-of-safety`, `feedback-loop` (interaction).
+
+## Cross-plugin pointers
+
+- For *visual* hierarchy and grouping, see `perception-and-hierarchy-principles`.
+- For *learnability*, see `cognition-and-learnability-principles`.
+- For *behavior*, see `interaction-and-control-principles`.
+- For *aesthetic and tonal* decisions, see `aesthetics-and-emotion-principles`.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/process-router/references/further-reading.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/process-router/references/further-reading.md
@@ -1,0 +1,48 @@
+# Further reading: process and robustness
+
+External sources for the process-related principles.
+
+## Foundational
+
+- **Petroski, H.** *To Engineer Is Human: The Role of Failure in Successful Design* (1985). Engineering-grounded discussion of factor-of-safety, weakest-link, and learning from failure. Applies surprisingly well to software.
+- **Maeda, J.** *The Laws of Simplicity* (2006). Ten laws including reduction, organization, time, learn, differences, context, emotion, trust, failure, the one. Closely related to many process principles.
+- **Cooper, A. et al.** *About Face* (multiple editions). Covers design process, personas, scenarios.
+- **Norman, D.** *The Design of Everyday Things* (1988, 2013). Process discussion in chapters on iterative design and design thinking.
+
+## Accessibility
+
+- **W3C Web Content Accessibility Guidelines (WCAG)** — w3.org/WAI/standards-guidelines/wcag. Current version is WCAG 2.2; WCAG 3 is in draft.
+- **Holmes, K.** *Mismatch: How Inclusion Shapes Design* (2018). Inclusive design as a design philosophy, not a compliance checklist.
+- **Microsoft Inclusive Design Toolkit** — microsoft.com/design/inclusive. Practical methods.
+- **Section508.gov** — US federal accessibility resources.
+- **European Accessibility Act** materials — for products serving EU customers.
+
+## Iteration and process
+
+- **Brown, T.** *Change by Design* (2009). Design thinking applied to organizations.
+- **Ries, E.** *The Lean Startup* (2011). Iteration, MVP, validated learning.
+- **Beck, K.** *Extreme Programming Explained* (2000) and the Agile Manifesto (2001). Iteration in software engineering.
+- **Knapp, J.** *Sprint* (2016). Five-day design sprint methodology.
+
+## Robustness and engineering reliability
+
+- **Petroski, H.** (cited above).
+- **Reason, J.** *Human Error* (1990). Slips vs. mistakes; system-level error analysis from aviation/medical safety research.
+- **Perrow, C.** *Normal Accidents* (1984). System-level failure analysis; useful framing for what robustness means in complex systems.
+
+## Design system governance
+
+- **Curtis, N.** *Modular Web Design* (2010). Early modular design system thinking.
+- **Frost, B.** *Atomic Design* (2016). Hierarchical component thinking.
+- **Design system literature** — Brad Frost's blog, Smashing Magazine articles, design-system community resources.
+
+## Online resources
+
+- **a11yproject.com** — practical accessibility patterns.
+- **WebAIM.org** — accessibility training, contrast checker, WCAG references.
+- **Inclusive Components** (Heydon Pickering) — book and articles on accessible component patterns.
+- **WAI-ARIA Authoring Practices Guide** — w3.org/WAI/ARIA/apg.
+
+## Closing
+
+Process and robustness are the principles most often relegated to "phase 2" — and by phase 2, most products have shipped phase 1 with permanent costs. The investment in accessibility, iteration discipline, and robustness from day one repays itself many times over.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping-concept-throwaway-evolutionary/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping-concept-throwaway-evolutionary/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: prototyping-concept-throwaway-evolutionary
+description: 'Use this skill when picking which kind of prototype to build for the question at hand — concept (exploratory), throwaway (testing one specific aspect), or evolutionary (incremental toward final). Trigger when planning a research method, when scoping a technical spike, or when deciding whether an MVP should evolve or be thrown away. Sub-aspect of `prototyping`; read that first.'
+---
+
+# The three prototype kinds
+
+The book identifies three prototype kinds — concept, throwaway, evolutionary — each with characteristic uses, costs, and failure modes.
+
+## Concept prototypes
+
+For exploring preliminary ideas. Quick, cheap, often disposable.
+
+**Use for**: brainstorming sessions, early stakeholder alignment, exploring whether a direction is worth pursuing.
+
+**Examples**: paper sketches, storyboards, mood boards, foam mockups, role-playing.
+
+**Failure mode**: artificial reality problem. A skilled designer can make any concept look plausible; the prototype's polish doesn't predict actual workability.
+
+## Throwaway prototypes
+
+For testing specific aspects of a design.
+
+**Use for**: performance benchmarks, A/B tests, single-flow user studies, technical spikes.
+
+**Examples**: standalone interactive demos, wind-tunnel models, isolated code experiments.
+
+**Failure mode**: scaling and integration problem. A throwaway that works in isolation may fail when integrated or at scale.
+
+## Evolutionary prototypes
+
+For incrementally building toward the final design.
+
+**Use for**: MVPs that grow into products, iterative startup development, products with uncertain requirements.
+
+**Examples**: software MVPs, agile sprint outputs, lean startup builds.
+
+**Failure mode**: tunnel vision. Iterations refine the current direction; teams may miss fundamentally better directions.
+
+## Picking the right kind
+
+| Situation | Prototype kind |
+|---|---|
+| Exploring ideas; "is this worth doing?" | Concept |
+| Testing one specific question | Throwaway |
+| Iterating toward a final product | Evolutionary |
+| Stakeholder alignment | Concept |
+| Performance benchmark | Throwaway |
+| Scaling a startup | Evolutionary |
+
+The kinds aren't mutually exclusive. A typical project uses concept prototypes early (to align), throwaway prototypes mid (to test specifics), and evolutionary prototypes late (to ship and refine).
+
+## Combining the kinds
+
+A common pattern:
+
+1. **Concept** prototypes to explore directions and align stakeholders.
+2. **Throwaway** prototypes to test specific risks (performance, user flow, integration).
+3. **Evolutionary** prototyping to build the actual product, informed by what concept and throwaway prototypes revealed.
+
+Each kind catches different issues; using all three reduces the risk of any single failure mode.
+
+## Resources
+
+- Lidwell, Holden, Butler — *Universal Principles of Design* (2003).
+- Schrage, M. *Serious Play* (1999).
+- Brooks, F. *The Mythical Man-Month* (1995).
+- Boehm, B. "A Spiral Model of Software Development and Enhancement" (1986).

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping-concept-throwaway-evolutionary/references/three-kinds-cases.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping-concept-throwaway-evolutionary/references/three-kinds-cases.md
@@ -1,0 +1,35 @@
+# Three prototype kinds: case reference
+
+A reference complementing `prototyping-concept-throwaway-evolutionary` with case examples.
+
+## Concept prototype cases
+
+- **IDEO's shopping-cart redesign** (1999, ABC Nightline). Sketched concepts, foam mockups, role-played scenarios — all concept prototypes that explored radically different directions before any commitment to build.
+- **Pixar's story reels.** Hand-drawn animated storyboards reviewed and revised dozens of times before any final animation. Concept prototypes for narrative.
+- **Architecture sketches.** Frank Gehry's crumpled-paper studies that became the Guggenheim Bilbao.
+
+## Throwaway prototype cases
+
+- **Wright brothers' wind-tunnel models.** Tested wing shapes in a homemade wind tunnel; informed final aircraft design; were not themselves the design.
+- **A/B test variants.** Each variant is a throwaway prototype testing a specific hypothesis. Discarded after the test resolves.
+- **SpaceX's SN8 / SN9 / SN10 etc.** — explicitly throwaway prototypes of the Starship; each tested specific things and was lost in the testing.
+
+## Evolutionary prototype cases
+
+- **Most modern startups.** The MVP is shipped, used by real customers, evolved based on what works.
+- **Slack** — started as an internal tool for a different game-development project (Tiny Speck); evolved into the team-chat product.
+- **Twitter** — started as side-project at Odeo (a podcasting company); evolved into something different.
+
+## When the kind matters
+
+Some failure cases come from picking the wrong kind:
+
+- **Treating an evolutionary prototype as a throwaway** (or vice versa). A team builds something to "explore" but then ships it as the product. The architecture isn't ready; technical debt accumulates.
+- **Treating a concept prototype as a working version.** Stakeholders see a polished concept and assume it's nearly built. Disappointment when the actual build takes much longer than they expected.
+- **Skipping concept prototypes** and going straight to throwaway. Often produces work that solves the wrong problem.
+
+## Resources
+
+- Lidwell, Holden, Butler — *Universal Principles of Design* (2003).
+- Schrage, M. *Serious Play* (1999).
+- Kelley, T. *The Art of Innovation* (2001).

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping-when-and-what/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping-when-and-what/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: prototyping-when-and-what
+description: 'Use this skill when deciding what to prototype, what fidelity to use, and when to stop prototyping and ship. Trigger when planning research, scoping a design phase, or facing pressure to "stop prototyping and just build it." Sub-aspect of `prototyping`; read that first.'
+---
+
+# Picking what and when to prototype
+
+Prototyping has costs (time, opportunity, sometimes confusion). Picking the right thing to prototype, at the right fidelity, at the right moment, is how teams get the benefits without the costs.
+
+## What to prototype
+
+Three categories of question prototypes answer well:
+
+### Risky assumptions
+
+Things you're not sure will work. The riskier the assumption, the more valuable the prototype.
+
+- "Users will understand this new flow" — prototype + user test.
+- "This algorithm will be fast enough at production scale" — throwaway performance prototype.
+- "Customers will pay for this feature" — concierge MVP or smoke test.
+
+### Disputed decisions
+
+When stakeholders disagree, prototypes resolve faster than discussion.
+
+- Designer vs. engineering on flow complexity.
+- PM vs. design on feature scope.
+- Marketing vs. design on visual direction.
+
+### High-investment decisions
+
+When the cost of being wrong is high — time, money, brand — invest in prototyping to reduce risk.
+
+- New product launches.
+- Architectural changes.
+- Brand redesigns.
+
+## What NOT to prototype
+
+- **Well-understood patterns.** Don't prototype the placement of a Save button on a CRUD form.
+- **Decisions you'd make the same way regardless of the prototype's outcome.** If you'd ship the favorite anyway, prototyping the alternative is wasted.
+- **Things you can't act on.** Prototyping a feature you won't have engineering to build is theater.
+
+## Picking fidelity
+
+The fidelity-to-question match (covered more in `iteration-prototype-fidelity`):
+
+| Question | Fidelity |
+|---|---|
+| "Does this structure make sense?" | Sketch / wireframe |
+| "Is this visual direction right?" | Mockup |
+| "Does the flow work for users?" | Clickable prototype |
+| "Will it be fast enough?" | Code prototype |
+| "Will users adopt it at scale?" | Production beta |
+
+Going higher than necessary wastes time and risks anchoring stakeholders.
+
+## When to stop prototyping
+
+A common failure: indefinite prototyping that never ships. Signals it's time to stop:
+
+- The current iteration is producing diminishing returns.
+- The remaining unknowns are best resolved by real users in production.
+- Stakeholders are reviewing prototypes that look final.
+- The next "iteration" is essentially the build phase.
+
+The discipline: define explicit "good enough to ship" criteria before starting to prototype. When the criteria are met, ship.
+
+## Communication with stakeholders
+
+Stakeholders often see polished prototypes as nearly-finished products. The artificial reality problem in stakeholder form.
+
+Communication patterns:
+
+- **Label fidelity explicitly.** "This is a low-fidelity prototype" prefacing demos.
+- **Name what's not yet built.** "The visual style is placeholder; the interaction is what we're testing."
+- **Set expectations for the timeline.** "From here to production is X weeks."
+
+Without this framing, stakeholders form unrealistic expectations.
+
+## Common patterns
+
+### Spike + commit
+
+Pre-engineering: a 1–3 day technical spike to validate feasibility. Then commit to building if the spike succeeds.
+
+### Test-then-design
+
+Pre-design: usability test of competitor products or prior versions to gather data; then design informed by the data.
+
+### Prototype-then-spec
+
+Pre-spec: build a prototype; specifications come from what the prototype reveals. The spec describes the working prototype rather than predicting it.
+
+### Continuous prototyping (modern agile)
+
+Each sprint produces something testable. Each release prototypes the next. The line between prototype and product blurs.
+
+## Anti-patterns
+
+- **Prototyping without a question.** Building because "we should make a prototype" rather than to answer something specific.
+- **Endless iteration.** Prototyping past the point of diminishing returns; never shipping.
+- **Production-quality prototypes.** Building prototypes to production code quality; the cost of throwaway evaporates.
+- **Stakeholder confusion.** Showing polished prototypes without framing; stakeholders think it's done.
+- **Fidelity creep.** Starting low-fi; gradually polishing; ending with a high-fi prototype that took as long as the actual product would have.
+
+## Heuristics
+
+1. **The "cheapest fidelity" rule.** Pick the cheapest fidelity that answers the question.
+2. **The "what would change?" check.** Before building a prototype, ask: if the prototype reveals X, what will I do? If Y, what? If you can't name actions, the prototype isn't worth building.
+3. **The disposability check.** If you'd be sad to throw the prototype away, you over-invested.
+4. **The stakeholder-framing audit.** Is everyone clear this is a prototype? If not, expectations will diverge from reality.
+
+## Related sub-skills
+
+- **`prototyping`** (parent).
+- **`prototyping-concept-throwaway-evolutionary`** — picking the kind.
+- **`iteration`** — prototypes power iteration.
+- **`iteration-prototype-fidelity`** — fidelity selection in detail.
+- **`80-20-rule`** — prototype the 20% that matters most.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping-when-and-what/references/when-to-stop.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping-when-and-what/references/when-to-stop.md
@@ -1,0 +1,51 @@
+# When to stop prototyping: reference
+
+A reference complementing `prototyping-when-and-what` with patterns for the prototype-to-ship transition.
+
+## Stopping criteria
+
+Define before starting:
+
+- **The question is answered.** The prototype's purpose was to resolve X; X is resolved.
+- **Diminishing returns.** Each iteration produces less new learning.
+- **Build-vs-prototype crossover.** The next iteration would essentially be the production build; just build.
+- **External pressure.** Time, budget, or competitive pressure forces commitment.
+
+Without explicit stopping criteria, prototyping can continue indefinitely (perfectionism) or stop too early (premature commitment).
+
+## The "good enough to ship" framing
+
+Lean Startup popularized "MVP" — minimum viable product. The threshold for "viable" is the stopping criterion: enough to learn from real users, not necessarily enough to be loved.
+
+For internal tools: viable might mean "team can use it without major friction."
+For consumer products: viable might mean "early adopters tolerate it; we learn from their use."
+For enterprise products: viable might mean "lighthouse customer signs."
+
+Each context has different viability thresholds.
+
+## Prototype-to-product transition
+
+The transition is risky:
+
+- **Code prototypes** often have technical debt that makes production-quality refactoring expensive.
+- **Visual prototypes** lack edge-case handling.
+- **Flow prototypes** miss accessibility considerations.
+
+Plan the transition explicitly. Some teams treat the production build as a separate project informed by the prototype; others continue evolving the prototype with progressively higher quality bars.
+
+## Risk of indefinite prototyping
+
+Symptoms:
+
+- Multiple "we just need one more iteration" cycles.
+- Stakeholders treating prototypes as products.
+- The prototype's polish exceeding the original brief.
+- Team forgetting why they started prototyping.
+
+When these appear, force the question: are we building this or not? If yes, ship the next iteration as v0.1 production; learn from real use.
+
+## Resources
+
+- Ries, E. *The Lean Startup* (2011) — MVP framing.
+- Brooks, F. *The Mythical Man-Month* (1995) — "plan to throw one away."
+- Knapp, J. *Sprint* (2016) — five-day design sprint with explicit stopping.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: prototyping
+description: 'Use this skill whenever the design has unknowns that need testing — when a sketch could resolve a debate, when assumptions about user behavior could be checked cheaply, when a high-fidelity build would benefit from a low-fidelity draft first. Trigger when planning research, when scoping a new feature, when stakeholders want to see something concrete, or when the team is stuck arguing about an approach. Prototyping is one of the foundational principles in ''Universal Principles of Design'' (Lidwell, Holden, Butler 2003) and one of the highest-leverage process principles — the cheapest prototype that resolves the question is almost always cheaper than the consequences of skipping it.'
+---
+
+# Prototyping
+
+Prototypes are simplified and incomplete models of a design used to explore ideas, validate assumptions, refine specifications, and test functionality before committing to full implementation. The discipline is matching prototype fidelity to the question being asked — paper sketches answer structural questions cheaply; coded prototypes answer performance questions but cost more. Picking the right fidelity for each question lets teams iterate fast where it matters most.
+
+## Definition (in our own words)
+
+A prototype is a deliberately incomplete version of a design built to answer a specific question that wasn't answerable from specifications alone. Prototypes range from paper sketches (minutes to make, structural questions only) to working code (days or weeks, real-world behavior questions). They are throwaway by intent — the team learns what they need to learn and moves on. The book identifies three kinds — *concept*, *throwaway*, and *evolutionary* — each suited to different questions.
+
+## Origins and research lineage
+
+- **Engineering practice** — prototypes have been used since the industrial revolution. Wright brothers built and tested over 200 wing prototypes before the Flyer.
+- **Software engineering** — Frederick Brooks' *The Mythical Man-Month* (1975, 1995) and Barry Boehm's spiral model (1986) both emphasized prototyping as risk reduction.
+- **Lidwell, Holden & Butler** (2003) compactly distinguish three prototype kinds: concept (exploratory), throwaway (specific question), evolutionary (incremental refinement toward the final).
+- **Tom Kelley & David Kelley** at IDEO, *The Art of Innovation* (2001) and *Creative Confidence* (2013). Codified prototyping as core to design thinking; "fail fast" via cheap prototypes.
+- **Michael Schrage**, *Serious Play: How the World's Best Companies Simulate to Innovate* (Harvard Business School Press, 1999). Argued that prototyping cultures outperform specification cultures.
+- **Modern continuous-delivery practice** — every staging deployment is, in a sense, a prototype of production behavior; canary releases prototype at increasing scale.
+
+## Why prototyping matters
+
+Specifications and discussions can hide assumptions that only become visible when something concrete exists. A team can argue for weeks about whether a flow makes sense; ten minutes with a paper prototype usually resolves it. Engineering can spend weeks building something that turns out to be wrong; a clickable Figma in advance would have caught the issue.
+
+The economics: prototyping costs scale roughly logarithmically with fidelity (sketch ~ 1x cost, wireframe ~ 5x, mockup ~ 20x, code ~ 100x), but error-discovery cost scales roughly logarithmically with the phase the error is found in (requirements ~ 1x, design ~ 5x, code ~ 50x, production ~ 500x+). Catching errors at the prototype phase is dramatically cheaper than catching them in production.
+
+## The three kinds (from the book)
+
+### Concept prototyping
+
+For exploring preliminary ideas. Quick, cheap, often disposable.
+
+Examples:
+- Concept sketches.
+- Storyboards.
+- Mood boards.
+- Wireframes.
+- Cardboard mockups for industrial design.
+- Foam props.
+
+The book's caution — the **artificial reality problem**: a skilled artist or modeler can make any design look like it will work in a concept prototype. Don't conflate "looks plausible" with "will work in production."
+
+When to use: very early, when the question is "is this concept worth exploring further?" or "do stakeholders agree on direction?".
+
+### Throwaway prototyping
+
+For testing specific aspects of a design. Built to answer a question, then discarded.
+
+Examples:
+- Wind-tunnel models of automobile aerodynamics.
+- Performance benchmarks of a specific algorithm.
+- A/B test variants.
+- Standalone interactive demos.
+
+The book's caution — the **scaling-and-integration problem**: a feature that works in a throwaway prototype may not scale or integrate properly when built into the production system.
+
+When to use: when one specific aspect needs verification (performance, usability of one flow, market reaction).
+
+### Evolutionary prototyping
+
+For incrementally building toward the final design. The prototype itself evolves into (or becomes) the production system.
+
+Examples:
+- Software MVPs that grow into the product.
+- Architectural mockups that inform the final building.
+- Iterative product development with continuous user feedback.
+
+The book's caution — the **tunnel vision problem**: evolutionary prototypers often get fixated on tuning existing specifications rather than exploring alternatives. Each iteration improves the current direction but may miss a better direction entirely.
+
+When to use: when design specifications are uncertain or changing, and the team can sustainably iterate.
+
+## When to apply
+
+- **Whenever there's significant uncertainty** about a design choice.
+- **Before major implementation investments** — a few hours of prototyping can save weeks of building the wrong thing.
+- **When stakeholders disagree** — concrete prototypes resolve disputes that abstract discussions can't.
+- **For user testing** — most useful research uses prototypes as the subject.
+- **For technical risk reduction** — performance, integration, and scale risks become visible in prototypes earlier than in production.
+
+## When NOT to over-apply
+
+- **For trivial, well-understood decisions.** Prototyping the placement of a Save button on a CRUD form wastes effort.
+- **In safety-critical final stages.** Prototypes are by definition incomplete; once a design is destined for safety-critical deployment, formal verification beats further prototyping.
+- **As a substitute for shipping.** Endless prototyping without commitment is procrastination disguised as research.
+
+## The fidelity ladder
+
+Different fidelities answer different questions; pick the cheapest fidelity that answers your question.
+
+| Fidelity | Cost | Answers |
+|---|---|---|
+| Paper sketch | Minutes | Structure, IA, "does this make sense?" |
+| Wireframe | Hours | Layout, component placement, navigation |
+| Mockup (static, high-fidelity) | Hours-days | Visual style, brand fit, "looks like" |
+| Clickable prototype (Figma, Framer) | Days | Interaction flow, "feels like" |
+| Coded prototype | Weeks | Performance, edge cases, real data |
+| Production beta | Months | Actual user behavior at scale |
+
+(See `iteration-prototype-fidelity` in this plugin for deeper detail on fidelity choices.)
+
+## Worked examples
+
+### Example 1: paper prototype to resolve a debate
+
+Designers and engineers disagree on a flow. Engineering says it's complicated; design says users will figure it out.
+
+A 30-minute paper prototype: sketch the flow on index cards, walk a colleague through it.
+
+Outcome: in 30 minutes, both sides see what works and what doesn't. The debate resolves with concrete evidence rather than opinion.
+
+### Example 2: clickable prototype for user research
+
+A new feature. Before building, the team makes a clickable Figma prototype. They test with 5 users.
+
+Outcome: 3 of 5 users misunderstand the same step. The team revises the flow before any code is written. The build, when it happens, reflects the revisions.
+
+If the team had skipped the prototype, the misunderstanding would have surfaced after weeks of engineering work.
+
+### Example 3: technical spike (throwaway prototype)
+
+A team wants to add real-time collaboration. They suspect their current architecture might not handle the latency. They spend a week building a throwaway prototype with WebSockets, just to measure latency under load.
+
+Outcome: latency is acceptable; the throwaway prototype is discarded; the team proceeds to design the production version informed by what they learned.
+
+If they had skipped the prototype and built the production version directly, they'd have been months in before discovering the latency problem.
+
+### Example 4: evolutionary prototype as MVP
+
+A startup builds an MVP — minimal feature set, minimal polish — and ships it to early customers. Each iteration adds features and polish based on what customers actually use.
+
+Outcome: after a year, the MVP has evolved into the production product. Many features the team initially planned were dropped because customers didn't want them; new features were added based on patterns observed in usage.
+
+The risk: the team may have stuck too closely to the initial concept, missing pivot opportunities. The book's tunnel-vision warning applies.
+
+## The three failure modes (from the book)
+
+Each prototype kind has a characteristic failure:
+
+### Concept: the artificial reality problem
+
+Skilled designers and modelers can make any design *look* like it works. Beautiful storyboards and high-fidelity Figma mockups can suggest a product that, when built, doesn't actually function. Stakeholders see polished prototypes and assume they're closer to ready than they are.
+
+Mitigation: be explicit about what the prototype proves and doesn't prove. A pretty Figma proves "the structure makes sense"; it doesn't prove "this will work."
+
+### Throwaway: the scaling/integration problem
+
+A prototype that works in isolation may not work when integrated. A performance benchmark that assumes idealized conditions may fail under real production load. A user-tested flow that worked with a small group may fail at scale.
+
+Mitigation: identify the assumptions the throwaway makes; verify those before trusting the result. "This worked in our prototype with 100 records" doesn't mean "this will work with 100 million."
+
+### Evolutionary: the tunnel vision problem
+
+Each iteration improves the current direction. Over time, the team gets fixated on tuning existing specifications rather than questioning whether a different direction would be better.
+
+Mitigation: periodically take a step back. Are we iterating on the right thing? Is there a fundamentally different approach we should explore? The "kill your darlings" discipline.
+
+## Cross-domain examples
+
+### Industrial design
+
+The book uses the OXO Good Grips peeler as an example of prototyping in industrial design. The Ojex juicer (also pictured in the book) went through many prototypes — 2D sketches for mechanical motion, 3D foam for form, functional models for usability — each at the right fidelity to answer the question of that stage.
+
+### Aviation
+
+Wright brothers built and tested over 200 wing prototypes before the Flyer. Modern aircraft go through years of prototyping before production — wind-tunnel models, partial assemblies, full mockups, flight prototypes.
+
+### Architecture
+
+Frank Lloyd Wright produced extensive sketches for each project. Mies van der Rohe built physical scale models. Modern architects use BIM software to prototype digitally before construction.
+
+### Software MVPs
+
+The Lean Startup approach (Eric Ries) treats early product versions as evolutionary prototypes. Build the smallest thing that lets you learn from real customers; iterate based on what you learn.
+
+## Anti-patterns
+
+- **Production-quality prototypes.** Building prototypes to production code quality defeats the cost advantage of prototyping.
+- **Treating prototypes as products.** Shipping a prototype as if it were finished. Usually missing edge cases, accessibility, performance.
+- **Prototypes that don't answer a question.** Building a prototype because "we should make a prototype" rather than because there's a specific question to answer.
+- **Skipping prototyping entirely.** "We'll just build it" — produces development-iteration churn that's far more expensive.
+- **Polishing too early.** Spending hours on visual design before structure is settled; the polish has to be redone.
+- **Stakeholder confusion.** Stakeholders see a prototype and think it's the product. Communicate fidelity explicitly.
+
+## Heuristics
+
+1. **The "what question is this answering?" check.** Before building any prototype, name the question. If you can't, you're not ready to prototype.
+2. **The cheapest-fidelity rule.** Pick the cheapest fidelity that answers the question. Going higher than needed is waste.
+3. **The "what does this prove?" framing.** State explicitly what the prototype proves and doesn't prove. Communicate this with stakeholders.
+4. **The disposability check.** If you'd be sad to throw the prototype away, you over-invested. Prototypes are means; the learning is the end.
+
+## Related principles
+
+- **`iteration`** — prototypes are the vehicles of iteration.
+- **`feedback-loop`** — prototypes generate feedback that shapes design.
+- **`satisficing`** — prototypes test whether designs satisfice for users; full optimization isn't needed.
+- **`scaling-fallacy`** — prototypes that work small may fail large; the throwaway-prototype caution.
+- **`uncertainty-principle`** — prototyping with measurement may itself affect what's being measured.
+- **`weakest-link`** — prototypes find weak links cheaply.
+
+## Sub-aspect skills
+
+- **`prototyping-concept-throwaway-evolutionary`** — distinguishing the three prototype kinds and when each applies.
+- **`prototyping-when-and-what`** — picking what to prototype, what fidelity to use, and when to stop prototyping and ship.
+
+## Closing
+
+Prototyping is the cheapest source of design certainty available. The teams that build the right prototypes — at the right fidelity, asking the right questions — consistently outperform teams that try to specify their way to certainty. The discipline is asking what the prototype is for, picking the cheapest fidelity that answers, and being willing to throw the prototype away once the answer arrives.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping/references/prototyping-history-and-method.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/prototyping/references/prototyping-history-and-method.md
@@ -1,0 +1,45 @@
+# Prototyping: history and methodology reference
+
+A reference complementing the `prototyping` SKILL.md with deeper context.
+
+## Engineering prototyping history
+
+Prototyping is older than industrial design. Examples:
+
+- **Wright brothers** built and tested over 200 wing prototypes (gliders, kites, wind-tunnel models) before the 1903 Flyer.
+- **Edison's invention factory** at Menlo Park was structured around rapid prototyping.
+- **NASA Apollo** program used both physical prototypes (full-size mockups) and analytical prototypes (computer simulations).
+
+Modern engineering inherits the discipline: every aerospace, automotive, or medical-device program has a prototyping phase that catches issues before production.
+
+## Software prototyping methods
+
+- **Fred Brooks**, *The Mythical Man-Month* (1975, 1995). Famous "plan to throw one away" advice — the first version teaches you what you should have built.
+- **Barry Boehm**, "A Spiral Model of Software Development" (1986). Risk-driven prototyping at each cycle.
+- **IDEO and design thinking** (1990s onward). Brought rapid prototyping to consumer-product design and software UX.
+- **Lean Startup** (Eric Ries, 2011). MVPs as evolutionary prototypes; build-measure-learn loop.
+
+## Cross-domain prototyping forms
+
+| Domain | Prototype form |
+|---|---|
+| Software | Code spike, MVP, A/B test variant |
+| Hardware | Foam mockup, breadboard circuit, 3D-printed part |
+| Architecture | Sketch, scale model, BIM walkthrough |
+| Industrial design | Sketch, foam study, working prototype |
+| Service design | Role-playing, journey-map walkthrough |
+| Branding | Mood board, concept ad, focus-group test |
+
+## Prototyping cultures vs. specification cultures
+
+Schrage's *Serious Play* (1999) argued that organizations divide into prototyping cultures (build-then-discuss) and specification cultures (discuss-then-build). His claim: prototyping cultures consistently outperform on innovation and speed.
+
+The pattern holds across many cases. Pixar's "story reels" (animated storyboards reviewed and revised continuously) vs. screenplays-only cultures. SpaceX's iterative-rocket development vs. traditional aerospace's specify-then-build.
+
+## Resources
+
+- Brooks, F. *The Mythical Man-Month* (1995).
+- Schrage, M. *Serious Play* (1999).
+- Kelley, T. & Kelley, D. *Creative Confidence* (2013).
+- Ries, E. *The Lean Startup* (2011).
+- Snyder, C. *Paper Prototyping* (2003).

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-fallacy/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-fallacy/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: scaling-fallacy
+description: 'Apply the principle of avoiding the Scaling Fallacy — the assumption that a system that works at one scale will work at a different (smaller or larger) scale. Use when scaling a feature from prototype to production, designing for an unfamiliar user volume, evaluating whether a process that works for 10 users will work for 10,000, or planning a launch in a much larger market. Two distinct kinds: load assumptions (will it handle the volume?) and interaction assumptions (will users behave the same way?). Both need testing at the actual scale.'
+---
+
+# Scaling Fallacy
+
+> **Definition.** The scaling fallacy is the tendency to assume that a system that works at one scale will also work at a different scale — usually larger, sometimes smaller. The assumption is wrong often enough that it's worth treating as a default suspect rather than a default expectation. Designs that work for 10 users frequently break for 10,000; designs that work for one team frequently fail for an entire company; mockups that look right on a single screen frequently fall apart in production data volumes.
+
+The fallacy is named because it's so common in engineering and design discussions: "We've tested this with 5 users in a session and it works great" → "Therefore it will work at full launch volume." The inference is unwarranted. Scale changes things in two distinct ways: it changes the load on the system (volume of data, volume of users, volume of operations), and it changes the kinds of users and use cases the system encounters (broader audience, more diverse use cases, more edge cases).
+
+Both kinds of change can break a design. The skill is anticipating which assumptions might fail at scale, testing them deliberately, and not assuming that small-scale success predicts large-scale success.
+
+## Two kinds of scaling fallacy
+
+The Lidwell taxonomy distinguishes two kinds, and the distinction is useful.
+
+**Load assumptions.** The system is asked to handle more (or sometimes less) data, traffic, transactions, or operations than it was designed for. Performance degrades, components fail, costs explode, infrastructure breaks.
+
+**Interaction assumptions.** The user base grows or changes, encountering use cases, edge cases, and behaviors that weren't anticipated. Designs that worked for the original audience fail for a broader one.
+
+Both are real; both deserve attention. Most scaling discussions focus on the first (will the servers handle it?) and underweight the second (will the design accommodate the new users?). The second is often the harder problem.
+
+## Why this principle matters
+
+Scaling problems hurt because:
+
+- They appear suddenly and dramatically. A system that was fine at 10x load can fail catastrophically at 11x.
+- They're costly to fix in production. Re-architecting for scale after launch is much more expensive than designing for it initially.
+- They're invisible until they happen. Pre-launch testing rarely captures the actual production scale.
+- They're often non-linear. A 10x increase in users can produce a 100x increase in some operation (e.g., notifications, search queries, support tickets).
+
+The discipline is to *anticipate* scaling problems before they bite, not to discover them in production.
+
+## Common scaling failures
+
+**Lists that work with 10 items and break with 10,000.** A feed designed to display all items fails when "all" is now 10,000. Need pagination, virtualization, or filtering.
+
+**Search that works on a small corpus and fails on a large one.** Linear search across 100 records is fine; across 100 million records, it's not. Need indexing.
+
+**Notifications that work for one user and overwhelm at scale.** A "we'll send you an email when X happens" feature fine for individual users; toxic when X happens 10,000 times a day to a single user.
+
+**UI that works in mockup and breaks with real data.** A design with placeholder text "User Name" works perfectly; the same design with "Dr. Jonathan Christopher Worthington-Smythe III" wraps awkwardly.
+
+**Workflow that works for 5 team members and fails for 500.** A process that depends on "everyone reviewing each other's work" doesn't scale to large teams.
+
+**Pricing that works for one customer segment and fails for another.** A free-tier model that scales to enterprise customers without limits is a financial disaster.
+
+**Feature discoverability that works for 10 features and breaks for 100.** A "show all features in the navigation" approach is fine for small apps; it becomes overwhelming and unsearchable for large ones.
+
+## Diagnosing scaling-fallacy risks
+
+Before assuming a system will scale, ask:
+
+**What's the actual scale we're targeting?** Be specific. 10x current users? 100x? Across what time period?
+
+**Which components are linear vs. exponential in load?** Some scale gracefully; others scale catastrophically.
+
+**What edge cases will become common at scale?** A one-in-a-million event happens daily at scale-of-a-million.
+
+**What use cases will become more diverse?** The new users will use the product in ways the original users didn't.
+
+**What dependencies have their own scaling limits?** A third-party API with a 1000 req/sec limit doesn't help when you have 10,000 req/sec.
+
+**What design choices were made for the small case that won't survive the large?** The "display everything" pattern fails at scale; the "manual moderation" pattern fails at scale; the "everyone gets notified" pattern fails at scale.
+
+## Sub-skills in this cluster
+
+- **scaling-load-assumptions** — Verifying and designing for load (data volume, traffic, transactions). Includes pagination, indexing, caching, queuing, rate limiting.
+- **scaling-interaction-assumptions** — Verifying and designing for user-base growth and diversity (edge cases, new use cases, broader audiences). Includes user-research at scale, feature-prioritization shifts, support patterns.
+
+## Worked examples
+
+### A feed that breaks at scale
+
+A startup builds a feed showing all activity in a user's account. With early users (10–100 events per account), the feed loads instantly and is useful. As the product grows, accounts accumulate thousands of events. The feed takes 30 seconds to load, then crashes the browser.
+
+The fix: pagination + virtualization (only render visible items) + filtering (let users find specific kinds of events). The original design assumed everything could be shown; at scale, "everything" is too much.
+
+### A notification system that overwhelms
+
+A product sends an email when "something interesting" happens. For early users with one teammate and a few projects, "interesting things" happen weekly. For enterprise customers with 100 teammates and 50 projects, "interesting things" happen 100x per day. Users start ignoring all emails and the value is lost.
+
+The fix: digest emails (batch into daily summaries), notification preferences (let users tune what's "interesting"), and intelligent filtering (machine learning to predict relevance). The original assumption of "low frequency = always notify" doesn't survive at scale.
+
+### A user-name field that works in mockup
+
+A design uses placeholder "Jane Doe" for user names. The design fits perfectly. In production, real names include long ones, hyphenated ones, ones with non-Latin characters, ones with diacritics, and titles. The design wraps awkwardly, breaks layout, or truncates important information.
+
+The fix: design for variable name lengths and character sets from the start. Test with real-world name examples (long, short, multi-script, special characters). Don't assume placeholder = reality.
+
+### A team-collaboration feature for 5 members
+
+A document tool's collaboration feature works wonderfully for 5 simultaneous editors: changes appear in real time, conflicts are rare, the cursor positions of others are visible. The same feature with 50 simultaneous editors becomes a flickering mess of cursors and conflicting changes.
+
+The fix: design collaboration patterns that scale. Active vs. passive participation; section-based locking; awareness controls. The 5-person assumption doesn't survive.
+
+### A free tier that scales to enterprise
+
+A SaaS product offers a generous free tier ("up to 1GB of storage, unlimited collaborators"). It works fine for individual users. Enterprise customers sign up under the free tier and use it for hundreds of employees, costing the company more in infrastructure than they could ever charge.
+
+The fix: tier-based limits that scale with usage. Pricing tiers that grow with the customer's actual cost to serve. The "unlimited" assumption doesn't survive enterprise.
+
+### A search that breaks beyond a million records
+
+A simple full-text search over a database table is fine for 1,000 records. At 1 million records, queries take 30 seconds. At 100 million, queries time out entirely.
+
+The fix: dedicated search infrastructure (Elasticsearch, Algolia, or similar). The query patterns also need to change — fuzzy matching, ranking, filtering all become essential. The "just search the table" assumption doesn't survive scale.
+
+## Anti-patterns
+
+**"It works in dev, ship it."** Local testing rarely captures production scale. Pre-launch testing should explicitly target production-scale data and load.
+
+**Assuming linear scaling.** "If it works for 100 users, it'll work for 100,000 because we'll just add 1000x more servers." Many systems have non-linear scaling characteristics; doubling load doesn't always require doubling capacity.
+
+**Ignoring the long tail.** "Most users will only have a few items." True, but the few users with many items will have a terrible experience, and they're often your most valuable customers.
+
+**Designing for the median user.** The median experience may be fine; the experience for users at the upper extreme of usage may be broken.
+
+**Underestimating diversity at scale.** "Our users are all engineers in their 30s in San Francisco." At scale, your users will be retirees in Korea, students in Brazil, and professionals across the entire spectrum of jobs and circumstances. The original audience assumptions don't survive.
+
+**Optimizing only for current scale.** A system optimized aggressively for current 10K users may be hard to re-architect for 1M. Plan for the next 10x even if you're not there yet.
+
+## Heuristic checklist
+
+When designing a system or feature, ask: **What scale am I targeting in 6 months? In 2 years?** Be specific. **Which components scale linearly, and which non-linearly?** Identify the non-linear ones and stress-test them. **What edge cases will become common at scale?** A 0.01% event happens daily at scale-of-a-million. **What user diversity will I encounter?** New users will be different from current users. **Have I tested at the actual target scale, or just smaller?** Small-scale testing doesn't predict large-scale behavior.
+
+## Related principles
+
+- **Weakest Link** — at scale, weak links surface that were invisible at small scale.
+- **Factor of Safety** — design with margin for the scale you might reach, not just the scale you have.
+- **80/20 Rule** — at scale, the 80% may behave very differently from at small scale.
+- **Iteration** — scaling-fallacy mistakes are usually only correctable through iteration.
+- **Errors** — error rates that are tolerable at small scale become unacceptable at large scale.
+
+## See also
+
+- `references/lineage.md` — origins in engineering, biology, and software systems.
+- `scaling-load-assumptions/` — sub-skill on load and capacity scaling.
+- `scaling-interaction-assumptions/` — sub-skill on user-base and behavioral scaling.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-fallacy/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-fallacy/references/lineage.md
@@ -1,0 +1,95 @@
+# Scaling Fallacy — origins and research lineage
+
+## Roots in biology and engineering
+
+The observation that systems behave differently at different scales is foundational to many natural and engineered systems.
+
+In biology, this is sometimes called "Galileo's principle" after Galileo's observation in *Two New Sciences* (1638) that the bones of larger animals must be proportionally thicker, not just scaled-up versions of smaller animals' bones. Doubling an animal's height doesn't just double its weight — it cubes it (volume scales with cube of linear dimension), but the strength of bones only scales with the square (cross-sectional area). So scaled-up animals would collapse under their own weight unless the bones became disproportionately thicker. This is now known as the square-cube law.
+
+This insight generalizes: systems that scale up (or down) often need fundamental architectural changes, not just more of the same. Heat dissipation, structural load, fluid dynamics, communication topology — all scale non-linearly.
+
+J.B.S. Haldane's classic 1926 essay "On Being the Right Size" elaborated the square-cube law through the lens of biology: why elephants need thick legs, why insects can't be much larger, why mice can fall from any height, why fleas can jump proportionally so far. The essay is a masterclass in why scaling assumptions are usually wrong.
+
+## In engineering and software
+
+Software systems exhibit similar scaling pathologies. Common patterns:
+
+**Algorithmic complexity.** An O(n²) algorithm that's fine at n=100 (10,000 operations) is unusable at n=10,000 (100 million operations). The algorithm doesn't scale; it has to be replaced.
+
+**Database scaling.** Single-database architectures hit limits at certain data volumes; sharding, replication, and read replicas become necessary. The "just put it in Postgres" approach has scaling limits that necessitate architectural change.
+
+**Network communication.** A mesh-network communication pattern that works for 10 nodes (45 connections) is impractical for 1000 nodes (~500,000 connections). Hub-and-spoke, hierarchies, or other architectures are needed.
+
+**State management.** Application state that fits in memory at small scale doesn't fit at large scale; persistent storage, caching layers, and stateful protocols become necessary.
+
+**Operational complexity.** Manual processes that work for 10 servers don't work for 10,000. Automation, monitoring, and orchestration become essential.
+
+The accumulation of these scaling pathologies is the central challenge of distributed systems engineering — a discipline that exists largely because the scaling fallacy keeps producing systems that don't survive growth.
+
+## Software design history
+
+The history of software is full of scaling-fallacy stories:
+
+- **The Y2K problem.** A two-digit year representation was fine at small scale; it didn't scale to dates after 1999. Massive remediation effort in the late 1990s.
+- **The IPv4 exhaustion.** A 32-bit address space was generous in 1981; the global internet outgrew it. IPv6 has been a decades-long migration.
+- **The 32-bit Unix timestamp.** A signed 32-bit second counter overflows in 2038. Code is being updated to 64-bit timestamps, but billions of lines of code still need verification.
+- **Twitter's "fail whale" era.** Twitter's monolithic Rails application worked at small scale and famously failed at the scale Twitter rapidly grew to. The "fail whale" image users saw during outages became a cultural symbol of scaling failure.
+- **Various startups whose architecture didn't scale.** A common pattern: rapid early growth, then a year-long re-architecture project that consumed most of the engineering team's capacity.
+
+Each of these is a scaling-fallacy story: assumptions that worked at one scale didn't survive at another.
+
+## In product and UX design
+
+Beyond infrastructure, product and UX design have their own scaling pathologies:
+
+- **The "all in one feed" pattern.** Works for users with little activity; breaks for power users with much.
+- **The "everyone gets notified" pattern.** Works for small teams; toxic for large ones.
+- **The "show all options" pattern.** Works for products with few features; overwhelms for products with many.
+- **The "moderation by humans" pattern.** Works for small communities; impossible for large ones.
+- **The "every user is a friend of an employee" assumption.** Works for early-stage products; fails when users are strangers in distant markets.
+
+Each of these is a design that worked at small scale and failed at larger scale, often catastrophically. Re-architecting for scale is much harder once you're already at scale.
+
+## Empirical patterns
+
+The literature on scaling failures converges on:
+
+- **Failures are often non-linear and sudden.** Systems work fine until they don't; the breaking point comes quickly.
+- **Pre-launch testing rarely captures real-world scale.** Internal testing happens at scales much smaller than production; the issues that matter at production scale don't appear.
+- **Architecture has more impact than optimization.** A system designed for the wrong scale can't usually be optimized into the right scale; it has to be re-architected.
+- **Edge cases dominate at scale.** A 0.01% event happens 100 times a day at a million users. What was rare at small scale is routine at large scale.
+- **Scaling problems reveal weak links.** The components that fail at scale are often the ones with hidden weaknesses that were tolerable at small scale.
+
+## When the principle is most relevant
+
+The scaling fallacy is most likely to bite when:
+
+- You're projecting from very small scale to much larger.
+- The growth has been or is expected to be rapid.
+- The new audience differs significantly from the original.
+- The system has dependencies with their own scaling characteristics.
+- You haven't tested at production scale.
+- The team has experience with the small-scale version but not the large.
+
+In these contexts, especially question scaling assumptions and test deliberately.
+
+## When the principle is less relevant
+
+The fallacy applies less strongly when:
+
+- The scale change is modest (2x rather than 100x).
+- The system has been deliberately designed for scale from the start.
+- The architecture has natural scaling properties (stateless, sharded, queue-based).
+- Production-scale testing is regularly performed.
+
+But even in these cases, surprises happen. The principle deserves attention even when scale changes seem small.
+
+## Sources informing this principle
+
+- Haldane, J. B. S. (1926). "On Being the Right Size." (Classic essay on biological scaling.)
+- Galilei, G. (1638). *Two New Sciences*. (Square-cube law.)
+- Brewer, E. A. (2000). The CAP theorem. (On the constraints of distributed systems at scale.)
+- Vogels, W. (2008). Eventually Consistent. (On the design choices needed at very large scale.)
+- Various war stories: Twitter's fail whale, Friendster's collapse, MySpace's growing pains, etc.
+- *Site Reliability Engineering* (Google, 2016).
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-interaction-assumptions/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-interaction-assumptions/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: scaling-interaction-assumptions
+description: 'Verify and design for user-base scaling — broader audiences, more diverse use cases, more edge cases, behaviors that weren''t anticipated. Use when launching to a new market, scaling from beta to GA, expanding from one team to a company, or any context where the user population is growing or changing. Interaction scaling is often harder than load scaling because it surfaces design assumptions that worked for the original audience but fail for a broader one.'
+---
+
+# Scaling — interaction assumptions
+
+The second kind of scaling fallacy: assumptions about how users will behave, what use cases they'll have, what they'll consider acceptable. A design that works for 100 early users — who tend to be sophisticated, motivated, and tolerant of rough edges — frequently fails for 100,000 broad-audience users who lack those qualities.
+
+Interaction scaling is often harder than load scaling because it requires anticipating how a broader, more diverse audience will use the product. Engineers can load-test infrastructure; product designers have to imagine future users.
+
+## Common interaction-scaling failures
+
+**Original audience assumptions don't transfer.** A productivity tool designed for engineers expects technical sophistication; when adopted by non-technical professionals, the assumptions fail.
+
+**Edge cases become common.** A 1-in-1000 case happens 100 times a day at a million users. Designs that assumed "this won't happen often" find that it does.
+
+**Feature discovery breaks down.** Features that were discoverable when the product had 5 of them become invisible when the product has 50. Users miss capabilities or use them wrong.
+
+**Onboarding doesn't scale.** A hands-on onboarding (calling each user, showing them around) works for hundreds; doesn't work for hundreds of thousands.
+
+**Support model doesn't scale.** Founders answering every support email is fine at 10 users; impossible at 10,000.
+
+**Moderation doesn't scale.** Manual content moderation works for small communities; impossible for large ones. Algorithmic moderation has its own issues.
+
+**Cultural and linguistic assumptions don't transfer.** A product designed for one country has assumptions (language, units, formats, cultural conventions) that fail in others.
+
+**Accessibility gaps surface.** A product that "works for our team" may have accessibility gaps that affect the broader audience disproportionately.
+
+**Naming conventions don't scale.** Personal names, address formats, ID systems vary widely; designs based on one convention fail for others.
+
+**Power-user features intimidate novices.** Capabilities that are useful for sophisticated users overwhelm casual users.
+
+## Designing for interaction scale
+
+**Anticipate diversity.** Imagine the full range of users you'll have, not just your current users. New audiences, languages, abilities, technical skill levels.
+
+**Design for the long tail.** Edge cases at scale become routine cases. Test with weird names, unusual addresses, unexpected workflows.
+
+**Build for self-service.** Users who can solve problems themselves don't need support. Documentation, error messages with recovery paths, contextual help.
+
+**Plan for moderation at scale.** What happens when bad-faith users find your product? Spam filtering, abuse reporting, automated detection.
+
+**Internationalize early.** Adding internationalization (translation, locale formatting, right-to-left layouts) after launch is much harder than designing for it from the start.
+
+**Plan for accessibility from the start.** Accessibility built in from the start is cheap; bolted on later is expensive and incomplete.
+
+**Calibrate features to scale.** Features that are appropriate at one scale may be inappropriate at another. Manual review, hand-curation, personal touch — all need to evolve.
+
+**Design for varying technical sophistication.** Unless your audience is uniformly sophisticated, design layers that accommodate different skill levels.
+
+## Worked examples
+
+### A productivity tool designed for engineers
+
+A team builds a document-editing tool initially used by engineers. Heavy use of keyboard shortcuts, technical terminology, and assumed comfort with markdown. Engineers love it.
+
+The product expands to non-technical professionals. They struggle: keyboard shortcuts they don't know exist; terms like "fork" and "branch" mean nothing; markdown is foreign.
+
+The fix: layered control. Engineers keep their keyboard-shortcut workflow; non-technical users get a WYSIWYG mode with simpler vocabulary. Both audiences served.
+
+The lesson: original-audience assumptions need to be questioned as the audience broadens.
+
+### A name field that breaks for international users
+
+A signup form has First Name and Last Name fields, each capped at 30 characters. Works for most US users. Fails for users with long names, multi-component names (Spanish, Korean naming conventions), single-name users (Indonesian convention), users with name characters outside ASCII.
+
+The fix: a single "Full Name" field with generous character limit and Unicode support. Don't impose name structure assumptions.
+
+The lesson: cultural assumptions baked into forms surface as the audience diversifies.
+
+### Manual moderation that doesn't scale
+
+A community platform's founders moderate every post personally for the first year. Quality stays high. As the platform grows past 10,000 users, manual moderation becomes impossible. They try to hire moderators; quality drops; bad-faith content slips through.
+
+The fix: combination of automated detection (machine learning), community moderation (trusted users), and reactive moderation (report-and-review). The previous "manual everything" approach can't scale.
+
+The lesson: processes that depend on human attention per item don't scale; design for scale by automating, distributing, or eliminating.
+
+### A help center that doesn't scale
+
+A startup answers every support email personally, with detailed explanations. Users love the personal touch. As the startup grows, the founders can't keep up; response times balloon to weeks.
+
+The fix: build a help center with searchable articles covering the most-common questions; in-product help that answers questions contextually; automated chatbots for common queries; human support reserved for complex cases.
+
+The lesson: personal touch doesn't scale; self-service does.
+
+### A feature set that overwhelms new users
+
+A product that started with 5 features now has 50. Original users learned the product gradually as features were added; new users see all 50 at once and don't know where to start.
+
+The fix: progressive disclosure (hide advanced features behind "more"); guided onboarding (introduce features one at a time); contextual feature discovery (show users features as they become relevant).
+
+The lesson: the cumulative complexity of growing products needs active management; just adding features creates an unscalable surface.
+
+### A pricing tier that doesn't scale to enterprise
+
+A SaaS product's free tier has no real limits. Individual users use modest resources. An enterprise customer signs up under the free tier and uses 1000x the resources of an individual; the company loses money on them.
+
+The fix: tier-based usage limits that scale with company size; enterprise pricing that reflects actual cost to serve; required contract for usage above thresholds.
+
+The lesson: pricing based on assumptions about user size doesn't scale when user sizes vary widely.
+
+## Anti-patterns
+
+**"Our users are all like us."** Designers assuming the user base looks like themselves. The actual user base is more diverse than the design team.
+
+**Assuming current users predict future users.** Early adopters are a particular kind of person; broad adoption brings different kinds of people.
+
+**Building for the median user only.** The median experience may be fine; the experience for users at the edges (high usage, low usage, unusual workflows, accessibility needs) may be broken.
+
+**Deferring internationalization.** Internationalization is much cheaper to design in from the start than to retrofit after.
+
+**Deferring accessibility.** Same as internationalization — cheaper from the start.
+
+**Manual processes that depend on the team's attention.** Moderation, support, onboarding — all break when scale exceeds team capacity.
+
+**Hand-curation that isn't sustainable.** Editorial models, personal recommendations, custom configurations — all need automation strategies for scale.
+
+## Heuristic checklist
+
+When designing for interaction scale, ask: **What audience am I targeting at scale, vs. now?** If different, design for the future audience too. **What edge cases will become common?** Test the rare cases; they happen frequently at scale. **What assumptions about users have I made that may not survive scale?** List them; verify each. **What processes depend on team attention?** They won't scale; design alternatives. **What's our internationalization and accessibility story?** Both need to be designed in, not bolted on.
+
+## Related sub-skills
+
+- `scaling-fallacy` — parent principle on scale-related assumption failures.
+- `scaling-load-assumptions` — sibling skill on load and capacity scaling.
+- `weakest-link` — at scale, weak design choices surface.
+- `mental-model` — broader audiences bring different mental models.
+- `accessibility` — accessibility issues become disproportionately impactful at scale.
+- `progressive-disclosure` — depth managed for growing feature sets.
+
+## See also
+
+- `references/audience-scale-checklist.md` — practical checklist for evaluating interaction scaling.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-interaction-assumptions/references/audience-scale-checklist.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-interaction-assumptions/references/audience-scale-checklist.md
@@ -1,0 +1,152 @@
+# Interaction scaling — audience scale checklist
+
+A practical checklist for evaluating whether a design will survive growth in audience size and diversity.
+
+## Audience composition
+
+**Who are your current users?** Demographics, technical sophistication, language, geography, organizational role.
+
+**Who will your future users be?** As you scale, expect: more diversity in all the above dimensions; less technical sophistication; more variety of use cases; more cultural and linguistic differences.
+
+**Have you designed for the future audience or only the current?** Audit assumptions baked into the design.
+
+## Cultural and linguistic
+
+**Internationalization status:**
+- Are strings externalized for translation?
+- Are date, time, number, and currency formats locale-aware?
+- Does the layout support right-to-left languages?
+- Are any features dependent on English idioms or metaphors?
+- Have you tested with locales beyond your launch market?
+
+**Cultural assumptions:**
+- Color conventions (red = stop, etc.) that don't transfer.
+- Icons that reference culturally specific objects.
+- Names, addresses, ID numbers that follow specific cultural conventions.
+- Holidays, calendars, time zones that vary.
+
+## Accessibility
+
+**Standards conformance:**
+- WCAG 2.1 AA at minimum.
+- Tested with screen readers.
+- Tested with keyboard-only navigation.
+- Tested with high-contrast and reduced-motion preferences.
+
+**Beyond standards:**
+- Cognitive accessibility (clear language, predictable patterns).
+- Low-vision support (text scaling, contrast).
+- Motor accessibility (large touch targets, low-friction interactions).
+
+## Use case diversity
+
+**What use cases is the product designed for?** List explicitly.
+
+**What use cases will users invent that you didn't design for?** Watch for these in early production data.
+
+**What edge cases exist that are rare now but will be common at scale?** A 0.01% case happens 100x daily at million-user scale.
+
+**Do you have a story for each edge case?** Either handle it gracefully or fail safely.
+
+## Technical sophistication
+
+**What level of technical sophistication does the product require?** Be explicit.
+
+**Does it match the broader audience's actual sophistication?** Often not.
+
+**Layered control:**
+- Simple defaults for novices.
+- Depth available for experts.
+- Progressive disclosure for growing feature sets.
+
+## Naming and identifiers
+
+**Name handling:**
+- Generous character limits (some names are very long).
+- Unicode support (not just ASCII).
+- Single-name users (some cultures have just one name).
+- Multi-component names (Spanish, Korean, etc.).
+
+**Address handling:**
+- Variable line counts (some addresses have 5 lines, some 1).
+- International postal codes (varying formats).
+- Non-Western address conventions (CJK addresses use a different order).
+
+**ID systems:**
+- National IDs vary widely; don't assume a US-style SSN.
+- Phone numbers vary in format and length.
+- Email is widely supported but not universal in some regions.
+
+## Operations and processes
+
+**Manual processes that depend on team attention:**
+- Identify them. They won't scale.
+- Plan for automation, distribution, or elimination as the audience grows.
+
+**Onboarding:**
+- Hands-on onboarding (calls, demos) doesn't scale beyond a few hundred users per month.
+- Self-service onboarding needed for larger audiences.
+- Onboarding content needs translation and localization.
+
+**Support:**
+- Personal-touch support doesn't scale.
+- Build self-service (help center, in-product help, chatbots).
+- Reserve human support for complex cases.
+
+**Moderation:**
+- Manual moderation doesn't scale beyond small communities.
+- Automated detection + community moderation + reactive moderation needed.
+
+## Feature surface
+
+**Number of features:**
+- Each new feature adds to discoverability load.
+- 10 features can be displayed; 100 cannot. Build progressive disclosure.
+
+**Feature discoverability:**
+- New features need active discovery mechanisms.
+- Feature announcements, contextual prompts, search.
+
+**Feature deprecation:**
+- Some features should be removed as the product matures.
+- Unused features are weight; deprecate deliberately.
+
+## Pricing and resource allocation
+
+**Tier structure:**
+- Limits should scale with usage, not be flat.
+- Enterprise customers shouldn't fit in the same tier as individuals.
+
+**Resource consumption:**
+- Some users will use 100x or 1000x what you expect.
+- Pricing should reflect cost to serve, not just nominal usage.
+
+## Process at scale
+
+**Hiring:**
+- Engineering, support, product, design teams need to grow.
+- Plan for the transitions in team structure as you scale.
+
+**Decision making:**
+- Decisions made by the founders don't scale.
+- Need processes, structures, RFC patterns.
+
+**Knowledge management:**
+- Tribal knowledge doesn't scale.
+- Documentation, wikis, decision records.
+
+## Audit moments
+
+Repeat the audit at:
+- Pre-launch.
+- Right after launch (compare to expectations).
+- 10x current users.
+- 100x current users.
+- Major new market entry.
+- Major new audience expansion.
+
+The right design choices at one scale may be wrong at another. Re-evaluate.
+
+## Cross-reference
+
+For load-related scaling, see `scaling-load-assumptions`. For the parent principle, see `scaling-fallacy`.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-load-assumptions/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-load-assumptions/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: scaling-load-assumptions
+description: 'Verify and design for load scaling — data volume, transaction volume, request rate, and user count. Use when sizing infrastructure, choosing data structures, designing pagination and lazy-loading patterns, evaluating dependencies'' rate limits, or load-testing before launch. Most scaling failures are load failures: a system that handled X requests/second can''t handle 10X. The skill is anticipating the load the system will see and designing or testing for it deliberately.'
+---
+
+# Scaling — load assumptions
+
+The first kind of scaling fallacy: assumptions about how the system will perform under load — data volume, request rate, user count, transaction volume. A system that handles current load gracefully may fail catastrophically at 10x or 100x load. Often the failure isn't a steady degradation but a sharp cliff: things work fine until the moment they don't.
+
+The work of treating load assumptions is partly architectural (designing systems that scale) and partly verification (testing at production-like scale before launch).
+
+## Common load-scaling failures
+
+**Linear search on a growing dataset.** A simple "search through all records" works for small datasets and times out for large ones. Eventually requires indexing or dedicated search infrastructure.
+
+**N+1 query patterns.** A code pattern that issues one database query per item in a list. Fine for 10 items; catastrophic for 10,000.
+
+**Unbounded results.** "Return all matching records" fine for small queries; explodes when "all matching" is millions of rows.
+
+**Synchronous external API calls in a critical path.** Each call adds latency; under load, latency compounds and the system slows.
+
+**Naive caching.** Caching every request individually fills memory; cache eviction becomes the new bottleneck.
+
+**No backpressure.** A system that accepts requests faster than it can process them accumulates a backlog that grows without bound.
+
+**Single points of failure under load.** A single database that handles all writes; a single cache server that holds all sessions. Works under low load; catastrophically fails when load exceeds the single instance's capacity.
+
+**Inadequate rate limiting on dependencies.** A third-party API has a 1000 req/sec limit; the system makes 10,000 req/sec and gets throttled or blocked.
+
+## Patterns for load resilience
+
+**Pagination.** Don't return all results at once. Return a page of results with a cursor or offset for the next page. Forces the user (or client) to consume in chunks.
+
+**Lazy loading / virtualization.** Load only what's currently visible. As the user scrolls, load more.
+
+**Indexing.** Database indexes make queries fast even at large data volumes. Search infrastructure (Elasticsearch, Algolia) for full-text queries.
+
+**Caching.** Store frequently-requested data in fast memory; serve from cache rather than recomputing or refetching.
+
+**Asynchronous processing.** Move expensive work to background queues. Respond quickly; process slowly.
+
+**Sharding / partitioning.** Split data across multiple databases or storage units. Each shard handles a fraction of the load.
+
+**Read replicas.** Multiple read-only copies of the database; reads distributed across replicas; writes go to a single master.
+
+**Rate limiting.** Cap the request rate per user or per source. Prevents single users from consuming disproportionate resources.
+
+**Circuit breakers.** Detect when a dependency is failing or slow; stop calling it temporarily; resume when it recovers.
+
+**Graceful degradation.** When some services are slow, return partial results or cached results rather than failing entirely.
+
+**Auto-scaling.** Add capacity dynamically as load increases; remove when load decreases.
+
+**Load testing.** Simulate production-scale load in a non-production environment. Identify bottlenecks before they hit users.
+
+## Worked examples
+
+### A list view that breaks at scale
+
+A team builds a feature showing all activity in a user's account. With 100 events per account, the page loads in 200ms. With 100,000 events, the page takes 30 seconds and crashes the browser.
+
+The fix: pagination (load 50 events per page) + virtualization (only render visible rows in the DOM) + filtering (let users narrow to specific event types). The system now scales to millions of events without breaking.
+
+### An N+1 query pattern
+
+An ORM auto-generates queries that fetch one user's data per row. For a list of 1000 users, it makes 1001 database queries (1 for the list, then 1 per user for related data). Page load takes 8 seconds.
+
+The fix: eager loading (fetch related data in a single query) + caching (store frequently-accessed user data). Page load drops to 200ms. Same result; very different performance.
+
+### A cache that becomes the bottleneck
+
+A team adds Redis caching to speed up database queries. Initially great. As traffic grows, the Redis instance starts to hit CPU and memory limits; queries are now slow because Redis is the bottleneck.
+
+The fix: Redis cluster (multiple instances handling different keys), local in-process caching for the hottest data, and cache eviction policies. The cache is no longer a single bottleneck.
+
+### A third-party API rate limit
+
+A product depends on a payment-processing API with a 100 req/sec limit. During a holiday sale, peak traffic produces 1000 req/sec. The API throttles; transactions fail; users see errors.
+
+The fix: queue payment requests locally; process them at the rate the API allows; show users an "in progress" state for delayed transactions. + Negotiate a higher rate limit with the provider. + Add a backup payment provider for failover.
+
+### A search query that times out
+
+A simple full-text search across user-generated content works fine at 100K records. As the corpus grows to 100M records, queries take 30 seconds.
+
+The fix: dedicated search infrastructure (Elasticsearch) with proper indexing. Queries become sub-second even at billion-record scale.
+
+## Load testing patterns
+
+**Synthetic load testing.** Tools like JMeter, Gatling, or k6 simulate users making requests. Run at multiples of expected production load.
+
+**Production traffic mirroring.** Mirror real production traffic to a test environment. Tests with real-world request distributions.
+
+**Chaos engineering.** Deliberately fail components to verify the system handles failure gracefully. Netflix's Chaos Monkey is the canonical example.
+
+**Canary deployments.** Roll out new code to a small fraction of users first; verify it doesn't degrade under their load before rolling out broadly.
+
+**Stress testing to find the breaking point.** Increase load until the system fails. Document the breaking point; design to be safely below it.
+
+## Designing for load from the start
+
+When designing a new system or feature, ask:
+
+**What's the expected load in 6 months and 2 years?** Project upward; design with margin.
+
+**Which operations are likely to scale poorly?** Linear scans, all-results queries, N+1 patterns.
+
+**What's our story for handling 10x current load?** Adding capacity, sharding, caching, async processing.
+
+**What dependencies have load limits?** Identify and design around them.
+
+**How will we know when we're approaching limits?** Monitoring and alerts on the right metrics.
+
+## Anti-patterns
+
+**Premature optimization.** Adding complexity (caching, sharding) before measurements show it's needed. Better to start simple and add complexity when bottlenecks emerge — but design with the architectural choices that allow adding complexity later.
+
+**No load testing.** Shipping to production without verifying that the system handles realistic load. Hoping it'll be fine.
+
+**Underestimating peak traffic.** Designing for average load and being shocked when peak is 10x average. Most systems have peak/average ratios of 3–10x; design accordingly.
+
+**Single instances of critical components.** A single database, a single cache server, a single application instance. Single points of failure under load.
+
+**Ignoring third-party limits.** Building features that depend on third-party APIs without checking their rate limits or planning for throttling.
+
+**Auto-scaling without budgets.** Auto-scaling is great until your bill becomes catastrophic. Set caps and alerts.
+
+## Heuristic checklist
+
+When designing for load, ask: **What's the projected load in the foreseeable future?** Design with margin. **Which operations scale linearly vs. non-linearly with input size?** Identify and improve the non-linear ones. **Have we load-tested at production-target scale?** If not, the load assumption is unverified. **What single points of failure exist?** Eliminate or accept the risk explicitly. **Do we have monitoring to detect approaching limits?** Surprises are costly.
+
+## Related sub-skills
+
+- `scaling-fallacy` — parent principle on the dangers of scale assumptions.
+- `scaling-interaction-assumptions` — sibling skill on user-base scaling.
+- `weakest-link` — load reveals weak links that were tolerable at small scale.
+- `factor-of-safety` — design with margin for the load you might see, not just the load you have.
+- `errors` — error handling becomes critical when load creates failure conditions.
+
+## See also
+
+- `references/load-test-patterns.md` — practical patterns for load testing and capacity planning.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-load-assumptions/references/load-test-patterns.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/scaling-load-assumptions/references/load-test-patterns.md
@@ -1,0 +1,115 @@
+# Load testing — patterns and tools
+
+A practical guide to testing systems for load before launch.
+
+## Test types
+
+**Smoke test.** Run at low load to verify the system responds at all. Catches deployment issues, basic functionality regressions.
+
+**Load test.** Run at expected production load. Verify that response times, error rates, and throughput meet targets.
+
+**Stress test.** Run beyond expected load. Find the breaking point. Document what happens when limits are exceeded.
+
+**Soak test.** Run at sustained load for an extended period (hours or days). Catch memory leaks, gradually-degrading behavior, queue overflows.
+
+**Spike test.** Sudden large increase in load. Simulates real-world events (a viral moment, a launch, a sale).
+
+**Volume test.** Test with large amounts of data (rather than just request volume). Verify queries, indexes, and storage handle growth.
+
+## Tools
+
+**JMeter.** Open-source, mature, comprehensive. Runs in JVM. Good for HTTP, SOAP, JDBC, and other protocols.
+
+**Gatling.** Open-source, Scala-based DSL. Generates fewer test machines for the same load due to async architecture.
+
+**k6.** Modern, JavaScript-based scripting. Good developer experience, excellent for cloud-native systems.
+
+**Locust.** Python-based, distributed-friendly, simple scripting.
+
+**Apache Bench (ab).** Very simple HTTP load tool; good for quick checks.
+
+**Cloud-native tools.** AWS Load Testing, Azure Load Testing, etc. Integrate with cloud-native infrastructure for spinning up large numbers of test machines.
+
+For modern web systems, k6 or Gatling are common starting choices. JMeter is mature and full-featured but more cumbersome.
+
+## Test environment considerations
+
+**Production-like environment.** Test in an environment that matches production (same instance types, same database, same dependencies). Tests in a smaller environment don't predict production behavior.
+
+**Realistic data.** Test with production-like data volumes and shapes. A 1000-row test database doesn't predict behavior at 10M rows.
+
+**Realistic request patterns.** Use real distribution of request types, not just the easy paths. Production traffic often has long tails of unusual requests.
+
+**Isolation.** Test in an environment that won't affect real users. Don't load-test production directly except in carefully-controlled circumstances.
+
+## Metrics to track
+
+**Response time.** P50 (median), P95, P99 (99th percentile), P99.9. The tail latencies matter — a system with great median and terrible P99 has a bad user experience for some users.
+
+**Throughput.** Requests per second the system can handle.
+
+**Error rate.** Percentage of requests that fail.
+
+**Resource utilization.** CPU, memory, disk I/O, network on each component.
+
+**Saturation.** How close components are to their limits. A 90% saturated database is one bad spike away from failing.
+
+**Queue depth.** For async systems, how many items are in queues. Growing queues = unmet demand.
+
+## Test execution patterns
+
+**Ramp-up.** Start at low load and increase gradually. Catches gradual degradation.
+
+**Sustained load.** Hold at target load for a sustained period (10 minutes, an hour, a day). Catches steady-state issues.
+
+**Step increase.** Hold at one level, jump to a higher level. Tests how the system reacts to sudden change.
+
+**Realistic schedule.** Simulate real-world traffic patterns (peak/off-peak cycles, weekly patterns). Catches issues specific to the actual usage shape.
+
+## Capacity planning
+
+After load testing:
+
+**Know your breaking point.** What load takes the system down?
+
+**Set capacity targets below breaking point.** Provision for 50–75% of breaking-point load to leave headroom.
+
+**Plan for growth.** Capacity should grow ahead of demand, not behind.
+
+**Monitor for approach to limits.** Alerts when utilization approaches dangerous levels.
+
+**Auto-scale where possible.** Add capacity dynamically based on demand.
+
+## Common load-test pitfalls
+
+**Testing only the happy path.** Load test only the easy requests. Misses the expensive operations that dominate real load.
+
+**Underestimating concurrency.** Real users do many things simultaneously; tests with sequential single-user patterns don't capture this.
+
+**Insufficient ramp-up.** Cold caches, JIT compilation, connection pools all affect early measurements. Warm up before measuring.
+
+**Test in too-small environment.** Tests in dev that don't predict production. Use production-like infrastructure.
+
+**Ignoring resource limits.** Tests that don't measure CPU, memory, etc. — only response time. Resources can be the limiting factor.
+
+**One-off tests.** Load testing once before launch and never again. Performance changes as code evolves; test continuously.
+
+**No baseline.** Tests without a baseline can't tell whether things are improving or degrading. Always have a previous test to compare against.
+
+## Production observability
+
+Beyond pre-launch testing:
+
+**Real-user monitoring (RUM).** Measure actual user experiences from the browser/device. Catches issues that synthetic tests miss.
+
+**Application performance monitoring (APM).** Tools like Datadog, New Relic, Honeycomb. Trace requests through the system to identify bottlenecks.
+
+**Distributed tracing.** Follow requests across multiple services. Identify which service is the bottleneck for slow requests.
+
+**Logging and analytics.** Structured logs that can be queried for performance analysis.
+
+**Synthetic monitoring.** Continuously execute key user journeys; alert on degradation.
+
+## Cross-reference
+
+For interaction-based scaling, see `scaling-interaction-assumptions`. For the parent principle, see `scaling-fallacy`.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link-identification/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link-identification/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: weakest-link-identification
+description: 'Apply methods for finding the weakest link in a workflow, system, or feature set. Use when planning a redesign, prioritizing engineering or design investment, auditing a product for quality issues, or beginning any improvement effort. Several methods exist (funnel analysis, journey mapping, failure-mode enumeration, support-pattern review, direct user observation); each surfaces different kinds of weakness, and combining them gives the clearest picture.'
+---
+
+# Weakest Link — identification
+
+Before you can treat a weakest link, you have to find it. The work of identification is often skipped in favor of optimizing whatever is currently visible or interesting; the result is misallocated effort. Several methods help find weakest links systematically.
+
+## Method 1: funnel analysis
+
+For sequential workflows (signup, checkout, onboarding, multi-step forms), measure completion at each step. The biggest single drop is your prime suspect.
+
+Practical setup:
+- Instrument each step with an event ("started step 3," "completed step 3").
+- Calculate the conversion rate from step n to step n+1 for each pair.
+- Look for the largest drop in conversion.
+
+Example:
+- Step 1: 10,000 users start.
+- Step 2: 9,000 users (90% conversion).
+- Step 3: 7,500 users (83%).
+- Step 4: 4,000 users (53%). ← Biggest drop.
+- Step 5: 3,800 users (95%).
+
+Step 4 is the weakest link. Investigate why users abandon there.
+
+## Method 2: user journey mapping
+
+Walk through the entire user experience as if you were a new user. For each step, ask:
+
+- What can go wrong here?
+- How often does it go wrong?
+- What's the cost when it does?
+- Can the user recover?
+
+Score each step on these dimensions. The step with the worst combined score is your weakest link.
+
+This method surfaces issues that funnel analysis misses — including issues that affect users without dropping them out entirely. A confusing step that users complete with frustration is a weakest link even though the funnel doesn't show it.
+
+## Method 3: failure-mode analysis (FMEA)
+
+A systematic enumeration of how things can go wrong. For each component or step:
+
+- List the failure modes (specific ways it can fail).
+- For each failure mode, estimate severity (1–10), occurrence (1–10), and detectability (1–10).
+- Compute the Risk Priority Number (RPN) = severity × occurrence × detectability.
+- Rank by RPN.
+
+The highest-RPN items are your weakest links.
+
+This is more work than funnel analysis but surfaces less-obvious risks (rare-but-catastrophic failures, hard-to-detect failures).
+
+## Method 4: support-pattern review
+
+Look at customer support tickets for the past 30/90/365 days. Categorize by topic. The most common categories are likely tracking the weakest links from the user's perspective.
+
+If support tickets cluster around specific features ("can't reset password," "billing confusion," "search not working"), those features are weakest links. Users are encountering them, struggling, and asking for help.
+
+This method has the advantage of reflecting real user friction, not designer hypotheses. The disadvantage: it only captures issues that users complain about; silent abandonment doesn't show up.
+
+## Method 5: direct user observation
+
+Watch real users use the product. Where do they hesitate, get confused, or fail? The recurring trouble spots are weakest links.
+
+This is the most expensive method but produces the richest insights. A user testing session of even 5–10 users typically reveals weakest links that data alone misses.
+
+Variants:
+
+- **Moderated user testing:** facilitator guides the user through tasks, observing behavior.
+- **Unmoderated user testing:** users complete tasks alone, recorded for later review.
+- **In-product analytics replays:** session replay tools (Hotjar, FullStory) record real-user sessions for review.
+- **Usability questions in support transcripts:** when users ask "how do I X" the X is often a weakest link.
+
+## Method 6: dependency reliability analysis
+
+For technical systems, audit external dependencies (services, APIs, libraries). Each dependency has its own reliability characteristics; the weakest is your composed-system weakest link.
+
+Practical setup:
+- List all dependencies.
+- Track uptime/error rate for each.
+- Identify the lowest-reliability dependency.
+- Calculate composed reliability and identify dependencies that drag it most.
+
+Often the weakest dependency isn't the one you expect. Newer integrations, less-popular services, and pre-production tools often have worse reliability than established ones.
+
+## Method 7: edge-case enumeration
+
+For each feature, enumerate the edge cases (unusual inputs, rare conditions, error states). For each edge case, ask:
+
+- Does the product handle this?
+- If not, what does the user experience?
+- How rare is this case?
+
+Edge cases that are common enough to hit users regularly and bad enough to harm the experience when they do are weakest links. Users hitting them typically don't report (they assume the product just doesn't support their case) but they leave with a bad impression.
+
+## Combining methods
+
+The methods complement each other. Funnel analysis catches drop-offs; journey mapping catches frustration without drop-off; FMEA catches rare-but-severe; support-review catches what users complain about; observation catches what users don't articulate; dependency analysis catches infrastructure issues; edge-case enumeration catches the "we forgot about that" problems.
+
+For a comprehensive audit, use multiple methods. The weakest links found by multiple methods are particularly high-priority.
+
+## Prioritizing among multiple weak links
+
+Once you've identified candidate weakest links, prioritize by:
+
+**User impact.** How many users hit this, and how badly does it affect them?
+
+**Business impact.** Does this weak link cost revenue, retention, or reputation?
+
+**Effort to fix.** Some weak links are quick fixes; others require major work. Fast-and-impactful ones first.
+
+**Cascading effects.** Fixing some weak links has positive effects throughout the system; others are isolated. Prefer the cascading ones.
+
+The ideal first targets are weak links that are high-impact, quick to fix, and have cascading benefits. The hardest decisions are the high-impact, hard-to-fix weak links — sometimes worth the investment, sometimes worth the patient strategy.
+
+## Worked examples
+
+### A product with multiple identified weak links
+
+After a comprehensive audit, the team identifies five weak links:
+
+1. **Sign-up email deliverability** (high user impact, infrastructure, hard to fix).
+2. **Onboarding step 4: data import** (high user impact, design, moderate effort).
+3. **Search results ranking** (medium user impact, ML, very hard to fix).
+4. **Mobile checkout flow** (high user impact, design, moderate effort).
+5. **Notification settings page** (low user impact, design, easy to fix).
+
+Prioritization:
+- Items 2 and 4 (high impact, moderate effort) get priority.
+- Item 1 gets investigation (deliverability is hard but might have quick wins).
+- Item 5 is bundled into a sprint as a quick win.
+- Item 3 is parked for a longer-term ML investment.
+
+This is a more deliberate allocation than treating all weak links equally.
+
+### Funnel reveals an unexpected weak link
+
+A team running a checkout funnel discovers the biggest drop is between "review order" and "submit payment." They had assumed the weak link would be earlier (cart abandonment, address entry).
+
+Investigation reveals: the "review order" page is missing the shipping cost; users discover the shipping cost only on the submit-payment page and abandon when they see it.
+
+The fix is to surface shipping cost earlier (on the review page, ideally on the cart page). Once shipping is transparent, the abandonment at submit-payment drops dramatically.
+
+The lesson: data revealed a weak link that designer intuition missed.
+
+## Anti-patterns
+
+**Optimizing without measuring.** Improving things based on intuition rather than data. Often optimizes the wrong thing.
+
+**Single-method audits.** Relying only on funnel data or only on support tickets. Different methods catch different weaknesses.
+
+**Treating "user complaints" as proportional to actual frequency.** Loud users may not represent silent ones. Combine complaint data with usage data.
+
+**Underweighting silent abandonment.** Users who leave without telling anyone are the largest category of negative outcomes for most products. Direct observation and analytics on hesitation/dropoff capture them better than support tickets.
+
+**Confusing the weakest link with the loudest issue.** The most-discussed issue isn't always the most-impactful. Look for impact, not just visibility.
+
+## Heuristic checklist
+
+When auditing for weakest links, ask: **Have I used multiple identification methods?** Single methods miss things. **Have I quantified frequency and impact for each candidate?** Subjective ranking misallocates. **Have I considered both observed and silent failures?** Drop-off + frustration. **Have I prioritized by impact and effort?** Or am I just fixing what I notice first?
+
+## Related sub-skills
+
+- `weakest-link` — parent principle on the disproportionate impact of the weakest component.
+- `weakest-link-treatment` — sibling skill on what to do once a weak link is identified.
+- `errors` — error-prone steps are often weak links.
+- `iteration` — weakest-link improvement is iterative.
+
+## See also
+
+- `references/audit-workflow.md` — a step-by-step workflow for conducting a weakest-link audit.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link-identification/references/audit-workflow.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link-identification/references/audit-workflow.md
@@ -1,0 +1,130 @@
+# Weakest-link audit — step-by-step workflow
+
+A practical workflow for conducting a weakest-link audit on a product or feature.
+
+## Phase 1: scope
+
+**Define the scope.** What are you auditing? A specific flow (signup, checkout, onboarding)? A specific feature area (notifications, search, billing)? The entire product? Be explicit.
+
+**Define the user(s).** Whose experience are you optimizing? New users? Power users? A specific segment (mobile, enterprise, free-tier)? Different audiences have different weakest links.
+
+**Define success.** How will you know if the audit produced useful results? Specific weak links identified? Prioritized list of fixes? Estimated impact?
+
+## Phase 2: gather data
+
+**Funnel analytics.** Pull the funnel for the relevant flow. Calculate step-by-step conversion. Identify the biggest drops.
+
+**User journey map.** Walk through the experience yourself, taking notes on every friction point. Time each step. Note where you get confused or have to think.
+
+**Support tickets.** Pull tickets from the past 90 days related to the scope. Categorize by topic. Identify the most common categories.
+
+**User research.** If recent user testing exists, review it for issues related to the scope. If not, consider whether to schedule new sessions.
+
+**Performance/error logs.** For technical scope, pull error rates, performance metrics, dependency reliability. Identify components with elevated failure rates.
+
+**Direct observation.** Watch 3–5 users use the relevant flow. Note where they hesitate, fail, or recover. (Even informal observation yields insights.)
+
+## Phase 3: synthesize
+
+**List candidate weak links.** From all the data sources, list the candidate weakest links. Each candidate should be a specific step, feature, or component.
+
+**For each candidate, document:**
+- What goes wrong (specific failure mode).
+- How often (frequency, from analytics).
+- How much it costs the user (impact: confusion, abandonment, frustration, error).
+- How much it costs the business (lost revenue, churn, support load).
+- Why it's weak (root cause, where known).
+
+**Cross-check across data sources.** Weak links that show up in multiple sources (funnel + support + observation) are particularly high-confidence.
+
+## Phase 4: prioritize
+
+**Score each candidate.** Use a simple framework like Impact × (1/Effort) × Confidence:
+
+- Impact: how much does fixing this improve the user experience? (1–10)
+- Effort: how much work to fix? (1–10, where 1 is trivial)
+- Confidence: how sure are you that the fix will work? (0–1, multiplier)
+
+**Score = Impact × (10/Effort) × Confidence.**
+
+The highest-scoring candidates are your priorities.
+
+**Adjust for dependencies and cascading effects.** Some fixes unblock other fixes. Some fixes have positive effects throughout the system. Adjust priority for these.
+
+**Distinguish quick wins from long-term work.** Quick wins (high score, low effort) should ship first. Long-term work needs to start now even if it ships later.
+
+## Phase 5: plan treatment
+
+For each prioritized weak link, decide on treatment:
+
+**Fix.** Direct improvement. Most common when feasible.
+
+**Eliminate.** Remove the weak link if it's unnecessary.
+
+**Buffer.** Reduce the impact when failures occur (better error messages, recovery paths).
+
+**Replicate / add redundancy.** For dependencies, add alternatives.
+
+**Communicate.** When fixes will take time, communicate honestly with users.
+
+For each treatment, estimate effort, identify owner, and set timeline.
+
+## Phase 6: execute
+
+Ship the fixes. For each:
+
+- Set a clear success metric (the funnel step's conversion goes from X% to Y%; support tickets in this category drop by Z%).
+- Implement.
+- Measure after deployment.
+- Verify the metric moved.
+
+## Phase 7: iterate
+
+Once weak links are fixed, the next-weakest become visible. Run the audit again periodically (quarterly is reasonable for active products). The product's weakest link should keep changing as you fix the previous ones.
+
+## Common audit pitfalls
+
+**Audit becomes the deliverable.** A long, beautiful audit document with no implementation. The audit's value is in the fixes that follow.
+
+**No prioritization.** Treating all weak links equally. Stretches resources thin and delays the highest-impact fixes.
+
+**Audit done once, never repeated.** Products change; weak links shift. A one-time audit decays in usefulness.
+
+**No measurement after fixes.** Shipping a fix without verifying it worked. Sometimes fixes don't work; sometimes they create new problems.
+
+**Audit that ignores quantitative data.** Pure intuition and observation; no funnel data; no analytics. Misses the silent abandonment.
+
+**Audit that ignores qualitative data.** Pure analytics; no user observation. Misses the why behind the what.
+
+## Templates
+
+### Audit candidate template
+
+```
+Candidate: [specific step/feature/component]
+Failure mode: [what goes wrong]
+Frequency: [how often, with source]
+User impact: [what users experience, severity]
+Business impact: [what it costs]
+Root cause: [why it's weak]
+Confidence: [how sure are we]
+Suggested treatment: [fix / eliminate / buffer / replicate]
+Estimated effort: [small / medium / large]
+Score: [impact × (10/effort) × confidence]
+```
+
+### Treatment plan template
+
+```
+Weak link: [from candidate]
+Treatment: [chosen approach]
+Owner: [name]
+Timeline: [estimated]
+Success metric: [specific measurable]
+Pre-treatment baseline: [current value]
+Target: [post-treatment value]
+```
+
+## Cross-reference
+
+For treatment strategies, see `weakest-link-treatment`. For the parent principle, see `weakest-link`.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link-treatment/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link-treatment/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: weakest-link-treatment
+description: 'Apply treatment strategies for identified weak links — fix, eliminate, buffer, replicate, or communicate. Use when you''ve identified a weakest link and are deciding what to do about it. Each treatment has different costs, benefits, and contexts where it''s right. The choice depends on whether the weak link is necessary, whether it''s fixable, what alternatives exist, and what timeline the fix can realistically follow.'
+---
+
+# Weakest Link — treatment
+
+Once you've identified a weak link, you have several treatment options. The right choice depends on the nature of the weakness, the resources available, and the timeline.
+
+The five primary treatments:
+
+## Treatment 1: fix
+
+Improve the weak link directly. The form field becomes clearer; the dependency becomes more reliable; the error becomes recoverable. Direct improvement is usually the best option when feasible.
+
+**When to fix:**
+- The weak link is necessary (you can't remove it).
+- The fix is achievable with available resources.
+- The improvement will substantially reduce the failure rate or impact.
+
+**Tactics for fixing:**
+- Redesign the UI/UX.
+- Improve the underlying technology (better algorithms, better infrastructure).
+- Add more thorough testing to prevent regressions.
+- Restructure the dependency relationship (caching, batching, retries).
+
+**Pitfalls:**
+- Fixes that don't address the root cause leave the weakness in different form.
+- Fixes that introduce new complexity create new weak links elsewhere.
+- "Quick fix" that turns into long-term project; budget time realistically.
+
+## Treatment 2: eliminate
+
+Remove the weak link entirely. The form field that nobody fills correctly maybe shouldn't be a required field. The dependency that often fails maybe doesn't need to be invoked in this flow.
+
+**When to eliminate:**
+- The weak link isn't actually necessary.
+- The cost of fixing exceeds the value of the feature.
+- The feature is rarely used and its absence wouldn't significantly hurt users.
+
+**Examples:**
+- A signup field for "company size" that no one fills correctly: remove it; ask later if needed.
+- A real-time price-update feature that often fails: replace with a periodic refresh.
+- A dependency on a third-party service that's been unreliable: cache the data and don't refetch on every request.
+
+**Pitfalls:**
+- Eliminating things users actually need; verify the weak link isn't valuable to a quiet audience.
+- Stripping features under deadline pressure that need to come back later.
+
+## Treatment 3: buffer
+
+Make the user's experience around the weak link more forgiving. Better error messages, clearer recovery paths, defaults that prevent the weak step from being needed.
+
+**When to buffer:**
+- The weak link can't be fixed in the short term.
+- The weak link must be retained (it's necessary).
+- The user's experience can be improved without changing the underlying weakness.
+
+**Tactics:**
+- Better error messages that tell users exactly what went wrong and how to recover.
+- Auto-save before risky operations.
+- Confirmation steps before irreversible actions.
+- Clear recovery paths after errors.
+- Progressive enhancement so partial failures don't break the whole flow.
+- Detailed help content for known-confusing areas.
+
+**Pitfalls:**
+- Buffering that masks the real problem and prevents long-term fixes.
+- Layers of buffering that add complexity and become weak links themselves.
+
+## Treatment 4: replicate (add redundancy)
+
+For dependencies — services, components, providers — add redundant alternatives so the failure of one doesn't take the system down.
+
+**When to replicate:**
+- The dependency is critical and its failure is unacceptable.
+- Multiple equivalent providers exist.
+- The cost of redundancy is justified by the criticality.
+
+**Tactics:**
+- Multiple service providers with automatic failover.
+- Redundant servers in different regions.
+- Caching layers that shield real-time dependencies.
+- Graceful degradation: when one feature fails, the rest still work.
+- Circuit breakers that detect failures and stop calling a failing dependency.
+
+**Pitfalls:**
+- Redundancy that adds complexity without truly redundant behavior.
+- "Active-passive" redundancy where the passive side hasn't been tested and fails when needed.
+
+## Treatment 5: communicate
+
+When the weak link can't be improved in the short term, tell users honestly what to expect.
+
+**When to communicate:**
+- The fix is genuinely a long-term project.
+- The weakness is acceptable if users are prepared.
+- Users can plan around or work around the weakness if they know about it.
+
+**Tactics:**
+- Clear messaging about known limitations.
+- Status pages showing service health.
+- Documentation of edge cases and workarounds.
+- In-product warnings ("This feature is in beta," "This may take a moment").
+
+**Pitfalls:**
+- Communication used as a substitute for actual improvement; communicate AND plan to fix.
+- Communication that's hidden in support docs that no one reads.
+- Communication that starts to read as excuse-making.
+
+## Choosing a treatment
+
+The decision often depends on a few questions:
+
+**Is the weak link necessary?** If no, eliminate. If yes, the other treatments apply.
+
+**Is the fix achievable in a reasonable time?** If yes, fix. If no, consider buffer + communicate while planning a long-term fix.
+
+**Is redundancy possible (and justified)?** For critical dependencies, replicate.
+
+**Is the user's experience the main concern, or the underlying reliability?** UX-focused weakness benefits from fix or buffer. Reliability-focused weakness benefits from fix or replicate.
+
+Often multiple treatments apply simultaneously. A weak link might be partially fixed, partially buffered, and openly communicated, with a redundancy plan in development.
+
+## Worked examples
+
+### A confusing form field — eliminate
+
+A signup form has a "Company Size" dropdown with 12 options. Analytics show users either pick the first option ("1–10") or abandon. The data isn't used by any downstream system.
+
+Treatment: eliminate. Remove the field. Ask later if needed (e.g., during onboarding when the user is more invested).
+
+Result: signup conversion improves; no downstream impact.
+
+### A flaky third-party API — replicate + buffer
+
+A product depends on a third-party email-delivery API. The API has 99% reliability, but the 1% downtime causes immediate problems for users.
+
+Treatment: replicate (use a second email-delivery provider as fallback) + buffer (queue email sends locally so failures retry automatically).
+
+Result: composed reliability rises to 99.99%; user-visible impact of provider failures becomes near-zero.
+
+### An onboarding step that confuses users — fix
+
+Onboarding step 4 (data import) has a 50% drop-off. Users don't understand the technical requirements.
+
+Treatment: fix. Redesign the step with clearer guidance, an interactive wizard, and an "I'll do this later" option.
+
+Result: drop-off falls to 15%; downstream onboarding completion improves.
+
+### A feature with rare critical bugs — fix + communicate
+
+A document collaboration feature occasionally loses user changes due to a synchronization bug. The fix is hard (it requires a substantial rewrite) but critical.
+
+Treatment: in the short term, communicate (warn users about the issue, provide a recovery process). In parallel, fix (rewrite the sync layer).
+
+Result: users have realistic expectations during the fix period; the fix eliminates the issue once shipped.
+
+### A search result quality problem — buffer
+
+A search feature returns mediocre results for some queries. Improving search quality is a long-term ML investment.
+
+Treatment: buffer. Improve the surrounding experience: add filters that let users refine results, add "did you mean" suggestions, surface recent and popular searches as alternatives.
+
+Result: users have more tools to work around mediocre relevance; the underlying quality problem can be improved over time.
+
+## Anti-patterns
+
+**Over-fixing.** Treating every weak link with the most expensive fix. Sometimes elimination or buffering is cheaper and equally effective.
+
+**Buffering that masks the problem.** Layers of error messages and recovery paths that hide a fundamental design flaw. The weakness remains; users keep encountering it.
+
+**Communication-only treatment.** Posting a status page about ongoing reliability issues without a plan to fix. Users notice that the issues never actually resolve.
+
+**Inconsistent treatment.** Fixing a weakness in one place but not in equivalent places elsewhere. Users encounter the weakness in surprising contexts.
+
+**Premature elimination.** Removing a feature because it's a weak link, when actually some users depend on it. Verify before eliminating.
+
+**Redundancy that isn't actually redundant.** A "fallback" provider that the team has never tested and that fails when called.
+
+## Heuristic checklist
+
+Before treating a weak link, ask: **Have I identified the right treatment for the situation?** Fix, eliminate, buffer, replicate, communicate — pick deliberately. **Will the treatment actually move the metric I care about?** Set a baseline and a target. **Have I addressed the root cause, or just the symptom?** Surface fixes leave the weakness intact. **Will the treatment introduce new weak links?** Complex fixes often do.
+
+## Related sub-skills
+
+- `weakest-link` — parent principle on disproportionate impact of weakest components.
+- `weakest-link-identification` — sibling skill on finding weak links.
+- `forgiveness` — buffering and recovery patterns are a form of treatment.
+- `errors` — error-related weak links benefit from buffering.
+- `factor-of-safety` — adding margin around weak links is a form of treatment.
+
+## See also
+
+- `references/treatment-decision-tree.md` — a decision tree for choosing among treatments.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link-treatment/references/treatment-decision-tree.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link-treatment/references/treatment-decision-tree.md
@@ -1,0 +1,124 @@
+# Weakest-link treatment — decision tree
+
+A decision tree for choosing among the five treatment options.
+
+## Step 1: is the weak link necessary?
+
+**No → Eliminate.**
+- Remove the feature, field, or step.
+- Verify that no important user is dependent on it.
+- Document the decision so it isn't reintroduced later.
+
+**Yes → continue to step 2.**
+
+## Step 2: is the weakness primarily about reliability (it works most of the time but fails sometimes)?
+
+**Yes → continue to step 3 (reliability path).**
+
+**No → continue to step 4 (UX path).**
+
+## Step 3 (reliability path): can you add redundancy?
+
+**Yes (multiple equivalent providers exist, redundancy is justified by criticality) → Replicate.**
+- Add a redundant provider with automatic failover.
+- Implement circuit breakers and graceful degradation.
+- Test the failover path regularly.
+
+**No → continue to step 5 (general fix).**
+
+## Step 4 (UX path): is the user's experience the primary concern?
+
+**Yes, and the fix is achievable in the short term → Fix.**
+- Redesign the UI/UX.
+- Improve clarity, reduce friction, prevent error.
+- Test the fix with users.
+
+**Yes, but the fix is long-term → Buffer + Communicate.**
+- Improve the user's experience around the weakness (better error messages, clear recovery paths).
+- Communicate honestly about the limitation and the plan to address it.
+- Schedule the long-term fix.
+
+**No (something else is the concern) → continue to step 5.**
+
+## Step 5 (general fix): can you fix the weak link directly?
+
+**Yes, with reasonable effort → Fix.**
+- Direct improvement.
+- Verify with metrics post-deployment.
+
+**Yes, but expensive → balance against alternatives.**
+- Could buffering achieve most of the benefit at lower cost?
+- Could elimination be reconsidered if the value is lower than estimated?
+- Could the fix be incrementalized?
+
+**No (genuinely can't fix in available timeline) → Buffer + Communicate.**
+- Reduce the impact of the weakness on users.
+- Be transparent about the limitation.
+- Plan the eventual fix even if it's far off.
+
+## Combining treatments
+
+Most real situations call for combinations:
+
+**Fix + Communicate.** A long fix, with honest communication during the work.
+
+**Fix + Buffer.** Improve the weak link while also improving the surrounding experience.
+
+**Replicate + Buffer.** Add redundancy and also improve degradation behavior.
+
+**Eliminate + Communicate.** Remove a feature, with clear communication about the change.
+
+**Buffer + Replicate + Fix.** A comprehensive treatment for a critical weak link.
+
+The combinations cost more but are sometimes warranted for high-impact weak links.
+
+## Common decision pitfalls
+
+**Defaulting to "fix" without considering eliminate.** Designers often want to improve things rather than remove them. Sometimes elimination is the right answer.
+
+**Defaulting to "communicate" as a substitute for actual treatment.** Posting a status page or warning isn't a treatment if there's no plan to fix or eliminate.
+
+**Choosing "buffer" because "fix" feels too hard.** Sometimes the fix is hard but justified; buffering accumulates technical and design debt.
+
+**Choosing "replicate" without verifying the redundancy works.** Many "fallback" mechanisms have never actually been used; when needed, they fail.
+
+**Choosing one treatment when combination is needed.** The most-impactful weak links often warrant multiple treatments simultaneously.
+
+## Concrete examples
+
+### A confusing form field
+
+- Necessary? Maybe — let's verify the data is used downstream.
+- Data isn't used → eliminate. (Removed the field; signup conversion improves.)
+
+### A flaky third-party service
+
+- Necessary? Yes (it provides core functionality).
+- Reliability problem? Yes.
+- Can add redundancy? Yes (multiple providers exist).
+- Treatment: Replicate (with fallback) + Buffer (cache for graceful degradation).
+
+### A feature with a complex bug
+
+- Necessary? Yes.
+- UX problem? Yes — users experience data loss occasionally.
+- Fix achievable short-term? No (requires rewrite).
+- Treatment: Buffer (warn users, add recovery) + Communicate (transparent about the issue) + Fix (long-term, schedule the rewrite).
+
+### A frequently-failing background job
+
+- Necessary? Yes (it processes user uploads).
+- Reliability problem? Yes (intermittent failures).
+- Can add redundancy? No (it's a bespoke job; no alternative exists).
+- Treatment: Fix (improve error handling, add retries) + Buffer (notify users when their upload didn't process; provide retry path).
+
+### A confusing error message that users don't understand
+
+- Necessary? Yes (the underlying error condition is real).
+- UX problem? Yes — users don't know how to recover.
+- Fix achievable? Yes (rewrite the message and add recovery path).
+- Treatment: Fix.
+
+## Cross-reference
+
+For methods of identifying weak links, see `weakest-link-identification`. For the parent principle, see `weakest-link`.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link/SKILL.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: weakest-link
+description: 'Apply the principle of the Weakest Link — a system''s reliability is determined by its least reliable component, not by the average. Use when designing critical-path workflows, evaluating dependencies for risk, deciding where to invest in robustness, auditing onboarding or checkout flows for the step most likely to fail. The user''s experience of the product is dominated by its worst step. Improving the average without improving the weakest step often doesn''t improve the experience at all.'
+---
+
+# Weakest Link
+
+> **Definition.** The reliability of a system is determined by its weakest component, not by the average of its components. A chain breaks where it's thinnest; a checkout flow fails at the step that most often errors; an onboarding sequence loses users at the most confusing screen. Improving stronger parts of the system doesn't improve overall reliability if the weakest part remains weak.
+
+The metaphor comes from physical engineering, but the principle applies broadly. In a workflow, the user's experience is dominated by the worst step they encounter. In a system of dependencies, total uptime is bounded by the least reliable dependency. In a feature set, the perceived quality is dragged down by the most-broken feature. Average quality is the wrong metric; weakest-link quality is closer to what users actually experience.
+
+## Why this principle matters
+
+Designers and engineers often optimize for averages. They polish the most-used features, improve the typical path, raise the median experience. These improvements feel satisfying and are usually measurable in dashboards.
+
+But the user's actual experience of the product is shaped by extremes, not averages. The one step where they get stuck. The one feature that crashes. The one flow that doesn't recover from an error. The one form field that's confusing. These weakest links dominate the user's mental model of the product, and improving everything around them while leaving them in place often produces no improvement in the user's perception.
+
+The principle has practical consequences:
+
+- **Audit for the weakest link before optimizing the strong ones.** Find the part of the experience that fails most often or most painfully. Fix that first.
+- **Reliability of dependencies multiplies.** If your product depends on five services, each 99% reliable, your composed reliability is 95% — substantially worse than any individual service. The weakest link is the upper bound of the composed reliability.
+- **Improving non-weakest parts has limited returns.** Polishing the dashboard while the checkout is broken doesn't fix the experience.
+- **Eliminating the weakest link reveals the next weakest.** Fixing one failure point promotes another. Improvement is iterative.
+
+## Identifying the weakest link
+
+Three approaches help identify weakest links.
+
+**User journey mapping.** Walk through every step a user takes from arrival to goal completion. For each step, ask: what fails here, how often, how painfully? The step with the worst failure profile is the weakest link.
+
+**Funnel analytics.** For digital products, sequential funnels show where users drop off. The biggest single drop is often the weakest link. Investigate why; fix; remeasure.
+
+**Failure-mode analysis.** Enumerate the things that can go wrong (a bank error, a network timeout, a missing piece of data, an unfamiliar UI). Rank by frequency × impact. The top of the list is your weakest link.
+
+**Customer support patterns.** What do users contact support about? The most common support tickets often track to the weakest link.
+
+**Direct observation.** Watch real users use the product. Where do they struggle? Where do they hesitate? Where do they fail and not realize it? The recurring trouble spots are weakest links.
+
+## Treating the weakest link
+
+Once identified, the weakest link can be treated several ways:
+
+**Fix it.** Make the component more reliable. The form field becomes clearer; the dependency becomes redundant; the error becomes recoverable. Direct improvement is usually the best option when feasible.
+
+**Strengthen the surrounding context.** Make the user's experience around the weak step more forgiving. Better error messages, clearer recovery paths, defaults that prevent the weak step from being needed. Sometimes you can't fix the weakest link directly but can buffer it.
+
+**Eliminate it.** Sometimes the weakest link is a step that doesn't actually need to exist. The form field that nobody fills in correctly maybe shouldn't be a required field at all. The dependency that often fails maybe doesn't need to be invoked in this flow. Removal is the cleanest fix when available.
+
+**Add redundancy.** For dependencies (services, components), adding redundant alternatives shifts the weakest-link bound. If you have two providers and either one's failure can be tolerated, your composed reliability becomes the probability that both fail simultaneously — much smaller than either's individual failure rate.
+
+**Communicate honestly.** Sometimes the weakest link can't be improved in the short term. Telling users honestly what to expect ("This step sometimes takes a moment; we'll show progress") is better than letting them encounter the weakness without preparation.
+
+## Sub-skills in this cluster
+
+- **weakest-link-identification** — Methods for finding the weakest link in a workflow, system, or feature set. Funnel analysis, journey mapping, failure-mode enumeration, support-pattern review.
+- **weakest-link-treatment** — Strategies for treating identified weak links: fix, buffer, eliminate, replicate, communicate.
+
+## Worked examples
+
+### A checkout flow
+
+An e-commerce site has a 5-step checkout. Funnel data shows: 60% of users complete step 1; 50% complete step 2; 35% complete step 3; 30% complete step 4; 28% complete step 5. The biggest drop is between step 2 and step 3 — the weakest link.
+
+Investigation: step 3 is "shipping address" with too many required fields and confusing label conventions. Users get stuck and abandon.
+
+Fix: simplify step 3. Remove unnecessary fields, add address autocomplete, clarify labels. Funnel completion rises from 30% to 45% — and the entire downstream funnel improves because more users get through.
+
+The lesson: improving step 1 or step 5 wouldn't have helped much; the weakest link was step 3, and fixing it lifted everything.
+
+### A SaaS product's onboarding
+
+A SaaS product has a 6-step onboarding. Funnel data shows users drop off most at step 4: "connect your data source." The connection requires technical knowledge most users don't have.
+
+Options:
+- **Fix:** simplify the connection process; add a wizard.
+- **Eliminate:** make step 4 optional; let users complete onboarding without it; offer to come back to it later.
+- **Buffer:** keep step 4 in place but add extensive guidance, customer support chat at this step, and easy recovery if the connection fails.
+
+The team chooses elimination: data connection becomes an optional step, with a "skip for now" option. Onboarding completion jumps from 40% to 75%. Users who skip data connection often complete it later when they're ready, after they've gotten value from other features.
+
+The lesson: sometimes the weakest link can be removed entirely, not just fixed.
+
+### A reliability problem in a dependency chain
+
+A web app depends on five third-party services. Each is 99.5% reliable individually. The composed reliability is 0.995^5 = 97.5% — the app is down for 18 hours per month even though each service is "highly reliable."
+
+Options:
+- **Add redundancy** for the most-failure-prone services (multiple providers, with fallback).
+- **Cache** to reduce dependency on real-time service calls.
+- **Degrade gracefully** so failure of one service doesn't take the whole app down.
+
+The team adds redundancy for the two most-critical services and graceful degradation for the others. Composed reliability rises to 99.5%, even though no individual service got more reliable.
+
+The lesson: in dependency systems, you can sometimes improve the composed weakest-link bound without improving any individual link.
+
+### A form with a confusing field
+
+A signup form has 8 fields, including one labeled "Account ID" that's actually meant to be the user's organization name. Users get confused, type the wrong thing, get an error, retry, give up. Conversion drops at this field.
+
+Fix: rename to "Organization name" with helper text "The name of your company or team." Conversion at this field rises to near-100%; downstream conversion improves.
+
+A small fix to the weakest link, with disproportionate impact.
+
+### A feature set dragged down by one weak feature
+
+A productivity product has 20 features. 19 are well-designed; one (sharing) is poorly designed and frequently broken. User reviews mention sharing as the most-painful part of the product.
+
+Options:
+- **Fix:** invest in fixing sharing.
+- **Eliminate:** remove sharing if it's not essential.
+- **Communicate:** be transparent about sharing's limitations and a plan to fix.
+
+The team invests in fixing sharing. Reviews improve significantly even though only one feature changed; the weakest-link drag was disproportionate to its size.
+
+## Anti-patterns
+
+**Optimizing the strong while ignoring the weak.** Adding new features to an already-polished part of the product while ignoring the broken part. Common when the strong part is more interesting to work on.
+
+**Counting averages, not extremes.** Reporting "95% of users complete the flow" when the 5% who fail have a horrible experience that drives them away. The 5% drag the product's perception more than the 95% lift it.
+
+**Hiding the weakest link.** Burying the broken feature behind a "more options" menu. Users still encounter it sometimes; the experience is still painful.
+
+**Adding workarounds without fixing.** Building elaborate paths around the weakest link that work for some users but not all. Eventually you accumulate so many workarounds that the system is harder to maintain than the original problem was.
+
+**Ignoring dependencies.** Treating service uptime as a vendor problem. The composed reliability is your problem; design for it.
+
+## Heuristic checklist
+
+When auditing a product or workflow, ask: **What's the weakest link?** Be specific about which step, feature, or dependency. **How often does it fail, and how painfully?** Quantify if possible. **What's the cost of fixing vs. eliminating vs. buffering?** Choose deliberately. **Have I been polishing other things instead of fixing this?** That's a sign of misallocated effort. **After fixing this, what becomes the new weakest link?** Plan for the next iteration.
+
+## Related principles
+
+- **Factor of Safety** — design for the weakest expected case, not the average.
+- **Forgiveness** — recovery patterns help when weakest links can't be eliminated.
+- **80/20 Rule** — 80% of the failures may concentrate in 20% of the components.
+- **Iteration** — improving weakest links is an iterative process; each fix promotes the next.
+- **Errors** — weakest-link analysis often identifies error-prone parts of the experience.
+
+## See also
+
+- `references/lineage.md` — origins in engineering reliability and process design.
+- `weakest-link-identification/` — sub-skill on finding weak links.
+- `weakest-link-treatment/` — sub-skill on treating weak links once identified.

--- a/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link/references/lineage.md
+++ b/plugins/HDeibler/universal-design-principles/plugins/process-and-robustness-principles/skills/weakest-link/references/lineage.md
@@ -1,0 +1,85 @@
+# Weakest Link — origins and research lineage
+
+## Engineering and reliability theory
+
+The weakest-link principle has roots in physical engineering. A chain's tensile strength is determined by its weakest link, not the average of all links. This was experimentally established in the 19th century and became foundational to materials science. Engineers learned to design for the strength of the weakest expected component, not the average — and to identify and reinforce the weakest component before composing it into a load-bearing system.
+
+The principle generalized to systems engineering through the 20th century. Reliability theory, developed through World War II's military-industrial work and refined in the postwar decades, formalized how individual component reliabilities compose into system reliability. Key insight: in a series system (where all components must work for the system to work), reliability is the product of individual reliabilities, and the system's reliability is bounded above by its weakest component.
+
+For a series of n components each with reliability r:
+- Total system reliability = r^n
+- Bound by the weakest: total reliability ≤ minimum component reliability
+
+For 5 components at 99% each: 0.99^5 ≈ 95%. The composed system is materially less reliable than its weakest link, and can never be more reliable than its weakest.
+
+This led to systematic reliability practices: identify the weakest components, strengthen them or add redundancy, and design for graceful degradation when failures occur.
+
+## Theory of Constraints
+
+In the 1980s, Eliyahu Goldratt formalized a related principle in production management as the Theory of Constraints (TOC), articulated in his book *The Goal* (1984). Goldratt's core insight: the throughput of any system is determined by its bottleneck (weakest link), not by improvements to non-bottleneck steps. Optimizing non-bottleneck steps doesn't improve total throughput; it just creates inventory or unused capacity.
+
+TOC provides a five-step process:
+
+1. Identify the system's constraint.
+2. Decide how to exploit the constraint (use it most effectively).
+3. Subordinate everything else to the constraint.
+4. Elevate the constraint (improve its capacity).
+5. If the constraint is broken (no longer the bottleneck), identify the new constraint.
+
+This is essentially a methodology for working with weakest-link dynamics. The lessons transfer beyond manufacturing to any system where throughput depends on a sequence of dependent steps: software development pipelines, customer-service workflows, sales funnels, even cognitive workflows.
+
+## In software and product design
+
+Software engineering inherited the principle and applied it to system reliability. Service-oriented architectures, distributed systems, and microservices all involve dependency chains where weakest-link reliability dominates. The "five 9s" reliability targets (99.999% uptime) require either extreme component reliability or extensive redundancy because composed reliability degrades quickly.
+
+In product design, the principle appears in several contexts:
+
+- **Conversion funnels.** The biggest single drop-off in a funnel is the weakest link. A 5-step signup with 50% drop at one step has its conversion bounded by that drop, regardless of how good the other steps are.
+- **User journey reliability.** A user's path through a product visits many features; the worst feature dominates their perception.
+- **Support load.** The features that generate the most support tickets are the weakest links in the user experience.
+- **Mobile vs. desktop performance.** A product's reliability on mobile is often the weakest link; desktop polish doesn't compensate.
+- **Edge cases.** The product's behavior on rare inputs or in unusual conditions is often weak; users who hit those cases have outsize negative experiences.
+
+## In design ethics and accessibility
+
+The principle has implications for how we think about design quality. If we measure quality by averages, we can ship products that work great for most users but terribly for some. The "some" can be:
+
+- Users with disabilities.
+- Users on older devices or slower networks.
+- Users with non-English names or addresses.
+- Users in unusual but legitimate workflows.
+- Users who hit our edge cases.
+
+For these users, the weakest link of our design may be everything they encounter. A design's quality is not "average user satisfaction"; it's "minimum user satisfaction across all the audiences we claim to serve."
+
+This framing has driven the shift toward inclusive design and accessibility-as-baseline. The accessibility audit identifies the weakest links from the perspective of users with disabilities; treating those weakest links improves the product for everyone (often the weakest link for one audience reflects a general weakness too).
+
+## Empirical patterns worth remembering
+
+The weakest-link literature converges on a few stable findings:
+
+- **The weakest link disproportionately drives the user's overall perception.** A single bad experience often outweighs many good ones in user judgment.
+- **Improving the weakest link has higher leverage than improving average performance.** Fixed budget on the weakest link beats the same budget spread evenly.
+- **Iteration is essential.** Fixing the weakest link reveals the next one. Continuous weakest-link work produces continuous improvement.
+- **Hiding doesn't help.** Burying the weakest link in a less-visible part of the product doesn't eliminate its impact; users still hit it eventually.
+- **Composed reliability degrades faster than people expect.** Five components at 99% each give 95% — a fact that surprises engineers regularly.
+
+## Related concepts
+
+**Single point of failure (SPOF).** The weakest link in a system whose failure causes total system failure. Systems engineering pays particular attention to identifying and eliminating SPOFs.
+
+**Graceful degradation.** When a component fails, the rest of the system continues to function (perhaps with reduced capability) rather than failing entirely. Buffers against weakest-link impact.
+
+**Bottleneck.** The constraint on throughput; the weakest link in a flow system. Focus on the bottleneck for throughput improvement.
+
+**Failure mode and effects analysis (FMEA).** A systematic methodology for identifying and prioritizing failure modes, ranking by severity, occurrence, and detection.
+
+## Sources informing this principle
+
+- Goldratt, E. M. (1984). *The Goal*. (Theory of Constraints.)
+- Goldratt, E. M. (1990). *What Is This Thing Called Theory of Constraints*.
+- Reliability engineering literature (multiple sources from 1940s onward).
+- Lidwell, W., Holden, K., & Butler, J. (2003). *Universal Principles of Design*.
+- Various failure-analysis methodologies (FMEA, RCFA, fault-tree analysis).
+- Modern devops and SRE literature (Google's *Site Reliability Engineering*, 2016).
+- Inclusive Design literature (Microsoft's Inclusive Design Toolkit and others).


### PR DESCRIPTION
## Summary
- Adds Universal Design Principles to the Development & Workflow community plugins list.
- Mirrors the root `universal-design-principles` Codex collection plugin, whose source repo now exposes `.codex-plugin/plugin.json` and validates all 137 skills.
- Updates `plugins.json` and `.agents/plugins/marketplace.json` so the README name, install URL, manifest name, and marketplace entry all resolve to `universal-design-principles`.
- Updates the stale OpenAI Codex plugins link in README.md to the current OpenAI Academy plugins-and-skills page so the link-check gate passes.

## Validation
- `python3 scripts/check-alphabetical.py README.md`
- `python3 scripts/generate_plugins_json.py`
- `jq empty plugins.json .agents/plugins/marketplace.json plugins/HDeibler/universal-design-principles/.codex-plugin/plugin.json`
- `node build.js`
- `pipx run codex-plugin-scanner verify plugins/HDeibler/universal-design-principles`
- `npx markdown-link-check@latest README.md --config .mlc_config.json`

## Note
The source repository also supports installing the five focused plugin bundles directly with `npx codex-marketplace add HDeibler/universal-design-principles --plugins`. This PR indexes the root collection plugin so the awesome-list metadata has one stable artifact name and install URL.
