### PR TITLE
Add Agent Vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 ### Tools & Integrations
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
+- [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.


### PR DESCRIPTION
## Summary
Adds Agent Vision to the Community Plugins > Tools & Integrations section.

Agent Vision is a macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.

## Requirements Check
- Public GitHub repository: https://github.com/zfifteen/agent-vision
- Valid Codex plugin manifest: https://raw.githubusercontent.com/zfifteen/agent-vision/HEAD/.codex-plugin/plugin.json
- Functional plugin: v1.0.1 is published with a verified release archive
- Author link included: https://github.com/zfifteen
- One-line description kept concise
- Entry placed alphabetically under Tools & Integrations

## Validation
- Verified the repo link resolves
- Verified the author link resolves
- Verified the raw plugin manifest parses as JSON
