### PR TITLE
Sync Thermal-Fluid Research Workflow proposal guidance

### DIFF
--- a/plugins/hanhuark/mechanical-engineering-research-skill/.claude-plugin/plugin.json
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "thermal-fluid-research-workflow",
+  "description": "Thermal-fluid mechanical engineering research workflow for literature review, technical writing, data analysis, presentations, proposals, research coding, and AI/ML-assisted workflows.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Han Hu",
+    "email": "72934230+hanhuark@users.noreply.github.com",
+    "url": "https://github.com/hanhuark"
+  },
+  "homepage": "https://github.com/hanhuark/mechanical-engineering-research-skill",
+  "repository": "https://github.com/hanhuark/mechanical-engineering-research-skill",
+  "license": "MIT"
+}

--- a/plugins/hanhuark/mechanical-engineering-research-skill/.codex-plugin/plugin.json
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/.codex-plugin/plugin.json
@@ -15,6 +15,7 @@
     "mechanical-engineering",
     "research",
     "technical-writing",
+    "proposal-development",
     "data-analysis",
     "codex-skill"
   ],
@@ -33,6 +34,7 @@
     "websiteURL": "https://github.com/hanhuark/mechanical-engineering-research-skill",
     "defaultPrompt": [
       "Plan a thermal-fluid research workflow.",
+      "Develop a proposal narrative with reviewer-focused logic.",
       "Write a technical section with domain rigor.",
       "Review this figure and explain the physics."
     ],

--- a/plugins/hanhuark/mechanical-engineering-research-skill/.codexignore
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/.codexignore
@@ -2,6 +2,7 @@
 .github/
 .tmp-paper-text/
 .tmp-proposal-analysis/
+.tmp-presentation-analysis/
 *.pdf
 *.pptx
 *.docx

--- a/plugins/hanhuark/mechanical-engineering-research-skill/.codexignore
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/.codexignore
@@ -1,6 +1,7 @@
 .git/
 .github/
 .tmp-paper-text/
+.tmp-proposal-analysis/
 *.pdf
 *.pptx
 *.docx

--- a/plugins/hanhuark/mechanical-engineering-research-skill/CONTRIBUTING.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Thank you for improving this thermal-fluid research workflow plugin.
+
+## Guidelines
+
+- Keep `SKILL.md` concise and focused on routing, workflow, and reference selection.
+- Put detailed guidance in `skills/mechanical-engineering-research/references/`.
+- Put reusable workflow prompts in `commands/`.
+- Prefer reusable research heuristics over project-specific details.
+- Preserve source-aware reasoning: separate evidence, assumptions, inference, and uncertainty.
+- Validate the skill before opening a pull request.
+
+## Validation
+
+Run:
+
+```powershell
+python "$env:USERPROFILE\.codex\skills\.system\skill-creator\scripts\quick_validate.py" ".\skills\mechanical-engineering-research"
+python "$env:USERPROFILE\.codex\skills\.system\plugin-creator\scripts\validate_plugin.py" "."
+```
+
+## Review Checklist
+
+- Does the change help future research, writing, analysis, plotting, presentation, or AI/ML work?
+- Is the guidance concise enough to be useful in a skill context?
+- Are new reference files linked from `SKILL.md`?
+- Are new workflow prompts placed in `commands/` when they are reusable across tasks?
+- Are examples generalizable beyond one paper, dataset, or presentation?

--- a/plugins/hanhuark/mechanical-engineering-research-skill/README.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/README.md
@@ -140,6 +140,7 @@ mechanical-engineering-research-skill/
     me-code-review.md
     me-data-analysis.md
     me-lit-review.md
+    me-proposal.md
     me-write-section.md
   skills/
     mechanical-engineering-research/
@@ -168,6 +169,7 @@ The `commands/` folder contains reusable workflow prompts that can be copied int
 | Prompt | Use |
 |---|---|
 | [`me-lit-review.md`](commands/me-lit-review.md) | Critical literature review and gap synthesis; Claude command `/thermal-fluid-research-workflow:me-lit-review` |
