### PR TITLE
Add Analyze Video plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
+- [Analyze Video](https://github.com/evillollive/Analyze-Video-Skill) - Turn videos (URLs or local files) into polished Word documents with embedded frames, timestamped analysis, contact sheets, and auto-chunking for long videos.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
 - [AxonFlow](https://github.com/getaxonflow/axonflow-codex-plugin) - Runtime governance for Codex with policy enforcement on terminal commands, advisory checks for non-terminal tools via skills, PII/secret detection, and compliance-grade audit trails. Self-hosted via Docker.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.

--- a/plugins/evillollive/Analyze-Video-Skill/.codex-plugin/plugin.json
+++ b/plugins/evillollive/Analyze-Video-Skill/.codex-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "Analyze one or more videos (URLs or local files) and produce a Word document with embedded frames, timestamped analysis, and captions.",
   "repository": "https://github.com/evillollive/Analyze-Video-Skill",
-  "license": "GPL-3.0",
+  "license": "AGPL-3.0",
   "interface": {
     "displayName": "Analyze Video",
     "shortDescription": "Turn videos into polished Word documents with frame analysis",

--- a/plugins/evillollive/Analyze-Video-Skill/.codex-plugin/plugin.json
+++ b/plugins/evillollive/Analyze-Video-Skill/.codex-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "analyze-video",
+  "version": "0.3.0",
+  "description": "Analyze one or more videos (URLs or local files) and produce a Word document with embedded frames, timestamped analysis, and captions.",
+  "repository": "https://github.com/evillollive/Analyze-Video-Skill",
+  "license": "GPL-3.0",
+  "interface": {
+    "displayName": "Analyze Video",
+    "shortDescription": "Turn videos into polished Word documents with frame analysis",
+    "composerIcon": "./assets/icon.svg"
+  }
+}

--- a/plugins/evillollive/Analyze-Video-Skill/assets/icon.svg
+++ b/plugins/evillollive/Analyze-Video-Skill/assets/icon.svg
@@ -35,7 +35,6 @@
   <rect x="332" y="324" width="56" height="4" rx="2" fill="#0f3460"/>
   <rect x="332" y="336" width="40" height="4" rx="2" fill="#0f3460"/>
   <!-- Magnifying glass -->
-  <circle cx="160" y="0" r="0" fill="none"/>
   <circle cx="380" cy="170" r="30" fill="none" stroke="#e94560" stroke-width="6"/>
   <line x1="402" y1="192" x2="420" y2="210" stroke="#e94560" stroke-width="6" stroke-linecap="round"/>
 </svg>

--- a/plugins/evillollive/Analyze-Video-Skill/assets/icon.svg
+++ b/plugins/evillollive/Analyze-Video-Skill/assets/icon.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a2e"/>
+      <stop offset="100%" style="stop-color:#16213e"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="64" fill="url(#bg)"/>
+  <!-- Film strip -->
+  <rect x="80" y="120" width="352" height="272" rx="16" fill="#0f3460" stroke="#e94560" stroke-width="4"/>
+  <!-- Sprocket holes top -->
+  <rect x="100" y="130" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="140" y="130" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="180" y="130" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="220" y="130" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="260" y="130" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="300" y="130" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="340" y="130" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="380" y="130" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <!-- Sprocket holes bottom -->
+  <rect x="100" y="366" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="140" y="366" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="180" y="366" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="220" y="366" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="260" y="366" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="300" y="366" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="340" y="366" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <rect x="380" y="366" width="24" height="16" rx="4" fill="#1a1a2e"/>
+  <!-- Play button -->
+  <polygon points="230,210 230,310 310,260" fill="#e94560"/>
+  <!-- Document icon overlay -->
+  <rect x="320" y="280" width="80" height="100" rx="6" fill="white" opacity="0.9"/>
+  <rect x="332" y="300" width="56" height="4" rx="2" fill="#0f3460"/>
+  <rect x="332" y="312" width="56" height="4" rx="2" fill="#0f3460"/>
+  <rect x="332" y="324" width="56" height="4" rx="2" fill="#0f3460"/>
+  <rect x="332" y="336" width="40" height="4" rx="2" fill="#0f3460"/>
+  <!-- Magnifying glass -->
+  <circle cx="160" y="0" r="0" fill="none"/>
+  <circle cx="380" cy="170" r="30" fill="none" stroke="#e94560" stroke-width="6"/>
+  <line x1="402" y1="192" x2="420" y2="210" stroke="#e94560" stroke-width="6" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Plugin Submission

**Plugin:** [Analyze Video](https://github.com/evillollive/Analyze-Video-Skill)
**Category:** Tools & Integrations
**License:** GPL-3.0

### What it does
Turn one or more videos (YouTube URLs or local files) into polished Word documents with:
- Embedded frames extracted at intelligent intervals
- Timestamped analysis prose per section
- Contact sheets for visual overview
- Auto-chunking for long videos (>12 min)
- Whisper API fallback for videos without captions

### Checklist
- [x] Plugin bundle at `plugins/evillollive/Analyze-Video-Skill/`
- [x] `.codex-plugin/plugin.json` with required fields
- [x] Icon at `assets/icon.svg`
- [x] README entry in alphabetical order under Tools & Integrations