### PR TITLE
Add GrayMatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
+- [GrayMatter](https://github.com/ValkyrLabs/GrayMatter) - Durable memory, shared graph state, and live ValkyrAI schema awareness for Codex and OpenClaw agents.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.


### PR DESCRIPTION
## Summary

Adds GrayMatter to the Community Plugins / Tools & Integrations section.

GrayMatter provides durable memory, shared graph state, and live ValkyrAI schema awareness for Codex and OpenClaw agents.

## Checklist

- Public GitHub repository: https://github.com/ValkyrLabs/GrayMatter
- Manifest present: https://raw.githubusercontent.com/ValkyrLabs/GrayMatter/main/.codex-plugin/plugin.json
- One plugin in this PR
- README entry placed alphabetically in Tools & Integrations

## Validation

- Checked GrayMatter repository link returns HTTP 200
- Checked `.codex-plugin/plugin.json` parses as valid JSON from `main`
- GrayMatter public-marketplace scanner preflight in upstream repo: `codex-plugin-scanner scan --profile public-marketplace --strict .` -> final score 96/100, findings 0

Related: ValkyrLabs/GrayMatter#35
