### PR TITLE
fix(readme): quote Codex marketplace repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Install plugins directly from this curated list by pointing Codex at the repo ma
 ```bash
 # Add this repo as a marketplace source (one-time setup)
 codex plugin marketplace add \
-  https://github.com/hashgraph-online/awesome-codex-plugins.git \
+  "https://github.com/hashgraph-online/awesome-codex-plugins.git" \
   --ref main \
   --sparse .agents/plugins \
   --sparse plugins


### PR DESCRIPTION
Summary:
- quote Codex marketplace Git repo URL for shell compatibility
- addresses Gemini review from PR 106 after PR auto-merged

Verification:
- README install command check passed
- marketplace JSON validates with jq
- git diff --check passed
- README guidance guard script passed