### PR TITLE
Add Bring Your AI Migration Auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Agenteam](https://github.com/yimwoo/codex-agenteam) - Specialist AI agents (researcher, PM, architect, developer, QA, reviewer) orchestrated as a configurable team pipeline.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
+- [Bring Your AI Migration Auditor](https://github.com/unitedideas/bringyour-mcp) - Read-only Codex plugin for auditing Claude Code to Codex migrations before Codex edits code. Checks AGENTS.md/CLAUDE.md scope, hooks, MCP config, skills, secret references, and validation notes.
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin for Codex, Claude Code, and Cline with structured planning, review, and verification guardrails.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.


### PR DESCRIPTION
Adds Bring Your AI Migration Auditor to Development & Workflow.

This fits as a Codex plugin with a public `.codex-plugin/plugin.json` and a read-only `SKILL.md` for auditing Claude Code to Codex migrations before Codex edits code. It checks instruction scope, hooks, MCP config, skills, secret references, and validation notes instead of treating file copying as the whole migration.

Scanner lint passed with policy score 87 on the public metadata repo.

Plugin repo: https://github.com/unitedideas/bringyour-mcp
Product guide: https://bringyour.ai/claude-code-to-codex