### PR TITLE
Update Frappe Agent trust signals

### DIFF
--- a/plugins/Dkm0315/frappe-agent/.codexignore
+++ b/plugins/Dkm0315/frappe-agent/.codexignore
@@ -1,0 +1,14 @@
+.git/
+.claude/settings.local.json
+.env
+.env.*
+dist/
+build/
+node_modules/
+__pycache__/
+.pytest_cache/
+.mypy_cache/
+*.pyc
+*.pyo
+*.pyd
+.DS_Store

--- a/plugins/Dkm0315/frappe-agent/README.md
+++ b/plugins/Dkm0315/frappe-agent/README.md
@@ -1,5 +1,10 @@
 # Frappe Agent for Codex
 
+[![HOL Trust Score](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Ddhairya-marwaha%252Ffrappe-agent%26metric%3Dtrust%26style%3Dflat)](https://hol.org/registry/plugins/dhairya-marwaha%2Ffrappe-agent)
+[![HOL Security](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Ddhairya-marwaha%252Ffrappe-agent%26metric%3Dsecurity%26style%3Dflat)](https://hol.org/registry/plugins/dhairya-marwaha%2Ffrappe-agent)
+[![Release](https://img.shields.io/github/v/release/Dkm0315/frappe-agent)](https://github.com/Dkm0315/frappe-agent/releases)
+[![License](https://img.shields.io/github/license/Dkm0315/frappe-agent)](./LICENSE)
+
 `frappe-agent` is a Codex plugin for Frappe Framework and ERPNext development. It makes Codex more aware of Frappe-specific patterns so it can inspect benches more safely, choose the right customization layer, and avoid generic framework mistakes.
 
 ## What It Covers

--- a/plugins/Dkm0315/frappe-agent/SECURITY.md
+++ b/plugins/Dkm0315/frappe-agent/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| `main` | Yes |
+| Latest published release | Yes |
+
+## Reporting a Vulnerability
+
+Please do not disclose security issues publicly before they have been reviewed.
+
+To report a vulnerability, open a private report through GitHub Security Advisories for this repository, or email `dhairya15marwaha@gmail.com` with:
+
+- a short description of the issue
+- affected files, skills, commands, or plugin metadata
+- reproduction steps or proof of concept details
+- expected impact
+- suggested fixes, if you already have them
+
+We aim to acknowledge reports within 72 hours and follow up with an initial assessment as soon as practical.
+
+## Security Practices
+
+- Keep credentials, site tokens, bench secrets, and ERPNext/Frappe environment values out of plugin files.
+- Review changes to skills and commands for prompt-injection risks before release.
+- Run the plugin scanner workflow before publishing release artifacts.
+- Prefer the latest published release when installing this plugin in day-to-day projects.


### PR DESCRIPTION
## Summary
- refresh the mirrored Frappe Agent bundle with its new security policy and `.codexignore`
- add HOL trust/security, release, and license badges to the mirrored README

## Why
The Frappe Agent source repository now includes stronger marketplace trust signals. Mirroring those files keeps the curated marketplace bundle aligned with the source repo and gives the HOL registry scanner more complete evidence.

## Validation
- `python3 -m json.tool plugins/Dkm0315/frappe-agent/.codex-plugin/plugin.json`
- `python3 -m json.tool .agents/plugins/marketplace.json`
- `python3 scripts/validate-plugin-pr.py --base-ref upstream/main`
- `pipx run --spec 'plugin-scanner' plugin-scanner scan plugins/Dkm0315/frappe-agent --format text` reported `Final Score: 97/100` with no critical/high/medium findings
