### PR TITLE
Add composer icon for Personal Data Protection

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -306,7 +306,8 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Development & Workflow",
-      "description": "Engineer-facing personal-data-protection compliance reference — Singapore PDPA, Thailand PDPA, Indonesia UU PDP, Malaysia PDPA (Act 709 + 2024 Amendments), Philippines DPA — organised by where in the stack each obligation lands, with checklists, breach-response runbook, and a developer-view divergence table across all five."
+      "description": "Engineer-facing personal-data-protection compliance reference — Singapore PDPA, Thailand PDPA, Indonesia UU PDP, Malaysia PDPA (Act 709 + 2024 Amendments), Philippines DPA — organised by where in the stack each obligation lands, with checklists, breach-response runbook, and a developer-view divergence table across all five.",
+      "icon": "./plugins/AltByteSG/personal-data-protection-skill/assets/icon.svg"
     },
     {
       "name": "praxis",

--- a/plugins/AltByteSG/personal-data-protection-skill/.codex-plugin/plugin.json
+++ b/plugins/AltByteSG/personal-data-protection-skill/.codex-plugin/plugin.json
@@ -26,6 +26,7 @@
     "displayName": "Personal Data Protection",
     "shortDescription": "PDP compliance checks for SEA apps.",
     "longDescription": "Engineer-facing personal-data-protection guidance for Singapore PDPA, Thailand PDPA, Indonesia UU PDP, Malaysia PDPA, and Philippines Data Privacy Act.",
+    "composerIcon": "./assets/icon.svg",
     "developerName": "AltByte",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/AltByteSG/personal-data-protection-skill/assets/icon.svg
+++ b/plugins/AltByteSG/personal-data-protection-skill/assets/icon.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Personal Data Protection</title>
+  <desc id="desc">A shield enclosing a stylized lock — engineering reference for personal-data-protection compliance across Southeast Asia.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3730A3"/>
+      <stop offset="100%" stop-color="#1E1B4B"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="40" fill="url(#bg)"/>
+  <path d="M128 36 L196 60 L196 132 C196 174 168 204 128 220 C88 204 60 174 60 132 L60 60 Z" fill="#F4F4F5"/>
+  <rect x="96" y="120" width="64" height="56" rx="8" fill="#1E1B4B"/>
+  <path d="M108 120 L108 96 C108 84 117 74 128 74 C139 74 148 84 148 96 L148 120" stroke="#1E1B4B" stroke-width="10" fill="none" stroke-linecap="round"/>
+  <circle cx="128" cy="144" r="5" fill="#F4F4F5"/>
+  <rect x="125" y="147" width="6" height="16" rx="1.5" fill="#F4F4F5"/>
+</svg>


### PR DESCRIPTION
Follow-up to #109 per your merge comment:

> Merged, but please follow up with a PR to add an icon. See CONTRIBUTING.md for the spec: add an SVG/PNG to `assets/`, set `composerIcon` in `.codex-plugin/plugin.json` interface section, and add the icon field in `.agents/plugins/marketplace.json`.

All three done in this PR.

## Changes

1. **`plugins/AltByteSG/personal-data-protection-skill/assets/icon.svg`** *(new)* — 1.1 KB shield-and-lock SVG. 256×256 viewBox, gradient background (indigo `#3730A3` → `#1E1B4B`), white shield enclosing a stylized lock. Reads cleanly at 32×32; no text in the mark. Well under the 50 KB cap in the icon spec.

2. **`plugins/AltByteSG/personal-data-protection-skill/.codex-plugin/plugin.json`** — added `interface.composerIcon: "./assets/icon.svg"`.

3. **`.agents/plugins/marketplace.json`** — added `"icon": "./plugins/AltByteSG/personal-data-protection-skill/assets/icon.svg"` to the `personal-data-protection` entry.

## Upstream

The same icon + manifest update has also landed in the source repo at AltByteSG/personal-data-protection-skill ([`b13552b`](https://github.com/AltByteSG/personal-data-protection-skill/commit/b13552b)) so the next sync from upstream won't drift.

## Validation

```
$ python3 scripts/validate-plugin-pr.py
Validating 1 changed plugin directory(ies)...
    ! No .codexignore file found (recommended)
Validation passed with warnings: 1 warning(s)
```

Only warning is the recommended-but-optional `.codexignore` (skipped for now to keep scope tight; ~80% of existing community plugins also don't ship one).

JSON validated locally with `python3 -m json.tool` on both `.agents/plugins/marketplace.json` and the mirror's `.codex-plugin/plugin.json` before push.