### PR TITLE
Add Ship to Development & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Sealos](https://github.com/labring/sealos-skills) - Deploy apps to Sealos Cloud from Codex with readiness checks, Dockerfile generation, Compose conversion, image builds, and rollout updates.
 - [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.
+- [Ship](https://github.com/heliohq/ship) - Agent-routed harness that drives a change from raw spec through design, implementation, E2E, review, QA, and handoff to a green PR.
 - [Simple Man](https://github.com/Maksim-Burtsev/simple-man) - High-compression communication mode for Codex agents that removes filler while preserving search, validation, and implementation effort.
 - [Spec-Driven Development](https://github.com/Habib0x0/spec-driven-plugin) - Three-phase Requirements → Design → Tasks workflow for Claude Code and Codex — EARS notation acceptance criteria, autonomous execution loop, cross-spec dependencies, and post-implementation acceptance testing.
 - [Staff Engineer Mode](https://github.com/sirmarkz/staff-engineer-mode) - Routes engineering design, delivery, reliability, security, operations, and maintenance prompts to focused staff-level specialist guidance for AI coding agents.

--- a/plugins/heliohq/ship/.codex-plugin/plugin.json
+++ b/plugins/heliohq/ship/.codex-plugin/plugin.json
@@ -1,0 +1,49 @@
+{
+  "name": "ship",
+  "version": "0.2.0",
+  "description": "An agent-routed harness for end-to-end software product development.",
+  "author": {
+    "name": "Helio",
+    "url": "https://www.helio.im/"
+  },
+  "homepage": "https://www.helio.im/",
+  "repository": "https://github.com/heliohq/ship",
+  "license": "MIT",
+  "keywords": [
+    "agent",
+    "coding",
+    "planning",
+    "qa",
+    "debugging",
+    "refactoring",
+    "orchestrator",
+    "workflows",
+    "ship",
+    "software-delivery"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Ship",
+    "shortDescription": "Agent-routed software delivery workflows for coding agents",
+    "composerIcon": "./assets/icon.svg",
+    "longDescription": "Use Ship to choose the right delivery route for a task: standalone skills, grouped quality/build phases, or the full raw-requirement-to-PR flow with design, implementation, E2E, review, QA, refactor, and handoff.",
+    "developerName": "Helio",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://www.helio.im/",
+    "privacyPolicyURL": "https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement",
+    "termsOfServiceURL": "https://docs.github.com/en/site-policy/github-terms/github-terms-of-service",
+    "defaultPrompt": [
+      "Choose a Ship route with /ship:use-ship",
+      "Plan this change with /ship:design",
+      "Review my current diff with /ship:review"
+    ],
+    "brandColor": "#0F766E",
+    "screenshots": []
+  }
+}

--- a/plugins/heliohq/ship/.codexignore
+++ b/plugins/heliohq/ship/.codexignore
@@ -1,0 +1,6 @@
+# Files excluded from the installable Codex plugin bundle
+.git/
+.github/
+node_modules/
+*.log
+.DS_Store

--- a/plugins/heliohq/ship/assets/icon.svg
+++ b/plugins/heliohq/ship/assets/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Ship">
+  <rect width="512" height="512" rx="114" fill="#0F766E"/>
+  <path d="M256 148 L350 262 L162 262 Z" fill="#ffffff"/>
+  <path d="M118 262 H394 L330 348 Q256 370 182 348 Z" fill="#ffffff"/>
+  <path d="M256 148 V262" stroke="#0F766E" stroke-width="12" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Add Ship

[Ship](https://github.com/heliohq/ship) is an agent-routed development harness for Claude Code, Codex & Cursor — it routes a change from a raw spec through design, implementation, E2E, review, QA, refactor, and handoff to a green PR.

### What's included
- **README entry** under *Community Plugins → Development & Workflow*, alphabetically placed between *Session Orchestrator* and *Simple Man*, linking to the public repo.
- **Plugin bundle** at `plugins/heliohq/ship/`:
  - `.codex-plugin/plugin.json` — mirrors the upstream manifest (name `ship`, MIT, valid `interface` block).
  - `assets/icon.svg` — a 373-byte vector icon in the project's brand teal `#0F766E`.
  - `.codexignore`.

### Checklist
- [x] README entry alphabetically sorted within its category
- [x] Plugin bundle exists under `plugins/<owner>/<repo>/`
- [x] `.codex-plugin/plugin.json` exists, is valid JSON, has required fields
- [x] `composerIcon` set; referenced icon exists (vector SVG, no embedded raster, <1KB)
- [x] Public GitHub repository with a valid manifest
- [x] `scripts/check-alphabetical.py` and `scripts/validate-plugin-pr.py` pass locally

I've left `plugins.json` / `.agents/plugins/marketplace.json` for your **Sync marketplace artifacts** workflow to regenerate — happy to commit the regenerated artifacts here instead if you'd prefer them in the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)