### PR TITLE
Update Agentgram plugin to v0.2.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -751,7 +751,7 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Tools & Integrations",
-      "description": "Send explicit Telegram messages from Codex and local AI agents through a Telegram bot token and chat id.",
+      "description": "Send explicit Telegram messages and files from Codex and local AI agents through a Telegram bot token and chat id.",
       "icon": "./plugins/jerryfane/agentgram/assets/agentgram-logo.svg"
     },
     {

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
-- [Agentgram](https://github.com/jerryfane/agentgram) - Send explicit Telegram messages from Codex and local AI agents through a Telegram bot token and chat id.
+- [Agentgram](https://github.com/jerryfane/agentgram) - Send explicit Telegram messages and files from Codex and local AI agents through a Telegram bot token and chat id.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
 - [AxonFlow](https://github.com/getaxonflow/axonflow-codex-plugin) - Runtime governance for Codex with policy enforcement on terminal commands, advisory checks for non-terminal tools via skills, PII/secret detection, and compliance-grade audit trails. Self-hosted via Docker.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.

--- a/plugins.json
+++ b/plugins.json
@@ -514,7 +514,7 @@
       "url": "https://github.com/jerryfane/agentgram",
       "owner": "jerryfane",
       "repo": "agentgram",
-      "description": "Send explicit Telegram messages from Codex and local AI agents through a Telegram bot token and chat id.",
+      "description": "Send explicit Telegram messages and files from Codex and local AI agents through a Telegram bot token and chat id.",
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/jerryfane/agentgram/HEAD/.codex-plugin/plugin.json"

--- a/plugins/jerryfane/agentgram/.codex-plugin/plugin.json
+++ b/plugins/jerryfane/agentgram/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentgram",
-  "version": "0.1.1",
-  "description": "Codex and AI-agent Telegram messaging plugin with a local CLI.",
+  "version": "0.2.0",
+  "description": "Codex and AI-agent Telegram messaging and file-sending plugin with a local CLI.",
   "author": {
     "name": "Jerry Fane",
     "url": "https://github.com/jerryfane"
@@ -19,8 +19,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Agentgram",
-    "shortDescription": "Send Telegram messages from Codex and agent sessions.",
-    "longDescription": "Agentgram is a Codex Telegram plugin and local CLI for AI agents. It sends explicit, user-requested Telegram messages through the Telegram Bot API using a bot token and chat id from the user's environment.",
+    "shortDescription": "Send Telegram messages and files from Codex and agent sessions.",
+    "longDescription": "Agentgram is a Codex Telegram plugin and local CLI for AI agents. It sends explicit, user-requested Telegram messages and files through the Telegram Bot API using a bot token and chat id from the user's environment.",
     "developerName": "Jerry Fane",
     "category": "Productivity",
     "websiteURL": "https://github.com/jerryfane/agentgram",
@@ -32,7 +32,7 @@
       "Write"
     ],
     "defaultPrompt": [
-      "Use Agentgram to send a Telegram message."
+      "Use Agentgram to send a Telegram message or file."
     ]
   }
 }

--- a/plugins/jerryfane/agentgram/README.md
+++ b/plugins/jerryfane/agentgram/README.md
@@ -63,6 +63,30 @@ agentgram send --silent --no-preview "quiet update"
 agentgram send --parse-mode HTML "<b>deploy finished</b>"
 ```
 
+Send an explicit local file when a user asks for a report, log, diff, archive,
+or generated artifact:
+
+```sh
+agentgram send-file ./report.md --caption "Report"
+agentgram send-file --chat-id 123456789 ./dist/agentgram-plugin.zip
+```
+
+Telegram limits bot text messages to 4096 visible characters after entity
+parsing. By default, Agentgram rejects over-limit `send` input so agents do not
+silently truncate messages. Choose an explicit long-text mode when needed:
+
+```sh
+agentgram send --split "long plain text..."
+agentgram send --as-file "long plain text..."
+agentgram send --as-file --filename report.md "long plain text..."
+```
+
+`--split` sends counted plain-text chunks such as `[1/3]` and currently rejects
+`--parse-mode`. `--as-file` writes a temporary UTF-8 document and sends it with
+Telegram `sendDocument`; no tracked or durable temp file is left behind. Telegram
+document uploads through bots are currently limited to 50 MB, and document
+captions are limited to 1024 visible characters after entity parsing.
+
 To discover a chat id, first send a message to the bot in Telegram, then run:
 
 ```sh
@@ -110,9 +134,12 @@ When a user asks an agent to send a Telegram message, the agent should:
 
 1. Run `agentgram doctor`, or `bin/agentgram doctor` only from this repository
    checkout.
-2. Run `agentgram send "message"`, or `bin/agentgram send "message"` only from
-   this repository checkout, if setup is valid.
-3. Avoid direct Telegram API calls unless the user explicitly asks to bypass the
+2. Run `agentgram send "message"` for short text, `agentgram send-file <path>`
+   for an explicit local file, or `agentgram send --split/--as-file` for long
+   text, if setup is valid.
+3. Confirm ambiguous file paths before sending and never send generated files
+   automatically just because a task completed.
+4. Avoid direct Telegram API calls unless the user explicitly asks to bypass the
    Agentgram CLI.
 
 ## Troubleshooting
@@ -123,6 +150,10 @@ When a user asks an agent to send a Telegram message, the agent should:
   or wrong tokens fail the Telegram `getMe` check.
 - Missing chat id: set `TELEGRAM_CHAT_ID`, or pass `--chat-id <id>` for a
   one-off send after the user provides the target chat.
+- Message too long: use `agentgram send --split` for plain text chunks or
+  `agentgram send --as-file --filename <name>` to deliver it as a document.
+- File rejected: verify the path is a readable, non-empty regular file at or
+  below Telegram's bot upload limit.
 - Forbidden chat: add the bot to the target chat or start a private chat with
   it, then retry after confirming the chat id.
 - Telegram API errors: Agentgram prints Telegram's error description without the
@@ -143,6 +174,6 @@ checklist and fresh-clone smoke.
 
 ## Status
 
-Released. Agentgram `v0.1.x` includes the Telegram CLI, Codex skill packaging,
-public Codex marketplace metadata, update ergonomics, release docs, and CI
-checks.
+Released. Agentgram `v0.2.x` includes the Telegram CLI, file sending, long-text
+delivery modes, Codex skill packaging, public Codex marketplace metadata, update
+ergonomics, release docs, and CI checks.

--- a/plugins/jerryfane/agentgram/bin/agentgram
+++ b/plugins/jerryfane/agentgram/bin/agentgram
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Agentgram command entry point."""
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agentgram_tg.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/jerryfane/agentgram/pyproject.toml
+++ b/plugins/jerryfane/agentgram/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentgram-tg"
-version = "0.1.1"
-description = "Telegram messaging CLI and Codex plugin for local AI agents."
+version = "0.2.0"
+description = "Telegram messaging and file-sending CLI plus Codex plugin for local AI agents."
 readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "MIT" }

--- a/plugins/jerryfane/agentgram/skills/agentgram/SKILL.md
+++ b/plugins/jerryfane/agentgram/skills/agentgram/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: agentgram
-description: Send explicit, user-requested Telegram messages from an agent session through the local Agentgram command-line tool.
+description: Send explicit, user-requested Telegram messages and files from an agent session through the local Agentgram command-line tool.
 ---
 
 # Agentgram
 
 Agentgram is a small Telegram messaging helper for agents. Use this skill when
-the user asks to send a Telegram message, verify Telegram messaging setup, find
-a chat id, or update the local Agentgram install.
+the user asks to send a Telegram message or file, verify Telegram messaging
+setup, find a chat id, or update the local Agentgram install.
 
 Before sending messages, prefer the installed `agentgram` command. If it is not
 on `PATH` and Agentgram is installed as a Codex plugin, resolve the plugin root
@@ -23,6 +23,9 @@ making an ad hoc Telegram API call.
 
 ```sh
 agentgram send "message text"
+agentgram send --split "long message text"
+agentgram send --as-file --filename report.md "long message text"
+agentgram send-file ./report.md --caption "Report"
 agentgram chat-id
 agentgram doctor
 agentgram update
@@ -49,18 +52,41 @@ plugin packages.
    for a best-effort send without preflight.
 3. If `doctor` only fails because `TELEGRAM_CHAT_ID` is missing and the user
    provided the target chat id for this message, proceed with
-   `$AGENTGRAM_CMD send --chat-id <id>`.
+   the selected send command plus `--chat-id <id>`, such as
+   `$AGENTGRAM_CMD send --chat-id <id> "message"` or
+   `$AGENTGRAM_CMD send-file --chat-id <id> <path>`.
 4. If `doctor` reports missing `TELEGRAM_CHAT_ID` and the user did not provide
    a chat id, run `$AGENTGRAM_CMD chat-id` only after the user has messaged the
    bot or added it to the target chat.
-5. Send only the exact user-requested message with `$AGENTGRAM_CMD send`.
+5. Send only the exact user-requested Telegram content.
 6. Use `--chat-id` only when the user provided a specific override for that
    message.
 7. Use `--parse-mode HTML` or `--parse-mode MarkdownV2` only when the user asks
    for formatted Telegram output or the message clearly requires it.
 
+Use `$AGENTGRAM_CMD send "message text"` for explicit short text messages.
+Plain text messages are limited to 4096 visible characters by Telegram.
+
+Use `$AGENTGRAM_CMD send-file <path>` when the user explicitly asks to send a
+file, report, log, diff, archive, generated artifact, or named local path. Do
+not glob paths, archive directories, or infer a file to send. If the requested
+path is ambiguous, ask the user to identify the exact file before sending.
+`send-file` accepts `--caption`, `--parse-mode HTML|MarkdownV2`, `--silent`,
+and `--chat-id`.
+
+Use `$AGENTGRAM_CMD send --split "long text"` only when the user asks to send
+long text or the text exceeds Telegram's message limit and should remain in the
+chat as text. Split mode currently supports plain text only; do not combine it
+with `--parse-mode`.
+
+Use `$AGENTGRAM_CMD send --as-file --filename report.md "long text"` when the
+user asks to send long text as a document, or when a long report/log/diff is
+better delivered as a file. Omit `--filename` only when the default
+`agentgram-message.txt` is acceptable.
+
 Do not send automatic status updates merely because an agent task completed.
-Agentgram sends should be explicit and user-requested.
+Do not send files automatically just because a task generated one. Agentgram
+sends should be explicit and user-requested.
 
 ## Update Workflow
 

--- a/plugins/jerryfane/agentgram/src/agentgram_tg/__init__.py
+++ b/plugins/jerryfane/agentgram/src/agentgram_tg/__init__.py
@@ -1,0 +1,5 @@
+"""Agentgram Telegram messaging helpers."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.2.0"

--- a/plugins/jerryfane/agentgram/src/agentgram_tg/cli.py
+++ b/plugins/jerryfane/agentgram/src/agentgram_tg/cli.py
@@ -1,0 +1,670 @@
+"""Command-line interface for Agentgram."""
+
+from __future__ import annotations
+
+import argparse
+from html.parser import HTMLParser
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from typing import Any, Iterable, TextIO
+from urllib.parse import urlsplit, urlunsplit
+
+from . import __version__
+from .telegram import (
+    MAX_DOCUMENT_BYTES,
+    TelegramClient,
+    TelegramError,
+    looks_like_token,
+    validate_document_path as validate_telegram_document_path,
+)
+
+
+MAX_TEXT_LENGTH = 4096
+MAX_CAPTION_LENGTH = 1024
+TOKEN_ENV = "TELEGRAM_BOT_TOKEN"
+CHAT_ID_ENV = "TELEGRAM_CHAT_ID"
+PLUGIN_NAME = "agentgram"
+PYTHON_PACKAGE = "agentgram_tg"
+
+
+class CliError(RuntimeError):
+    """Raised for user-correctable command errors."""
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(argv, stdout=sys.stdout, stderr=sys.stderr, environ=os.environ)
+
+
+def run(
+    argv: list[str] | None = None,
+    *,
+    stdout: TextIO,
+    stderr: TextIO,
+    environ: dict[str, str],
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = args.func(args, stdout=stdout, environ=environ)
+    except CliError as exc:
+        print(f"agentgram: {exc}", file=stderr)
+        return 2
+    except TelegramError as exc:
+        print(f"agentgram: {exc}", file=stderr)
+        return 1
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agentgram",
+        description="Send explicit Telegram messages from local agent sessions.",
+    )
+    parser.add_argument("--version", action="version", version=f"agentgram {__version__}")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    send = subcommands.add_parser("send", help="send a Telegram text message")
+    send.add_argument("--chat-id", help=f"override {CHAT_ID_ENV}")
+    send.add_argument("--parse-mode", choices=("HTML", "MarkdownV2"), help="Telegram parse mode")
+    send.add_argument("--silent", action="store_true", help="send without notification sound")
+    send.add_argument("--no-preview", action="store_true", help="disable link previews")
+    long_mode = send.add_mutually_exclusive_group()
+    long_mode.add_argument("--split", action="store_true", help="split long plain text into multiple messages")
+    long_mode.add_argument("--as-file", action="store_true", help="send the text as a UTF-8 document")
+    send.add_argument("--filename", help="document filename for --as-file")
+    send.add_argument("text", nargs="+", help="message text")
+    send.set_defaults(func=cmd_send)
+
+    send_file = subcommands.add_parser("send-file", help="send a Telegram document")
+    send_file.add_argument("--chat-id", help=f"override {CHAT_ID_ENV}")
+    send_file.add_argument("--caption", help="optional document caption")
+    send_file.add_argument("--parse-mode", choices=("HTML", "MarkdownV2"), help="Telegram caption parse mode")
+    send_file.add_argument("--silent", action="store_true", help="send without notification sound")
+    send_file.add_argument("path", help="path to the local file to send")
+    send_file.set_defaults(func=cmd_send_file)
+
+    chat_id = subcommands.add_parser("chat-id", help="show candidate chat ids from recent updates")
+    chat_id.add_argument("--raw", action="store_true", help="print raw getUpdates JSON")
+    chat_id.set_defaults(func=cmd_chat_id)
+
+    doctor = subcommands.add_parser("doctor", help="check Agentgram and Telegram configuration")
+    doctor.add_argument("--json", action="store_true", dest="json_output", help="print JSON")
+    doctor.set_defaults(func=cmd_doctor)
+
+    update = subcommands.add_parser("update", help="check or update a git-based Agentgram checkout")
+    update.add_argument("--check", action="store_true", help="only check update status")
+    update.add_argument("--repo", default=str(repo_root()), help="Agentgram repository path")
+    update.set_defaults(func=cmd_update)
+    return parser
+
+
+def cmd_send(args: argparse.Namespace, *, stdout: TextIO, environ: dict[str, str]) -> int:
+    token = require_env(environ, TOKEN_ENV)
+    chat_id = args.chat_id or require_env(environ, CHAT_ID_ENV)
+    text = normalize_text(args.text)
+    if args.filename and not args.as_file:
+        raise CliError("--filename requires --as-file")
+    if args.as_file:
+        if args.parse_mode:
+            raise CliError("--as-file does not support --parse-mode; file contents are sent as plain UTF-8")
+        if args.no_preview:
+            raise CliError("--no-preview is only supported for text messages")
+        return send_text_as_file(
+            token=token,
+            chat_id=chat_id,
+            text=text,
+            filename=args.filename,
+            silent=args.silent,
+            stdout=stdout,
+        )
+    if args.split:
+        if args.parse_mode:
+            raise CliError("--split does not support --parse-mode yet")
+        return send_split_text(
+            token=token,
+            chat_id=chat_id,
+            text=text,
+            silent=args.silent,
+            no_preview=args.no_preview,
+            stdout=stdout,
+        )
+    payload = build_send_payload(
+        chat_id=chat_id,
+        text=text,
+        parse_mode=args.parse_mode,
+        silent=args.silent,
+        no_preview=args.no_preview,
+    )
+    message = TelegramClient(token).send_message(payload)
+    message_id = message.get("message_id")
+    if message_id is None:
+        print("sent", file=stdout)
+    else:
+        print(f"sent message_id={message_id}", file=stdout)
+    return 0
+
+
+def send_split_text(
+    *,
+    token: str,
+    chat_id: str,
+    text: str,
+    silent: bool,
+    no_preview: bool,
+    stdout: TextIO,
+) -> int:
+    client = TelegramClient(token)
+    message_ids: list[str] = []
+    chunks = split_message_text(text)
+    for chunk in chunks:
+        payload = build_send_payload(
+            chat_id=chat_id,
+            text=chunk,
+            parse_mode=None,
+            silent=silent,
+            no_preview=no_preview,
+        )
+        message = client.send_message(payload)
+        message_id = message.get("message_id")
+        if message_id is not None:
+            message_ids.append(str(message_id))
+    if message_ids:
+        print(f"sent messages count={len(chunks)} message_ids={','.join(message_ids)}", file=stdout)
+    else:
+        print(f"sent messages count={len(chunks)}", file=stdout)
+    return 0
+
+
+def send_text_as_file(
+    *,
+    token: str,
+    chat_id: str,
+    text: str,
+    filename: str | None,
+    silent: bool,
+    stdout: TextIO,
+) -> int:
+    document_name = validate_text_filename(filename)
+    client = TelegramClient(token)
+    with tempfile.TemporaryDirectory(prefix="agentgram-") as tmp:
+        document_path = Path(tmp) / document_name
+        document_path.write_text(text, encoding="utf-8")
+        payload = build_document_payload(chat_id=chat_id, caption=None, parse_mode=None, silent=silent)
+        message = client.send_document(payload, document_path)
+    message_id = message.get("message_id")
+    if message_id is None:
+        print("sent document", file=stdout)
+    else:
+        print(f"sent document message_id={message_id}", file=stdout)
+    return 0
+
+
+def cmd_send_file(args: argparse.Namespace, *, stdout: TextIO, environ: dict[str, str]) -> int:
+    token = require_env(environ, TOKEN_ENV)
+    chat_id = args.chat_id or require_env(environ, CHAT_ID_ENV)
+    document_path = validate_document_path(args.path)
+    payload = build_document_payload(
+        chat_id=chat_id,
+        caption=args.caption,
+        parse_mode=args.parse_mode,
+        silent=args.silent,
+    )
+    message = TelegramClient(token).send_document(payload, document_path)
+    message_id = message.get("message_id")
+    if message_id is None:
+        print("sent document", file=stdout)
+    else:
+        print(f"sent document message_id={message_id}", file=stdout)
+    return 0
+
+
+def cmd_chat_id(args: argparse.Namespace, *, stdout: TextIO, environ: dict[str, str]) -> int:
+    token = require_env(environ, TOKEN_ENV)
+    updates = TelegramClient(token).get_updates()
+    if args.raw:
+        print(json.dumps(updates, indent=2, sort_keys=True), file=stdout)
+        return 0
+
+    candidates = extract_chat_candidates(updates)
+    if not candidates:
+        print("No chat ids found. Send a message to the bot, then run this command again.", file=stdout)
+        return 0
+    for candidate in candidates:
+        title = candidate.get("title") or candidate.get("username") or candidate.get("name") or "(untitled)"
+        print(f"{candidate['id']}\t{candidate['type']}\t{title}", file=stdout)
+    return 0
+
+
+def cmd_doctor(args: argparse.Namespace, *, stdout: TextIO, environ: dict[str, str]) -> int:
+    checks: list[dict[str, Any]] = []
+    token = environ.get(TOKEN_ENV, "").strip()
+    chat_id = environ.get(CHAT_ID_ENV, "").strip()
+    root = repo_root()
+    checks.append(check("bot_token_env", bool(token), f"{TOKEN_ENV} is {'set' if token else 'missing'}"))
+    checks.append(
+        check(
+            "bot_token_shape",
+            bool(token and looks_like_token(token)),
+            "token shape looks valid" if token and looks_like_token(token) else "token shape is invalid or unknown",
+            required=False,
+        )
+    )
+    checks.append(check("chat_id_env", bool(chat_id), f"{CHAT_ID_ENV} is {'set' if chat_id else 'missing'}"))
+    checks.append(
+        check(
+            "plugin_manifest",
+            (root / ".codex-plugin" / "plugin.json").is_file(),
+            ".codex-plugin/plugin.json present",
+            required=False,
+        )
+    )
+    checks.append(
+        check(
+            "skill_file",
+            (root / "skills" / "agentgram" / "SKILL.md").is_file(),
+            "skills/agentgram/SKILL.md present",
+            required=False,
+        )
+    )
+    origin = git_origin_url(root)
+    safe_origin = redact_url_userinfo(origin)
+    checks.append(
+        check(
+            "git_origin",
+            bool(origin),
+            f"origin remote is {safe_origin}" if origin else "origin remote is missing or unavailable",
+            required=False,
+        )
+    )
+
+    if token:
+        try:
+            bot = TelegramClient(token).get_me()
+            username = bot.get("username") or bot.get("first_name") or "bot"
+            checks.append(check("telegram_get_me", True, f"authenticated as {username}"))
+        except TelegramError as exc:
+            checks.append(check("telegram_get_me", False, str(exc)))
+
+    ok = all(item["ok"] for item in checks if item["required"])
+    if args.json_output:
+        print(json.dumps({"ok": ok, "checks": checks}, indent=2, sort_keys=True), file=stdout)
+    else:
+        for item in checks:
+            status = "ok" if item["ok"] else "fail"
+            required = "required" if item["required"] else "optional"
+            print(f"{status}\t{item['name']}\t{required}\t{item['detail']}", file=stdout)
+    return 0 if ok else 1
+
+
+def cmd_update(args: argparse.Namespace, *, stdout: TextIO, environ: dict[str, str]) -> int:
+    del environ
+    repo = Path(args.repo).expanduser().resolve()
+    if not (repo / ".git").exists():
+        raise CliError(f"{repo} is not a git checkout")
+
+    if args.check:
+        status = git_update_status(repo)
+        print(status, file=stdout)
+        return 0
+
+    ensure_clean_worktree(repo)
+    validate_checkout(repo)
+    print(git_update_status(repo), file=stdout)
+    pull_result = run_git(repo, "pull", "--ff-only")
+    if pull_result:
+        print(pull_result, file=stdout)
+    validate_checkout(repo)
+    print("validation ok", file=stdout)
+    for line in update_next_steps(repo):
+        print(line, file=stdout)
+    return 0
+
+
+def build_send_payload(
+    *,
+    chat_id: str,
+    text: str,
+    parse_mode: str | None,
+    silent: bool,
+    no_preview: bool,
+) -> dict[str, Any]:
+    if not str(chat_id).strip():
+        raise CliError("chat id is required")
+    validate_text(text, parse_mode=parse_mode)
+    payload: dict[str, Any] = {"chat_id": chat_id, "text": text}
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+    if silent:
+        payload["disable_notification"] = True
+    if no_preview:
+        payload["link_preview_options"] = {"is_disabled": True}
+    return payload
+
+
+def build_document_payload(
+    *,
+    chat_id: str,
+    caption: str | None,
+    parse_mode: str | None,
+    silent: bool,
+) -> dict[str, Any]:
+    if not str(chat_id).strip():
+        raise CliError("chat id is required")
+    validate_caption(caption, parse_mode=parse_mode)
+    payload: dict[str, Any] = {"chat_id": chat_id}
+    if caption:
+        payload["caption"] = caption
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+    if silent:
+        payload["disable_notification"] = True
+    return payload
+
+
+def normalize_text(parts: Iterable[str]) -> str:
+    text = " ".join(parts).strip()
+    validate_text(text, parse_mode=None, enforce_max=False)
+    return text
+
+
+def validate_text(text: str, *, parse_mode: str | None = None, enforce_max: bool = True) -> None:
+    if not text:
+        raise CliError("message text is required")
+    length = telegram_text_length(text, parse_mode)
+    if enforce_max and length > MAX_TEXT_LENGTH:
+        raise CliError(f"message text is too long: {length} characters; maximum is {MAX_TEXT_LENGTH}")
+
+
+def validate_caption(caption: str | None, *, parse_mode: str | None = None) -> None:
+    if caption is None or caption == "":
+        return
+    length = telegram_text_length(caption, parse_mode)
+    if length > MAX_CAPTION_LENGTH:
+        raise CliError(f"caption is too long: {length} characters; maximum is {MAX_CAPTION_LENGTH}")
+
+
+def validate_document_path(path: str | Path) -> Path:
+    try:
+        return validate_telegram_document_path(path)
+    except TelegramError as exc:
+        raise CliError(str(exc)) from exc
+
+
+def validate_text_filename(filename: str | None) -> str:
+    if filename is None:
+        return "agentgram-message.txt"
+    name = filename.strip()
+    if not name:
+        raise CliError("filename is required")
+    if "/" in name or "\\" in name or Path(name).name != name or name in (".", ".."):
+        raise CliError("filename must be a file name, not a path")
+    return name
+
+
+def split_message_text(text: str, *, limit: int = MAX_TEXT_LENGTH) -> list[str]:
+    validate_text(text, parse_mode=None, enforce_max=False)
+    expected_chunks = 1
+    while True:
+        prefix_length = len(f"[{expected_chunks}/{expected_chunks}] ")
+        chunk_limit = limit - prefix_length
+        if chunk_limit <= 0:
+            raise CliError("message limit is too small for split counters")
+        raw_chunks = split_plain_text(text, chunk_limit)
+        if len(raw_chunks) == expected_chunks:
+            return [f"[{index}/{expected_chunks}] {chunk}" for index, chunk in enumerate(raw_chunks, start=1)]
+        expected_chunks = len(raw_chunks)
+
+
+def split_plain_text(text: str, limit: int) -> list[str]:
+    chunks: list[str] = []
+    remaining = text
+    while remaining:
+        if len(remaining) <= limit:
+            chunks.append(remaining)
+            break
+        split_at = best_plain_text_split(remaining, limit)
+        chunks.append(remaining[:split_at])
+        remaining = remaining[split_at:]
+    return chunks
+
+
+def best_plain_text_split(text: str, limit: int) -> int:
+    window = text[:limit]
+    for boundary in ("\n\n", "\n", " "):
+        position = window.rfind(boundary)
+        if position > 0:
+            return position + len(boundary)
+    return limit
+
+
+def telegram_text_length(text: str, parse_mode: str | None) -> int:
+    if parse_mode == "HTML":
+        return len(html_visible_text(text))
+    if parse_mode == "MarkdownV2":
+        return len(markdown_v2_visible_text(text))
+    return len(text)
+
+
+class _VisibleHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        self.parts.append(data)
+
+
+def html_visible_text(text: str) -> str:
+    parser = _VisibleHTMLParser()
+    parser.feed(text)
+    parser.close()
+    return "".join(parser.parts)
+
+
+def markdown_v2_visible_text(text: str) -> str:
+    visible: list[str] = []
+    i = 0
+    formatting = set("_*[]()~`>#+-=|{}.!")
+    while i < len(text):
+        if text.startswith("```", i):
+            i += 3
+            closing = text.find("```", i)
+            if closing == -1:
+                visible.append(text[i:])
+                break
+            visible.append(text[i:closing])
+            i = closing + 3
+            continue
+        char = text[i]
+        if char == "[":
+            label_end = text.find("](", i + 1)
+            if label_end != -1:
+                destination_end = text.find(")", label_end + 2)
+                if destination_end != -1:
+                    visible.append(markdown_v2_visible_text(text[i + 1 : label_end]))
+                    i = destination_end + 1
+                    continue
+        if char == "`":
+            closing = text.find("`", i + 1)
+            if closing == -1:
+                i += 1
+                continue
+            visible.append(text[i + 1 : closing])
+            i = closing + 1
+            continue
+        if char == "\\" and i + 1 < len(text):
+            visible.append(text[i + 1])
+            i += 2
+            continue
+        if char in formatting:
+            i += 1
+            continue
+        visible.append(char)
+        i += 1
+    return "".join(visible)
+
+
+def require_env(environ: dict[str, str], name: str) -> str:
+    value = environ.get(name, "").strip()
+    if not value:
+        raise CliError(f"{name} is required")
+    return value
+
+
+def extract_chat_candidates(updates: list[dict[str, Any]]) -> list[dict[str, str]]:
+    seen: set[str] = set()
+    candidates: list[dict[str, str]] = []
+    for update in updates:
+        for key in ("message", "edited_message", "channel_post", "edited_channel_post", "business_message"):
+            message = update.get(key)
+            if not isinstance(message, dict):
+                continue
+            chat = message.get("chat")
+            if not isinstance(chat, dict) or "id" not in chat:
+                continue
+            chat_id = str(chat["id"])
+            if chat_id in seen:
+                continue
+            seen.add(chat_id)
+            name = chat.get("title") or " ".join(
+                part for part in (chat.get("first_name"), chat.get("last_name")) if part
+            )
+            candidates.append(
+                {
+                    "id": chat_id,
+                    "type": str(chat.get("type") or "unknown"),
+                    "title": str(chat.get("title") or ""),
+                    "username": str(chat.get("username") or ""),
+                    "name": str(name or ""),
+                }
+            )
+    return candidates
+
+
+def check(name: str, ok: bool, detail: str, *, required: bool = True) -> dict[str, Any]:
+    return {"name": name, "ok": ok, "detail": detail, "required": required}
+
+
+def git_update_status(repo: Path) -> str:
+    branch = run_git(repo, "rev-parse", "--abbrev-ref", "HEAD", allow_fail=True) or "unknown"
+    upstream = run_git(repo, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}", allow_fail=True)
+    if not upstream:
+        return f"{branch}: unknown update state; no upstream configured"
+    left_right = run_git(repo, "rev-list", "--left-right", "--count", f"{branch}...{upstream}", allow_fail=True)
+    if not left_right:
+        return f"{branch}: unknown update state relative to {upstream}"
+    try:
+        ahead, behind = [int(part) for part in left_right.split()]
+    except ValueError:
+        return f"{branch}: unknown update state relative to {upstream}"
+    if ahead == 0 and behind == 0:
+        return f"{branch}: up to date with local ref {upstream}"
+    return f"{branch}: ahead {ahead}, behind {behind} relative to local ref {upstream}"
+
+
+def ensure_clean_worktree(repo: Path) -> None:
+    status = run_git(repo, "status", "--porcelain")
+    if status:
+        raise CliError("refusing to update because the git worktree has uncommitted changes")
+
+
+def validate_checkout(repo: Path) -> None:
+    required_files = [
+        repo / "bin" / "agentgram",
+        repo / ".codex-plugin" / "plugin.json",
+        repo / "skills" / PLUGIN_NAME / "SKILL.md",
+        repo / "src" / PYTHON_PACKAGE / "cli.py",
+    ]
+    missing = [str(path.relative_to(repo)) for path in required_files if not path.is_file()]
+    if missing:
+        raise CliError(f"checkout validation failed; missing {', '.join(missing)}")
+
+    try:
+        manifest = json.loads((repo / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CliError(f"checkout validation failed; plugin manifest is invalid JSON: {exc}") from exc
+    if manifest.get("name") != PLUGIN_NAME:
+        raise CliError(f"checkout validation failed; plugin manifest name is not {PLUGIN_NAME}")
+    if manifest.get("skills") != "./skills/":
+        raise CliError("checkout validation failed; plugin manifest skills path is not ./skills/")
+
+
+def update_next_steps(repo: Path) -> list[str]:
+    steps = [
+        "Next steps:",
+        f"- CLI users: keep using {repo / 'bin' / 'agentgram'} or refresh your PATH/symlink if needed.",
+    ]
+    codex_entry = detected_codex_agentgram_entry()
+    if codex_entry:
+        steps.extend(
+            [
+                f"- Codex plugin detected: refresh with `codex plugin add {codex_entry}`.",
+                "- Start a new Codex thread after reinstall so updated skills are loaded.",
+            ]
+        )
+    else:
+        steps.append("- Codex users: reinstall or refresh the Agentgram plugin from the marketplace where you added it.")
+    return steps
+
+
+def detected_codex_agentgram_entry() -> str | None:
+    try:
+        proc = subprocess.run(
+            ["codex", "plugin", "list"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    for line in proc.stdout.splitlines():
+        fields = line.split()
+        if not fields:
+            continue
+        entry = fields[0]
+        status = fields[1] if len(fields) > 1 else ""
+        if entry.startswith(f"{PLUGIN_NAME}@") and status.startswith("installed"):
+            return entry
+    return None
+
+
+def git_origin_url(repo: Path) -> str:
+    return run_git(repo, "remote", "get-url", "origin", allow_fail=True)
+
+
+def redact_url_userinfo(url: str) -> str:
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return url
+    if parsed.scheme and "@" in parsed.netloc:
+        host = parsed.netloc.rsplit("@", 1)[1]
+        return urlunsplit((parsed.scheme, host, parsed.path, parsed.query, parsed.fragment))
+    return url
+
+
+def run_git(repo: Path, *args: str, allow_fail: bool = False) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        if allow_fail:
+            return ""
+        raise CliError(proc.stderr.strip() or f"git {' '.join(args)} failed")
+    return proc.stdout.strip()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]

--- a/plugins/jerryfane/agentgram/src/agentgram_tg/telegram.py
+++ b/plugins/jerryfane/agentgram/src/agentgram_tg/telegram.py
@@ -1,0 +1,208 @@
+"""Small Telegram Bot API client built on the Python standard library."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import mimetypes
+from pathlib import Path
+import re
+from typing import Any
+from urllib import error, request
+import uuid
+
+
+API_ROOT = "https://api.telegram.org"
+TOKEN_RE = re.compile(r"^[0-9]+:[A-Za-z0-9_-]{20,}$")
+MAX_DOCUMENT_BYTES = 50 * 1024 * 1024
+
+
+class TelegramError(RuntimeError):
+    """Raised when Telegram returns an error response or cannot be reached."""
+
+
+@dataclass(frozen=True)
+class TelegramClient:
+    token: str
+    api_root: str = API_ROOT
+    timeout: float = 15.0
+
+    def request(self, method: str, payload: dict[str, Any] | None = None) -> Any:
+        token = self.token.strip()
+        if not looks_like_token(token):
+            raise TelegramError("Telegram bot token shape is invalid")
+        payload = payload or {}
+        body = json.dumps(payload).encode("utf-8")
+        req = request.Request(
+            self.method_url(token, method),
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        return self._perform_request(req, token)
+
+    def request_multipart(
+        self,
+        method: str,
+        fields: dict[str, Any],
+        file_field: str,
+        file_path: Path,
+    ) -> Any:
+        token = self.token.strip()
+        if not looks_like_token(token):
+            raise TelegramError("Telegram bot token shape is invalid")
+        body, content_type = encode_multipart_form(fields, file_field, file_path)
+        req = request.Request(
+            self.method_url(token, method),
+            data=body,
+            headers={"Content-Type": content_type},
+            method="POST",
+        )
+        return self._perform_request(req, token)
+
+    def method_url(self, token: str, method: str) -> str:
+        return f"{self.api_root}/bot{token}/{method}"
+
+    def _perform_request(self, req: request.Request, token: str) -> Any:
+        try:
+            with request.urlopen(req, timeout=self.timeout) as response:
+                raw = response.read().decode("utf-8")
+        except error.HTTPError as exc:
+            raw_error = exc.read().decode("utf-8", errors="replace")
+            raise TelegramError(redact_token(_telegram_error_message(raw_error), token)) from exc
+        except error.URLError as exc:
+            raise TelegramError(redact_token(f"Telegram request failed: {exc.reason}", token)) from exc
+
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise TelegramError("Telegram returned invalid JSON") from exc
+
+        if not decoded.get("ok"):
+            description = decoded.get("description") or "Telegram API request failed"
+            raise TelegramError(redact_token(str(description), token))
+        return decoded.get("result")
+
+    def get_me(self) -> dict[str, Any]:
+        return self.request("getMe", {})
+
+    def get_updates(self, limit: int = 20) -> list[dict[str, Any]]:
+        result = self.request("getUpdates", {"limit": limit, "timeout": 0})
+        if not isinstance(result, list):
+            raise TelegramError("Telegram getUpdates returned an unexpected result")
+        return result
+
+    def send_message(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = self.request("sendMessage", payload)
+        if not isinstance(result, dict):
+            raise TelegramError("Telegram sendMessage returned an unexpected result")
+        return result
+
+    def send_document(self, payload: dict[str, Any], document_path: Path) -> dict[str, Any]:
+        document_path = validate_document_path(document_path)
+        result = self.request_multipart("sendDocument", payload, "document", document_path)
+        if not isinstance(result, dict):
+            raise TelegramError("Telegram sendDocument returned an unexpected result")
+        return result
+
+
+def validate_document_path(path: str | Path) -> Path:
+    candidate = Path(path).expanduser()
+    try:
+        info = candidate.stat()
+    except FileNotFoundError as exc:
+        raise TelegramError(f"file does not exist: {candidate}") from exc
+    except OSError as exc:
+        raise TelegramError(f"cannot inspect file {candidate}: {exc}") from exc
+
+    if not candidate.is_file():
+        raise TelegramError(f"path is not a regular file: {candidate}")
+    if info.st_size <= 0:
+        raise TelegramError(f"file is empty: {candidate}")
+    if info.st_size > MAX_DOCUMENT_BYTES:
+        raise TelegramError(
+            f"file is too large: {info.st_size} bytes; maximum is {MAX_DOCUMENT_BYTES} bytes"
+        )
+    try:
+        with candidate.open("rb"):
+            pass
+    except OSError as exc:
+        raise TelegramError(f"file is not readable: {candidate}: {exc}") from exc
+    return candidate
+
+
+def encode_multipart_form(
+    fields: dict[str, Any],
+    file_field: str,
+    file_path: Path,
+    *,
+    boundary: str | None = None,
+) -> tuple[bytes, str]:
+    boundary = boundary or f"agentgram-{uuid.uuid4().hex}"
+    filename = file_path.name
+    content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    parts: list[bytes] = []
+
+    for name, value in fields.items():
+        if value is None:
+            continue
+        parts.extend(
+            [
+                f"--{boundary}\r\n".encode("ascii"),
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode("utf-8"),
+                multipart_field_value(value).encode("utf-8"),
+                b"\r\n",
+            ]
+        )
+
+    parts.extend(
+        [
+            f"--{boundary}\r\n".encode("ascii"),
+            (
+                f'Content-Disposition: form-data; name="{file_field}"; '
+                f'filename="{escape_multipart_filename(filename)}"\r\n'
+            ).encode("utf-8"),
+            f"Content-Type: {content_type}\r\n\r\n".encode("ascii"),
+            read_file_bytes(file_path),
+            b"\r\n",
+            f"--{boundary}--\r\n".encode("ascii"),
+        ]
+    )
+    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
+
+
+def read_file_bytes(file_path: Path) -> bytes:
+    try:
+        return file_path.read_bytes()
+    except OSError as exc:
+        raise TelegramError(f"cannot read file {file_path}: {exc}") from exc
+
+
+def multipart_field_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, separators=(",", ":"))
+    return str(value)
+
+
+def escape_multipart_filename(filename: str) -> str:
+    return filename.replace("\\", "\\\\").replace('"', '\\"').replace("\r", "_").replace("\n", "_")
+
+
+def looks_like_token(value: str) -> bool:
+    return bool(TOKEN_RE.match(value.strip()))
+
+
+def redact_token(message: str, token: str | None) -> str:
+    if not token:
+        return message
+    return message.replace(token, "<redacted>")
+
+
+def _telegram_error_message(raw: str) -> str:
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw or "Telegram API request failed"
+    return str(decoded.get("description") or decoded.get("error_code") or "Telegram API request failed")

--- a/plugins/jerryfane/agentgram/src/agentgram_tg/telegram.py
+++ b/plugins/jerryfane/agentgram/src/agentgram_tg/telegram.py
@@ -78,18 +78,13 @@ class TelegramClient:
         except json.JSONDecodeError as exc:
             raise TelegramError("Telegram returned invalid JSON") from exc
 
-        if not isinstance(decoded, dict):
-            raise TelegramError("Telegram returned an unexpected JSON response")
         if not decoded.get("ok"):
             description = decoded.get("description") or "Telegram API request failed"
             raise TelegramError(redact_token(str(description), token))
         return decoded.get("result")
 
     def get_me(self) -> dict[str, Any]:
-        result = self.request("getMe", {})
-        if not isinstance(result, dict):
-            raise TelegramError("Telegram getMe returned an unexpected result")
-        return result
+        return self.request("getMe", {})
 
     def get_updates(self, limit: int = 20) -> list[dict[str, Any]]:
         result = self.request("getUpdates", {"limit": limit, "timeout": 0})
@@ -210,6 +205,4 @@ def _telegram_error_message(raw: str) -> str:
         decoded = json.loads(raw)
     except json.JSONDecodeError:
         return raw or "Telegram API request failed"
-    if isinstance(decoded, dict):
-        return str(decoded.get("description") or decoded.get("error_code") or "Telegram API request failed")
-    return raw or "Telegram API request failed"
+    return str(decoded.get("description") or decoded.get("error_code") or "Telegram API request failed")

--- a/plugins/jerryfane/agentgram/src/agentgram_tg/telegram.py
+++ b/plugins/jerryfane/agentgram/src/agentgram_tg/telegram.py
@@ -78,13 +78,18 @@ class TelegramClient:
         except json.JSONDecodeError as exc:
             raise TelegramError("Telegram returned invalid JSON") from exc
 
+        if not isinstance(decoded, dict):
+            raise TelegramError("Telegram returned an unexpected JSON response")
         if not decoded.get("ok"):
             description = decoded.get("description") or "Telegram API request failed"
             raise TelegramError(redact_token(str(description), token))
         return decoded.get("result")
 
     def get_me(self) -> dict[str, Any]:
-        return self.request("getMe", {})
+        result = self.request("getMe", {})
+        if not isinstance(result, dict):
+            raise TelegramError("Telegram getMe returned an unexpected result")
+        return result
 
     def get_updates(self, limit: int = 20) -> list[dict[str, Any]]:
         result = self.request("getUpdates", {"limit": limit, "timeout": 0})
@@ -205,4 +210,6 @@ def _telegram_error_message(raw: str) -> str:
         decoded = json.loads(raw)
     except json.JSONDecodeError:
         return raw or "Telegram API request failed"
-    return str(decoded.get("description") or decoded.get("error_code") or "Telegram API request failed")
+    if isinstance(decoded, dict):
+        return str(decoded.get("description") or decoded.get("error_code") or "Telegram API request failed")
+    return raw or "Telegram API request failed"

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -58,6 +58,9 @@ EXTRA_MIRROR_PATHS = {
     # files from a top-level specialists/ directory at runtime.
     "sirmarkz/staff-engineer-mode": ("specialists",),
 }
+PRESERVE_EXECUTABLE_PATHS = {
+    "jerryfane/agentgram": ("bin",),
+}
 
 
 def normalize_relative_path(value: str) -> str:
@@ -324,7 +327,10 @@ def mirror_plugin_bundle(plugin: dict[str, str]) -> tuple[dict[str, object], str
         existing_manifest = destination_root / ".codex-plugin" / "plugin.json"
         if existing_manifest.exists():
             print(f"Warning: failed to fetch {owner_repo}; reusing existing mirror: {e}")
-            manifest = json.loads(existing_manifest.read_text(encoding="utf-8"))
+            try:
+                manifest = json.loads(existing_manifest.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as fallback_error:
+                raise ValueError(f"Failed to fetch {owner_repo}: {e}") from fallback_error
             plugin_root_relative = existing_plugin_root_relative(plugin)
             return manifest, f"./plugins/{plugin['owner']}/{plugin['repo']}", plugin_root_relative
         raise ValueError(f"Failed to fetch {owner_repo}: {e}") from e
@@ -358,8 +364,7 @@ def mirror_plugin_bundle(plugin: dict[str, str]) -> tuple[dict[str, object], str
             )
         else:
             write_archive_file(archive, archive_name, destination_path)
-            if owner_repo == "jerryfane/agentgram" and relative_path.startswith("bin/"):
-                destination_path.chmod(0o755)
+            preserve_executable_mode(archive, archive_name, destination_path, owner_repo, relative_path)
 
     return mirrored_manifest, f"./plugins/{plugin['owner']}/{plugin['repo']}", plugin_root_relative_path(plugin_root)
 
@@ -405,6 +410,22 @@ def write_json(path: Path, data: dict[str, object]) -> None:
 
 def write_archive_file(archive: zipfile.ZipFile, archive_name: str, destination_path: Path) -> None:
     destination_path.write_bytes(archive.read(archive_name))
+
+
+def preserve_executable_mode(
+    archive: zipfile.ZipFile,
+    archive_name: str,
+    destination_path: Path,
+    owner_repo: str,
+    relative_path: str,
+) -> None:
+    executable_roots = PRESERVE_EXECUTABLE_PATHS.get(owner_repo, ())
+    if not any(relative_path == root or relative_path.startswith(f"{root}/") for root in executable_roots):
+        return
+
+    unix_mode = (archive.getinfo(archive_name).external_attr >> 16) & 0o777
+    if unix_mode & 0o111:
+        destination_path.chmod(destination_path.stat().st_mode | 0o111)
 
 
 def main() -> None:

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -52,6 +52,8 @@ METADATA_ONLY_MIRROR_REPOS = {
     "mturac/everything-openai-codex",
 }
 EXTRA_MIRROR_PATHS = {
+    # Agentgram's plugin skill shells out to its bundled local CLI.
+    "jerryfane/agentgram": ("bin", "src"),
     # Staff Engineer Mode exposes one router skill and loads routed specialist
     # files from a top-level specialists/ directory at runtime.
     "sirmarkz/staff-engineer-mode": ("specialists",),
@@ -169,6 +171,31 @@ def build_raw_manifest_url(plugin: dict[str, str], plugin_root_relative: str) ->
         f"https://raw.githubusercontent.com/{plugin['owner']}/{plugin['repo']}/"
         f"{RAW_DEFAULT_BRANCH_REF}/{manifest_path}"
     )
+
+
+def existing_plugin_root_relative(plugin: dict[str, str]) -> str:
+    if not OUTPUT.exists():
+        return ""
+    try:
+        data = json.loads(OUTPUT.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+
+    marker = f"/{RAW_DEFAULT_BRANCH_REF}/"
+    suffix = ".codex-plugin/plugin.json"
+    for existing in data.get("plugins", []):
+        if not isinstance(existing, dict):
+            continue
+        if existing.get("owner") != plugin["owner"] or existing.get("repo") != plugin["repo"]:
+            continue
+        install_url = str(existing.get("install_url") or "")
+        if marker not in install_url:
+            return ""
+        manifest_path = install_url.rsplit(marker, 1)[1]
+        if not manifest_path.endswith(suffix):
+            return ""
+        return manifest_path[: -len(suffix)].rstrip("/")
+    return ""
 
 
 def add_recursive_selection(
@@ -290,9 +317,16 @@ def sanitize_metadata_only_manifest(manifest: dict[str, object], plugin: dict[st
 
 def mirror_plugin_bundle(plugin: dict[str, str]) -> tuple[dict[str, object], str, str]:
     owner_repo = f"{plugin['owner']}/{plugin['repo']}"
+    destination_root = PLUGINS_ROOT / plugin["owner"] / plugin["repo"]
     try:
         archive = fetch_repo_archive(plugin["owner"], plugin["repo"])
     except Exception as e:
+        existing_manifest = destination_root / ".codex-plugin" / "plugin.json"
+        if existing_manifest.exists():
+            print(f"Warning: failed to fetch {owner_repo}; reusing existing mirror: {e}")
+            manifest = json.loads(existing_manifest.read_text(encoding="utf-8"))
+            plugin_root_relative = existing_plugin_root_relative(plugin)
+            return manifest, f"./plugins/{plugin['owner']}/{plugin['repo']}", plugin_root_relative
         raise ValueError(f"Failed to fetch {owner_repo}: {e}") from e
     names = {name for name in archive.namelist() if not name.endswith("/")}
     try:
@@ -308,7 +342,6 @@ def mirror_plugin_bundle(plugin: dict[str, str]) -> tuple[dict[str, object], str
     )
     mirrored_manifest = sanitize_metadata_only_manifest(manifest, plugin) if metadata_only else manifest
 
-    destination_root = PLUGINS_ROOT / plugin["owner"] / plugin["repo"]
     # Clear destination to avoid stale files from previous runs (Thread 2 fix)
     if destination_root.exists():
         shutil.rmtree(destination_root)
@@ -324,7 +357,9 @@ def mirror_plugin_bundle(plugin: dict[str, str]) -> tuple[dict[str, object], str
                 encoding="utf-8",
             )
         else:
-            destination_path.write_bytes(archive.read(archive_name))
+            write_archive_file(archive, archive_name, destination_path)
+            if owner_repo == "jerryfane/agentgram" and relative_path.startswith("bin/"):
+                destination_path.chmod(0o755)
 
     return mirrored_manifest, f"./plugins/{plugin['owner']}/{plugin['repo']}", plugin_root_relative_path(plugin_root)
 
@@ -366,6 +401,10 @@ def build_marketplace_entry(
 def write_json(path: Path, data: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_archive_file(archive: zipfile.ZipFile, archive_name: str, destination_path: Path) -> None:
+    destination_path.write_bytes(archive.read(archive_name))
 
 
 def main() -> None:


### PR DESCRIPTION
WHAT
- Sync the curated Agentgram mirror to v0.2.0.
- Include the bundled Agentgram `bin/` and `src/` files so curated marketplace installs can run the local CLI.
- Refresh public descriptions to mention Telegram messages and files.
- Teach the marketplace generator to include Agentgram's bundled CLI/source paths and preserve the executable bit for `bin/agentgram`.
- Add a generator fallback for transient archive fetch failures that reuses an existing mirror while preserving known subdirectory plugin roots.

WHY
- Agentgram v0.2.0 adds `send-file`, `send --split`, and `send --as-file`; the curated marketplace mirror should expose those capabilities.
- The Agentgram skill invokes the bundled local CLI, so the mirror needs `bin/` and `src/` to be installable from this curated repo.

CHANGES
- Updated `plugins/jerryfane/agentgram` from Agentgram v0.1.1 metadata/docs to v0.2.0.
- Added `plugins/jerryfane/agentgram/bin/agentgram` and `plugins/jerryfane/agentgram/src/agentgram_tg/*`.
- Updated `README.md`, `plugins.json`, and `.agents/plugins/marketplace.json` descriptions.
- Updated `scripts/generate_plugins_json.py` so future syncs retain Agentgram `bin/` and `src/`.

RESULTS
- `python3 scripts/generate_plugins_json.py` passed.
- `python3 scripts/validate-plugin-pr.py --base-ref upstream/main` passed with one existing-style warning: `No .codexignore file found (recommended)`.
- `python3 scripts/check-alphabetical.py README.md` passed.
- `python3 /root/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /root/awesome-codex-plugins/plugins/jerryfane/agentgram` passed.
- `PYTHONDONTWRITEBYTECODE=1 plugins/jerryfane/agentgram/bin/agentgram --version` printed `agentgram 0.2.0`.
- `PYTHONDONTWRITEBYTECODE=1 plugins/jerryfane/agentgram/bin/agentgram send --help` passed.
- `PYTHONDONTWRITEBYTECODE=1 plugins/jerryfane/agentgram/bin/agentgram send-file --help` passed.
- `git diff --check` passed.

Final `codex exec review --uncommitted` output:

```text
codex
I did not find any discrete, actionable bugs in the current staged, unstaged, or untracked changes. The Agentgram mirror updates, CLI additions, and generator changes appear internally consistent.
I did not find any discrete, actionable bugs in the current staged, unstaged, or untracked changes. The Agentgram mirror updates, CLI additions, and generator changes appear internally consistent.
```

RISK
- PyPI publishing for Agentgram itself is still blocked outside this repo until the Agentgram PyPI Trusted Publisher is configured.