+| [`me-proposal.md`](commands/me-proposal.md) | Solicitation-aligned proposal development, figure planning, preliminary-results integration, milestones, and risk mitigation; Claude command `/thermal-fluid-research-workflow:me-proposal` |
 | [`me-write-section.md`](commands/me-write-section.md) | Manuscript, proposal, report, or thesis-section drafting; Claude command `/thermal-fluid-research-workflow:me-write-section` |
 | [`me-data-analysis.md`](commands/me-data-analysis.md) | Baseline-first analysis and hypothesis-driven DOE; Claude command `/thermal-fluid-research-workflow:me-data-analysis` |
 | [`me-build-slides.md`](commands/me-build-slides.md) | Graphics-first research presentations; Claude command `/thermal-fluid-research-workflow:me-build-slides` |
@@ -187,6 +189,12 @@ Use the mechanical-engineering-research skill to develop a critical literature r
 
 ```text
 Use the mechanical-engineering-research skill to expand this DOE EPSCoR pre-application into a full proposal narrative. Follow the solicitation structure, map the narrative to review criteria, integrate preliminary results under each thrust, add quantifiable milestones, and cite seminal, recent, and team-relevant papers.
+```
+
+Or use the proposal workflow command:
+
+```text
+/thermal-fluid-research-workflow:me-proposal
 ```
 
 ### Data Analysis Plan

--- a/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-build-slides.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-build-slides.md
@@ -1,0 +1,24 @@
+---
+description: Build a graphics-first thermal-fluid research presentation with slide-to-slide logic, visual plans, speaker notes, and backup-slide structure.
+---
+
+# Thermal-Fluid Research Presentation
+
+Use `mechanical-engineering-research` to build a graphics-first research presentation.
+
+Workflow:
+
+1. Define the audience, time limit, and single central message.
+2. Build a slide-to-slide logic chain where each slide prepares the next.
+3. Use figures, videos, schematics, animations, and baseline raw-data slides as the primary communication layer.
+4. Keep text minimal and reserve it for take-home messages, labels, and caveats.
+5. Write speaker notes that complement the slides rather than repeating them.
+6. Place derivations, dense tables, and extra comparisons in backup slides.
+
+Expected output:
+
+- slide-by-slide outline
+- visual plan for each slide
+- take-home message per slide
+- speaker-note bullets
+- backup-slide list

--- a/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-build-slides.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-build-slides.md
@@ -4,7 +4,7 @@ description: Build a graphics-first thermal-fluid research presentation with sli
 
 # Thermal-Fluid Research Presentation
 
-Use `mechanical-engineering-research` to build a graphics-first research presentation.
+Use `mechanical-engineering-research` to build a graphics-first research presentation or poster.
 
 Workflow:
 
@@ -13,7 +13,8 @@ Workflow:
 3. Use figures, videos, schematics, animations, and baseline raw-data slides as the primary communication layer.
 4. Keep text minimal and reserve it for take-home messages, labels, and caveats.
 5. Write speaker notes that complement the slides rather than repeating them.
-6. Place derivations, dense tables, and extra comparisons in backup slides.
+6. For posters, use a title banner, 3-4 clear columns, a central visual path, captioned figures, and a compact acknowledgment/contact rail.
+7. Place derivations, dense tables, and extra comparisons in backup slides.
 
 Expected output:
 
@@ -21,4 +22,5 @@ Expected output:
 - visual plan for each slide
 - take-home message per slide
 - speaker-note bullets
+- poster column plan when relevant
 - backup-slide list

