### PR TITLE
Add pluginpool to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Universal Design Principles](https://github.com/HDeibler/universal-design-principles) - Cross-agent UX and product-design marketplace with a root Codex collection plugin, five focused plugin bundles, and 137 Agent Skills for design review, accessibility, layout, interaction, cognition, and product polish.
 - [VibePortrait](https://github.com/dadwadw233/VibePortrait) - Developer personality portrait generator — analyzes AI conversation history to produce MBTI type (16 color themes), capability radar, developer rating, 3-dimension famous match, and a persona skill that lets any AI "think like you".
 - [Writer's Loop](https://github.com/xxsang/writers-loop) - Structured AI writing workflow for planning, critique, revision, translation, style distillation, and opt-in local preference learning.
+- [pluginpool](https://github.com/mturac/pluginpool) - Ten focused Claude Code plugins for everyday developer productivity wrapped as a plugin marketplace. Includes commit-narrator, pr-storyteller, test-gap, deps-doctor, env-lint, secret-guard, standup-gen, todo-harvest, flaky-detector, changelog-forge. Each plugin is a deterministic Python helper (stdlib only) wrapped as a slash command. 89 hermetic tests, MIT.
 ### Tools & Integrations
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.


### PR DESCRIPTION
Adds [pluginpool](https://github.com/mturac/pluginpool) to *Community Plugins → Development & Workflow*.

Ten focused Claude Code plugins (also work with Codex via standard plugin install) for everyday developer productivity:

| Plugin | What it does | Tests |
|---|---|---:|
| commit-narrator | Semantic commit message from `git diff --cached`, with the *why* | 8 |
| pr-storyteller | PR title + body + test plan from commits and diff vs base | 6 |
| test-gap | Lines in your diff lacking test coverage | 9 |
| deps-doctor | Multi-ecosystem dependency audit (npm, pip, cargo, go) | 8 |
| env-lint | `.env` vs `.env.example` key parity | 7 |
| secret-guard | Pre-commit secret scanner (pattern + entropy, redacted) | 10 |
| standup-gen | Daily standup notes from git activity | 8 |
| todo-harvest | TODO/FIXME/HACK scan with git blame author + age | 9 |
| flaky-detector | Run a test command N times, report flakiness % | 11 |
| changelog-forge | Conventional commits → CHANGELOG section + semver bump | 13 |

**89 hermetic tests, Python stdlib only at runtime, MIT.** Each plugin is its own repo; install one or all via marketplace: `/plugin marketplace add mturac/pluginpool`.