### PR TITLE
Add Codex SkillForge

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ For this curated list, the machine-readable source of truth is the generated rep
 
 After scaffolding with `$plugin-creator`, use [codex-plugin-scanner](https://github.com/hashgraph-online/codex-plugin-scanner) as your quality gate before publishing, review, or distribution.
 
+For skill/plugin authoring workflows, [Codex SkillForge](https://github.com/f0d010c/skillforge) provides an ESLint-style CLI and GitHub Action for scaffolding, linting, smoke-testing, and packaging Codex skills/plugins before publishing.
+
 ### Local Preflight
 
 ```bash


### PR DESCRIPTION
Adds Codex SkillForge, an ESLint-style CLI and GitHub Action for scaffolding, linting, smoke-testing, and packaging Codex skills/plugins before publishing.

Repo: https://github.com/f0d010c/skillforge
npm: https://www.npmjs.com/package/codex-skillforge

Install:
```bash
npx codex-skillforge lint .
```