### PR TITLE
fix(readme): correct Codex marketplace install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,19 @@ Install plugins directly from this curated list by pointing Codex at the repo ma
 ```bash
 # Add this repo as a marketplace source (one-time setup)
 codex plugin marketplace add \
-  "https://raw.githubusercontent.com/hashgraph-online/awesome-codex-plugins/main/.agents/plugins/marketplace.json"
+  https://github.com/hashgraph-online/awesome-codex-plugins.git \
+  --ref main \
+  --sparse .agents/plugins \
+  --sparse plugins
 
 # Then browse and install (the marketplace name is derived from the repo name)
 codex plugin list --source awesome-codex-plugins
 codex plugin install <plugin-name> --source awesome-codex-plugins
 ```
+
+Do not use the raw `marketplace.json` URL with `codex plugin marketplace add`.
+The Codex marketplace command clones a Git repository, so a raw GitHub file URL is
+treated like a repo URL and fails with `remote: 404: Not Found`.
 
 **Desktop App / IDE Extension:**
 1. Open Codex settings → Plugins → Next to search plugins input click on menu and select → `+Add More...` 


### PR DESCRIPTION
Summary:
- replace raw marketplace JSON URL with Git repo marketplace command Codex expects
- include sparse paths for marketplace manifest and mirrored plugin bundles
- document why raw GitHub file URLs fail with remote 404

Closes #64.

Verification:
- README install command check passed
- marketplace JSON validates with jq
- git diff --check passed
- README guidance guard script passed