### PR TITLE
add authsome under Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
 - [AxonFlow](https://github.com/getaxonflow/axonflow-codex-plugin) - Runtime governance for Codex with policy enforcement on terminal commands, advisory checks for non-terminal tools via skills, PII/secret detection, and compliance-grade audit trails. Self-hosted via Docker.
+- [authsome](https://github.com/agentrhq/authsome) - Local credential broker for AI agents. Log in once via OAuth2 or API key, encrypted vault stores credentials, local proxy injects them at request time so Codex never sees raw secrets. 45 providers bundled (14 OAuth2, 31 API key). Install via `npx skills add agentrhq/authsome`.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.


### PR DESCRIPTION
hey, opening this to add authsome under Tools & Integrations.

authsome is a local credential broker for AI agents (Codex included). log in once via OAuth2 or API key, encrypted vault stores credentials, a local proxy injects them at request time so Codex never sees raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe.

slotted alphabetically near `AxonFlow` since it's in the agent-runtime-governance space, though authsome operates at the auth layer rather than policy enforcement. happy to move under Development & Workflow if that reads better.

works in Codex via standard skill installation: `npx skills add agentrhq/authsome` or `/codex-setup` flows. Codex integration docs: https://authsome.ai/docs/integrations/agents/codex.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT