### PR TITLE
fix(readme): use literal quoting for marketplace URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Install plugins directly from this curated list by pointing Codex at the repo ma
 # Add this repo as a marketplace source (one-time setup)
 codex plugin marketplace add \
   'https://github.com/hashgraph-online/awesome-codex-plugins.git' \
-  --ref main \
-  --sparse .agents/plugins \
-  --sparse plugins
+  --ref 'main' \
+  --sparse '.agents/plugins' \
+  --sparse 'plugins'
 
 # Then browse and install (the marketplace name is derived from the repo name)
 codex plugin list --source awesome-codex-plugins

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Install plugins directly from this curated list by pointing Codex at the repo ma
 ```bash
 # Add this repo as a marketplace source (one-time setup)
 codex plugin marketplace add \
-  "https://github.com/hashgraph-online/awesome-codex-plugins.git" \
+  'https://github.com/hashgraph-online/awesome-codex-plugins.git' \
   --ref main \
   --sparse .agents/plugins \
   --sparse plugins


### PR DESCRIPTION
Summary:
- use single quotes around Codex marketplace Git repo URL
- addresses Gemini review from PR 107 after PR auto-merged

Verification:
- README install command check passed
- marketplace JSON validates with jq
- git diff --check passed
- README guidance guard script passed