--- a/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-code-review.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-code-review.md
@@ -1,0 +1,24 @@
+---
+description: Review or refactor thermal-fluid research code for reproducibility, baseline-case traceability, units, assumptions, physics checks, and publication figures.
+---
+
+# Thermal-Fluid Research Code Review
+
+Use `mechanical-engineering-research` to write, review, or refactor research code.
+
+Workflow:
+
+1. Identify the research question and expected outputs.
+2. Verify the baseline case is reproducible from raw inputs.
+3. Check units, assumptions, constants, paths, metadata, and raw-data preservation.
+4. Separate data processing, analysis, plotting, and simulation/ML execution when practical.
+5. Add sanity checks based on physics, conservation laws, known correlations, or benchmark cases.
+6. Confirm figures and tables can be traced back to scripts and processed data.
+
+Expected output:
+
+- code review findings or implementation plan
+- reproducibility checklist
+- suggested project structure
+- tests or sanity checks
+- next refactor steps

--- a/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-data-analysis.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-data-analysis.md
@@ -1,0 +1,24 @@
+---
+description: Plan thermal-fluid experimental, simulation, CFD, or AI-assisted data analysis around a baseline case, hypothesis-driven DOE, plotting, and validation checks.
+---
+
+# Thermal-Fluid Data Analysis
+
+Use `mechanical-engineering-research` to plan or implement experimental, simulation, CFD, or AI-assisted data analysis.
+
+Workflow:
+
+1. Start with a representative baseline case.
+2. Show the full raw-data to metric or figure pipeline on the baseline case.
+3. Define metrics, units, thresholds, filters, fitting windows, uncertainty, and sanity checks.
+4. Design hypothesis-driven DOE for experiments or simulations.
+5. Avoid broad parameter sweeps until the dominant mechanisms and useful ranges are known.
+6. Use plots to reveal mechanisms, not merely display data.
+
+Expected output:
+
+- baseline analysis plan
+- DOE table or staged case matrix
+- processing pipeline
+- plotting plan
+- validation and sanity checks

--- a/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-lit-review.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-lit-review.md
@@ -1,0 +1,24 @@
+---
+description: Develop a critical thermal-fluid or mechanical-engineering literature review with mechanism-based synthesis, citation grouping, and gap identification.
+---
+
+# Thermal-Fluid Literature Review
+
+Use `mechanical-engineering-research` to produce a critical literature review for a thermal-fluid or mechanical engineering topic.
+
+Workflow:
+
+1. Define the research question and purpose of the review.
+2. Identify seminal work and trace both prior references and citing papers when browsing is available.
+3. Group papers by theory, mechanism, method, structure, metric, material, or unresolved challenge.
+4. Use professional citation style: first-author last name plus "et al." for prose citations.
+5. Treat background references as category-level citations, not one-paper-one-sentence summaries.
+6. End each major prior-work group with a limitation, knowledge gap, or motivation for the present work.
+
+Expected output:
+
+- literature map
+- critical synthesis
+- key limitations and gaps
+- recommended review figures/tables
+- next papers or searches to perform

--- a/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-proposal.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-proposal.md
@@ -1,0 +1,25 @@
+---
+description: Develop, revise, or review a thermal-fluid mechanical-engineering proposal using solicitation alignment, reviewer logic, preliminary results, proposal figures, milestones, and risk mitigation.
+---
+
+# Thermal-Fluid Proposal Development
+
+Use `mechanical-engineering-research` to develop, revise, or review a proposal for thermal-fluid or mechanical-engineering research.
+
+Workflow:
+
+1. Start from the solicitation, review criteria, page limits, required sections, and collaborator-document requirements.
+2. Build the first-page logic: importance, unresolved barrier, proposed advance, feasibility, and expected impact.
+3. Organize the narrative around one overall goal and two to four objectives, aims, or thrusts.
+4. For each thrust, connect hypothesis, tasks, methods, preliminary results, expected outcomes, metrics, risks, and alternatives.
+5. Use figures as reviewer shortcuts: overview, mechanism, testbed, preliminary data, workflow, milestone table, and collaboration map.
+6. Revise against reviewer-friction points: vague central hypothesis, parallel rather than integrated methods, unmeasurable milestones, weak risk mitigation, and unclear partner roles.
+
+Expected output:
+
+- proposal logic map
+- section-by-section outline or revised narrative
+- figure and caption plan
+- preliminary-results integration plan
+- milestone and risk table
+- review-criteria alignment checklist

--- a/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-write-section.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/commands/me-write-section.md
@@ -1,0 +1,23 @@
+---
+description: Draft or revise thermal-fluid manuscript, proposal, report, or thesis sections with clear paragraph logic, methods detail, assumptions, and figure-led discussion.
+---
+
+# Thermal-Fluid Technical Writing
+
+Use `mechanical-engineering-research` to draft or revise a manuscript, proposal, report, or thesis section.
+
+Workflow:
+
+1. Identify the section type: introduction, methods, modeling, results, discussion, conclusion, proposal narrative, or response to review criteria.
+2. Use clear paragraph logic: one central topic per paragraph, usually in the first sentence.
+3. For background sections, move from importance to state of the art, gap, challenge, innovation, and impact.
+4. For methods, include facility, procedure, instrumentation, data reduction, uncertainty, and reproducibility details.
+5. For modeling, list assumptions upfront and justify each assumption.
+6. For results, discuss figures through description, observation, physical explanation, and literature comparison.
+
+Expected output:
+
+- polished technical prose
+- assumptions and caveats
+- citation and evidence notes
+- suggested figures or tables if useful

--- a/plugins/hanhuark/mechanical-engineering-research-skill/skills/mechanical-engineering-research/SKILL.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/skills/mechanical-engineering-research/SKILL.md
@@ -61,7 +61,7 @@ For a research brief, use:
 
 For a literature review, read `references/literature-review.md`. Group sources by mechanism, method, design family, or unresolved question rather than listing papers chronologically.
 
-For federal research proposals, DOE EPSCoR/National Laboratory partnership proposals, full narrative expansions, review-criteria responses, or ready-to-submit proposal polishing, read `references/proposal-development.md`.
+For federal research proposals, DOE EPSCoR/National Laboratory partnership proposals, full narrative expansions, review-criteria responses, proposal figure planning, preliminary-results integration, or ready-to-submit proposal polishing, read `references/proposal-development.md`.
 
 For a design comparison, include a compact decision matrix and explain the dominant physics behind each score.
 
@@ -116,7 +116,7 @@ Read `references/paper-writing-style.md` when the user asks to write, revise, ou
 
 Read `references/literature-review.md` when the user asks for a literature review, related-work section, research background, citation map, state-of-the-art comparison, review figure/table, future-work analysis, or paper discovery strategy.
 
-Read `references/proposal-development.md` when the user asks for grant/proposal development, solicitation alignment, pre-application expansion, DOE EPSCoR or National Lab partnership narratives, collaborator document planning, review-criteria mapping, milestones, preliminary-results integration, proposal figures, references, or ready-to-submit polish.
+Read `references/proposal-development.md` when the user asks for grant/proposal development, solicitation alignment, pre-application expansion, DOE EPSCoR or National Lab partnership narratives, collaborator document planning, review-criteria mapping, milestones, preliminary-results integration, proposal figures, reviewer-friction diagnosis, references, or ready-to-submit polish.
 
 Read `references/presentation-slides.md` when the user asks for presentation slides, a research talk, conference talk, group-meeting slides, slide-by-slide narrative, speaker notes, animation/video suggestions, or figure-focused storytelling.
 

--- a/plugins/hanhuark/mechanical-engineering-research-skill/skills/mechanical-engineering-research/references/presentation-slides.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/skills/mechanical-engineering-research/references/presentation-slides.md
@@ -120,6 +120,87 @@ When preparing talks in the style of the provided thermal-fluid conference examp
 
 Use slide numbers unobtrusively when helpful for conference navigation and discussion.
 
