### PR TITLE
Add Codex Multi Auth marketplace icon

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -207,7 +207,8 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Development & Workflow",
-      "description": "Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools."
+      "description": "Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.",
+      "icon": "./plugins/ndycode/codex-multi-auth/assets/codex-multi-auth-icon.svg"
     },
     {
       "name": "codex-reviewer",

--- a/plugins/ndycode/codex-multi-auth/.codex-plugin/plugin.json
+++ b/plugins/ndycode/codex-multi-auth/.codex-plugin/plugin.json
@@ -1,6 +1,13 @@
 {
   "name": "codex-multi-auth",
-  "version": "1.2.2",
+  "version": "2.1.10",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
+  "repository": "https://github.com/ndycode/codex-multi-auth",
+  "license": "MIT",
+  "interface": {
+    "displayName": "Codex Multi Auth",
+    "shortDescription": "Multi-account OAuth manager for the official Codex CLI.",
+    "composerIcon": "./assets/codex-multi-auth-icon.svg"
+  },
   "skills": "./skills/"
 }

--- a/plugins/ndycode/codex-multi-auth/assets/codex-multi-auth-icon.svg
+++ b/plugins/ndycode/codex-multi-auth/assets/codex-multi-auth-icon.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="72" y1="44" x2="440" y2="468" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="1" stop-color="#020617"/>
+    </linearGradient>
+    <linearGradient id="card" x1="138" y1="152" x2="366" y2="352" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#cbd5e1"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="164" y1="184" x2="344" y2="332" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#22c55e"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="16" flood-color="#000000" flood-opacity="0.34"/>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="url(#bg)"/>
+  <circle cx="256" cy="256" r="176" fill="none" stroke="#1e293b" stroke-width="24"/>
+  <path d="M376 138a176 176 0 0 1 54 116" fill="none" stroke="#38bdf8" stroke-linecap="round" stroke-width="24"/>
+  <path d="M136 374a176 176 0 0 1-54-116" fill="none" stroke="#22c55e" stroke-linecap="round" stroke-width="24"/>
+  <path d="M424 232l20 33 19-34" fill="none" stroke="#38bdf8" stroke-linecap="round" stroke-linejoin="round" stroke-width="18"/>
+  <path d="M88 280l-20-33-19 34" fill="none" stroke="#22c55e" stroke-linecap="round" stroke-linejoin="round" stroke-width="18"/>
+  <g filter="url(#shadow)">
+    <rect x="142" y="158" width="228" height="170" rx="34" fill="#334155" opacity="0.9"/>
+    <rect x="124" y="184" width="228" height="170" rx="34" fill="#475569"/>
+    <rect x="104" y="210" width="228" height="170" rx="34" fill="url(#card)"/>
+  </g>
+  <circle cx="172" cy="278" r="36" fill="url(#accent)"/>
+  <path d="M130 342c12-31 35-47 70-47s58 16 70 47" fill="none" stroke="#0f172a" stroke-linecap="round" stroke-width="22"/>
+  <rect x="210" y="254" width="82" height="18" rx="9" fill="#0f172a" opacity="0.9"/>
+  <rect x="210" y="290" width="58" height="18" rx="9" fill="#0f172a" opacity="0.56"/>
+  <g transform="translate(302 318)">
+    <rect x="0" y="0" width="104" height="74" rx="20" fill="#020617" stroke="#38bdf8" stroke-width="10"/>
+    <path d="M28 26l16 12-16 12" fill="none" stroke="#e2e8f0" stroke-linecap="round" stroke-linejoin="round" stroke-width="10"/>
+    <path d="M56 52h26" fill="none" stroke="#22c55e" stroke-linecap="round" stroke-width="10"/>
+  </g>
+</svg>


### PR DESCRIPTION
Summary:
- Add the Codex Multi Auth SVG icon to the mirrored plugin bundle.
- Add required interface metadata and composerIcon to the mirrored plugin manifest.
- Wire the curated marketplace entry to the local icon asset.

Upstream source:
- ndycode/codex-multi-auth#483
- Fixes ndycode/codex-multi-auth#481 on the source repository side.

Validation:
- PASS uv run python scripts/validate-plugin-pr.py --base-ref origin/main
- PASS direct JSON/path check confirms plugin composerIcon and marketplace icon both resolve to existing files

Notes:
- validate-plugin-pr reports one existing warning: no .codexignore file found for plugins/ndycode/codex-multi-auth.