### PR TITLE
Add Espresso plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -266,6 +266,13 @@
       "description": "MCP server exposing reasoning, code, anti-deception, and memory harness tools for Codex."
     },
     {
+      "name": "Espresso",
+      "description": "Full token-saving stack - output compression, global rules, RTK hook, Caveman ultra, GitNexus config. Detects existing setup, installs only what is missing.",
+      "install_url": "https://raw.githubusercontent.com/mirkobozzetto/espresso/HEAD/.codex-plugin/plugin.json",
+      "source_url": "https://github.com/mirkobozzetto/espresso",
+      "category": "Development & Workflow"
+    },
+    {
       "name": "frappe-agent",
       "displayName": "Frappe Agent",
       "source": {
@@ -1163,5 +1170,6 @@
       "description": "GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.",
       "icon": "./plugins/nebelov/yandex-direct-for-all/assets/icon.png"
     }
-  ]
+  ],
+  "total": 81
 }

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Development Skills](https://github.com/reidemeister94/development-skills) - Three-tier triage (PASS_THROUGH / LIGHT / FULL 4-phase) development workflow for Codex and Claude Code with language auto-detection (Python, Java, TypeScript, Swift, frontend) and a staff-reviewer subagent for fresh-eyes review on every change.
 - [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) - MCP server exposing reasoning, code, anti-deception, and memory harness tools for Codex.
 - [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.
+- [Espresso](https://github.com/mirkobozzetto/espresso) - Full token-saving stack in one plugin - output compression, global rules, RTK hook, Caveman ultra, GitNexus config. Detects existing setup, installs only what's missing. Works on Claude Code and Codex.
 - [Flaky Detector](./plugins/mturac/flaky-detector) - Run a test command N times, report per-test flakiness %.
 - [Frappe Agent](https://github.com/Dkm0315/frappe-agent) - Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.
 - [GrayMatter](https://github.com/ValkyrLabs/GrayMatter) - Durable memory and shared graph state for Codex and OpenClaw agents, with live ValkyrAI schema awareness.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-05-18",
-  "total": 80,
+  "total": 81,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -188,6 +188,16 @@
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/ejentum/ejentum-mcp/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Espresso",
+      "url": "https://github.com/mirkobozzetto/espresso",
+      "owner": "mirkobozzetto",
+      "repo": "espresso",
+      "description": "Full token-saving stack - output compression, global rules, RTK hook, Caveman ultra, GitNexus config. Detects existing setup, installs only what is missing.",
+      "category": "Development & Workflow",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/mirkobozzetto/espresso/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Frappe Agent",

--- a/plugins/mirkobozzetto/espresso/.codex-plugin/plugin.json
+++ b/plugins/mirkobozzetto/espresso/.codex-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "espresso",
+  "version": "2.0.0",
+  "description": "Full token-saving stack - output compression, global rules, RTK, Caveman, GitNexus auto-config. 70-85% fewer tokens.",
+  "repository": "https://github.com/mirkobozzetto/espresso",
+  "license": "MIT",
+  "interface": {
+    "displayName": "Espresso",
+    "shortDescription": "One plugin. Full token-saving stack. 70-85% fewer tokens.",
+    "composerIcon": "./assets/icon.svg"
+  }
+}

--- a/plugins/mirkobozzetto/espresso/assets/icon.svg
+++ b/plugins/mirkobozzetto/espresso/assets/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="80" fill="#1a1a1a"/>
+  <path d="M152 210h208a8 8 0 0 1 8 8v16c0 80-46 144-104 160-58-16-104-80-104-160v-16a8 8 0 0 1 8-8z" fill="#c77d3c"/>
+  <rect x="144" y="192" width="224" height="28" rx="10" fill="#e8a04c"/>
+  <path d="M360 240h28c28 0 50 22 50 50v4c0 28-22 50-50 50h-28" stroke="#e8a04c" stroke-width="14" fill="none" stroke-linecap="round"/>
+  <path d="M208 172c0-20 10-32 18-42s14-24 14-40" stroke="#e8a04c" stroke-width="10" stroke-linecap="round" fill="none" opacity="0.5"/>
+  <path d="M256 172c0-20 10-32 18-42s14-24 14-40" stroke="#e8a04c" stroke-width="10" stroke-linecap="round" fill="none" opacity="0.5"/>
+  <path d="M304 172c0-20 10-32 18-42s14-24 14-40" stroke="#e8a04c" stroke-width="10" stroke-linecap="round" fill="none" opacity="0.5"/>
+  <rect x="192" y="400" width="128" height="10" rx="5" fill="#e8a04c" opacity="0.3"/>
+</svg>


### PR DESCRIPTION
Adds Espresso - a full token-saving stack plugin for Claude Code and Codex.

What it does:
- Output compression (120 char lines, no filler, result-first)
- Global rules auto-install (Exa search, clean git, GitNexus, project rules)
- RTK hook config (if binary found)
- Caveman ultra config (if plugin found)
- GitNexus MCP + auto-reindex (if binary found)

Detection-first: scans existing setup, installs only what's missing.

Ships .claude-plugin and .codex-plugin manifests.
Repo: https://github.com/mirkobozzetto/espresso
License: MIT