+## Presentation Corpus Lessons
+
+This guidance is calibrated against the user's conference talks, seminar decks, outreach decks, and posters. Apply the patterns as reusable presentation judgment; do not copy private slides, unpublished data, or sponsor-specific material into public examples.
+
+The strongest recurring style is **visual evidence first, short text second, explanation spoken live**. Most technical talks use roughly 13-30 slides, with figures or images on most slides and only a few dense backup-style slides. The design language is restrained: clean white backgrounds, red/orange section titles or footer accents, institutional/team identity on title and acknowledgment slides, and technical figures that carry the argument.
+
+### NED3 Talk Grammar
+
+For a thermal-fluid conference or seminar talk, use this slide grammar unless the user gives a different venue constraint:
+
+1. **Title and identity:** precise technical title, speaker, collaborators, department/institution, venue, date, and sponsor/team identity when appropriate.
+2. **Motivation through recognizable systems:** show applications, hardware, energy/safety/reliability context, or mission relevance with photos, schematics, and one or two anchor numbers.
+3. **Background physics:** introduce the phenomenon, bottleneck, regime transition, metric, or measurement challenge visually.
+4. **Research question or gap:** state what the talk will answer, preferably as two or three concrete questions rather than a paragraph.
+5. **Approach overview:** show the diagnostic, model, ML workflow, facility, or experimental logic as a compact schematic.
+6. **Experimental setup or data source:** use labeled photos and diagrams so the audience can inspect sensors, sample, geometry, heating/cooling path, cameras, DAQ, or simulation domain.
+7. **Baseline/raw-data slide:** show representative raw traces, images, videos, thermographs, spectrograms, or synchronized signals before showing processed trends.
+8. **Metric extraction or analysis pipeline:** explain how the raw data becomes event labels, features, regimes, heat flux, HTC, temperature field, model input, or prediction target.
+9. **Parametric result slides:** vary one meaningful factor at a time and preserve axes, colors, marker meanings, panel layout, and annotations across related slides.
+10. **Mechanism synthesis:** turn observations into physical reasoning using schematics, highlighted regions, arrows, side-by-side comparisons, or simplified governing ideas.
+11. **Comparison and implication:** benchmark against literature, baseline cases, physical models, or design targets when generalizability matters.
+12. **Conclusion and acknowledgment:** provide concise takeaways, next steps, sponsor logos, collaborators, and a team/photo element when appropriate.
+
+For 12-15 minute conference talks, compress motivation and literature into the first 3-4 slides and prioritize setup, baseline, 2-4 result slides, mechanism, and conclusion. For seminars, expand background, literature comparison, and method details.
+
+### Visual Figure Patterns
+
+Use figures as the slide's main object. Strong recurring figure types include:
+
+- **Annotated facility photos:** test rig, sensor locations, heater, sample, optical/acoustic/IR hardware, and data path marked directly on the image.
+- **Raw-to-processed panels:** raw image/video frame, time trace, extracted metric, and final trend shown in one reading path.
+- **Synchronized multimodal data:** temperature, heat flux, pressure, acoustic energy, images, spectrograms, or ML predictions aligned by time or event.
+- **Mechanism cartoons beside data:** schematic of bubble/interface/film/surface structure next to the plot it explains.
+- **Small-multiple parameter sweeps:** repeated panels for pressure, surface structure, heat flux, mass flow, geometry, or model condition with fixed visual grammar.
+- **Workflow diagrams:** experiment, data preprocessing, model, validation, and output connected in a left-to-right or top-to-bottom process.
+- **Benchmark/literature plots:** symbols, colors, or annotations that clearly distinguish this work, baseline, and literature.
+
+Every figure slide should have a short title that states the finding or question. Avoid slides where the first visible text is only a slide number, a generic topic label, or an unexplained plot title.
+
+### Text And Annotation Style
+
+Use red/orange for titles, section emphasis, arrows, borders, or key callouts, but keep the data and images visually dominant. Prefer short phrases and labels over full sentences on the slide. When a slide contains a dense plot, reduce surrounding text and use direct annotations on the figure itself.
+
+Good slide text usually does one of three jobs:
+
+- names the mechanism or comparison;
+- tells the audience what to look at;
+- states the take-home conclusion that the presenter will explain verbally.
+
+Avoid putting the full physical explanation on the slide. Put that explanation in speaker notes or spoken narration.
+
+### Result Slide Sequencing
+
+Do not jump from setup directly to final aggregate conclusions. Use a sequence:
+
+1. Representative raw case.
+2. How the metric or label is extracted.
+3. First trend under a simple condition.
+4. Comparison across cases.
+5. Mechanism explanation.
+6. Literature/baseline comparison or design implication.
+
+This structure lets the audience trust the analysis before accepting the conclusion. It is especially important for boiling, acoustic sensing, IR thermography, computer vision, sequence regression, POD/NN, and surrogate-model workflows.
+
+### Poster Grammar
+
+Posters in this corpus are one-slide, graphics-dense artifacts. They should not be built like a single enlarged talk slide. Use a poster-specific structure:
+
+- **Top banner:** title, authors, affiliations, institutional/lab identity, and sponsor logos.
+- **Three to four vertical columns:** motivation/background, methods/setup, results/analysis, conclusions/impact.
+- **Central visual path:** large facility/photo/schematic/plot cluster that makes the project understandable from a distance.
+- **Compact text blocks:** short paragraphs or bullets that explain only what the figures cannot.
+- **Captioned figures:** each major figure needs a short local takeaway, not just a label.
+- **Bottom rail:** acknowledgments, funding, QR/code/contact, and optional references.
+
+For posters, preserve alignment and column boundaries. The same rectangle test still applies, but at poster scale: each column, figure group, title block, and acknowledgment block should occupy a clean non-overlapping region.
+
+### Outreach And General-Audience Talks
+
+For K-12, outreach, summer academy, or non-specialist audiences, simplify the physics but keep real visuals. Use photos, demonstrations, animations, and everyday objects before equations. Replace dense result plots with a visible phenomenon, a question, and a simple observation. The goal is curiosity and conceptual understanding, not exhaustive technical defense.
+
 ## Baseline And Raw-Data Slides
 
 Include at least one slide that shows representative raw data, raw images/video, or the baseline case before polished aggregate plots.

