### PR TITLE
ci(workflows): fix registry sync and link check

### DIFF
--- a/.github/workflows/sync-to-ai-plugins.yml
+++ b/.github/workflows/sync-to-ai-plugins.yml
@@ -1,6 +1,7 @@
 name: Sync to awesome-ai-plugins
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -15,11 +16,9 @@ jobs:
   dispatch:
     name: Trigger sync to awesome-ai-plugins
     runs-on: ubuntu-latest
-    # Requires BOT_TOKEN secret with repo scope for cross-repo dispatch
-    # Without it, this step will be skipped
+    # Requires the configured repo secret with repo scope for cross-repo dispatch.
     steps:
       - name: Repository Dispatch
-        if: ${{ secrets.BOT_TOKEN }}
         uses: peter-evans/repository-dispatch@v4
         with:
           repository: hashgraph-online/awesome-ai-plugins

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="http://makeapullrequest.com"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
+  <a href="#contributing"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
   <a href="https://hol.org/registry/plugins"><img src="https://img.shields.io/badge/Browse-Registry-green" alt="Browse Registry"></a>
 </p>


### PR DESCRIPTION
## Summary
- replace the dead PR badge target with the local Contributing section so markdown link check is stable
- remove the invalid secret-context conditional from the cross-repo sync workflow
- add workflow_dispatch so admins can manually smoke-test the sync workflow after it lands

## Root cause
- Build & Deploy failed because README linked to http://makeapullrequest.com, which markdown-link-check reports as dead
- Sync to awesome-ai-plugins failed before jobs ran because GitHub Actions does not allow secrets context directly in a step if expression

## Verification
- yq parsed .github/workflows/sync-to-ai-plugins.yml and .github/workflows/deploy.yml
- npx markdown-link-check@latest README.md --config .mlc_config.json
- node build.js