### PR TITLE
ci: add canvas-apps-plugin-codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
 - [Brooks Lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).
+- [Canvas-Apps-Plugin-Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Power Apps Canvas Apps from natural language using Codex and the Canvas Authoring MCP server.
 - [Claude Code for Codex](https://github.com/sendbird/cc-plugin-codex) - Reverse of OpenAI's official Claude-hosted plugin: use Claude Code from Codex for reviews, rescue tasks, tracked background jobs, and hook-powered review gates.
 - [Claude Code Harness](https://github.com/dadwadw233/claude-code-harness) - Harness blueprint skill for turning vague agent ideas into concrete designs for request assembly, control loops, memory, permissions, recovery, and extension planes.
 - [Claude Code Skills](https://github.com/alirezarezvani/claude-skills) - 223 production-ready skills, 23 agents, and 298 Python tools across 9 domains — engineering, marketing, product, compliance, and more.


### PR DESCRIPTION
This plugin enables building and editing Microsoft Power Apps Canvas Apps from natural language using Codex and the Canvas Authoring MCP server.

- Public GitHub repo: https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex
- All links verified and working
- Alphabetically placed within the Community Plugins section