--- a/plugins/hanhuark/mechanical-engineering-research-skill/skills/mechanical-engineering-research/references/presentation-slides.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/skills/mechanical-engineering-research/references/presentation-slides.md
@@ -122,7 +122,7 @@ Use slide numbers unobtrusively when helpful for conference navigation and discu
 
 ## Presentation Corpus Lessons
 
-This guidance is calibrated against the user's conference talks, seminar decks, outreach decks, and posters. Apply the patterns as reusable presentation judgment; do not copy private slides, unpublished data, or sponsor-specific material into public examples.
+This guidance is calibrated against the investigator's conference talks, seminar decks, outreach decks, and posters. Apply the patterns as reusable presentation judgment; do not copy private slides, unpublished data, or sponsor-specific material into public examples.
 
 The strongest recurring style is **visual evidence first, short text second, explanation spoken live**. Most technical talks use roughly 13-30 slides, with figures or images on most slides and only a few dense backup-style slides. The design language is restrained: clean white backgrounds, red/orange section titles or footer accents, institutional/team identity on title and acknowledgment slides, and technical figures that carry the argument.
 

--- a/plugins/hanhuark/mechanical-engineering-research-skill/skills/mechanical-engineering-research/references/proposal-development.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/skills/mechanical-engineering-research/references/proposal-development.md
@@ -10,7 +10,7 @@ Use AI only as proposal-development support. Preserve the investigators' scienti
 
 ## Proposal Corpus Lessons
 
-This guidance is calibrated against a representative corpus of the user's awarded, declined, example, and pending proposals. Apply the patterns as reusable writing judgment, not as confidential proposal-specific examples.
+This guidance is calibrated against a representative corpus of the investigator's awarded, declined, example, and pending proposals. Apply the patterns as reusable writing judgment, not as confidential proposal-specific examples.
 
 ### Winning Narrative Signature
 

