### PR TITLE
Add System Knowledge Graph plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Staff Engineer Mode](https://github.com/sirmarkz/staff-engineer-mode) - Routes engineering design, delivery, reliability, security, operations, and maintenance prompts to focused staff-level specialist guidance for AI coding agents.
 - [Standup Generator](./plugins/mturac/standup-gen) - Daily standup notes from git activity across repos.
 - [Stark](https://github.com/f0d010c/stark) - UI/UX design plugin for AI coding agents with product-flow routing, platform-native interface guidance, asset planning, and shipped-reference analysis before code.
+- [System Knowledge Graph](https://github.com/Myzmzz/system-knowledge-plugin) - System knowledge graph infrastructure for agent-collaborative development: query feature dependencies, analyze change impact, and generate business-chain test paths.
 - [tailtest](https://github.com/avansaber/tailtest-codex) - Hook-powered test generation -- detects files changed during an agent turn and instructs Codex to write and run tests automatically. Zero config, 8 languages.
 - [Tandem Workflow Architect](https://github.com/frumu-ai/tandem-codex-plugin) - Plan Tandem workflows in Codex, then validate, preview, and run them through the governed Tandem engine.
 - [Tartiner Labs](https://github.com/tartinerlabs/skills) - Agent skills for git workflows, GitHub automation, security audits, code refactoring, and project tooling.

--- a/plugins/Myzmzz/system-knowledge-plugin/.codex-plugin/plugin.json
+++ b/plugins/Myzmzz/system-knowledge-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "system-knowledge-plugin",
+  "version": "0.1.0",
+  "displayName": "System Knowledge Graph",
+  "description": "System knowledge graph infrastructure for agent-collaborative development: query feature dependencies, analyze change impact, and generate business-chain test paths.",
+  "shortDescription": "Query feature dependencies, analyze change impact, and generate business-chain test paths.",
+  "author": "Myzmzz",
+  "homepage": "https://github.com/Myzmzz/system-knowledge-plugin",
+  "repository": "https://github.com/Myzmzz/system-knowledge-plugin",
+  "license": "MIT",
+  "category": "Code Quality",
+  "capabilities": [
+    "dependency-analysis",
+    "impact-analysis",
+    "test-planning",
+    "knowledge-graph"
+  ],
+  "keywords": [
+    "knowledge-graph",
+    "dependency-analysis",
+    "impact-analysis",
+    "test-planning",
+    "mcp",
+    "agent-collaboration"
+  ],
+  "websiteURL": "https://github.com/Myzmzz/system-knowledge-plugin",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "System Knowledge Graph",
+    "shortDescription": "Query feature dependencies, analyze change impact, and generate business-chain test paths.",
+    "longDescription": "维护系统功能节点、依赖关系、数据实体、状态流转、业务链路和测试路径，并通过 12 个 MCP 工具与 3 个 Skill 支持开发前依赖分析、变更影响分析、业务链路测试路径生成与知识图校验。",
+    "developerName": "Myzmzz",
+    "category": "Coding",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "composerIcon": "./assets/icon.svg",
+    "brandColor": "#4F46E5"
+  }
+}

--- a/plugins/Myzmzz/system-knowledge-plugin/.codexignore
+++ b/plugins/Myzmzz/system-knowledge-plugin/.codexignore
@@ -1,0 +1,6 @@
+.git/
+node_modules/
+coverage/
+dist/
+tmp/
+*.log

--- a/plugins/Myzmzz/system-knowledge-plugin/.mcp.json
+++ b/plugins/Myzmzz/system-knowledge-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "system-knowledge": {
+      "command": "node",
+      "args": ["mcp/index.js"]
+    }
+  }
+}

--- a/plugins/Myzmzz/system-knowledge-plugin/assets/icon.svg
+++ b/plugins/Myzmzz/system-knowledge-plugin/assets/icon.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="System Knowledge Graph">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4F46E5"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="480" height="480" rx="96" fill="url(#bg)"/>
+  <g stroke="#FFFFFF" stroke-width="14" stroke-linecap="round" opacity="0.92">
+    <line x1="256" y1="150" x2="150" y2="288"/>
+    <line x1="256" y1="150" x2="362" y2="288"/>
+    <line x1="150" y1="288" x2="256" y2="392"/>
+    <line x1="362" y1="288" x2="256" y2="392"/>
+    <line x1="150" y1="288" x2="362" y2="288"/>
+  </g>
+  <g fill="#FFFFFF">
+    <circle cx="256" cy="150" r="44"/>
+    <circle cx="150" cy="288" r="36"/>
+    <circle cx="362" cy="288" r="36"/>
+    <circle cx="256" cy="392" r="40"/>
+  </g>
+  <circle cx="256" cy="150" r="20" fill="#4F46E5"/>
+  <circle cx="256" cy="392" r="18" fill="#0EA5E9"/>
+</svg>

--- a/plugins/Myzmzz/system-knowledge-plugin/skills/business-chain-testing/SKILL.md
+++ b/plugins/Myzmzz/system-knowledge-plugin/skills/business-chain-testing/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: business-chain-testing
+description: 指导按"业务链路"（business chain / journey）而非单个按钮来组织测试。当用户要 test a feature end-to-end（端到端测试某功能）、plan/organize tests（规划测试用例）、do regression testing（做回归测试）、或问"该按什么顺序测 / 前置条件是什么 / 要回归哪些链路 / 异常怎么验"时触发。把测试拆成前置条件、主链路、后置验收、异常恢复、上下游回归五层。当任务是开发前的功能闭环分析（用 feature-closure-development），或只是查询/维护知识图（用 system-knowledge-map）时，不要触发本 skill。
+---
+
+# 按业务链路组织测试
+
+不要只测"点了某个按钮"。一个功能要放进它所属的**业务链路**里测：先满足前置条件，再走主链路，验收后置结果，验证异常恢复，最后回归受影响的上下游。本 Skill 用 `test_path_generate`、`journey_get` 和测试路径里的 `regression_scope` 把测试拆成五层。
+
+工作流位置（§9.4 测试前）：`test_path_generate` 得到前置条件/步骤/验收项 → 执行浏览器/API/命令测试 → 对照验收项记录结果。
+
+> 约定：工具名用下划线（`test_path_generate` 等），点号写法为别名。
+
+## 第 0 步：取测试路径与链路
+
+1. 调用 `test_path_generate` 生成目标功能的测试路径：
+
+   ```json
+   { "featureId": "execution-verify", "scope": "e2e" }
+   ```
+
+   返回 `testPath`、`preconditions`、`steps`、`assertions`。**注意区分**：结果会标明是"已登记测试路径"还是"基于链路+依赖图推导的草案"——草案需人工核对后再执行。
+
+2. 调用 `journey_get` 取对应业务链路，拿到完整 `steps`、`failure_recovery`、`acceptance`：
+
+   ```json
+   { "journeyId": "full-deploy" }
+   ```
+
+3. 需要查回归范围时，从该功能登记的测试路径里读 `regression_scope`（也可由 `impact_analyze` 的 `regressionTests` 汇总得到）。
+
+## 五层测试组织
+
+### 第 1 层：前置条件测试（precondition）
+
+来自 `test_path_generate` 的 `preconditions`（如：集群已接入、应用已选择、部署资产已解析、部署配置已保存、预检通过）。逐项搭建/校验前置状态——前置不满足，主链路结果不可信。每个 precondition 通常对应上游功能的某个产出状态（`feature.state`，如 `deploy-config.configured`）。
+
+### 第 2 层：主链路测试（main chain）
+
+按 `test_path_generate` 的 `steps` 顺序执行（如：保存部署配置 → 执行预检 → 点击部署 → 查看实时日志 → 同步资源），并与 `journey_get` 的 `steps` 对齐，确保覆盖整条链路而非单点。用浏览器/API/命令逐步执行。
+
+### 第 3 层：后置验收测试（post-acceptance）
+
+对照 `assertions`（来自测试路径）与链路的 `acceptance`（如：Helm Release 为 deployed、Deployment Ready、Pod Running、Service 已创建、报告可导出）逐条核验并记录结果。验收项来自真实外部系统状态时（Kubernetes/Helm/数据库），必须实查对应系统，不得用知识图伪造。
+
+### 第 4 层：异常恢复测试（failure-recovery）
+
+读 `journey_get` 的 `failure_recovery`，按步骤注入失败并验证恢复动作可用（如：preflight 失败 → fix-config / re-run-preflight；execution-verify 失败 → view-log / retry / rollback / uninstall）。危险操作（部署/删除/卸载/权限/凭证类）必须覆盖至少一个异常场景。
+
+### 第 5 层：上下游回归测试（upstream/downstream regression）
+
+读测试路径的 `regression_scope`（或 `impact_analyze` 的 `regressionTests`），对其中每个功能/链路再跑一遍其自身的主链路 + 验收：
+
+```json
+{ "featureId": "application-management", "changeType": "modify",
+  "changedFiles": ["部署系统/prototype/Page1Deploy.jsx"] }
+```
+
+`impact_analyze` 返回的 `regressionTests`（如 `deploy-e2e`、`application-switching`、`asset-upload-and-parse`）即回归清单，逐个用 `test_path_generate` 取其路径后执行。
+
+## 输出：测试执行与记录
+
+- 按五层顺序执行，逐项对照 `assertions` / `acceptance` 记录通过/失败与证据。
+- 若发现知识图中测试路径缺前置或缺验收（违反"测试路径不能只含按钮动作"的质量规则），切到 system-knowledge-map 用 `test_path_upsert` 补登记（默认草稿，确认后加 `confirm:true`），并跑 `knowledge validate`。
+- 测试完成后，把回归结果回填，作为 §9.5 开发后审计（`audit-diff`）的输入。

--- a/plugins/Myzmzz/system-knowledge-plugin/skills/feature-closure-development/SKILL.md
+++ b/plugins/Myzmzz/system-knowledge-plugin/skills/feature-closure-development/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: feature-closure-development
+description: 指导在动手写代码前做"功能闭环分析"（pre-development feature-closure analysis）。当用户准备 develop / modify / refactor a feature（开发或修改某功能）、问"开发前要先弄清什么"、或需要回答"这个功能依赖什么 / 产出什么 / 谁使用它 / 失败后怎么恢复 / 状态如何变化 / 需要回归什么"这六个问题时触发。在真正改动业务代码之前先跑这套分析。当任务只是宽泛地查依赖图或维护知识库（用 system-knowledge-map）、或已进入测试阶段要组织业务链路测试（用 business-chain-testing）时，不要触发本 skill。
+---
+
+# 开发前功能闭环分析
+
+在为某个功能写或改代码**之前**，先用知识图把这个功能的"闭环"看清楚，避免只盯单点、漏掉上下游和异常恢复。本 Skill 把六个核心问题逐一映射到具体的 MCP 工具调用。
+
+工作流位置（§9.2 开发前）：用户提需求 → `feature_get` → `dependency_trace` → `impact_analyze` → 输出功能闭环分析 → 再进入开发。
+
+> 约定：工具名用下划线（`feature_get` 等），点号写法为别名。读取类工具均为只读，可放心调用。
+
+## 第 0 步：锁定目标功能
+
+先确认目标功能在知识图中的 `featureId`。不确定时用 `feature_list` 浏览，或直接 `feature_get` 让其在找不到时返回相近 ID 建议。
+
+## 六个核心问题 → 工具映射
+
+### 1. 这个功能依赖什么？（depends on）
+
+调用 `feature_get`（看 `dependsOn` / `provides` 概览），再调用 `dependency_trace` 取上游细节：
+
+```json
+{ "featureId": "deploy-config", "direction": "upstream", "depth": 1 }
+```
+
+逐条读 `upstream[].reason`，确认每个上游真实 `provides` 你需要的数据/状态。若上游是 `external` 类型依赖（Kubernetes/Helm/数据库/第三方 API），记下"状态来源"，开发时不要伪造其状态。
+
+### 2. 它产出什么？（produces）
+
+继续看 `feature_get` 返回的 `provides`（产出的数据或状态名，如 `helm-values`、`deploy-task-config`）。这些是下游契约——改动时不可随意删改产出，否则会断链。
+
+### 3. 谁使用它？（who uses it）
+
+调用 `dependency_trace` 取下游：
+
+```json
+{ "featureId": "deploy-config", "direction": "downstream", "depth": 1 }
+```
+
+读 `downstream[].reason`，明确每个消费方依赖你的哪一项产出。`feature_get` 的 `usedBy` 给出同样的消费方清单，可交叉核对。
+
+### 4. 失败后怎么恢复？（failure recovery）
+
+调用 `journey_get` 取该功能所在的业务链路，重点读 `failure_recovery`（按步骤列出的恢复动作，如 preflight 失败 → fix-config / re-run-preflight；execution-verify 失败 → view-log / retry / rollback / uninstall）：
+
+```json
+{ "journeyId": "full-deploy" }
+```
+
+如果该功能属于危险操作（部署、删除、卸载、权限、凭证类），必须确认它有明确的失败恢复路径；缺失则在闭环报告里标注为待补，并提示用 system-knowledge-map 的 `journey_upsert` 补登记。
+
+### 5. 状态如何变化？（state transitions）
+
+查实体状态机：用 CLI 生成可读图，或在功能定义里看 `states` 字段。
+
+```bash
+knowledge graph --type state-machine --entity DeployTask
+# 产物：reports/state-machine-DeployTask.md
+```
+
+关注每个状态的 `allowed_actions` 与 `disabled_actions`——开发时要保证你的改动遵守状态门禁（如 draft 状态下 deploy/uninstall 必须 disabled）。
+
+### 6. 需要回归什么？（regression scope）
+
+调用 `impact_analyze`，传目标功能与你计划改动的文件：
+
+```json
+{
+  "featureId": "deploy-config",
+  "changeType": "modify",
+  "changedFiles": ["部署系统/prototype/Page1Deploy.jsx"]
+}
+```
+
+读取 `directImpact`（直接受影响功能）、`affectedEntities`、`regressionTests`（由测试路径的 `regression_scope` 汇总）、`knowledgeUpdateSuggestions`。`regressionTests` 就是开发后要回归的最小集合。
+
+## 输出：功能闭环分析报告
+
+把上述结果汇总成一份简明报告再开始编码，至少包含：
+
+1. **依赖（上游）**：功能 + 原因 + 是否外部系统。
+2. **产出（契约）**：provides 列表，标注哪些是下游强依赖、不可破坏。
+3. **消费方（下游）**：used_by + 各自依赖的产出。
+4. **失败恢复**：链路中该功能的恢复动作；危险操作是否齐备。
+5. **状态变化**：相关状态机的 allowed/disabled actions 约束。
+6. **回归范围**：impact 给出的 `regressionTests` 与受影响实体。
+
+报告产出后，再进入实际开发。开发中若新增了功能、状态、实体或测试路径，切回 system-knowledge-map 用 `*_upsert`（默认草稿，确认后加 `confirm:true`）同步知识图，并跑 `knowledge validate`。

--- a/plugins/Myzmzz/system-knowledge-plugin/skills/system-knowledge-map/SKILL.md
+++ b/plugins/Myzmzz/system-knowledge-plugin/skills/system-knowledge-map/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: system-knowledge-map
+description: 指导智能体如何查询、维护和更新系统知识图（system knowledge graph / knowledge base）。当用户要求 analyze feature dependencies（分析功能依赖）、design a new feature（设计新功能）、assess change impact（评估改动影响）、或 maintain the knowledge base（维护/更新知识库 features/dependencies/entities/states/journeys/test-paths）时触发。也适用于"这个功能依赖谁/谁依赖它"、"改了某文件会影响什么"、"把新功能登记进知识图"。当任务只是纯写业务代码、调试逻辑、不涉及知识图谱的查询或维护时，不要触发；具体的"开发前功能闭环分析"请用 feature-closure-development，"按业务链路测试"请用 business-chain-testing。
+---
+
+# 系统知识图：查询、维护与更新
+
+本 Skill 指导你（智能体）正确使用系统知识图插件的 MCP 工具与 `knowledge` CLI，去**查询**功能依赖、**评估**改动影响、并**维护**知识库（`knowledge/` 下的 6 个 YAML：`features` / `dependencies` / `entities` / `states` / `journeys` / `test-paths`）。
+
+核心原则（务必遵守）：
+
+- **智能体负责语义，脚本负责确定性**：依赖原因、业务判断由你补充；唯一性、引用完整性、图生成由 CLI/工具保证。
+- **影响分析只给建议，不替用户做业务确认**：输出影响面与回归建议后，需要人工确认核心依赖再落地。
+- **写入分草稿与正式两态**：所有 `*_upsert` 工具**默认只写 `knowledge/.drafts/`**；只有显式传 `confirm: true` 才写入正式 YAML。先写草稿、校验、人工确认，再正式落盘。
+- 工具名按 MCP 约定用下划线（如 `feature_get`），文档中的点号写法（`feature.get`）是同一工具的别名。
+
+下面按四类常见任务给出具体调用顺序。
+
+## 场景 A：分析功能依赖（analyze feature dependencies）
+
+目的：搞清一个功能"是什么、依赖谁、被谁依赖"。
+
+1. 调用 `feature_get` 取功能定义。先用摘要，必要时再取全量：
+
+   ```json
+   { "featureId": "deploy-config", "detail": "summary" }
+   ```
+
+   关注返回的 `dependsOn` / `usedBy` / `provides`。若 `featureId` 不存在，工具会返回相近 ID 建议，据此纠正。
+
+2. 调用 `dependency_trace` 取上下游及多级依赖。默认 `depth: 1`、`direction: "both"`，避免上下文膨胀；确需深链路时再加大 `depth`：
+
+   ```json
+   { "featureId": "deploy-config", "depth": 1, "direction": "both" }
+   ```
+
+   返回的 `upstream` / `downstream` 每条都带 `reason`（依赖原因），把它读给用户。
+
+3. 需要整图视角时，用 CLI 生成 Mermaid 依赖图供人阅读：
+
+   ```bash
+   knowledge graph --type dependency
+   # 产物：reports/dependency-graph.md
+   ```
+
+   状态机或链路图同理：`knowledge graph --type state-machine --entity DeployTask`、`knowledge graph --type journey --name full-deploy`。
+
+## 场景 B：设计新功能（design a new feature）
+
+目的：在登记新功能前，先确认它在系统中的位置，再写入草稿。
+
+1. 用 `feature_list` 浏览现有功能，避免重复登记、确认命名风格。
+
+2. 对新功能的每个上游候选调用 `feature_get` / `dependency_trace`，确认它真实 `provides` 你要消费的数据或状态。
+
+3. 用 `feature_upsert` 写**草稿**（不带 confirm，落到 `knowledge/.drafts/`）。补齐建议字段：`name` `module` `description` `maturity`（idea/prototype/usable/production）`owner_role` `entry_points` `code_refs` `depends_on` `provides` `used_by` `states`：
+
+   ```json
+   {
+     "featureId": "deploy-report",
+     "feature": {
+       "name": "部署报告", "module": "部署流程",
+       "maturity": "prototype", "owner_role": "运维",
+       "depends_on": ["execution-verify"], "provides": ["deploy-report-doc"],
+       "used_by": [], "states": ["draft", "ready"]
+     }
+   }
+   ```
+
+4. 为每条新依赖边调用 `dependency_upsert`（草稿），务必写明 `type`（data/state/gate/ui/external）和 `reason`——没有原因的依赖边会被校验质量规则挑出。
+
+5. 运行 `knowledge validate`（或 `knowledge_validate` 工具）校验草稿；按报错修正。
+
+6. 与用户确认核心依赖无误后，**重发同一 upsert 调用并加 `"confirm": true`**，正式写入 `knowledge/` YAML。
+
+## 场景 C：评估改动影响（assess change impact）
+
+目的：改某功能或某文件前，先算清影响面与回归范围。
+
+1. 调用 `impact_analyze`。可按功能、也可按变更文件（用 `code_refs` 反查功能）：
+
+   ```json
+   {
+     "featureId": "application-management",
+     "changeType": "modify",
+     "changedFiles": ["部署系统/prototype/Page1Deploy.jsx"]
+   }
+   ```
+
+   读取返回的 `directImpact`（直接受影响功能）、`affectedEntities`（受影响实体）、`regressionTests`（来自测试路径 `regression_scope`）、`knowledgeUpdateSuggestions`（知识图待更新提示）。
+
+2. 需要落盘报告时，用 CLI：
+
+   ```bash
+   knowledge impact --feature deploy-config
+   knowledge impact --changed-files 部署系统/prototype/Page1Deploy.jsx
+   # 产物：reports/impact-report.md
+   ```
+
+3. 把 `regressionTests` 交给 business-chain-testing 去组织实际回归测试；把 `knowledgeUpdateSuggestions` 落到场景 D 去同步知识图。
+
+## 场景 D：维护/更新知识库（maintain the knowledge base）
+
+目的：代码变更后保持知识图与代码一致；初始建图同理。
+
+1. 让脚本先发现变更，再由你补语义：
+
+   ```bash
+   knowledge audit-diff   # 结合 git diff，提示哪些 feature 的 code_refs 被命中、是否漏登记页面/状态/测试
+   ```
+
+   或用 `change_audit` 工具做同样的提示。新建图时先 `knowledge scan-code --root .` 生成 `reports/feature-draft.yaml`（**仅草稿**，不可直接作为最终业务图）。
+
+2. 按提示补全：新功能 → `feature_upsert`；新依赖边 → `dependency_upsert`；新业务链路 → `journey_upsert`（含 `failure_recovery` 与 `acceptance`）；新测试路径 → `test_path_upsert`（含 `preconditions` / `steps` / `assertions` / `regression_scope`）。这些写入**默认是草稿**。
+
+3. 运行 `knowledge validate`（或 `knowledge_validate`）跑全部基础规则 + 质量规则：唯一 `featureId`、引用存在性、核心功能须有测试路径与下游说明、危险操作（部署/删除/卸载/权限/凭证）须有前置条件与失败恢复、状态机须定义 allowed/disabled actions、依赖边须有原因等。按报错修正草稿。
+
+4. 校验通过且与用户确认后，对相应 `*_upsert` 重发并加 `"confirm": true` 正式落盘；最后可再跑一次 `knowledge graph` 让图与文档同步。
+
+## 安全与边界
+
+- 知识库不写入任何敏感凭证明文；不要把密钥、令牌写进 YAML。
+- 真实外部系统状态（Kubernetes、Helm、数据库、第三方 API）必须由对应系统查询，知识图只记录"状态来源"，不得伪造真实状态。
+- MCP 工具默认只操作插件知识库，不直接调用业务系统 API。


### PR DESCRIPTION
## Plugin: System Knowledge Graph

System knowledge graph infrastructure for agent-collaborative development — maintain feature nodes, dependencies, entities, state machines, business journeys, and test paths as queryable/verifiable YAML, and expose them to the agent.

- **Repo:** https://github.com/Myzmzz/system-knowledge-plugin
- **Category:** Development & Workflow
- **Contents:** 1 MCP server with **12 tools** (feature/dependency/impact/journey/test-path query, draft+confirm upsert, validate, change-audit) + **3 skills** (system-knowledge-map, feature-closure-development, business-chain-testing)
- **Works in:** Codex and Claude Code (dual-marketplace repo)

### Checklist
- [x] Public GitHub repository
- [x] README entry added under **Development & Workflow** (alphabetically sorted — passes `scripts/check-alphabetical.py`)
- [x] Plugin bundle under `plugins/Myzmzz/system-knowledge-plugin/` with `.codex-plugin/plugin.json` + `assets/icon.svg`
- [x] `composerIcon` set and icon present (SVG, ~1KB, no raster/base64)
- [x] `.codexignore` included
- [x] `scripts/validate-plugin-pr.py` passes (PASS, no warnings)
- [x] One plugin per PR

The bundle mirrors the upstream repo's `plugins/codex/` manifest; the upstream repo is verified installable in Codex 0.135.0 (`codex plugin add` → `codex mcp list` shows the server enabled).