### PR TITLE
Add agenttrace plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -49,6 +49,21 @@
       "description": "DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions."
     },
     {
+      "name": "agenttrace",
+      "displayName": "agenttrace",
+      "source": {
+        "source": "local",
+        "path": "./plugins/luoyuctl/agenttrace"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development & Workflow",
+      "description": "Audit local AI coding-agent sessions for costs, token waste, failures, latency, anomalies, health, diffs, and CI gate signals.",
+      "icon": "./plugins/luoyuctl/agenttrace/assets/plugin-icon.svg"
+    },
+    {
       "name": "antigravity",
       "displayName": "Antigravity Workspace Template",
       "source": {

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Aegis](https://github.com/GanyuanRan/Aegis) - An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.
 - [Agentizer](https://github.com/Humiris/wwa-transform) - Turn any website into an AI-powered agentfront with split-pane
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - Audit local AI coding-agent sessions for costs, token waste, failures, latency, anomalies, health, diffs, and CI gate signals.
 - [Antigravity Workspace Template](https://github.com/study8677/antigravity-workspace-template) - Multi-agent codebase knowledge graph generator with context-aware planning and automatic scope management — turns codebases into coherent agent workspaces.
 - [Archcore](https://github.com/archcore-ai/plugin) - Gives coding agents the architecture, rules, and prior decisions of the repo via skills, hooks, and MCP — so new changes land where the project says they belong across Claude Code, Cursor, and Codex CLI.
 - [Bring Your AI Migration Auditor](https://github.com/unitedideas/bringyour-mcp) - Read-only Codex plugin for auditing Claude Code to Codex migrations before Codex edits code. Checks AGENTS.md/CLAUDE.md scope, hooks, MCP config, skills, secret references, and validation notes.

--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-05-18",
-  "total": 80,
+  "last_updated": "2026-05-20",
+  "total": 81,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -38,6 +38,16 @@
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/boshu2/agentops/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "agenttrace",
+      "url": "https://github.com/luoyuctl/agenttrace",
+      "owner": "luoyuctl",
+      "repo": "agenttrace",
+      "description": "Audit local AI coding-agent sessions for costs, token waste, failures, latency, anomalies, health, diffs, and CI gate signals.",
+      "category": "Development & Workflow",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/luoyuctl/agenttrace/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Antigravity Workspace Template",

--- a/plugins/luoyuctl/agenttrace/.codex-plugin/plugin.json
+++ b/plugins/luoyuctl/agenttrace/.codex-plugin/plugin.json
@@ -38,8 +38,8 @@
       "Create a Markdown overview report for agent sessions."
     ],
     "brandColor": "#54FF00",
-    "composerIcon": "./assets/logo-icon.png",
-    "logo": "./assets/logo-icon.png",
+    "composerIcon": "./assets/plugin-icon.svg",
+    "logo": "./assets/plugin-icon.svg",
     "screenshots": [
       "./assets/tui-preview.png",
       "./assets/terminal-demo.png"

--- a/plugins/luoyuctl/agenttrace/assets/plugin-icon.svg
+++ b/plugins/luoyuctl/agenttrace/assets/plugin-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="agenttrace icon">
+  <rect width="512" height="512" rx="96" fill="#101417"/>
+  <path d="M112 318c36 54 84 80 144 80s108-26 144-80" fill="none" stroke="#54ff00" stroke-width="34" stroke-linecap="round"/>
+  <path d="M128 256c35-45 78-67 128-67s93 22 128 67" fill="none" stroke="#e9f5ec" stroke-width="30" stroke-linecap="round"/>
+  <circle cx="256" cy="256" r="47" fill="#54ff00"/>
+  <circle cx="256" cy="256" r="18" fill="#101417"/>
+  <path d="M256 114v45m0 194v45M114 256h45m194 0h45" stroke="#54ff00" stroke-width="24" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add agenttrace to Development & Workflow
- add the generated plugins.json and repo marketplace entries
- update the mirrored agenttrace manifest to use a lightweight plugin icon

agenttrace audits local AI coding-agent sessions across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor, OpenCode, and generic JSON/JSONL logs for spend, token waste, failures, latency, health, diffs, and CI-ready gate signals.

## Validation
- /opt/homebrew/bin/python3.13 -m json.tool plugins.json
- /opt/homebrew/bin/python3.13 -m json.tool .agents/plugins/marketplace.json
- /opt/homebrew/bin/python3.13 -m json.tool plugins/luoyuctl/agenttrace/.codex-plugin/plugin.json
- /opt/homebrew/bin/python3.13 scripts/check-alphabetical.py README.md
- /opt/homebrew/bin/python3.13 scripts/validate-plugin-pr.py --base-ref origin/main
- git diff --check