--- a/plugins/hanhuark/mechanical-engineering-research-skill/skills/mechanical-engineering-research/references/proposal-development.md
+++ b/plugins/hanhuark/mechanical-engineering-research-skill/skills/mechanical-engineering-research/references/proposal-development.md
@@ -8,6 +8,105 @@ Build the proposal around the solicitation, the review criteria, and the investi
 
 Use AI only as proposal-development support. Preserve the investigators' scientific direction, original technical content, preliminary results, and final responsibility. If the solicitation requires AI disclosure, flag the requirement and suggest wording for institutional review.
 
+## Proposal Corpus Lessons
+
+This guidance is calibrated against a representative corpus of the user's awarded, declined, example, and pending proposals. Apply the patterns as reusable writing judgment, not as confidential proposal-specific examples.
+
+### Winning Narrative Signature
+
+Strong proposals tend to read as a sequence of reviewer answers:
+
+1. **Why this matters now:** Start from a mission, market, scientific, safety, energy, reliability, workforce, or infrastructure need that the solicitation already cares about.
+2. **What blocks progress:** Move quickly from broad importance to a specific technical barrier: missing diagnostics, inaccessible measurements, coupled multiphysics, weak transferability, limited benchmark data, scale mismatch, or lack of validated models.
+3. **What the team will uniquely do:** State the proposed instrument, model, dataset, experimental platform, AI/ML workflow, or collaboration as the means to overcome the barrier.
+4. **Why it is feasible:** Anchor the idea in preliminary data, existing facilities, prior publications, working prototypes, collaborator access, or previous grant lineage.
+5. **What success looks like:** Name the measurable output: validated mechanism, dataset, diagnostic accuracy, prediction error, design rule, prototype, demonstration, student training, publication, software release, or commercialization milestone.
+
+Do not let a proposal remain at the level of "important problem plus ambitious methods." Reviewers need to see the conversion from importance to barrier to capability to validation to impact.
+
+### Opening Paragraph Pattern
+
+Use a compact three-step opening for the first page:
+
+1. **Context sentence:** Establish the application, mission, or scientific area with a concrete consequence.
+2. **Barrier sentence:** Identify the unresolved technical challenge that prevents progress.
+3. **Proposed advance sentence:** State the project goal and the differentiating method or insight.
+
+Then, within the same first page, add a one-sentence preview of outcomes and impact. Avoid starting with a long literature review, a historical survey, or a generic claim that the topic is "important."
+
+### Objective And Thrust Architecture
+
+Award-style narratives usually make the architecture easy to recover from headings alone. Use one overall goal, then two to four objectives, aims, or thrusts. Each objective should have a different job:
+
+- **Objective/Thrust 1:** Build or characterize the experimental, observational, or computational foundation.
+- **Objective/Thrust 2:** Develop the model, mechanism, data representation, or diagnostic method.
+- **Objective/Thrust 3:** Validate, generalize, transfer, demonstrate, or translate the capability.
+- **Optional Objective/Thrust 4:** Education, workforce, commercialization, deployment, or community infrastructure when the solicitation values it.
+
+For each objective, include tasks, methods, expected outcomes, quantitative metrics, risks, and alternatives. If objectives are numerous or overlapping, merge them until each one answers a visibly different reviewer question.
+
+### Preliminary Results As Proof Of Capability
+
+Strong proposals do not merely show preliminary figures. They explain what each result proves about execution risk.
+
+Use this pattern:
+
+1. **Result:** State the measurement, simulation, prototype, dataset, or prior analysis.
+2. **Condition:** Give the key operating condition, geometry, sample, platform, or dataset.
+3. **Capability proven:** Explain what the team can now do because of this result.
+4. **Remaining gap:** State what the preliminary result cannot yet answer.
+5. **Proposed task connection:** Tie that gap directly to the next task or objective.
+
+Preliminary results are most persuasive when embedded inside the task they justify. A standalone preliminary-results section can work, but only if every figure is later used as evidence in the research plan.
+
+### Figure Grammar For Proposals
+
+Proposal figures should be designed as reviewer shortcuts. Common high-value figure types include:
+
+- **One-page project overview:** Problem, barrier, proposed innovation, work packages, and expected outcome.
+- **Mechanism schematic:** Physical process, competing mechanisms, key variables, and what will be measured.
+- **Testbed or facility figure:** Hardware, sensors, operating envelope, synchronization, calibration, and data products.
+- **Preliminary-result figure:** Real data or model output that proves feasibility.
+- **Workflow figure:** Experiment, simulation, AI/ML, validation, and uncertainty loops.
+- **Timeline/milestone table:** Year, task, deliverable, metric, and go/no-go outcome.
+- **Collaboration map:** Roles, facilities, student flow, partner feedback, and review cadence when multi-institutional work matters.
+
+Captions should be mini-arguments, not labels. A strong caption states what is shown, what is observed, why it matters, and how it supports the proposed work. If the proposal text never uses a figure as evidence, remove or redesign the figure.
+
+### Writing Style Patterns
+
+Prefer clear, direct topic sentences. Many effective paragraphs use this rhythm:
+
+1. Claim or need.
+2. Evidence or current limitation.
+3. Proposed response.
+4. Expected outcome or reviewer-relevant implication.
+
+Use strong verbs such as **quantify**, **validate**, **benchmark**, **integrate**, **resolve**, **demonstrate**, **predict**, and **translate**. Avoid stacking inflated adjectives. Words like "transformative" or "novel" should be earned by a precise statement of what capability becomes possible.
+
+Use citation density strategically. Background claims can cite grouped references by category, but method gaps and feasibility claims need targeted citations or team evidence. Do not write one sentence for every reference unless the point is a critical comparison.
+
+### Reviewer Friction Patterns To Avoid
+
+Declined or vulnerable drafts often show one or more of these risks:
+
+- The proposal has many tasks but the central hypothesis or organizing question is hard to state.
+- AI/ML, CFD, experiments, or sensing are described as parallel activities rather than an integrated validation loop.
+- Preliminary results are impressive but not explicitly tied to risk reduction.
+- The literature review is either too broad for the page limit or too narrow to show awareness of competing approaches.
+- Milestones list activities instead of measurable completion criteria.
+- The project claims broad impact but does not specify the user, mission, dataset, prototype, design rule, or adoption path.
+- Collaboration roles are named but the work transfer, meeting cadence, data sharing, and decision points are vague.
+- Figures are visually rich but captions do not explain the reviewer takeaway.
+
+When revising, first fix these reviewer-friction points before polishing sentence style.
+
+### Pending Proposal Discipline
+
+For pending proposals, preserve live strategy. Do not overfit to old awarded proposals if the solicitation, program language, or partner constraints have changed. Before drafting, ask what is still unsettled: target program, page limit, required sections, partner roles, budget model, data rights, institutional commitments, and whether the proposal is a pre-application, feasibility review, white paper, full narrative, or supplement.
+
+When reusing material from prior proposals, update the logic chain rather than pasting text. Carry forward strong figures, preliminary results, and methods only after rewriting the gap, objective, and impact for the current solicitation.
+
 ## Solicitation-First Workflow
 
 1. Read the solicitation before drafting.


### PR DESCRIPTION
﻿## Summary
- Sync the mirrored Thermal-Fluid Research Workflow plugin bundle with the source repo
- Add the new `me-proposal` workflow command
- Add proposal-corpus guidance for reviewer-focused proposal narratives, preliminary-results integration, proposal figures, milestones, and reviewer-friction diagnosis

## Validation
- Source repo skill validation passed
- Source repo plugin validation passed
- In this repo, `validate-plugin-pr.py` reports `PASS` for `plugins\hanhuark\mechanical-engineering-research-skill`; unrelated existing plugin validation failures are present in other changed plugin directories relative to this fork snapshot
- `check-alphabetical.py` passed
- `git diff --cached --check` passed before commit
