### PR TITLE
ci(sync): pass dispatch token

### DIFF
--- a/.github/workflows/sync-to-ai-plugins.yml
+++ b/.github/workflows/sync-to-ai-plugins.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v4
         with:
+          token: ${{ secrets.BOT_TOKEN }}
           repository: hashgraph-online/awesome-ai-plugins
           event-type: sync-to-ai-plugins
           token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/sync-to-ai-plugins.yml
+++ b/.github/workflows/sync-to-ai-plugins.yml
@@ -24,4 +24,3 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           repository: hashgraph-online/awesome-ai-plugins
           event-type: sync-to-ai-plugins
-          token: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- restore the required repository-dispatch token input
- keep the previous fix that removes invalid secret-context conditionals and avoids continue-on-error bandaids

## Root cause
- repository-dispatch failed after PR #96 because the workflow invoked peter-evans/repository-dispatch without token/opts.auth
- the repo already has BOT_TOKEN configured; the action needs it passed explicitly

## Verification
- yq parsed .github/workflows/sync-to-ai-plugins.yml
- gh secret list confirms BOT_TOKEN exists in hashgraph-online/awesome-codex-plugins