### PR TITLE
Add Agentizer plugin to Development & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 
 <!-- pinned -->
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
+- [Agentizer](https://github.com/Humiris/wwa-transform) - Turn any website into an AI-powered agentfront with split-pane chat, voice, embedded MCP, real CDN imagery, and one-command deploy to `{brand}.codiris.app`. Works as a Codex skill, Claude Code skill, or standalone CLI.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
 - [Brooks Lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).
 - [Claude Code for Codex](https://github.com/sendbird/cc-plugin-codex) - Reverse of OpenAI's official Claude-hosted plugin: use Claude Code from Codex for reviews, rescue tasks, tracked background jobs, and hook-powered review gates.


### PR DESCRIPTION
## What this adds

[**Agentizer**](https://github.com/Humiris/wwa-transform) — a Codex / Claude Code / Cursor plugin that turns any website into a deployed AI-powered agentfront in one command.

Slot: **Community Plugins → Development & Workflow** (alphabetical, before AgentOps).

## What Agentizer does

Given a single URL, the skill:

1. **Crawls** the website (4+ pages with consent handling) and extracts brand identity — name, colors, products, copy, real CDN imagery
2. **Generates** a full Next.js 16 split-pane app with AI chat (GPT-5.4-mini + Gemini fallback), live voice (OpenAI Realtime `gpt-realtime`), 3D product cards, conversational checkout, and an MCP-Connect component that lets any AI agent connect to the deployed brand
3. **Deploys** to Vercel with custom domain at `{brand}.codiris.app`, sets up Cloudflare DNS + SSL, exposes a public Streamable-HTTP MCP endpoint with discovery manifest at `/.well-known/mcp.json`

19 brand transforms shipped via this skill so far — every one publicly browsable at https://codiris.app/skill-creator. Examples: [habyt.codiris.app](https://habyt.codiris.app), [joivy.codiris.app](https://joivy.codiris.app), [ycombinator.codiris.app](https://ycombinator.codiris.app).

## How to install

```bash
codex marketplace add https://github.com/Humiris/wwa-transform
codex plugin install agentizer
```

Or as a one-shot CLI without Codex:

```bash
npx github:Humiris/wwa-transform https://stripe.com
```

## Manifest checks

- ✅ `.codex-plugin/plugin.json` v2.0.1 (logo, brandColor, displayName, capabilities, defaultPrompt)
- ✅ `skills/agentizer/SKILL.md` follows Codex skill convention
- ✅ `marketplace.json` with `source: github` so anyone can install remotely
- ✅ MIT licensed
- ✅ 1024×1024 + 256×256 PNG logos in `assets/`

Built by [Iris Lab / Codiris](https://codiris.app).