### PR TITLE
Add AxonFlow to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
+- [AxonFlow](https://github.com/getaxonflow/axonflow-codex-plugin) - Runtime governance for Codex with policy enforcement on terminal commands, advisory checks for non-terminal tools via skills, PII/secret detection, and compliance-grade audit trails. Self-hosted via Docker.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.


### PR DESCRIPTION
Adds AxonFlow to Community Plugins → Tools & Integrations (alphabetically between Apple Productivity and Bitbucket CLI).

**Plugin:** https://github.com/getaxonflow/axonflow-codex-plugin

**Checklist:**
- [x] Public GitHub repository
- [x] Includes `.codex-plugin/plugin.json` (v1.4.0, MIT)
- [x] Functional — runtime governance plugin (policy enforcement on `exec_command` via PreToolUse hook, advisory `check_policy` MCP tool, audit trail)
- [x] One plugin, one PR
- [x] Concise one-line description
- [x] Alphabetized within section
- [x] Links verified

Filed in response to https://github.com/getaxonflow/axonflow-codex-plugin/issues/53.