### PR TITLE
Add Data Product Builder for dbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Obsidian](https://github.com/greg-asher/codex-obsidian) - Local Obsidian note and vault workflows through the official desktop `obsidian` CLI.
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
+- [Data Product Builder for dbt](https://github.com/entropy-data/dataproduct-builder-dbt) - Full data-product lifecycle on dbt for Entropy Data: scaffold projects, audit and integrate existing repos, implement output-port models from ODCS data contracts, and wire up ODPS, OpenLineage, and GitHub Actions.
 - [Dodo Payments](https://github.com/dodopayments/dodo-agent-plugin) - Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth.
 - [Education Agent Skills](https://github.com/GarethManning/education-agent-skills) - 131 evidence-based education skills for curriculum design, lesson planning, and assessment, with transparent evidence ratings and MCP server.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Obsidian](https://github.com/greg-asher/codex-obsidian) - Local Obsidian note and vault workflows through the official desktop `obsidian` CLI.
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
-- [Data Product Builder for dbt](https://github.com/entropy-data/dataproduct-builder-dbt) - Full data-product lifecycle on dbt for Entropy Data: scaffold projects, audit and integrate existing repos, implement output-port models from ODCS data contracts, and wire up ODPS, OpenLineage, and GitHub Actions.
+- [Data Product Builder for dbt](https://github.com/entropy-data/dataproduct-builder-dbt) - Full data-product lifecycle on dbt for Entropy Data: scaffold, audit, and integrate projects with ODCS, ODPS, OpenLineage, and GitHub Actions.
 - [Dodo Payments](https://github.com/dodopayments/dodo-agent-plugin) - Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth.
 - [Education Agent Skills](https://github.com/GarethManning/education-agent-skills) - 131 evidence-based education skills for curriculum design, lesson planning, and assessment, with transparent evidence ratings and MCP server.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.


### PR DESCRIPTION
Adds [Data Product Builder for dbt](https://github.com/entropy-data/dataproduct-builder-dbt) under **Community Plugins → Tools & Integrations** (alphabetized between *Context Pack* and *Dodo Payments*).

### About the plugin
Codex/Claude plugin for the full data-product lifecycle on dbt, integrated with Entropy Data:

- Scaffold a new dbt data product (greenfield)
- Audit and integrate an existing dbt project with the Entropy Data reference layout (ODPS, ODCS, OpenLineage, GitHub Actions, git connections)
- Implement output-port models from a published data contract
- Edit and test data contracts
- Upload sample data and manage CLI authentication

Ships seven skills, a `pii-scanner` subagent, and an ODCS-lint hook.

### Checklist
- [x] Public GitHub repo
- [x] Valid `.codex-plugin/plugin.json` manifest
- [x] Functional (not a stub)
- [x] One-line description
- [x] Author/org linked
- [x] Alphabetized within category