### PR TITLE
Add GH Project plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Dodo Payments](https://github.com/dodopayments/dodo-agent-plugin) - Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth.
 - [Education Agent Skills](https://github.com/GarethManning/education-agent-skills) - 131 evidence-based education skills for curriculum design, lesson planning, and assessment, with transparent evidence ratings and MCP server.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
+- [GH Project](https://github.com/zfifteen/gh-project-plugin) - Create GitHub repositories from Codex with inferred defaults, native menus, explicit confirmation, and deterministic local cloning.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.


### PR DESCRIPTION
## Summary
- Add GH Project to the Tools & Integrations community plugin list.
- Keep the PR scoped to the README entry requested by CONTRIBUTING.md.

## Requirement Check
- Public repo: https://github.com/zfifteen/gh-project-plugin
- Manifest: `.codex-plugin/plugin.json` present and valid.
- Functional release: v1.0.0 published with packaged release asset.
- Description: one-line concise catalog description.
- Author link: entry links to the zfifteen GitHub repo.
- Alphabetical order: `python3 scripts/check-alphabetical.py` passes.

## Validation
- `uvx codex-plugin-scanner verify .` passes on `zfifteen/gh-project-plugin`.
- `uvx codex-plugin-scanner lint .` reports `policy_pass=True` with an effective score of 84.
- `npm run validate` passes in the plugin repo and confirms the production package surface.