### PR TITLE
Add SeparateWeb Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex with the official Remotion docs MCP, composition scaffolding, and a data-driven launch-video workflow.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.
 - [Rust Reverse Engineering](https://github.com/jingjing2222/rust-reverse-engineering-skill) - Reverse engineer Rust binaries and libraries: triage targets, demangle symbols, recover crate namespaces, and map panic, unwind, async, and FFI paths.
+- [SeparateWeb Capture](https://github.com/AUN-PN/SeparateWeb) - Give Codex eyes on real webpages with full-page screenshots, UI crops, and JSON manifests for frontend visual QA.
 - [sitemd](https://github.com/sitemd-cc/sitemd) - Build websites from Markdown via MCP — 22 tools for creating pages, generating content, validating, running SEO audits, configuring settings, and deploying static sites to Cloudflare Pages.
 - [Synta MCP](https://github.com/Synta-ai/n8n-mcp-codex-plugin-synta) - Build, edit, validate, and self-heal n8n workflows with Synta MCP tools and Codex-ready workflow guidance.
 - [Task Scheduler](https://github.com/6Delta9/task-scheduler-codex-plugin) - OpenAI Codex plugin and local MCP server for turning task lists into realistic schedules with blocked dates, capacity overrides, overflow tracking, and markdown planning output.


### PR DESCRIPTION
## Summary

Adds SeparateWeb Capture to the Community Plugins list.

SeparateWeb Capture gives Codex eyes on real webpages with full-page screenshots, UI crops, and JSON manifests for frontend review and visual QA.

## Before submitting, verify

- [x] README.md entry is alphabetically sorted within its category
- [x] `.codex-plugin/plugin.json` exists and is valid JSON
- [x] `composerIcon` field is set in `plugin.json` interface section
- [x] Icon file exists at the path referenced by `composerIcon`
- [x] All links in the README entry are valid
- [x] No placeholder or TODO values in `plugin.json`