### PR TITLE
Add Antigravity Workspace Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 <!-- pinned -->
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
+- [Antigravity Workspace Template](https://github.com/study8677/antigravity-workspace-template) - Multi-agent codebase knowledge hub for Codex and Claude with ag-ask/ag-refresh CLI workflows, onboarding templates, and optional MCP integration.
 - [Brooks Lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).
 - [Claude Code for Codex](https://github.com/sendbird/cc-plugin-codex) - Reverse of OpenAI's official Claude-hosted plugin: use Claude Code from Codex for reviews, rescue tasks, tracked background jobs, and hook-powered review gates.
 - [Claude Code Harness](https://github.com/dadwadw233/claude-code-harness) - Harness blueprint skill for turning vague agent ideas into concrete designs for request assembly, control loops, memory, permissions, recovery, and extension planes.


### PR DESCRIPTION
## Summary

- Add Antigravity Workspace Template to the Community Plugins / Development & Workflow list.
- Describe the current CLI-backed ag-ask/ag-refresh workflow and optional MCP integration.

## Validation

- `python3 scripts/check-alphabetical.py README.md`
- `git diff --check`
- Verified `study8677/antigravity-workspace-template` exposes `.codex-plugin/plugin.json`.
