### PR TITLE
Add Codex Usage Tracker

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -731,6 +731,21 @@
       "icon": "./plugins/BestLemoon/codex-seo/assets/icon.svg"
     },
     {
+      "name": "codex-usage-tracker",
+      "displayName": "Codex Usage Tracker",
+      "source": {
+        "source": "local",
+        "path": "./plugins/douglasmonsky/codex-usage-tracker"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tools & Integrations",
+      "description": "Track aggregate Codex token usage from local session logs with MCP tools for summaries, session detail, CSV export, and dashboard generation.",
+      "icon": "./plugins/douglasmonsky/codex-usage-tracker/assets/icon.svg"
+    },
+    {
       "name": "context-pack",
       "displayName": "Context Pack",
       "source": {

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Archcore](https://github.com/archcore-ai/plugin) - Gives coding agents the architecture, rules, and prior decisions of the repo via skills, hooks, and MCP — so new changes land where the project says they belong across Claude Code, Cursor, and Codex CLI.
 - [Bring Your AI Migration Auditor](https://github.com/unitedideas/bringyour-mcp) - Read-only Codex plugin for auditing Claude Code to Codex migrations before Codex edits code. Checks AGENTS.md/CLAUDE.md scope, hooks, MCP config, skills, secret references, and validation notes.
 - [Brooks Lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).
+- [Changelog Forge](./plugins/mturac/changelog-forge) - Conventional commits → CHANGELOG section + semver bump.
 - [Claude Code for Codex](https://github.com/sendbird/cc-plugin-codex) - Reverse of OpenAI's official Claude-hosted plugin: use Claude Code from Codex for reviews, rescue tasks, tracked background jobs, and hook-powered review gates.
 - [Claude Code Harness](https://github.com/dadwadw233/claude-code-harness) - Harness blueprint skill for turning vague agent ideas into concrete designs for request assembly, control loops, memory, permissions, recovery, and extension planes.
 - [Claude Code Skills](https://github.com/alirezarezvani/claude-skills) - 223 production-ready skills, 23 agents, and 298 Python tools across 9 domains — engineering, marketing, product, compliance, and more.
@@ -136,38 +137,37 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
 - [Codex rg Guard](https://github.com/Rycen7822/codex-rg-guard) - Budgeted `rg`/`grep` replacement for Codex that narrows broad searches before they waste model context.
+- [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the *why*.
+- [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.
 - [Development Skills](https://github.com/reidemeister94/development-skills) - Three-tier triage (PASS_THROUGH / LIGHT / FULL 4-phase) development workflow for Codex and Claude Code with language auto-detection (Python, Java, TypeScript, Swift, frontend) and a staff-reviewer subagent for fresh-eyes review on every change.
 - [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) - MCP server exposing reasoning, code, anti-deception, and memory harness tools for Codex.
+- [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.
+- [Flaky Detector](./plugins/mturac/flaky-detector) - Run a test command N times, report per-test flakiness %.
 - [Frappe Agent](https://github.com/Dkm0315/frappe-agent) - Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.
 - [GrayMatter](https://github.com/ValkyrLabs/GrayMatter) - Durable memory and shared graph state for Codex and OpenClaw agents, with live ValkyrAI schema awareness.
 - [HOL Guard Plugin](https://github.com/hashgraph-online/hol-guard-plugin) - AI antivirus workflow for Codex, Claude Code, Cursor, Gemini, OpenCode, MCP servers, skills, and plugin release checks with local approvals and receipts.
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin for Codex, Claude Code, and Cline with structured planning, review, and verification guardrails.
 - [Personal Data Protection](https://github.com/AltByteSG/personal-data-protection-skill) - Engineer-facing personal-data-protection compliance reference — Singapore PDPA, Thailand PDPA, Indonesia UU PDP, Malaysia PDPA (Act 709 + 2024 Amendments), Philippines DPA — organised by where in the stack each obligation lands, with checklists, breach-response runbook, and a developer-view divergence table across all five.
+- [PR Storyteller](./plugins/mturac/pr-storyteller) - PR title + body + test plan from commits and diff vs base branch.
 - [Praxis](https://github.com/ouonet/praxis) - Intent-driven workflow skills for coding agents: describe what done looks like, not the steps. Triage-first design keeps token costs low across design, TDD, debug, review, and release.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
+- [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.
 - [Spec-Driven Development](https://github.com/Habib0x0/spec-driven-plugin) - Three-phase Requirements → Design → Tasks workflow for Claude Code and Codex — EARS notation acceptance criteria, autonomous execution loop, cross-spec dependencies, and post-implementation acceptance testing.
+- [Standup Generator](./plugins/mturac/standup-gen) - Daily standup notes from git activity across repos.
 - [Stark](https://github.com/f0d010c/stark) - UI/UX design plugin for AI coding agents with product-flow routing, platform-native interface guidance, asset planning, and shipped-reference analysis before code.
 - [tailtest](https://github.com/avansaber/tailtest-codex) - Hook-powered test generation -- detects files changed during an agent turn and instructs Codex to write and run tests automatically. Zero config, 8 languages.
 - [Tandem Workflow Architect](https://github.com/frumu-ai/tandem-codex-plugin) - Plan Tandem workflows in Codex, then validate, preview, and run them through the governed Tandem engine.
 - [Tartiner Labs](https://github.com/tartinerlabs/skills) - Agent skills for git workflows, GitHub automation, security audits, code refactoring, and project tooling.
 - [Team Skills Platform](https://github.com/Colin4k1024/tsp) - Role-based team delivery framework — Tech Lead-orchestrated 8-role system with 195+ skills, 27 specialist agents, 80+ commands, hooks, and ECC harness for Claude Code, Codex, and OpenCode.
+- [Test Gap](./plugins/mturac/test-gap) - Find lines in your diff lacking test coverage (Cobertura, lcov, coverage.json).
+- [TODO Harvest](./plugins/mturac/todo-harvest) - TODO/FIXME/HACK scan with `git blame` author + age.
 - [Tool Advisor](https://github.com/dragon1086/claude-skills) - Read-only meta-skill that scans your MCP servers, skills, plugins, and CLI tools, then suggests up to three ranked approaches (Methodical / Fast / Deep) with a copy-paste Quick Action table.
 - [Unity Agent Workflows](https://github.com/AUN-PN/unity-agent-workflows) - Codex plugin and skill for Unity 2D agents that enforces "No proof, no edit" workflows with runtime-owner proof, Teach structure maps, and validation gates.
 - [Universal Design Principles](https://github.com/HDeibler/universal-design-principles) - Cross-agent UX and product-design marketplace with a root Codex collection plugin, five focused plugin bundles, and 137 Agent Skills for design review, accessibility, layout, interaction, cognition, and product polish.
 - [VibePortrait](https://github.com/dadwadw233/VibePortrait) - Developer personality portrait generator — analyzes AI conversation history to produce MBTI type (16 color themes), capability radar, developer rating, 3-dimension famous match, and a persona skill that lets any AI "think like you".
 - [Writer's Loop](https://github.com/xxsang/writers-loop) - Structured AI writing workflow for planning, critique, revision, translation, style distillation, and opt-in local preference learning.
-- [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the *why*.
-- [PR Storyteller](./plugins/mturac/pr-storyteller) - PR title + body + test plan from commits and diff vs base branch.
-- [Test Gap](./plugins/mturac/test-gap) - Find lines in your diff lacking test coverage (Cobertura, lcov, coverage.json).
-- [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.
-- [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.
-- [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.
-- [Standup Generator](./plugins/mturac/standup-gen) - Daily standup notes from git activity across repos.
-- [TODO Harvest](./plugins/mturac/todo-harvest) - TODO/FIXME/HACK scan with `git blame` author + age.
-- [Flaky Detector](./plugins/mturac/flaky-detector) - Run a test command N times, report per-test flakiness %.
-- [Changelog Forge](./plugins/mturac/changelog-forge) - Conventional commits → CHANGELOG section + semver bump.
 ### Tools & Integrations
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
@@ -182,6 +182,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.
 - [Codex Obsidian](https://github.com/greg-asher/codex-obsidian) - Local Obsidian note and vault workflows through the official desktop `obsidian` CLI.
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
+- [Codex Usage Tracker](https://github.com/douglasmonsky/codex-usage-tracker) - Track aggregate Codex token usage from local session logs with MCP tools for summaries, session detail, CSV export, and dashboard generation.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
 - [Data Product Builder for dbt](https://github.com/entropy-data/dataproduct-builder-dbt) - Full data-product lifecycle on dbt for Entropy Data: scaffold, audit, and integrate projects with ODCS, ODPS, OpenLineage, and GitHub Actions.
 - [Dodo Payments](https://github.com/dodopayments/dodo-agent-plugin) - Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-05-18",
-  "total": 79,
+  "total": 80,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -508,6 +508,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/BestLemoon/codex-seo/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Codex Usage Tracker",
+      "url": "https://github.com/douglasmonsky/codex-usage-tracker",
+      "owner": "douglasmonsky",
+      "repo": "codex-usage-tracker",
+      "description": "Track aggregate Codex token usage from local session logs with MCP tools for summaries, session detail, CSV export, and dashboard generation.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/douglasmonsky/codex-usage-tracker/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Context Pack",

--- a/plugins/douglasmonsky/codex-usage-tracker/.codex-plugin/plugin.json
+++ b/plugins/douglasmonsky/codex-usage-tracker/.codex-plugin/plugin.json
@@ -1,0 +1,51 @@
+{
+  "name": "codex-usage-tracker",
+  "version": "0.2.0",
+  "description": "Unofficial local tracker for aggregate Codex token usage from local session logs.",
+  "author": {
+    "name": "Douglas Monsky"
+  },
+  "homepage": "https://github.com/douglasmonsky/codex-usage-tracker",
+  "repository": "https://github.com/douglasmonsky/codex-usage-tracker",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "tokens",
+    "usage",
+    "mcp",
+    "dashboard"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Codex Usage Tracker",
+    "shortDescription": "Unofficial local aggregate token usage analytics for Codex",
+    "longDescription": "Unofficial independent project, not made by, affiliated with, endorsed by, sponsored by, or supported by OpenAI. Reads local Codex session logs, aggregates exact token usage counters, and generates summaries, CSV exports, and a hoverable dashboard with optional localhost-only raw context loading.",
+    "developerName": "Douglas Monsky",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/douglasmonsky/codex-usage-tracker",
+    "privacyPolicyURL": "https://github.com/douglasmonsky/codex-usage-tracker",
+    "termsOfServiceURL": "https://github.com/douglasmonsky/codex-usage-tracker",
+    "defaultPrompt": [
+      "Check my Codex usage tracker setup",
+      "Show my Codex token usage summary",
+      "Show my most expensive Codex calls",
+      "Show my Codex pricing coverage",
+      "Update Codex usage pricing from OpenAI docs",
+      "Generate a Codex usage dashboard",
+      "Generate a threaded Codex usage dashboard",
+      "Serve a Codex dashboard with on-demand context",
+      "Show my Codex subagent usage",
+      "Export my Codex token usage CSV"
+    ],
+    "brandColor": "#2563EB",
+    "composerIcon": "./assets/icon.svg",
+    "logo": "./assets/icon.svg",
+    "screenshots": []
+  }
+}

--- a/plugins/douglasmonsky/codex-usage-tracker/.mcp.json
+++ b/plugins/douglasmonsky/codex-usage-tracker/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "codex-usage-tracker": {
+      "command": "./.venv/bin/python",
+      "args": ["-m", "codex_usage_tracker.mcp_server"],
+      "cwd": "."
+    }
+  }
+}

--- a/plugins/douglasmonsky/codex-usage-tracker/.mcp.json
+++ b/plugins/douglasmonsky/codex-usage-tracker/.mcp.json
@@ -1,9 +1,10 @@
 {
   "mcpServers": {
     "codex-usage-tracker": {
-      "command": "./.venv/bin/python",
-      "args": ["-m", "codex_usage_tracker.mcp_server"],
-      "cwd": "."
+      "command": "python3",
+      "args": ["./skills/codex-usage-tracker/scripts/run_mcp.py"],
+      "cwd": ".",
+      "startup_timeout_sec": 120
     }
   }
 }

--- a/plugins/douglasmonsky/codex-usage-tracker/LICENSE
+++ b/plugins/douglasmonsky/codex-usage-tracker/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Douglas Monsky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/douglasmonsky/codex-usage-tracker/README.md
+++ b/plugins/douglasmonsky/codex-usage-tracker/README.md
@@ -1,0 +1,348 @@
+# Codex Usage Tracker
+
+Local-first analytics for Codex token usage.
+
+> **Unofficial project:** Codex Usage Tracker is an independent open-source project. It is not made by, affiliated with, endorsed by, sponsored by, or supported by OpenAI. OpenAI and Codex are trademarks of OpenAI; this project only reads local log files from your machine.
+
+Codex Usage Tracker reads the JSONL logs already written by Codex, indexes aggregate usage counters into SQLite, and gives you a dashboard, CLI, and MCP tools for understanding where tokens are going. It is built for investigating real usage patterns while keeping prompts, assistant messages, tool output, and pasted secrets out of the stored index and generated dashboard HTML.
+
+## Dashboard Preview
+
+![Calls view with filters, totals, model-call rows, and the details panel.](docs/assets/dashboard-calls.png)
+
+![Threads view with grouped Codex threads and expanded chronological calls.](docs/assets/dashboard-threads.png)
+
+![Call Details panel showing aggregate token, pricing, context, and thread attachment fields.](docs/assets/dashboard-details.png)
+
+These screenshots use synthetic aggregate fixture data. They do not contain prompts, assistant responses, tool output, or real Codex session content.
+
+## Why Use It
+
+Use this when you want to answer questions like:
+
+- Which Codex threads are using the most tokens or estimated cost?
+- Which models and reasoning efforts are driving usage?
+- Do long-running chats get more expensive over time?
+- Are subagents, auto-reviews, or review passes attached to the right parent work?
+- Which calls have low cache reuse, high context-window pressure, or large reasoning output?
+- Which active project directories are consuming the most usage?
+- Did a change in workflow, model choice, or reasoning mode improve efficiency?
+
+The dashboard is intentionally split into two views:
+
+- `Calls`: inspect individual model calls, token fields, pricing status, cache ratio, reasoning output, and context-window percentage.
+- `Threads`: group calls by Codex thread, expand a thread chronologically, and see spawned subagents and inferred auto-review work in context.
+
+## Important Pattern: Long Chats Can Bloat Fast
+
+A common pattern this tool makes obvious is that staying in the same Codex chat for a long time can rapidly grow the context carried into later turns.
+
+Prompt caching helps, but cached input is not the same as no input. Long threads can accumulate a large cached context, and each new turn may still include a large amount of cached input plus new uncached input, reasoning output, and tool-related context. That can make usage climb quickly even when the visible user request looks small.
+
+Watch these fields when investigating that pattern:
+
+- `Cached input`: how much previously seen context was reused.
+- `Uncached input`: how much fresh context was added for the call.
+- `Session cumulative`: how large the running session total has become.
+- `Context use`: how much of the model context window the call consumed.
+- `Cache ratio`: useful for spotting whether a thread is mostly reused context or mostly new context.
+
+Practical takeaway: when old context is no longer relevant, starting a fresh thread can be more efficient than dragging a large cached history forward. This is not a rule for every task, but it is one of the clearest usage patterns the dashboard is designed to reveal.
+
+## What It Does
+
+- Reads local Codex JSONL logs from `~/.codex/sessions/**/*.jsonl`.
+- Optionally includes `~/.codex/archived_sessions/*.jsonl`.
+- Stores aggregate-only usage metrics in local SQLite at `~/.codex-usage-tracker/usage.sqlite3`.
+- Exposes MCP tools for refresh, summaries, session detail, lazy call context, CSV export, and dashboard generation.
+- Generates a static hoverable dashboard with flat calls and threaded-by-thread views.
+- Can serve the dashboard from localhost so raw logged context is loaded only after a row action.
+- Provides a read-only doctor command for local plugin/MCP setup checks.
+- Optionally estimates costs from a local pricing file that can be refreshed from OpenAI's published pricing docs.
+- Tracks aggregate subagent metadata, including explicit parent session ids when Codex logs them.
+
+The tracker intentionally does not store prompts, assistant messages, tool outputs, pasted secrets, or raw transcript snippets in SQLite, CSV exports, or generated dashboard HTML. The optional localhost server can read redacted, size-limited context from the original JSONL file on demand.
+
+## Quick Install
+
+### Let Codex Install It
+
+Open a Codex session on your machine and paste this:
+
+```text
+Install and configure Codex Usage Tracker from https://github.com/douglasmonsky/codex-usage-tracker.
+Use pipx if it is available. If pipx is missing, install it with Homebrew or use a local virtual environment.
+After installation, run codex-usage-tracker install-plugin, update-pricing, refresh, doctor, and serve-dashboard --open.
+Verify the dashboard opens locally and tell me the dashboard URL plus whether I need to restart Codex for plugin discovery.
+```
+
+Codex should run roughly:
+
+```bash
+brew install pipx
+pipx ensurepath
+pipx install "git+https://github.com/douglasmonsky/codex-usage-tracker.git"
+codex-usage-tracker install-plugin
+codex-usage-tracker update-pricing
+codex-usage-tracker refresh
+codex-usage-tracker doctor
+codex-usage-tracker serve-dashboard --open
+```
+
+Restart Codex after `install-plugin` if you want Codex to discover the plugin tools in a fresh session. The localhost dashboard can run immediately.
+
+### Manual Install
+
+Run:
+
+```bash
+brew install pipx
+pipx ensurepath
+pipx install "git+https://github.com/douglasmonsky/codex-usage-tracker.git"
+codex-usage-tracker install-plugin
+codex-usage-tracker update-pricing
+codex-usage-tracker refresh
+codex-usage-tracker serve-dashboard --open
+```
+
+After a PyPI release, the install command becomes:
+
+```bash
+pipx install codex-usage-tracker
+```
+
+`install-plugin` creates `~/plugins/codex-usage-tracker`, writes a package-owned `.mcp.json` that points at the installed Python executable, and updates `~/.agents/plugins/marketplace.json`. Restart Codex after registration so it discovers the plugin.
+
+## Fastest Useful Workflow
+
+```bash
+codex-usage-tracker update-pricing
+codex-usage-tracker serve-dashboard --open
+```
+
+Then:
+
+1. Leave `Live` enabled while working, or click `Refresh` after a Codex run finishes.
+2. Open `Threads` view to find the active work thread and any spawned subagent or auto-review calls.
+3. Sort by `Cost`, `Tokens`, `Cache`, or `Context` depending on the question.
+4. Expand an expensive thread and read calls oldest to newest.
+5. Hover or click rows to inspect exact aggregate fields in `Call Details`.
+6. Use `Load context` only when the aggregate fields are not enough; context is fetched on demand from the local source JSONL and is not saved into SQLite or the dashboard.
+
+For a screenshot-driven walkthrough, see [`docs/dashboard-guide.md`](docs/dashboard-guide.md).
+Generated dashboards also link to a bundled local HTML copy of the guide. Set `CODEX_USAGE_TRACKER_DOCS_URL` if you want generated dashboards to point at a hosted docs page instead.
+
+## Development Setup
+
+```bash
+git clone https://github.com/douglasmonsky/codex-usage-tracker.git
+cd codex-usage-tracker
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install ".[dev]"
+codex-usage-tracker install-plugin --python .venv/bin/python
+```
+
+## Usage
+
+Refresh the local aggregate index:
+
+```bash
+codex-usage-tracker refresh
+```
+
+Check setup:
+
+```bash
+codex-usage-tracker doctor
+codex-usage-tracker --version
+python -m codex_usage_tracker --version
+```
+
+Generate the local dashboard:
+
+```bash
+codex-usage-tracker dashboard --open
+codex-usage-tracker open-dashboard
+```
+
+Serve the dashboard with live aggregate refresh and lazy raw-context loading:
+
+```bash
+codex-usage-tracker serve-dashboard --open
+```
+
+When served this way, the dashboard gets a `Refresh` button plus a `Live` toggle that polls the localhost `/api/usage` endpoint every 10 seconds while the tab is visible. Each poll refreshes the SQLite aggregate index from local Codex logs and replaces the in-memory dashboard rows without embedding raw transcript content. Use the `Load` selector to fetch 5,000, 10,000, 20,000, or all aggregate calls; `--limit 0` also means all calls for CLI-generated dashboards. The table renders 500 rows or thread groups per page so larger histories remain responsive. Each call detail panel also gets a `Load context` action. Pressing it fetches only that call's logged turn context from the original local JSONL source. Tool output is omitted by default; the `Include tool output` action loads redacted, size-limited tool output for that call. None of this raw context is written to SQLite, CSV, or the generated HTML.
+
+Dashboard behavior:
+
+- The flat `Calls` view opens newest-first for inspecting individual model calls.
+- The `Threads` view groups filtered calls by thread, shows the most recently active thread first by default, and lets multiple threads stay expanded.
+- Expanded thread calls are ordered oldest to newest so you can see how usage grew across the conversation.
+- Spawned subagents with logged parent sessions are shown under their parent thread when Codex logs enough metadata.
+- Auto-review sessions do not currently log an explicit parent session id, so the dashboard can infer attachment by cwd and nearby activity and marks that relationship in the details panel.
+- Mixed thread model summaries prefer non-review models; `codex-auto-review` is shown as the thread model only for review-only threads.
+
+Useful investigations:
+
+- Sort `Threads` by `Tokens` or `Cost` to find the conversations worth reviewing first.
+- Sort by `Cache` to find threads that are mostly new context versus mostly reused context.
+- Sort by `Context` to find calls approaching the model context window.
+- Filter by model or reasoning effort to compare usage patterns across model choices.
+- Use `summary --preset by-subagent-role` to see whether delegated work is driving a large share of usage.
+- Use `expensive --limit 10` for a quick CLI list of the highest-cost calls.
+
+Show a summary:
+
+```bash
+codex-usage-tracker summary --group-by model
+codex-usage-tracker summary --group-by thread --limit 20
+codex-usage-tracker summary --preset today
+codex-usage-tracker summary --preset last-7-days
+codex-usage-tracker summary --preset expensive
+codex-usage-tracker summary --preset by-subagent-role
+codex-usage-tracker expensive --limit 10
+codex-usage-tracker pricing-coverage
+```
+
+Show one session:
+
+```bash
+codex-usage-tracker session <session-id>
+```
+
+Load one call's logged context on demand:
+
+```bash
+codex-usage-tracker context <record-id>
+```
+
+Export CSV:
+
+```bash
+codex-usage-tracker export --output usage.csv
+codex-usage-tracker export --output usage.csv --limit 0
+```
+
+Enable optional cost estimates:
+
+```bash
+codex-usage-tracker update-pricing
+```
+
+This fetches OpenAI text-token pricing from `https://developers.openai.com/api/docs/pricing.md`, parses the selected tier, and writes a source-stamped local cache to `~/.codex-usage-tracker/pricing.json`. The default tier is `standard`; other supported tiers are `batch`, `flex`, and `priority`. If a pricing file already exists, the updater leaves a timestamped `.bak` copy next to it before replacing the active cache.
+
+The updater also includes marked best-guess estimates for Codex labels that are not finalized in the public pricing table. `codex-auto-review` uses OpenAI's published `codex-mini-latest` Codex pricing from `https://openai.com/index/introducing-codex/`: `$1.50` per 1M input tokens, a 75% prompt-cache discount (`$0.375` per 1M cached input tokens), and `$6.00` per 1M output tokens. `gpt-5.3-codex-spark` is listed by OpenAI as a research preview with non-final Codex rates, so the tracker estimates it as `gpt-5.3-codex` at `$1.75` per 1M input tokens, `$0.175` per 1M cached input tokens, and `$14.00` per 1M output tokens. Use `--no-estimates` when you want only pricing rows parsed from the OpenAI pricing table.
+
+For a manual template instead:
+
+```bash
+codex-usage-tracker init-pricing
+```
+
+Edit `~/.codex-usage-tracker/pricing.json` with USD-per-million-token rates for any local overrides or models that are not present in the OpenAI pricing table. Normal reports never contact the network; only `update-pricing` refreshes the local pricing cache.
+
+## Current Limitations
+
+- This is a sidecar dashboard and plugin, not a native Codex chat overlay. Native hover tooltips inside Codex chat would require a transcript UI extension point that is not part of this v1 surface.
+- Token counts come from Codex's logged counters. The tracker does not re-tokenize prompts or reconstruct usage from raw text.
+- Pricing is optional and local. Rows are unpriced when no matching model rate is configured, and some Codex-specific labels may use marked best-guess estimates.
+- Parent-child thread relationships are only as good as the metadata Codex logs. Explicit parent session ids are preferred; inferred auto-review attachments are labeled as inferred.
+- On-demand context loading reads from the original local JSONL source. It is redacted and size-limited, but it is still local raw log context and should be treated as sensitive.
+
+## Install As A Local Codex Plugin
+
+After installing the Python package, register the plugin locally:
+
+```bash
+codex-usage-tracker install-plugin
+```
+
+For a source checkout that should use the repo-local virtual environment:
+
+```bash
+codex-usage-tracker install-plugin --python .venv/bin/python
+```
+
+If you previously installed the older source-checkout symlink, replace it once:
+
+```bash
+codex-usage-tracker install-plugin --python .venv/bin/python --force
+```
+
+The compatibility script remains available for local development:
+
+```bash
+python scripts/install_local_plugin.py --python .venv/bin/python
+```
+
+Restart Codex after registration so it can discover the plugin.
+
+## MCP Tools
+
+- `refresh_usage_index`
+- `usage_doctor`
+- `usage_summary`
+- `session_usage`
+- `usage_call_context`
+- `most_expensive_usage_calls`
+- `usage_pricing_coverage`
+- `generate_usage_dashboard`
+- `export_usage_csv`
+- `init_usage_pricing_config`
+- `update_usage_pricing_config`
+
+## Data Privacy
+
+The SQLite database is stored at `~/.codex-usage-tracker/usage.sqlite3` by default and contains only aggregate metrics:
+
+- session id, thread name, cwd, source file, turn id, timestamps
+- model, reasoning effort, context window
+- token counts and derived efficiency ratios
+- subagent source, role, nickname, parent session id, and parent thread name when present
+
+Raw chat text and tool outputs are ignored by the parser and are never written to the tracker database, CSV exports, or generated dashboard HTML. `usage_call_context`, `codex-usage-tracker context`, and the `serve-dashboard` context endpoint read a single source JSONL file only when explicitly requested, redact common secret patterns, and cap returned text size.
+
+For MCP users, `usage_call_context` is additionally disabled unless the MCP server process has `CODEX_USAGE_TRACKER_ALLOW_RAW_CONTEXT=1` in its environment. Aggregate MCP tools do not require that opt-in.
+
+Cost estimates are calculated only from aggregate token fields and your local pricing config. They are omitted when no matching model price is configured. Pricing refreshes pull only OpenAI's public pricing markdown and do not send local usage data anywhere.
+
+## Test
+
+```bash
+python -m pytest
+python -m compileall src
+python -m build
+python scripts/check_release.py --dist
+git diff --check
+codex-usage-tracker update-pricing --output /tmp/codex-usage-pricing.json
+codex-usage-tracker doctor
+codex-usage-tracker dashboard --output /tmp/codex-usage-dashboard.html
+codex-usage-tracker serve-dashboard --help
+codex-usage-tracker pricing-coverage
+codex-usage-tracker summary --preset by-subagent-role
+codex-usage-tracker expensive --limit 5
+```
+
+## Release Checklist
+
+Before making the repository public or publishing a package:
+
+```bash
+python -m pytest
+python -m compileall src
+python -m build
+python scripts/check_release.py --dist
+git diff --check
+```
+
+Then verify the local package install path:
+
+```bash
+python -m pip install ".[dev]"
+codex-usage-tracker --version
+codex-usage-tracker install-plugin --plugin-dir /tmp/codex-usage-tracker-plugin-smoke --marketplace /tmp/codex-usage-marketplace-smoke.json --python .venv/bin/python --force
+```
+
+Keep the GitHub repository private until you are ready to intentionally switch visibility. The release checker verifies version alignment, required public docs, packaged plugin assets, wheel contents, and obvious tracked secret patterns; it does not publish anything.

--- a/plugins/douglasmonsky/codex-usage-tracker/README.md
+++ b/plugins/douglasmonsky/codex-usage-tracker/README.md
@@ -279,6 +279,12 @@ python scripts/install_local_plugin.py --python .venv/bin/python
 
 Restart Codex after registration so it can discover the plugin.
 
+Marketplace installs use the bundled MCP launcher at
+`skills/codex-usage-tracker/scripts/run_mcp.py`. On first MCP startup it creates
+a cached runtime under `~/.cache/codex-usage-tracker/mcp-runtime/` and installs
+the Python package from GitHub, so it does not require a `.venv` inside the
+plugin directory.
+
 ## MCP Tools
 
 - `refresh_usage_index`

--- a/plugins/douglasmonsky/codex-usage-tracker/README.md
+++ b/plugins/douglasmonsky/codex-usage-tracker/README.md
@@ -271,12 +271,6 @@ If you previously installed the older source-checkout symlink, replace it once:
 codex-usage-tracker install-plugin --python .venv/bin/python --force
 ```
 
-The compatibility script remains available for local development:
-
-```bash
-python scripts/install_local_plugin.py --python .venv/bin/python
-```
-
 Restart Codex after registration so it can discover the plugin.
 
 Marketplace installs use the bundled MCP launcher at

--- a/plugins/douglasmonsky/codex-usage-tracker/SECURITY.md
+++ b/plugins/douglasmonsky/codex-usage-tracker/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes target the latest release on `main`.
+
+## Reporting A Vulnerability
+
+Open a private GitHub security advisory when this repository is public and advisories are enabled. Until then, contact the maintainer directly.
+
+## Data Boundary
+
+Codex Usage Tracker is designed to index aggregate token metadata from local Codex logs. Reports, CSV exports, dashboards, and the SQLite database must not contain raw prompts, assistant text, tool outputs, pasted secrets, or transcript snippets.
+
+The optional localhost context endpoint reads one selected source JSONL record on demand, redacts common secret patterns, caps returned text size, and does not persist the loaded context.
+
+The MCP `usage_call_context` tool is disabled unless the MCP server process explicitly sets `CODEX_USAGE_TRACKER_ALLOW_RAW_CONTEXT=1`. This keeps aggregate MCP reporting available while requiring a separate opt-in for raw local context reads.

--- a/plugins/douglasmonsky/codex-usage-tracker/assets/icon.svg
+++ b/plugins/douglasmonsky/codex-usage-tracker/assets/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Codex Usage Tracker">
+  <rect width="64" height="64" rx="12" fill="#2563EB"/>
+  <path d="M14 44h36" stroke="#DBEAFE" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 38V24M30 38V16M42 38V28" stroke="#FFFFFF" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="18" cy="24" r="4" fill="#BFDBFE"/>
+  <circle cx="30" cy="16" r="4" fill="#BFDBFE"/>
+  <circle cx="42" cy="28" r="4" fill="#BFDBFE"/>
+</svg>

--- a/plugins/douglasmonsky/codex-usage-tracker/skills/codex-usage-tracker/SKILL.md
+++ b/plugins/douglasmonsky/codex-usage-tracker/skills/codex-usage-tracker/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: codex-usage-tracker
+description: Use when the user asks about Codex token usage, model/reasoning efficiency, usage dashboards, CSV exports, or per-session/per-turn Codex usage stats from local logs.
+---
+
+# Codex Usage Tracker
+
+Unofficial project: Codex Usage Tracker is independent and is not made by, affiliated with, endorsed by, sponsored by, or supported by OpenAI. OpenAI and Codex are trademarks of OpenAI.
+
+Use this plugin to inspect aggregate token usage from local Codex session logs.
+
+## Privacy Boundary
+
+The index, dashboard payload, CSV export, and normal summaries are aggregate-only. They should never return prompts, assistant message text, tool outputs, pasted secrets, or raw transcript snippets.
+
+The only exception is `usage_call_context`, which intentionally reads one selected record's source JSONL on demand. It requires `CODEX_USAGE_TRACKER_ALLOW_RAW_CONTEXT=1` in the MCP server environment. Use it only when the user explicitly asks to inspect actual context, and mention that returned text is local, redacted, size-limited, and not persisted by the tracker.
+
+## Common Workflows
+
+- Refresh the index before answering usage questions.
+- Use `usage_doctor` when setup, plugin discovery, MCP launch, dashboard output, or pricing estimates look wrong.
+- Use `usage_summary` for high-level totals by date, model, effort, cwd, thread, or session.
+- Use `usage_summary` presets `today`, `last-7-days`, `by-model`, `by-cwd`, `by-thread`, and `expensive` for common requests.
+- Use `usage_pricing_coverage` when the user asks whether costs are fully priced or which models use estimated or missing pricing.
+- Use `session_usage` for per-call and per-turn detail for one session.
+- Use `usage_call_context` for one selected model call when the user asks to load actual logged context on demand.
+- Use `most_expensive_usage_calls` to identify high-token calls and aggregate efficiency signals.
+- Use `generate_usage_dashboard` when the user wants a visual hoverable report, including flat calls, threaded-by-thread views, parent-thread latching for spawned subagents, auto-review attachment details, and controls that can call a localhost context endpoint when the dashboard is served.
+- Use `export_usage_csv` when the user wants local spreadsheet-friendly data.
+- Use `update_usage_pricing_config` when the user wants cost estimates based on OpenAI-published text-token pricing. This refreshes the local pricing cache and does not send local usage data anywhere. Internal Codex labels may include explicitly marked best-guess estimates when no public pricing row exists.
+- Use `init_usage_pricing_config` only when the user wants a manual local pricing template or override file.

--- a/plugins/douglasmonsky/codex-usage-tracker/skills/codex-usage-tracker/scripts/run_mcp.py
+++ b/plugins/douglasmonsky/codex-usage-tracker/skills/codex-usage-tracker/scripts/run_mcp.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Bootstrap and run the Codex Usage Tracker MCP server.
+
+Marketplace installs mirror only the plugin bundle, not a repo-local virtual
+environment. This launcher creates a cached runtime on first use, installs the
+package from GitHub, and then execs the real MCP server.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PACKAGE_SPEC = os.environ.get(
+    "CODEX_USAGE_TRACKER_PACKAGE_SPEC",
+    "git+https://github.com/douglasmonsky/codex-usage-tracker.git@main",
+)
+RUNTIME_VERSION = "0.2.0"
+MODULE_CHECK = (
+    "import importlib.metadata; "
+    "importlib.metadata.version('codex-usage-tracker'); "
+    "importlib.metadata.version('mcp')"
+)
+MODULE_ARGS = ["-m", "codex_usage_tracker.mcp_server"]
+
+
+def main() -> int:
+    plugin_root = Path(__file__).resolve().parents[3]
+    runtime_python = _runtime_python()
+
+    for candidate in _candidate_pythons(plugin_root, runtime_python):
+        if candidate.exists() and _can_import_server(candidate):
+            _exec_server(candidate)
+
+    _ensure_runtime(runtime_python)
+    if not _can_import_server(runtime_python):
+        print(
+            "Codex Usage Tracker runtime installed, but the MCP server could not be imported.",
+            file=sys.stderr,
+        )
+        return 1
+    _exec_server(runtime_python)
+    return 1
+
+
+def _candidate_pythons(plugin_root: Path, runtime_python: Path) -> list[Path]:
+    candidates: list[Path] = []
+    override = os.environ.get("CODEX_USAGE_TRACKER_MCP_PYTHON")
+    if override:
+        candidates.append(Path(override).expanduser())
+    candidates.append(plugin_root / ".venv" / _python_bin())
+    candidates.append(runtime_python)
+    return candidates
+
+
+def _runtime_python() -> Path:
+    configured = os.environ.get("CODEX_USAGE_TRACKER_RUNTIME_DIR")
+    runtime_dir = (
+        Path(configured).expanduser()
+        if configured
+        else Path.home() / ".cache" / "codex-usage-tracker" / "mcp-runtime" / RUNTIME_VERSION
+    )
+    return runtime_dir / _python_bin()
+
+
+def _python_bin() -> Path:
+    return Path("Scripts/python.exe") if os.name == "nt" else Path("bin/python")
+
+
+def _venv_root(python_path: Path) -> Path:
+    return python_path.parents[1]
+
+
+def _can_import_server(python_path: Path) -> bool:
+    try:
+        result = subprocess.run(
+            [str(python_path), "-c", MODULE_CHECK],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=20,
+        )
+    except subprocess.TimeoutExpired:
+        return False
+    return result.returncode == 0
+
+
+def _ensure_runtime(python_path: Path) -> None:
+    venv_root = _venv_root(python_path)
+    if not python_path.exists():
+        print(f"Creating Codex Usage Tracker MCP runtime at {venv_root}", file=sys.stderr)
+        subprocess.run([sys.executable, "-m", "venv", str(venv_root)], check=True)
+    print(f"Installing Codex Usage Tracker MCP runtime from {PACKAGE_SPEC}", file=sys.stderr)
+    subprocess.run(
+        [str(python_path), "-m", "pip", "install", "--upgrade", PACKAGE_SPEC],
+        check=True,
+    )
+
+
+def _exec_server(python_path: Path) -> None:
+    os.execv(str(python_path), [str(python_path), *MODULE_ARGS])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/douglasmonsky/codex-usage-tracker/skills/codex-usage-tracker/scripts/run_mcp.py
+++ b/plugins/douglasmonsky/codex-usage-tracker/skills/codex-usage-tracker/scripts/run_mcp.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 PACKAGE_SPEC = os.environ.get(
     "CODEX_USAGE_TRACKER_PACKAGE_SPEC",
-    "git+https://github.com/douglasmonsky/codex-usage-tracker.git@main",
+    "git+https://github.com/douglasmonsky/codex-usage-tracker.git@21740923d11eea03ed1eab30603aa1362b528d3b",
 )
 RUNTIME_VERSION = "0.2.0"
 MODULE_CHECK = (


### PR DESCRIPTION
## Summary
- Add Codex Usage Tracker to the Tools & Integrations section
- Reorder existing Development & Workflow entries alphabetically so the README check passes

## Validation
- python3 scripts/check-alphabetical.py README.md
- git diff --check
- python3 scripts/validate-plugin-pr.py --base-ref upstream/main

## Notes
- The plugin repository is public and ships `.codex-plugin/plugin.json` with an SVG icon at `assets/icon.svg`.