### PR TITLE
ci: add honeydew-ai plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
+- [Honeydew AI](https://github.com/honeydew-ai/honeydew-ai-coding-agents-plugins) - Skills and tools powered by the Honeydew MCP that help coding agents query data and build semantic models through a governed semantic layer.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.


### PR DESCRIPTION
## Summary

Adds [Honeydew AI](https://github.com/honeydew-ai/honeydew-ai-coding-agents-plugins) to the **Tools & Integrations** section of Community Plugins, alphabetically between Flow Studio Power Automate and Jenkins CLI.

## Plugin details

- **Repo:** https://github.com/honeydew-ai/honeydew-ai-coding-agents-plugins
- **Manifest:** `.codex-plugin/plugin.json` ✓
- **Description:** Skills and tools powered by the Honeydew MCP that help coding agents query data and build semantic models through a governed semantic layer.
- **Author:** Honeydew AI (https://honeydew.ai)

## Checklist

- [x] Public GitHub repository
- [x] Valid `.codex-plugin/plugin.json` manifest
- [x] Functional and well-documented
- [x] Description is one line
- [x] Entry is alphabetized within the category
- [x] All links verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)