### PR TITLE
ci: add guixu dataset discovery plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -365,6 +365,18 @@
       "category": "Tools & Integrations"
     },
     {
+      "name": "guixu",
+      "source": {
+        "source": "local",
+        "path": "./plugins/guixu-project/guixu"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tools & Integrations"
+    },
+    {
       "name": "jk",
       "source": {
         "source": "local",

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
-- [Guixu](https://github.com/guixu-project/guixu) - Dataset discovery, valuation, and acquisition for AI agents. Search, evaluate, and purchase datasets from Kaggle, HuggingFace, IPFS, and more.
+- [Guixu](https://github.com/guixu-project/guixu) - Dataset discovery, valuation, and acquisition for AI agents. Search, evaluate, and purchase datasets from Kaggle, Hugging Face, IPFS, and more.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
+- [Guixu](https://github.com/guixu-project/guixu) - Dataset discovery, valuation, and acquisition for AI agents. Search, evaluate, and purchase datasets from Kaggle, HuggingFace, IPFS, and more.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-05-02",
-  "total": 53,
+  "total": 54,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -308,6 +308,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/ninihen1/power-automate-mcp-skills/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Guixu",
+      "url": "https://github.com/guixu-project/guixu",
+      "owner": "guixu-project",
+      "repo": "guixu",
+      "description": "Dataset discovery, valuation, and acquisition for AI agents. Search, evaluate, and purchase datasets from Kaggle, HuggingFace, IPFS, and more.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/guixu-project/guixu/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Jenkins CLI",

--- a/plugins.json
+++ b/plugins.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-05-02",
+  "last_updated": "2026-05-04",
   "total": 54,
   "categories": [
     "Development & Workflow",

--- a/plugins.json
+++ b/plugins.json
@@ -314,7 +314,7 @@
       "url": "https://github.com/guixu-project/guixu",
       "owner": "guixu-project",
       "repo": "guixu",
-      "description": "Dataset discovery, valuation, and acquisition for AI agents. Search, evaluate, and purchase datasets from Kaggle, HuggingFace, IPFS, and more.",
+      "description": "Dataset discovery, valuation, and acquisition for AI agents. Search, evaluate, and purchase datasets from Kaggle, Hugging Face, IPFS, and more.",
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/guixu-project/guixu/HEAD/.codex-plugin/plugin.json"

--- a/plugins/guixu-project/guixu/.codex-plugin/plugin.json
+++ b/plugins/guixu-project/guixu/.codex-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "guixu",
+  "version": "0.1.0",
+  "description": "Dataset discovery, valuation, and acquisition for AI agents. Search, evaluate, and purchase datasets from Kaggle, Hugging Face, IPFS, and more.",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/guixu-project/guixu/.mcp.json
+++ b/plugins/guixu-project/guixu/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "guixu": {
+      "command": "guixu",
+      "args": ["mcp"],
+      "description": "Guixu dataset discovery and acquisition MCP server"
+    }
+  }
+}

--- a/plugins/guixu-project/guixu/skills/guixu/SKILL.md
+++ b/plugins/guixu-project/guixu/skills/guixu/SKILL.md
@@ -1,0 +1,163 @@
+<!--
+Copyright (c) 2026 The State Key Laboratory of Blockchain and Data Security, Zhejiang University
+SPDX-License-Identifier: Apache-2.0
+-->
+
+---
+name: guixu
+description: "Dataset discovery, valuation, and acquisition for AI training. Use when: (1) finding datasets for model training or fine-tuning, (2) evaluating dataset quality and relevance, (3) downloading datasets from Kaggle, HuggingFace, IPFS, or other sources, (4) assessing dataset licensing and provenance, (5) acquiring paid or free datasets. NOT for: generic web search (use browser), local file operations (use file tools), or data labeling/annotation tasks."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "📊",
+        "requires": { "bins": ["guixu"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "guixu",
+              "bins": ["guixu"],
+              "label": "Install Guixu CLI (brew)",
+            },
+          ],
+      },
+  }
+---
+
+# Guixu Data Agent
+
+Guixu provides dataset discovery, valuation, and acquisition for AI agents.
+It searches across Kaggle, HuggingFace, IPFS, arXiv, DBLP, and other sources.
+
+## When to Use
+
+✅ **USE this skill when:**
+
+- User asks to "find a dataset for training..."
+- User asks to "download a dataset about..."
+- User asks to "evaluate dataset quality..."
+- User asks about dataset licensing or provenance
+- User mentions specific datasets (Kaggle, HuggingFace, etc.)
+- User wants to search for training data
+
+❌ **DON'T use this skill when:**
+
+- Generic web search → use browser or web search tools
+- Local file read/write → use file tools
+- Data labeling or annotation → use coding tools
+- Code implementation questions → use coding-agent skill
+
+## Workflow
+
+### Step 1: Parse Intent (REQUIRED first)
+
+Always start with `intent_parse` to structure the request:
+
+```
+intent_parse(query="find me a cat image dataset for classification", task_type="classification")
+```
+
+This returns a structured `QueryProfile` with:
+- `task_type`: classification, detection, segmentation, etc.
+- `keywords`: dataset content terms
+- `target_entity`: main subject
+- `data_standard`: sample_unit, budget, schema expectations
+
+### Step 2: Search Datasets
+
+Use `dataset_search` with keywords from intent_parse:
+
+```
+dataset_search(query="cat image", task_type="classification", limit=10)
+```
+
+Supported sources (leave empty to search all):
+- `kaggle`, `huggingface`, `ipfs`, `bittorrent`
+- `arxiv`, `dblp`, `semanticscholar`
+- `defillama`, `rwa_xyz`, `guixu-hub`
+- `pansearch` (cloud drives)
+
+Filter options:
+- `filters.max_price`: maximum price in USD
+- `filters.free_only`: only free datasets
+- `filters.license`: specific license (e.g., "CC-BY-4.0")
+
+### Step 3: Evaluate Candidates
+
+For each promising candidate, call `dataset_evaluate`:
+
+```
+dataset_evaluate(cid="kaggle:owner/dataset-name", task_description="cat image classification", task_type="classification", required_columns=["image_path", "label"])
+```
+
+This returns:
+- `tcv_score`: -100 (harmful) to +100 (highly valuable)
+- `schema_fit`: compatibility with required columns
+- `community_signal`: reviews and ratings
+
+### Step 4: Download
+
+Once a dataset is selected:
+
+```
+dataset_download(cid="kaggle:owner/dataset-name")
+# or
+dataset_download(cid="hf:owner/dataset-name")
+```
+
+Free sources: `uci:`, `openml:`, `zenodo:`, `figshare:`, `hf:` (public), `ipfs:`, `guixu-hub:`
+Requires login: `kaggle:`
+
+## Tool Chaining Examples
+
+### Classification Dataset
+
+```
+1. intent_parse(query="find me a dog vs cat classification dataset", task_type="classification")
+2. dataset_search(query="cat dog classification", task_type="classification", limit=10)
+3. dataset_evaluate(cid="kaggle:username/dataset", task_description="dog cat binary classification", task_type="classification", required_columns=["image_path", "label"])
+4. dataset_download(cid="kaggle:username/dataset")
+```
+
+### Detection Dataset
+
+```
+1. intent_parse(query="find helmet detection dataset with bounding boxes", task_type="detection")
+2. dataset_search(query="helmet detection bounding box", task_type="detection", limit=10)
+3. For each candidate: dataset_evaluate(cid, task_description="helmet detection", task_type="detection", required_columns=["image_path", "bbox"])
+4. Download best candidate
+```
+
+### Tabular Finance Dataset
+
+```
+1. intent_parse(query="find stock price dataset for time series forecasting", task_type="forecasting")
+2. dataset_search(query="stock price time series", task_type="forecasting", filters={source: "defillama"})
+3. dataset_evaluate(cid, task_description="stock price prediction", task_type="forecasting", required_columns=["timestamp", "price"])
+4. dataset_download(cid)
+```
+
+## Important Notes
+
+- **Always call `intent_parse` FIRST** — it extracts task_type and keywords that improve search quality
+- **Keywords should be CONTENT only** — no task words like "classification" or "detection"
+- **Check license before purchase** — use `require_license_review: true` in evaluation
+- **Budget enforcement** — set `filters.max_price` or `budget` to limit spending
+- **Free sources first** — try `guixuhub`, `huggingface`, `ipfs` before paid sources
+
+## Error Handling
+
+If `dataset_search` returns no results:
+- Try broader keywords
+- Remove source filters
+- Check if the source is spelled correctly
+
+If `dataset_evaluate` fails:
+- Dataset may be unavailable
+- Try a different candidate
+
+If `dataset_download` fails:
+- Check if login is required (Kaggle)
+- Verify the CID format is correct: `source:owner/dataset`


### PR DESCRIPTION
## Summary
- Add Guixu to Community Plugins (Tools & Integrations category)
## Plugin Details
- **Name:** Guixu
- **Repo:** https://github.com/guixu-project/guixu
- **Description:** Dataset discovery, valuation, and acquisition for AI agents. Search, evaluate, and purchase datasets from Kaggle, Hugging Face, IPFS, and more.
## Verification
- Plugin has valid `.codex-plugin/plugin.json` manifest
- Public GitHub repository with functional implementation
- Meets all CONTRIBUTING.md requirements