### PR TITLE
Add Frappe Agent

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -137,6 +137,18 @@
       "category": "Development & Workflow"
     },
     {
+      "name": "frappe-agent",
+      "source": {
+        "source": "local",
+        "path": "./plugins/Dkm0315/frappe-agent"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development & Workflow"
+    },
+    {
       "name": "hotl",
       "source": {
         "source": "local",

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Agenteam](https://github.com/yimwoo/codex-agenteam) - Specialist AI agents (researcher, PM, architect, developer, QA, reviewer) orchestrated as a configurable team pipeline.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
+- [Frappe Agent](https://github.com/Dkm0315/frappe-agent) - Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin for Codex, Claude Code, and Cline with structured planning, review, and verification guardrails.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.

--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-05-04",
-  "total": 55,
+  "last_updated": "2026-05-06",
+  "total": 56,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -118,6 +118,16 @@
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/schuettc/codex-reviewer/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Frappe Agent",
+      "url": "https://github.com/Dkm0315/frappe-agent",
+      "owner": "Dkm0315",
+      "repo": "frappe-agent",
+      "description": "Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.",
+      "category": "Development & Workflow",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/Dkm0315/frappe-agent/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "HOTL Plugin",

--- a/plugins/Dkm0315/frappe-agent/.codex-plugin/plugin.json
+++ b/plugins/Dkm0315/frappe-agent/.codex-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "frappe-agent",
+  "version": "0.1.0",
+  "description": "Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.",
+  "author": {
+    "name": "Dhairya Marwaha",
+    "email": "dhairya15marwaha@gmail.com",
+    "url": "https://github.com/Dkm0315"
+  },
+  "homepage": "https://github.com/Dkm0315/frappe-agent",
+  "repository": "https://github.com/Dkm0315/frappe-agent",
+  "license": "MIT",
+  "keywords": [
+    "frappe",
+    "erpnext",
+    "bench",
+    "python",
+    "javascript",
+    "react",
+    "vue"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Frappe Agent",
+    "shortDescription": "Frappe-aware coding, bench, SQL, and customization help.",
+    "longDescription": "Adds Frappe and ERPNext-specific skills for full-stack work, bench operations, SQL and ORM decisions, admin customizations, and workflow-aware code review.",
+    "developerName": "Dhairya Marwaha",
+    "category": "Development & Workflow",
+    "capabilities": [
+      "Read",
+      "Write",
+      "Interactive"
+    ],
+    "websiteURL": "https://github.com/Dkm0315/frappe-agent",
+    "privacyPolicyURL": "https://github.com/Dkm0315/frappe-agent",
+    "termsOfServiceURL": "https://github.com/Dkm0315/frappe-agent",
+    "defaultPrompt": [
+      "Use Frappe Agent to inspect this bench before changing anything.",
+      "Use Frappe Agent to choose the right Frappe customization layer.",
+      "Use Frappe Agent to review this Frappe SQL or ORM code."
+    ],
+    "brandColor": "#1F7A5A"
+  }
+}

--- a/plugins/Dkm0315/frappe-agent/LICENSE
+++ b/plugins/Dkm0315/frappe-agent/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dhairya Marwaha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/Dkm0315/frappe-agent/README.md
+++ b/plugins/Dkm0315/frappe-agent/README.md
@@ -1,0 +1,130 @@
+# Frappe Agent for Codex
+
+`frappe-agent` is a Codex plugin for Frappe Framework and ERPNext development. It makes Codex more aware of Frappe-specific patterns so it can inspect benches more safely, choose the right customization layer, and avoid generic framework mistakes.
+
+## What It Covers
+
+- Frappe full-stack reasoning across backend, frontend, customization, and bench work
+- Bench-aware inspection before app installs, migrations, or environment changes
+- Frappe-native SQL and ORM guidance
+- Customization-layer routing for `Custom Field`, `Property Setter`, `Client Script`, `Server Script`, `Workspace`, `Web Page`, `Report`, `Dashboard`, and related surfaces
+- ERPNext-aware guidance for deciding between configuration, metadata, workflow, and code changes
+- Frontend guidance for Vue, React, `frappe-ui`, desk pages, `www`, and external SPA patterns
+
+## Included Skills
+
+- `frappe-fullstack`
+- `frappe-backend`
+- `frappe-frontend`
+- `frappe-bench`
+- `frappe-sql`
+- `frappe-customization`
+- `frappe-search`
+- `frappe-erpnext`
+
+## Installation
+
+This mirrored bundle ships the Codex plugin files used by the curated `awesome-codex-plugins` marketplace.
+
+For the full upstream repository, including cross-agent packaging and development docs, see:
+
+```text
+https://github.com/Dkm0315/frappe-agent
+```
+
+### Codex
+
+Codex supports repo marketplaces and local plugin installation.
+
+If you cloned this repository locally, add it as a local marketplace:
+
+```bash
+codex marketplace add /path/to/frappe-agent
+```
+
+Then enable `frappe-agent` from the added marketplace in Codex and restart Codex in a fresh session.
+
+Local repo flow:
+
+1. Clone this repository somewhere on disk.
+2. Run:
+
+```bash
+codex marketplace add /path/to/frappe-agent
+```
+
+3. Enable `frappe-agent` from that marketplace in Codex.
+4. Restart Codex.
+
+GitHub repo flow:
+
+1. Clone this repository or open the repo locally.
+2. Run:
+
+```bash
+codex marketplace add /path/to/local/clone/of/frappe-agent
+```
+
+3. Enable `frappe-agent` and restart Codex.
+
+This mirrored bundle includes `.codex-plugin/plugin.json` and `skills/` for Codex installation through the curated marketplace.
+
+## Usage Examples
+
+Ask Codex to use the plugin naturally in the prompt:
+
+```text
+Use Frappe Agent to inspect this bench before changing anything.
+```
+
+```text
+Use Frappe Agent to choose the right Frappe customization layer for adding fields to Sales Order.
+```
+
+```text
+Use Frappe Agent to review whether this Frappe SQL should use frappe.db, frappe.qb, or raw SQL.
+```
+
+```text
+Use Frappe Agent to decide whether this UI should be a desk page, a www page, a Vue frappe-ui page, or a React SPA.
+```
+
+## Repository Layout
+
+```text
+frappe-agent/
+├── .codex-plugin/
+│   └── plugin.json
+├── skills/
+│   ├── frappe-backend/
+│   ├── frappe-bench/
+│   ├── frappe-customization/
+│   ├── frappe-erpnext/
+│   ├── frappe-frontend/
+│   ├── frappe-fullstack/
+│   ├── frappe-search/
+│   └── frappe-sql/
+└── README.md
+```
+
+## Current Scope
+
+This mirrored bundle is a Codex-native plugin package. The upstream repository may contain additional host adapters and docs.
+
+## Design Goals
+
+- Inspect first, mutate second
+- Prefer Frappe-native customization surfaces before invasive code changes
+- Separate ERPNext configuration work from framework-code work
+- Respect bench context, app provenance, and version boundaries
+- Help agents make fewer generic Python, JavaScript, SQL, and frontend mistakes in Frappe codebases
+
+## Roadmap
+
+- Add more first-class skills for custom fields, reports, workflows, dashboards, and upgrade planning
+- Add better source-backed command and flag coverage for Bench
+- Add richer repo examples and team onboarding docs
+
+## License
+
+MIT

--- a/plugins/Dkm0315/frappe-agent/skills/frappe-backend/SKILL.md
+++ b/plugins/Dkm0315/frappe-agent/skills/frappe-backend/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: frappe-backend
+description: Frappe backend guidance for Python and backend-adjacent JavaScript surfaces such as client interaction patterns, hooks, APIs, patches, scheduler logic, reports, and server-side review. Use when implementing or reviewing Frappe backend behavior.
+---
+
+Treat Frappe backend work as a Python-first system with important JavaScript touchpoints.
+
+Cover:
+- controllers and document lifecycle methods
+- hooks
+- whitelisted methods
+- scheduler jobs and background work
+- patches and migrations
+- server scripts when they are the right layer
+- report backends
+- client-to-server API contracts
+
+Principles:
+- prefer framework APIs over ad hoc patterns
+- keep imports clean and explicit
+- use permissions deliberately
+- separate document logic, service logic, and integration logic
+- avoid accidental public APIs
+
+Before writing code, decide whether the request should instead be handled by:
+- `Custom Field`
+- `Property Setter`
+- `Client Script`
+- `Server Script`
+- `Workflow`
+- `Report`
+- `Workspace`
+

--- a/plugins/Dkm0315/frappe-agent/skills/frappe-bench/SKILL.md
+++ b/plugins/Dkm0315/frappe-agent/skills/frappe-bench/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: frappe-bench
+description: Bench-aware Frappe operations guidance for app installs, branch switching, updates, migrations, site inspection, ports, and process state. Use when a task involves bench commands or local environment operations.
+---
+
+Operate as a careful bench assistant.
+
+Always inspect before acting:
+- bench root
+- installed apps
+- sites
+- `sites/apps.txt`
+- `sites/common_site_config.json`
+- running ports and process state
+- app remotes and branches
+
+Prefer read-only checks first.
+
+Never assume:
+- the bench is stopped
+- the default site is the target site
+- the app remote is official
+- a version switch is safe
+
+When proposing commands:
+- explain why that command is appropriate
+- call out risky flags
+- show what bench or site it targets
+- warn before actions that mutate apps, sites, DBs, or branches
+

--- a/plugins/Dkm0315/frappe-agent/skills/frappe-customization/SKILL.md
+++ b/plugins/Dkm0315/frappe-agent/skills/frappe-customization/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: frappe-customization
+description: Frappe customization-surface guidance covering Custom Field, Property Setter, Client Script, Server Script, Workspace, Web Page, Page, Print Format, Report, Dashboard, Workflow, Role, Notification, Webhook, and related builder/admin DocTypes. Use when choosing or changing Frappe customization layers.
+---
+
+Choose the right Frappe customization surface before suggesting code.
+
+Check these surfaces first when relevant:
+- `Custom Field`
+- `Property Setter`
+- `Client Script`
+- `Server Script`
+- `Workspace`
+- `Web Page`
+- `Page`
+- `Print Format`
+- `Report`
+- `Dashboard`
+- `Dashboard Chart`
+- `Number Card`
+- `Web Form`
+- `Workflow`
+- `Role`
+- `Notification`
+- `Assignment Rule`
+- `Webhook`
+- `Auto Repeat`
+- `Email Template`
+- `Letter Head`
+- `Print Style`
+
+Preferred decision ladder:
+1. built-in configuration
+2. metadata/admin DocType customization
+3. page/workspace/report/dashboard/print/web surfaces
+4. hooks and custom app code
+5. changes inside a custom-derived app only when necessary
+
+Explicitly call out when a request should use `Custom Field` rather than editing a DocType JSON file directly.
+

--- a/plugins/Dkm0315/frappe-agent/skills/frappe-erpnext/SKILL.md
+++ b/plugins/Dkm0315/frappe-agent/skills/frappe-erpnext/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: frappe-erpnext
+description: ERPNext-aware reasoning for module customization, workflows, reports, dashboards, workspaces, and choosing between configuration, metadata, and code changes. Use when a task affects ERPNext module behavior.
+---
+
+Act as an ERPNext customization advisor for developers.
+
+Help the user determine:
+- what the standard module already supports
+- whether the request is configuration, metadata, workflow, reporting, or code work
+- whether a change belongs in ERPNext settings, builder DocTypes, a custom app, or a custom-derived app
+
+Cover common domains broadly:
+- manufacturing
+- buying
+- selling
+- CRM
+- HR
+- accounts and reporting
+- customer-facing website or portal flows
+
+Prefer showing the safest customization layer before proposing invasive code changes.

--- a/plugins/Dkm0315/frappe-agent/skills/frappe-frontend/SKILL.md
+++ b/plugins/Dkm0315/frappe-agent/skills/frappe-frontend/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: frappe-frontend
+description: Frappe frontend guidance for Vue and React, including desk pages, `www` pages, `frappe-ui`, Doppio-style frontends, client scripts, and external SPA integrations. Use when building or reviewing Frappe UI work.
+---
+
+Treat Frappe frontend work as a React-or-Vue decision, not a generic browser task.
+
+Support:
+- desk-native pages
+- `www` pages
+- `Web Page`
+- `Workspace`
+- `Client Script`
+- Vue with `frappe-ui`
+- Doppio-generated app patterns
+- React SDK and external SPA patterns
+
+Decide first:
+- desk-native vs website/public vs external SPA
+- Vue vs React
+- metadata/configuration surface vs code surface
+
+Prefer:
+- Vue when the app is already using `frappe-ui` or desk-native Vue patterns
+- React when the project is already React-based or clearly external-SPA oriented
+
+Do not flatten everything into the same UI recommendation.
+

--- a/plugins/Dkm0315/frappe-agent/skills/frappe-fullstack/SKILL.md
+++ b/plugins/Dkm0315/frappe-agent/skills/frappe-fullstack/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: frappe-fullstack
+description: End-to-end Frappe and ERPNext implementation guidance spanning backend Python, backend JavaScript surfaces, Vue or React frontends, customizations, and bench-aware delivery. Use when the task crosses multiple Frappe layers.
+---
+
+Work as a Frappe full-stack specialist.
+
+Always start by identifying:
+- whether this is a custom app, official app, or custom-derived app
+- whether the change belongs in configuration, metadata, customization surfaces, or code
+- whether the frontend path is desk-native, `www`, Vue, React, or external SPA
+- whether bench state should be inspected before any command is suggested
+
+Default flow:
+1. Inspect bench/app/site context before proposing actions.
+2. Choose the narrowest valid customization layer first.
+3. Split implementation into backend, frontend, metadata, and bench tasks.
+4. Keep Python and JavaScript responsibilities explicit.
+5. Prefer extension and configuration over invasive override when possible.
+
+When relevant, route into these companion skills:
+- `frappe-backend`
+- `frappe-frontend`
+- `frappe-bench`
+- `frappe-sql`
+- `frappe-customization`
+- `frappe-search`
+- `frappe-erpnext`
+
+Be opinionated about:
+- not restarting an already running bench
+- not patching upstream-derived apps when a custom app can own the change
+- not using raw SQL when a Frappe-native path is better
+

--- a/plugins/Dkm0315/frappe-agent/skills/frappe-search/SKILL.md
+++ b/plugins/Dkm0315/frappe-agent/skills/frappe-search/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: frappe-search
+description: Frappe-specific search and discovery guidance for finding benches, apps, remotes, sites, ports, hooks, DocTypes, builder DocTypes, and frontend surfaces quickly. Use when the task starts with locating or classifying Frappe context.
+---
+
+Search like a Frappe operator, not a generic grep user.
+
+Look for:
+- bench roots
+- `apps.txt`
+- `common_site_config.json`
+- `hooks.py`
+- DocType folders
+- `www` pages
+- client or server scripts
+- report, workspace, dashboard, and print-format definitions
+- app remotes and branch markers
+
+Prefer:
+- `rg --files`
+- `rg`
+- focused file inspection
+- config and manifest discovery before code edits
+
+When searching, summarize:
+- what was found
+- what type of Frappe surface it is
+- whether it is official, custom-derived, or custom
+- what the safest next step is
+

--- a/plugins/Dkm0315/frappe-agent/skills/frappe-sql/SKILL.md
+++ b/plugins/Dkm0315/frappe-agent/skills/frappe-sql/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: frappe-sql
+description: Frappe-native SQL and ORM guidance for `frappe.db`, Query Builder, `tab{DocType}` tables, permission-sensitive queries, and raw SQL review. Use when writing or reviewing database access in Frappe.
+---
+
+Treat SQL and ORM decisions as first-class Frappe architecture choices.
+
+Cover:
+- `frappe.db.get_list`
+- `frappe.db.get_all`
+- `frappe.db.get_value`
+- `frappe.db.exists`
+- `frappe.qb`
+- `frappe.db.sql`
+- transaction boundaries
+- permission implications
+
+Rules:
+- prefer Frappe-native APIs when they express the query clearly
+- treat `get_all` and raw SQL as deliberate choices
+- use correct `tab{DocType}` table naming when raw SQL is necessary
+- flag brittle or permission-blind SQL
+- distinguish reporting SQL from transactional logic
+
+When reviewing code, explicitly state:
+- why the chosen access layer is or is not appropriate
+- whether permissions are respected or bypassed
+- whether the query belongs in a report, service, patch, or controller
+


### PR DESCRIPTION
## Summary

- Add Frappe Agent to the Development & Workflow community plugin list
- Regenerate `plugins.json` and the curated Codex marketplace entry
- Mirror the installable Frappe Agent plugin bundle under `plugins/Dkm0315/frappe-agent`

## Verification

- `python3 scripts/check-alphabetical.py README.md`
- `python3 -m json.tool plugins.json`
- `python3 -m json.tool .agents/plugins/marketplace.json`
- `python3 -m json.tool plugins/Dkm0315/frappe-agent/.codex-plugin/plugin.json`
- `node build.js`
