### PR TITLE
Add Antigravity 2.0 plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -814,6 +814,21 @@
       "icon": "./plugins/haf/aient-codex-plugin/assets/aient-icon-beveled-light.png"
     },
     {
+      "name": "antigravity-2",
+      "displayName": "Antigravity 2.0",
+      "source": {
+        "source": "local",
+        "path": "./plugins/comprono/antigravity-2-codex-plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tools & Integrations",
+      "description": "Local Codex bridge for Antigravity desktop with setup checks, model limit summaries, DevTools UI automation, and safe project/chat handoff.",
+      "icon": "./plugins/comprono/antigravity-2-codex-plugin/assets/icon.svg"
+    },
+    {
       "name": "apple-calendar",
       "displayName": "Apple Productivity",
       "source": {

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
 - [Agentgram](https://github.com/jerryfane/agentgram) - Send explicit Telegram messages from Codex and local AI agents through a Telegram bot token and chat id.
 - [Aient](https://github.com/haf/aient-codex-plugin) - AI operations plugin for Codex that connects production telemetry, problem lifecycle context, and remediation workflows through Aient's MCP server.
+- [Antigravity 2.0](https://github.com/comprono/antigravity-2-codex-plugin) - Local Codex bridge for Antigravity desktop with setup checks, model limit summaries, DevTools UI automation, and safe project/chat handoff.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
 - [AxonFlow](https://github.com/getaxonflow/axonflow-codex-plugin) - Runtime governance for Codex with policy enforcement on terminal commands, advisory checks for non-terminal tools via skills, PII/secret detection, and compliance-grade audit trails. Self-hosted via Docker.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-06-04",
-  "total": 98,
+  "total": 99,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -558,6 +558,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/haf/aient-codex-plugin/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Antigravity 2.0",
+      "url": "https://github.com/comprono/antigravity-2-codex-plugin",
+      "owner": "comprono",
+      "repo": "antigravity-2-codex-plugin",
+      "description": "Local Codex bridge for Antigravity desktop with setup checks, model limit summaries, DevTools UI automation, and safe project/chat handoff.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/comprono/antigravity-2-codex-plugin/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Apple Productivity",

--- a/plugins/comprono/antigravity-2-codex-plugin/.codex-plugin/plugin.json
+++ b/plugins/comprono/antigravity-2-codex-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,62 @@
+{
+  "name": "antigravity-2",
+  "version": "0.1.0",
+  "description": "Google Antigravity Codex Plugin for connecting OpenAI Codex to Antigravity 2.0 through MCP, DevTools, and local Windows helper commands.",
+  "repository": "https://github.com/comprono/antigravity-2-codex-plugin",
+  "homepage": "https://github.com/comprono/antigravity-2-codex-plugin",
+  "license": "MIT",
+  "author": {
+    "name": "comprono"
+  },
+  "keywords": [
+    "google-antigravity",
+    "openai-codex",
+    "codex-plugin",
+    "codex-mcp-plugin",
+    "devtools-mcp",
+    "antigravity",
+    "antigravity-2",
+    "desktop",
+    "windows",
+    "local"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Antigravity 2.0",
+    "shortDescription": "Connect OpenAI Codex to a local Antigravity 2.0 desktop app.",
+    "longDescription": "Adds Codex-side helpers for Antigravity 2.0 on Windows. The plugin exposes local MCP tools for compact quick readiness checks, status, live readiness, model limit summaries, full model limits, and privacy scans, plus a DevTools MCP bridge for live UI automation. It can verify setup on another user's machine, launch the desktop app, report install and process status, read model quota state from Antigravity's local language server, inspect visible projects and chats, continue existing chats, start new chats in existing projects, start new projects, and hand off instructions safely after live UI verification.",
+    "developerName": "comprono",
+    "websiteURL": "https://github.com/comprono/antigravity-2-codex-plugin",
+    "privacyPolicyURL": "https://github.com/comprono/antigravity-2-codex-plugin/blob/main/SECURITY.md",
+    "termsOfServiceURL": "https://github.com/comprono/antigravity-2-codex-plugin/blob/main/README.md",
+    "composerIcon": "./assets/icon.svg",
+    "logo": "./assets/icon.svg",
+    "category": "Productivity",
+    "capabilities": [
+      "Local app launch",
+      "Compact quick status",
+      "Autonomous setup checks",
+      "Local MCP setup tools",
+      "Install inspection",
+      "Model quota inspection",
+      "Live UI inspection",
+      "DevTools bridge",
+      "Live DevTools repair",
+      "Project and chat inspection",
+      "New project and chat handoff",
+      "Public repo privacy scan"
+    ],
+    "defaultPrompt": [
+      "Quick check Antigravity 2.0",
+      "Open Antigravity 2.0",
+      "Repair Antigravity live inspection",
+      "Check Antigravity setup",
+      "Show Antigravity model limits",
+      "Inspect Antigravity projects",
+      "Start a new Antigravity chat",
+      "Continue an Antigravity chat"
+    ],
+    "brandColor": "#14B8A6"
+  }
+}

--- a/plugins/comprono/antigravity-2-codex-plugin/.codexignore
+++ b/plugins/comprono/antigravity-2-codex-plugin/.codexignore
@@ -1,0 +1,10 @@
+.git/
+.codex-remote-attachments/
+*.log
+*.tmp
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+node_modules/

--- a/plugins/comprono/antigravity-2-codex-plugin/.gitignore
+++ b/plugins/comprono/antigravity-2-codex-plugin/.gitignore
@@ -1,0 +1,15 @@
+# Local/editor noise
+.DS_Store
+Thumbs.db
+*.log
+
+# Node/Python transient files
+node_modules/
+__pycache__/
+*.pyc
+
+# Local screenshots or captures from plugin development
+*.png
+*.webp
+*.jpg
+*.jpeg

--- a/plugins/comprono/antigravity-2-codex-plugin/.mcp.json
+++ b/plugins/comprono/antigravity-2-codex-plugin/.mcp.json
@@ -1,0 +1,25 @@
+{
+  "mcpServers": {
+    "antigravity-devtools": {
+      "command": "powershell.exe",
+      "args": [
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "& \"$env:USERPROFILE\\plugins\\antigravity-2\\scripts\\antigravity-devtools-mcp.ps1\""
+      ],
+      "env": {
+        "CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS": "1"
+      }
+    },
+    "antigravity-local": {
+      "command": "powershell.exe",
+      "args": [
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "& node \"$env:USERPROFILE\\plugins\\antigravity-2\\scripts\\antigravity-local-mcp.js\""
+      ]
+    }
+  }
+}

--- a/plugins/comprono/antigravity-2-codex-plugin/CHANGELOG.md
+++ b/plugins/comprono/antigravity-2-codex-plugin/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-06-03
+
+- Initial public release of the Google Antigravity Codex Plugin.
+- Added a local Antigravity 2.0 Codex bridge for Windows.
+- Added MCP server entries for local setup/status/model-limit tools and DevTools-driven Antigravity UI work.
+- Added PowerShell helper commands for setup checks, app launch, live readiness, model quota summaries, and privacy scanning.
+- Added documentation for safe local handoff from OpenAI Codex to a visible Antigravity desktop session.

--- a/plugins/comprono/antigravity-2-codex-plugin/CITATION.cff
+++ b/plugins/comprono/antigravity-2-codex-plugin/CITATION.cff
@@ -1,0 +1,17 @@
+cff-version: 1.2.0
+message: "If you use this plugin, please cite it as below."
+title: "Google Antigravity Codex Plugin"
+version: "0.1.0"
+date-released: "2026-06-03"
+authors:
+  - name: "comprono"
+repository-code: "https://github.com/comprono/antigravity-2-codex-plugin"
+url: "https://github.com/comprono/antigravity-2-codex-plugin"
+license: "MIT"
+keywords:
+  - "google antigravity codex plugin"
+  - "openai codex antigravity"
+  - "antigravity 2.0 codex plugin"
+  - "codex mcp plugin"
+  - "devtools mcp antigravity"
+abstract: "A community Codex plugin for connecting OpenAI Codex to Google Antigravity / Antigravity 2.0 through MCP, Chromium DevTools, and local Windows helper commands."

--- a/plugins/comprono/antigravity-2-codex-plugin/CONTRIBUTING.md
+++ b/plugins/comprono/antigravity-2-codex-plugin/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+Thanks for improving the Google Antigravity Codex Plugin.
+
+## Scope
+
+This repository is a community Codex plugin for connecting OpenAI Codex to a local Antigravity 2.0 desktop app on Windows. Contributions should keep the plugin focused on local MCP tools, Chromium DevTools integration, PowerShell helper commands, setup checks, model-limit inspection, and safe handoff into visible Antigravity UI workflows.
+
+Do not add claims that the plugin is official unless the project status changes and the repository owner documents that clearly.
+
+## Development Checks
+
+Before opening a pull request, run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File ".\scripts\antigravity.ps1" privacy
+git diff --check
+python -m pipx run plugin-scanner lint .
+python -m pipx run plugin-scanner verify . --format json
+```
+
+`plugin-scanner verify` may safety-skip stdio MCP execution and request manual review. That is expected for executable MCP server entries; document the result in the pull request.
+
+## Privacy
+
+Do not commit local Antigravity logs, screenshots, chat contents, project names, runtime ports, CSRF tokens, OAuth tokens, cookies, API keys, or personal identifiers.
+
+Use environment-variable examples such as `%USERPROFILE%`, `%APPDATA%`, and `%LOCALAPPDATA%` instead of machine-specific absolute paths.

--- a/plugins/comprono/antigravity-2-codex-plugin/GITHUB_TOPICS.md
+++ b/plugins/comprono/antigravity-2-codex-plugin/GITHUB_TOPICS.md
@@ -1,0 +1,26 @@
+# GitHub Topics
+
+Add these topics manually in the GitHub repository settings so GitHub Search and AI search tools can classify the project correctly:
+
+```text
+codex
+openai-codex
+codex-plugin
+chatgpt-codex
+google-antigravity
+antigravity
+antigravity-2
+mcp
+mcp-server
+devtools-mcp
+vscode-extension
+ai-agents
+powershell
+windows
+```
+
+Suggested repository description:
+
+```text
+Google Antigravity Codex Plugin — connect OpenAI Codex to Antigravity 2.0 via MCP, DevTools, and local Windows helper commands.
+```

--- a/plugins/comprono/antigravity-2-codex-plugin/LICENSE
+++ b/plugins/comprono/antigravity-2-codex-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 comprono
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/comprono/antigravity-2-codex-plugin/README.md
+++ b/plugins/comprono/antigravity-2-codex-plugin/README.md
@@ -1,0 +1,196 @@
+# Google Antigravity Codex Plugin
+
+Created by [comprono](https://github.com/comprono).
+
+This Google Antigravity Codex Plugin is a community local Windows bridge for Codex and Google Antigravity. It helps OpenAI Codex Antigravity workflows connect to the Antigravity 2.0 desktop app using a Codex MCP plugin, DevTools MCP Antigravity controls, and local helper commands.
+
+This is a local Codex plugin that helps Codex connect to the Antigravity 2.0 desktop app on Windows. It can open Antigravity, inspect whether it is running, discover the Chromium DevTools endpoint exposed by the Electron app, read model quota state from the local language server, inspect visible projects and chats, verify the visible model, and hand off prompts into Antigravity conversations.
+
+After setup, you can start from the ChatGPT mobile app, open Codex, and use this local plugin as the bridge into your Windows Antigravity desktop session.
+
+## Google Antigravity Codex Plugin
+
+This is a community Codex plugin for Google Antigravity / Antigravity 2.0. It lets OpenAI Codex connect to a local Antigravity desktop app on Windows using MCP tools, Chromium DevTools, and local PowerShell helper commands. It provides an Antigravity 2.0 Codex bridge for people who want Codex, including Codex sessions started from ChatGPT on mobile, to hand off work into a locally running Antigravity desktop environment.
+
+Keywords: Google Antigravity Codex plugin, OpenAI Codex Antigravity, Antigravity 2.0 Codex bridge, Codex MCP plugin, DevTools MCP Antigravity.
+
+## What It Does
+
+- Launches the local Antigravity desktop app.
+- Reports install path, user data path, running process IDs, setup readiness, and DevTools port.
+- Reports Antigravity model quota state from the local language server.
+- Connects to Antigravity's bundled `chrome-devtools-mcp` server when available.
+- Exposes local setup/model/status commands as MCP tools, so Codex can use them even when skill files are unavailable.
+- Helps Codex inspect live project/chat context from the UI.
+- Supports safe handoff to continue an existing chat, start a new chat in an existing project, or start a new project.
+- Provides a local privacy scan for sensitive data before publishing changes.
+
+## Requirements
+
+- Windows.
+- Antigravity installed at `%LOCALAPPDATA%\Programs\Antigravity\Antigravity.exe`.
+- Codex plugins loaded from `%USERPROFILE%\plugins`.
+- Node.js available on `PATH` for the DevTools MCP bridge.
+
+## Install
+
+Clone this repository into your Codex plugins directory:
+
+```powershell
+git clone https://github.com/comprono/antigravity-2-codex-plugin.git "$env:USERPROFILE\plugins\antigravity-2"
+```
+
+Then install or refresh the plugin from your Codex personal marketplace.
+
+For a setup check after cloning:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" setup
+```
+
+The setup report tells Codex whether Antigravity is installed, whether Node.js is available, whether the bundled DevTools MCP package exists, whether the DevTools endpoint is reachable, and whether the local language-server model-limit API is ready.
+
+## MCP Tools
+
+The plugin registers two MCP servers:
+
+- `antigravity-local`: direct local tools for `quick`, `setup`, `doctor`, `status`, `open`, `repair-live`, `inspect`, `live`, `devtools-health`, `submission-guide`, `prepare-offload`, `submit-offload`, `limits-summary`, `limits`, `models`, `offload-advice`, `handoff-template`, and `privacy`.
+- `antigravity-devtools`: Chromium DevTools controls for inspecting and driving the Antigravity UI.
+
+Codex should call `antigravity-local.submit-offload` first when the correct Antigravity project/chat is already selected and the goal is to hand work to Antigravity with minimum friction. It prepares the compact handoff, fills the active composer, and submits with a direct CDP Enter keypress, avoiding repeated `list_pages`, snapshots, fill, key, and evaluate calls. If the MCP tool list is stale and does not show `submit-offload`, use the PowerShell helper `antigravity.ps1 submit-offload` before falling back to DevTools choreography. Use `antigravity-local.prepare-offload` when Codex should show the plan first or when the selected chat is uncertain. For nontrivial workspace, repo, browser, UI, research, planning, debugging, review, implementation, and job-application work, the intended cost split is: Antigravity explores and works locally; Codex plans, gates safety, reviews final changes, and summarizes. Use `antigravity-local.quick` for general setup checks. If `ReadyForLiveUiInspection` is false, call `antigravity-local.repair-live` once before using DevTools. If repair restarts Antigravity, an already-started DevTools MCP connection may need to reconnect to the new port. If `antigravity-devtools` fails with `Transport closed`, call `antigravity-local.devtools-health`; do not keep retrying `list_pages` in the same broken transport. Use `limits-summary` for normal quota checks and full `limits` only when the complete per-model JSON is needed.
+
+## Usage
+
+Check status:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" status
+```
+
+Fast combined readiness and quota summary:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" quick
+```
+
+Open Antigravity:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" open
+```
+
+Repair live DevTools inspection if Antigravity is running but exposes zero pages:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" repair-live
+```
+
+Inspect integration details:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" inspect
+```
+
+Inspect live UI connection:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" live
+```
+
+After a DevTools MCP `Transport closed` error, use the local fallback:
+
+```text
+Call antigravity-local.devtools-health.
+```
+
+If it reports pages are ready, restart Codex to recreate the DevTools MCP transport or use `antigravity-local.handoff-template` for a manual paste into Antigravity for the current turn.
+
+Report model quota state:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" limits-summary
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" models
+```
+
+The `limits-summary` command gives a compact availability summary. The `models` and `limits` commands call Antigravity's local language server over its gRPC-web API (`LanguageServerService/GetAvailableModels` and `GetLoadCodeAssist`) and return the fuller per-model data. This is the same source the Antigravity Models tab uses. It returns per-model quota metadata such as remaining fraction and reset time when available. It does not expose a raw all-model token ledger if Antigravity itself does not publish one.
+
+Run a local repository privacy scan:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" privacy
+```
+
+## Codex Operating Model
+
+This plugin intentionally combines two local surfaces:
+
+- Stable status and model-limit checks use local helper commands and Antigravity's local language server.
+- Project/chat actions use the live Antigravity UI through the `antigravity-devtools` MCP bridge, because the UI is the source of truth for selected projects, selected conversations, composer state, and model selection.
+
+For chat actions, Codex should verify the target project, conversation, and selected model before sending anything. For new projects or new chats, Codex should use the visible Antigravity controls through DevTools automation and report whether Antigravity accepted the action or showed an error/quota state.
+
+For nontrivial work, Codex should act as the orchestrator, not the main worker. Codex gives Antigravity compact tasks, waits, reads only status artifacts or targeted diffs, reviews the result, and sends the next improvement task back to Antigravity. Codex should avoid duplicating Antigravity's broad file reading, browser operation, and long reasoning unless Antigravity is blocked or final verification requires it.
+
+For prompt submission, Codex should call `antigravity-local.submission-guide` or follow the same rule: fill/type the prompt without a `submitKey`, then click the visible Send/arrow button. If a keyboard submit is required, use a separate key call with a simple accepted key such as `Enter`. Do not use `Control+Enter`, `Ctrl+Enter`, or chord strings unless the active tool schema explicitly lists that exact value; some DevTools tools reject those strings with `Unknown key`.
+
+## Token-Saving Offload Pattern
+
+Use this plugin to make Codex the router and verifier while Antigravity does the long work. Codex should avoid reading huge files, full logs, or full Antigravity chat transcripts. Instead, Codex sends Antigravity a compact handoff, lets Antigravity inspect the workspace locally, and reads back only a small artifact or status checkpoint.
+
+Token savings are not automatic. First decide whether the task is worth offloading:
+
+- Keep Codex direct only for arithmetic, short factual answers, tiny shell checks, small summaries, and prompts that do not need workspace context.
+- Use Antigravity by default for project work, implementation, debugging, reviews, planning, research, UI operation, job-search/application workflows, and analysis where Antigravity can inspect local files and write a compact result.
+- In existing project chats, assume Antigravity may inspect attached folders before answering. That is useful for real project work and wasteful for tiny tests.
+- If Antigravity starts broad folder exploration for a small task, cancel it and answer directly in Codex.
+
+Recommended flow:
+
+1. If the correct Antigravity project/chat is already selected, run `antigravity-local.submit-offload` with `submit=true`, plus `expectedProject` and `expectedChat` when known.
+2. If the selected chat is uncertain, run `antigravity-local.prepare-offload`, then use DevTools only to select the project/chat/model.
+3. If it returns `codex-direct`, do not open or drive Antigravity.
+4. Ask Antigravity to write progress to a small artifact such as `notes/antigravity-status.md`, `plans/antigravity-next.md`, or `reports/antigravity-result.json`.
+5. Codex reads only that artifact, a targeted diff, or a compact visible UI status.
+6. If the result is incomplete, Codex sends a short follow-up task back to Antigravity with the exact gap instead of pulling broad context into Codex.
+7. Codex summarizes for the user after Antigravity has produced a useful result or is clearly blocked.
+
+If a Codex session cannot see MCP tools and can only run shell commands, use the equivalent PowerShell helper:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" prepare-offload -Goal "<goal>" -Workspace "<path>" -StatusFile "notes/antigravity-status.md" -NextStep "<next step>"
+```
+
+For selected-chat direct submission through the PowerShell helper:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\plugins\antigravity-2\scripts\antigravity.ps1" submit-offload -Goal "<goal>" -Workspace "<path>" -StatusFile "notes/antigravity-status.md" -NextStep "<next step>" -ExpectedProject "<project text>" -ExpectedChat "<chat text>" -Submit true
+```
+
+Use `-Submit false` for verify-only; it should not fill the composer. Use `-FillOnly true` only when the user wants to manually review the handoff before sending.
+
+If UI submission is blocked by a stale DevTools port, use `antigravity-local.handoff-template` to generate the compact prompt and avoid repeated CDP probing. Restart Codex or paste the generated handoff manually so the next session attaches to the current Antigravity port.
+
+Compact handoff template:
+
+```text
+Goal: <goal>
+Workspace: <path>
+Constraints: inspect files locally; do not paste full files, full logs, or full source; use search before reading whole files.
+Token rule: work token-efficiently; write progress to <small-status-file>; output max 10 bullets plus changed file list.
+Next step: <specific next action>
+If blocked: ask one concise question; otherwise continue autonomously.
+```
+
+## Safety
+
+This plugin operates only on the local machine and local Antigravity profile. It does not patch Antigravity internals, commit runtime tokens, or call Antigravity cloud APIs directly. Treat Antigravity user data, settings, chats, and workspace files as user-owned state.
+
+Before publishing changes, run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File ".\scripts\antigravity.ps1" privacy
+```
+
+## License
+
+MIT

--- a/plugins/comprono/antigravity-2-codex-plugin/RELEASE_NOTES_v0.1.0.md
+++ b/plugins/comprono/antigravity-2-codex-plugin/RELEASE_NOTES_v0.1.0.md
@@ -1,0 +1,17 @@
+# Antigravity 2.0 Codex Plugin — local Windows bridge for Codex + Google Antigravity
+
+## Initial public release
+
+This is the first public release of the Antigravity 2.0 Codex Plugin, a community local Windows bridge for OpenAI Codex users who want to connect with Google Antigravity / Antigravity 2.0.
+
+## Included
+
+- Initial public release.
+- MCP tool bridge for Codex.
+- Chromium DevTools integration for visible Antigravity UI inspection and handoff.
+- Local Windows / PowerShell helper commands for setup, status, launch, live readiness, model-limit summaries, and privacy checks.
+- Designed for OpenAI Codex users who want to connect with Google Antigravity / Antigravity 2.0.
+
+## Notes
+
+This is a community plugin. It does not bypass Antigravity authentication, quota, billing, or safety controls, and it does not commit local Antigravity user data.

--- a/plugins/comprono/antigravity-2-codex-plugin/SECURITY.md
+++ b/plugins/comprono/antigravity-2-codex-plugin/SECURITY.md
@@ -1,0 +1,32 @@
+# Security And Privacy
+
+This plugin is a local bridge between OpenAI Codex and a user's own Google Antigravity / Antigravity 2.0 desktop app.
+
+## Public Repo Rules
+
+Do not commit:
+
+- Antigravity logs, screenshots, or user data.
+- Project names, chat contents, emails, or personal identifiers.
+- Runtime ports as fixed assumptions.
+- CSRF tokens, OAuth tokens, cookies, API keys, or credentials.
+- Machine-specific absolute paths except documented environment-variable based examples.
+
+## Local Runtime Rules
+
+- Read model quota state through the local language server only.
+- Use DevTools for live UI verification before submitting chat messages.
+- Treat the live UI as the source of truth for selected project, selected chat, composer state, and model.
+- Do not bypass Antigravity authentication, quota, billing, or safety controls.
+- Do not repeatedly resubmit after quota or rate-limit errors.
+
+## Before Publishing
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File ".\scripts\antigravity.ps1" privacy
+git diff --check
+```
+
+Also run a targeted local scan for any personal names, emails, project names, or task names mentioned during development. Keep those terms out of commits and public documentation.

--- a/plugins/comprono/antigravity-2-codex-plugin/assets/icon.svg
+++ b/plugins/comprono/antigravity-2-codex-plugin/assets/icon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Antigravity 2.0 Codex Plugin</title>
+  <desc id="desc">A local bridge icon showing a terminal linked to an Antigravity orb.</desc>
+  <defs>
+    <linearGradient id="bg" x1="64" x2="448" y1="448" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F172A"/>
+      <stop offset="0.58" stop-color="#164E63"/>
+      <stop offset="1" stop-color="#14B8A6"/>
+    </linearGradient>
+    <linearGradient id="orb" x1="176" x2="384" y1="140" y2="348" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F8FAFC"/>
+      <stop offset="0.48" stop-color="#A7F3D0"/>
+      <stop offset="1" stop-color="#22D3EE"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#bg)"/>
+  <path fill="#E2E8F0" fill-opacity="0.18" d="M96 336c0-91.7 74.3-166 166-166h88c15.5 0 28 12.5 28 28s-12.5 28-28 28h-88c-60.8 0-110 49.2-110 110 0 15.5-12.5 28-28 28s-28-12.5-28-28Z"/>
+  <circle cx="318" cy="218" r="104" fill="url(#orb)"/>
+  <circle cx="318" cy="218" r="62" fill="#0F172A" fill-opacity="0.82"/>
+  <path fill="#F8FAFC" d="M320 150c8.8 31.6 25.1 47.9 56 56-30.9 8.1-47.2 24.4-56 56-8.8-31.6-25.1-47.9-56-56 30.9-8.1 47.2-24.4 56-56Z"/>
+  <rect x="82" y="288" width="236" height="116" rx="24" fill="#020617" fill-opacity="0.88"/>
+  <path fill="#14B8A6" d="m130 326 44 34-44 34v-31l22-17-22-17v-3Z"/>
+  <rect x="190" y="369" width="82" height="14" rx="7" fill="#E2E8F0"/>
+  <path fill="#E2E8F0" fill-opacity="0.9" d="M336 320h54c15.5 0 28-12.5 28-28s-12.5-28-28-28h-28a128.6 128.6 0 0 1-26 56Z"/>
+</svg>

--- a/plugins/comprono/antigravity-2-codex-plugin/description.txt
+++ b/plugins/comprono/antigravity-2-codex-plugin/description.txt
@@ -1,0 +1,1 @@
+A community Codex plugin for connecting OpenAI Codex to Google Antigravity / Antigravity 2.0 through MCP, Chromium DevTools, and local Windows helper commands.

--- a/plugins/comprono/antigravity-2-codex-plugin/docs/index.html
+++ b/plugins/comprono/antigravity-2-codex-plugin/docs/index.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Google Antigravity Codex Plugin</title>
+  <meta name="description" content="A community Codex plugin for connecting OpenAI Codex to Google Antigravity / Antigravity 2.0 through MCP, Chromium DevTools, and local Windows helper commands.">
+  <meta name="keywords" content="Google Antigravity Codex Plugin, OpenAI Codex Antigravity, Antigravity 2.0 Codex bridge, Codex MCP plugin, DevTools MCP Antigravity, Codex Windows bridge">
+  <meta name="author" content="comprono">
+  <link rel="canonical" href="https://comprono.github.io/antigravity-2-codex-plugin/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Google Antigravity Codex Plugin">
+  <meta property="og:description" content="Connect OpenAI Codex to a local Antigravity 2.0 desktop app on Windows using MCP tools, Chromium DevTools, and PowerShell helper commands.">
+  <meta property="og:url" content="https://comprono.github.io/antigravity-2-codex-plugin/">
+  <meta property="og:site_name" content="Google Antigravity Codex Plugin">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Google Antigravity Codex Plugin">
+  <meta name="twitter:description" content="A community local Windows bridge for OpenAI Codex and Google Antigravity / Antigravity 2.0.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "name": "Google Antigravity Codex Plugin",
+    "alternateName": "Antigravity 2.0 Codex Plugin",
+    "description": "A community Codex plugin for connecting OpenAI Codex to Google Antigravity / Antigravity 2.0 through MCP, Chromium DevTools, and local Windows helper commands.",
+    "codeRepository": "https://github.com/comprono/antigravity-2-codex-plugin",
+    "programmingLanguage": ["PowerShell", "JavaScript"],
+    "runtimePlatform": "Windows",
+    "license": "https://github.com/comprono/antigravity-2-codex-plugin/blob/main/LICENSE",
+    "isAccessibleForFree": true,
+    "keywords": [
+      "Google Antigravity Codex Plugin",
+      "OpenAI Codex Antigravity",
+      "Antigravity 2.0 Codex bridge",
+      "Codex MCP plugin",
+      "DevTools MCP Antigravity"
+    ],
+    "author": {
+      "@type": "Person",
+      "name": "comprono",
+      "url": "https://github.com/comprono"
+    }
+  }
+  </script>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f8fafc;
+      --text: #111827;
+      --muted: #4b5563;
+      --panel: #ffffff;
+      --border: #d1d5db;
+      --accent: #0f766e;
+      --accent-strong: #115e59;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a;
+        --text: #f8fafc;
+        --muted: #cbd5e1;
+        --panel: #111827;
+        --border: #334155;
+        --accent: #2dd4bf;
+        --accent-strong: #5eead4;
+      }
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Arial, Helvetica, sans-serif;
+      line-height: 1.6;
+    }
+    main {
+      width: min(960px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 48px 0;
+    }
+    header {
+      padding: 32px 0 24px;
+      border-bottom: 1px solid var(--border);
+    }
+    h1 {
+      margin: 0 0 16px;
+      font-size: clamp(2rem, 5vw, 4rem);
+      line-height: 1.05;
+      letter-spacing: 0;
+    }
+    h2 {
+      margin-top: 36px;
+      font-size: 1.45rem;
+      letter-spacing: 0;
+    }
+    p {
+      max-width: 760px;
+    }
+    .lede {
+      font-size: 1.15rem;
+      color: var(--muted);
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 24px;
+    }
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+      padding: 10px 16px;
+      border: 1px solid var(--accent);
+      border-radius: 6px;
+      color: #ffffff;
+      background: var(--accent);
+      font-weight: 700;
+      text-decoration: none;
+    }
+    .button.secondary {
+      color: var(--accent-strong);
+      background: transparent;
+    }
+    section {
+      padding: 8px 0;
+    }
+    ul {
+      padding-left: 22px;
+    }
+    code {
+      padding: 2px 5px;
+      border-radius: 4px;
+      background: color-mix(in srgb, var(--border), transparent 60%);
+    }
+    pre {
+      overflow-x: auto;
+      padding: 16px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--panel);
+    }
+    footer {
+      margin-top: 40px;
+      padding-top: 20px;
+      border-top: 1px solid var(--border);
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <p><strong>Google Antigravity Codex Plugin</strong></p>
+      <h1>Use OpenAI Codex with Google Antigravity</h1>
+      <p class="lede">A community local Windows bridge that helps OpenAI Codex connect to a local Antigravity 2.0 desktop app through MCP tools, Chromium DevTools, and PowerShell helper commands.</p>
+      <div class="actions">
+        <a class="button" href="https://github.com/comprono/antigravity-2-codex-plugin">View on GitHub</a>
+        <a class="button secondary" href="https://github.com/comprono/antigravity-2-codex-plugin#install">Install instructions</a>
+      </div>
+    </header>
+
+    <section>
+      <h2>What the plugin does</h2>
+      <p>The Antigravity 2.0 Codex bridge gives Codex a local way to check whether Antigravity is installed and running, open the desktop app, inspect setup readiness, summarize model-limit metadata exposed by Antigravity's local language server, and use the live UI as the source of truth before handing off prompts.</p>
+    </section>
+
+    <section>
+      <h2>Who it is for</h2>
+      <p>This community plugin is for OpenAI Codex users who want a Codex MCP plugin that can work with a local Antigravity desktop session on Windows. It is also designed to support workflows where a user starts from ChatGPT or Codex on mobile, then uses Codex locally as the bridge into Antigravity.</p>
+    </section>
+
+    <section>
+      <h2>How it connects Codex to Antigravity 2.0</h2>
+      <ul>
+        <li><strong>MCP tools:</strong> expose setup, status, launch, live readiness, model-limit summary, and privacy checks to Codex.</li>
+        <li><strong>Chromium DevTools:</strong> connects to the DevTools endpoint exposed by the Antigravity desktop app for visible UI inspection and handoff.</li>
+        <li><strong>PowerShell helper commands:</strong> provide local Windows checks and commands without hardcoding another user's machine paths.</li>
+        <li><strong>Local Windows bridge:</strong> keeps the integration on the user's own computer and does not bypass Antigravity authentication, quota, billing, or safety controls.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Get started</h2>
+      <p>Clone the plugin into your Codex plugins directory, then refresh or install it from your Codex personal marketplace.</p>
+      <pre><code>git clone https://github.com/comprono/antigravity-2-codex-plugin.git "%USERPROFILE%\plugins\antigravity-2"</code></pre>
+      <p>Run a setup check from PowerShell:</p>
+      <pre><code>powershell -ExecutionPolicy Bypass -File "%USERPROFILE%\plugins\antigravity-2\scripts\antigravity.ps1" setup</code></pre>
+    </section>
+
+    <footer>
+      <p>This is a community plugin, not an official Google or Antigravity product. See the GitHub repository for full technical instructions, security guidance, and release notes.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/plugins/comprono/antigravity-2-codex-plugin/docs/robots.txt
+++ b/plugins/comprono/antigravity-2-codex-plugin/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://comprono.github.io/antigravity-2-codex-plugin/sitemap.xml

--- a/plugins/comprono/antigravity-2-codex-plugin/docs/sitemap.xml
+++ b/plugins/comprono/antigravity-2-codex-plugin/docs/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://comprono.github.io/antigravity-2-codex-plugin/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/plugins/comprono/antigravity-2-codex-plugin/keywords.txt
+++ b/plugins/comprono/antigravity-2-codex-plugin/keywords.txt
@@ -1,0 +1,9 @@
+google antigravity codex plugin
+openai codex antigravity
+antigravity 2.0 codex plugin
+codex mcp plugin
+devtools mcp antigravity
+codex windows bridge
+local antigravity desktop app
+mcp server for codex
+chromium devtools codex plugin

--- a/plugins/comprono/antigravity-2-codex-plugin/scripts/antigravity-devtools-mcp.ps1
+++ b/plugins/comprono/antigravity-2-codex-plugin/scripts/antigravity-devtools-mcp.ps1
@@ -1,0 +1,63 @@
+$ErrorActionPreference = "Stop"
+
+$installRoot = Join-Path $env:LOCALAPPDATA "Programs\Antigravity"
+$exePath = Join-Path $installRoot "Antigravity.exe"
+$userDataPath = Join-Path $env:APPDATA "Antigravity"
+$devToolsPortFile = Join-Path $userDataPath "DevToolsActivePort"
+$helperScript = Join-Path (Split-Path -Parent $PSScriptRoot) "scripts\antigravity.ps1"
+$mcpBin = Join-Path $installRoot "resources\app.asar.unpacked\node_modules\chrome-devtools-mcp\build\src\bin\chrome-devtools-mcp.js"
+$logFile = Join-Path $env:TEMP "antigravity-devtools-mcp.log"
+
+if (-not (Test-Path -LiteralPath $exePath)) {
+  throw "Antigravity.exe was not found at $exePath"
+}
+
+if (-not (Test-Path -LiteralPath $mcpBin)) {
+  throw "chrome-devtools-mcp was not found at $mcpBin"
+}
+
+$processes = @(Get-Process -Name "Antigravity" -ErrorAction SilentlyContinue)
+if ($processes.Count -eq 0) {
+  Start-Process -FilePath $exePath -WorkingDirectory $installRoot
+  Start-Sleep -Seconds 3
+}
+
+function Get-LivePageCount {
+  if (-not (Test-Path -LiteralPath $devToolsPortFile)) {
+    return 0
+  }
+  $lines = @(Get-Content -LiteralPath $devToolsPortFile -ErrorAction SilentlyContinue)
+  if ($lines.Count -eq 0 -or [string]::IsNullOrWhiteSpace([string]$lines[0])) {
+    return 0
+  }
+  try {
+    $pages = @(Invoke-RestMethod -Uri "http://127.0.0.1:$($lines[0])/json/list" -TimeoutSec 3 -ErrorAction Stop)
+    return $pages.Count
+  } catch {
+    return 0
+  }
+}
+
+if ((Get-LivePageCount) -eq 0) {
+  & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $helperScript repair-live | Out-Null
+  Start-Sleep -Seconds 2
+}
+
+if (-not (Test-Path -LiteralPath $devToolsPortFile)) {
+  throw "Antigravity is running, but DevToolsActivePort was not found at $devToolsPortFile"
+}
+
+$lines = @(Get-Content -LiteralPath $devToolsPortFile)
+if ($lines.Count -eq 0 -or [string]::IsNullOrWhiteSpace([string]$lines[0])) {
+  throw "DevToolsActivePort exists but does not contain a port."
+}
+
+$port = [string]$lines[0]
+$browserUrl = "http://127.0.0.1:$port"
+
+if ((Get-LivePageCount) -eq 0) {
+  throw "Antigravity DevTools has no inspectable pages after repair. Run antigravity-local.live or antigravity-local.repair-live, then restart Codex so the DevTools MCP transport can reconnect."
+}
+
+& node $mcpBin --browserUrl $browserUrl --no-usage-statistics --no-performance-crux --acceptInsecureCerts --logFile $logFile
+exit $LASTEXITCODE

--- a/plugins/comprono/antigravity-2-codex-plugin/scripts/antigravity-local-mcp.js
+++ b/plugins/comprono/antigravity-2-codex-plugin/scripts/antigravity-local-mcp.js
@@ -1,0 +1,722 @@
+#!/usr/bin/env node
+
+const { spawn } = require("node:child_process");
+const path = require("node:path");
+const fs = require("node:fs");
+const os = require("node:os");
+
+const pluginRoot = path.resolve(__dirname, "..");
+const helperScript = path.join(pluginRoot, "scripts", "antigravity.ps1");
+const devToolsPortFile = path.join(process.env.APPDATA || "", "Antigravity", "DevToolsActivePort");
+
+const tools = [
+  {
+    name: "quick",
+    description: "Preferred first call. Compact setup, live UI, and model-limit summary in one low-token report.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "setup",
+    description: "Verify Antigravity 2.0 local setup readiness: install path, runtime, Node.js, DevTools, and model-limit API.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "doctor",
+    description: "Alias for setup. Diagnose whether the local Antigravity bridge is ready.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "status",
+    description: "Report whether Antigravity is installed/running and the current DevTools port.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "open",
+    description: "Open Antigravity 2.0 if it is installed and not already running.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "repair-live",
+    description: "Restart Antigravity and wait for an inspectable DevTools page when live UI control is not ready.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "inspect",
+    description: "Inspect local Antigravity integration details, bundled helpers, and known binaries.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "live",
+    description: "Report the live Chromium DevTools connection and page list for UI inspection.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "devtools-health",
+    description: "Low-token fallback for antigravity-devtools transport errors. Reports live pages and the recommended recovery step.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "submission-guide",
+    description: "Compact guidance for reliably submitting Antigravity chat prompts through DevTools without invalid key names.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "prepare-offload",
+    description: "Default first call for nontrivial work. Decide offload, check live/model readiness, generate the compact handoff, and give submit instructions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        goal: { type: "string", description: "Task goal for Antigravity." },
+        workspace: { type: "string", description: "Local workspace path or Antigravity project name." },
+        statusFile: { type: "string", description: "Small artifact Antigravity should write.", default: "notes/antigravity-status.md" },
+        nextStep: { type: "string", description: "Specific next action.", default: "Inspect the relevant files and write a compact status checkpoint." },
+        hasWorkspaceWork: { type: "boolean", description: "Whether the task needs files, diffs, logs, browser state, or project context.", default: true },
+        estimatedCodexInputTokens: { type: "number", description: "Rough Codex tokens needed if handled directly.", default: 2000 },
+      },
+      required: ["goal"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "submit-offload",
+    description: "Fast path: prepare and submit a compact handoff into the currently selected Antigravity chat via direct CDP, avoiding repeated snapshots.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        goal: { type: "string", description: "Task goal for Antigravity." },
+        workspace: { type: "string", description: "Local workspace path or Antigravity project name." },
+        statusFile: { type: "string", description: "Small artifact Antigravity should write.", default: "notes/antigravity-status.md" },
+        nextStep: { type: "string", description: "Specific next action.", default: "Inspect the relevant files and write a compact status checkpoint." },
+        expectedProject: { type: "string", description: "Optional visible project text that must be present before submit." },
+        expectedChat: { type: "string", description: "Optional visible chat/conversation text that must be present before submit." },
+        submit: { type: "boolean", description: "Set true to fill and click Send.", default: false },
+        fillOnly: { type: "boolean", description: "Set true to fill the composer without clicking Send. Use only when the user wants a manual review before submit.", default: false },
+      },
+      required: ["goal", "submit"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "limits-summary",
+    description: "Preferred quota check. Compact model availability summary without dumping full per-model JSON.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "limits",
+    description: "Read full Antigravity model quota/limit state from the local language server. Use limits-summary first to save tokens.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "models",
+    description: "Alias for limits. Read Antigravity model quota/limit state.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "privacy",
+    description: "Scan this plugin repository for obvious sensitive data before publishing.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "handoff-template",
+    description: "Generate a compact Antigravity offload prompt without reading files or using DevTools UI tokens.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        goal: { type: "string", description: "Task goal for Antigravity." },
+        workspace: { type: "string", description: "Local workspace path or project name." },
+        statusFile: { type: "string", description: "Small artifact Antigravity should write.", default: "notes/antigravity-status.md" },
+        nextStep: { type: "string", description: "Specific next action.", default: "Inspect the relevant files and write a compact status checkpoint." },
+      },
+      required: ["goal"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "offload-advice",
+    description: "Cheap decision gate for whether Codex should offload a task to Antigravity or answer/act directly.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        goal: { type: "string", description: "User task or intended Antigravity handoff." },
+        hasWorkspaceWork: { type: "boolean", description: "Whether the task needs local project files, diffs, logs, or long workspace inspection.", default: false },
+        estimatedCodexInputTokens: { type: "number", description: "Rough Codex tokens needed if handled directly.", default: 0 },
+      },
+      required: ["goal"],
+      additionalProperties: false,
+    },
+  },
+];
+
+function sendMessage(message) {
+  const body = Buffer.from(JSON.stringify(message), "utf8");
+  process.stdout.write(`Content-Length: ${body.length}\r\n\r\n`);
+  process.stdout.write(body);
+}
+
+function sendResult(id, result) {
+  sendMessage({ jsonrpc: "2.0", id, result });
+}
+
+function sendError(id, code, message) {
+  sendMessage({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+function runHelper(command) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "powershell.exe",
+      ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", helperScript, command],
+      { windowsHide: true }
+    );
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || `antigravity.ps1 ${command} exited with code ${code}`));
+        return;
+      }
+
+      const text = stdout.trim();
+      if (!text) {
+        resolve("");
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(text));
+      } catch {
+        resolve(text);
+      }
+    });
+  });
+}
+
+function buildHandoffTemplate(args = {}) {
+  const goal = String(args.goal || "<goal>").trim();
+  const workspace = String(args.workspace || "<workspace/path>").trim();
+  const statusFile = String(args.statusFile || "notes/antigravity-status.md").trim();
+  const nextStep = String(args.nextStep || "Inspect the relevant files and write a compact status checkpoint.").trim();
+
+  return [
+    "Use this as a compact Antigravity offload handoff:",
+    "",
+    "```text",
+    `Goal: ${goal}`,
+    `Workspace: ${workspace}`,
+    "Constraints: inspect files locally; do not paste full files, full logs, or full source; use search before reading whole files.",
+    `Token rule: work token-efficiently; write progress to ${statusFile}; output max 10 bullets plus changed file list.`,
+    `Next step: ${nextStep}`,
+    "If blocked: ask one concise question; otherwise continue autonomously.",
+    "```",
+    "",
+    "Codex follow-up rule: do not read the full Antigravity chat. Read only the status artifact, targeted diffs, or a compact visible UI status.",
+  ].join("\n");
+}
+
+function getOffloadDecision(args = {}) {
+  const goal = String(args.goal || "").trim();
+  const hasWorkspaceWork = Boolean(args.hasWorkspaceWork);
+  const estimatedCodexInputTokens = Number(args.estimatedCodexInputTokens || 0);
+  const lowerGoal = goal.toLowerCase();
+  const trivialPattern = /\b(2\s*\+\s*2|add\s+2\s*\+\s*2|what\s+is|time|date|summari[sz]e\s+this\s+short|one\s+line|yes\s+or\s+no)\b/;
+  const workspacePattern = /\b(repo|workspace|project|files?|diff|logs?|tests?|build|lint|implement|refactor|debug|apply|continue\s+chat|job\s+search|browser|ui|analy[sz]e|review|plan|research|inspect|investigate|fix|patch|error|failure|trace|search|compare)\b/;
+
+  const trivial = trivialPattern.test(lowerGoal) || (!hasWorkspaceWork && estimatedCodexInputTokens > 0 && estimatedCodexInputTokens < 400);
+  const workspaceLikely = hasWorkspaceWork || workspacePattern.test(lowerGoal) || estimatedCodexInputTokens >= 800;
+  const shouldOffload = workspaceLikely && !trivial;
+
+  const decision = shouldOffload ? "offload-to-antigravity" : "codex-direct";
+  const reason = shouldOffload
+    ? "The task appears to benefit from Antigravity inspecting the local workspace or running longer reasoning while Codex reads back a compact artifact."
+    : "The task is small enough that DevTools navigation, project context scanning, and Antigravity startup/agent overhead will likely cost more time and tokens than Codex answering directly.";
+
+  return { decision, reason, shouldOffload };
+}
+
+function buildOffloadAdvice(args = {}) {
+  const { decision, reason } = getOffloadDecision(args);
+  return [
+    `Decision: ${decision}`,
+    `Reason: ${reason}`,
+    "",
+    "Rules:",
+    "- Use Codex direct only for arithmetic, short factual answers, tiny commands, and small summaries.",
+    "- Use Antigravity by default for nontrivial workspace tasks, UI/project continuation, job-search/application work, debugging, implementation, reviews, research, planning, and analysis that would make Codex read files or long output.",
+    "- In existing project chats, assume Antigravity may scan attached folders. For small tests, use a blank/no-workspace chat when available or do not offload.",
+    "- If Antigravity unexpectedly starts broad folder exploration for a small task, cancel and report that offload is not token-efficient.",
+    "- When offloading, send a compact handoff and ask Antigravity to write a small status artifact; Codex should read only that artifact or a targeted diff.",
+  ].join("\n");
+}
+
+function buildPrepareOffload(args = {}, quick = null) {
+  const decision = getOffloadDecision(args);
+  const handoff = buildHandoffTemplate(args).replace(/^Use this as a compact Antigravity offload handoff:\n\n/, "");
+  const setup = quick?.Setup || {};
+  const live = quick?.Live || {};
+  const recommended = quick?.Limits?.RecommendedAvailable?.[0] || null;
+  const readiness = [
+    `Installed: ${setup.Installed === true}`,
+    `Running: ${setup.Running === true}`,
+    `LiveReady: ${setup.ReadyForLiveUiInspection === true}`,
+    `PageCount: ${live.PageCount ?? "<unknown>"}`,
+    `BestModel: ${recommended ? `${recommended.DisplayName || recommended.Id} (${recommended.RemainingPercent ?? "?"}% remaining)` : "<unknown>"}`,
+  ].join("\n");
+
+  const nextAction = decision.shouldOffload
+    ? "Use antigravity-devtools only to select the project/chat/model, fill the handoff, and click the Send/arrow button. Then stop monitoring and read only the status artifact or targeted diff."
+    : "Do not open or drive Antigravity for this task. Answer or act directly in Codex.";
+
+  return [
+    "FastAntigravityOffloadPlan:",
+    `Decision: ${decision.decision}`,
+    `Reason: ${decision.reason}`,
+    "",
+    "Readiness:",
+    readiness,
+    "",
+    "NextAction:",
+    nextAction,
+    "",
+    "SubmitRule:",
+    "Fill/type the prompt without submitKey. Prefer clicking the visible Send/arrow button. If keyboard submit is required, use a separate simple Enter key call. Never use Control+Enter unless the active tool schema explicitly accepts it.",
+    "",
+    "CompactHandoff:",
+    handoff,
+  ].join("\n");
+}
+
+function getDevToolsPort() {
+  if (!devToolsPortFile || !fs.existsSync(devToolsPortFile)) {
+    throw new Error(`DevToolsActivePort not found at ${devToolsPortFile}`);
+  }
+  const firstLine = fs.readFileSync(devToolsPortFile, "utf8").split(/\r?\n/)[0]?.trim();
+  if (!firstLine) {
+    throw new Error("DevToolsActivePort exists but does not contain a port.");
+  }
+  return firstLine;
+}
+
+async function getAntigravityPage() {
+  const port = getDevToolsPort();
+  const pages = await fetch(`http://127.0.0.1:${port}/json/list`).then((response) => response.json());
+  const page = pages.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl)
+    || pages.find((entry) => entry.webSocketDebuggerUrl);
+  if (!page) {
+    throw new Error(`No inspectable Antigravity page found on DevTools port ${port}.`);
+  }
+  return { port, page };
+}
+
+function createCdpClient(webSocketDebuggerUrl) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(webSocketDebuggerUrl);
+    let nextId = 1;
+    const pending = new Map();
+    const timeout = setTimeout(() => reject(new Error("Timed out connecting to Antigravity DevTools WebSocket.")), 5000);
+
+    ws.addEventListener("open", () => {
+      clearTimeout(timeout);
+      resolve({
+        send(method, params = {}) {
+          const id = nextId++;
+          ws.send(JSON.stringify({ id, method, params }));
+          return new Promise((sendResolve, sendReject) => {
+            const timer = setTimeout(() => {
+              pending.delete(id);
+              sendReject(new Error(`CDP command timed out: ${method}`));
+            }, 10000);
+            pending.set(id, { resolve: sendResolve, reject: sendReject, timer });
+          });
+        },
+        close() {
+          try {
+            ws.close();
+          } catch {
+            // Ignore close races.
+          }
+        },
+      });
+    });
+
+    ws.addEventListener("message", (event) => {
+      let message;
+      try {
+        message = JSON.parse(String(event.data));
+      } catch {
+        return;
+      }
+      if (!message.id || !pending.has(message.id)) {
+        return;
+      }
+      const entry = pending.get(message.id);
+      pending.delete(message.id);
+      clearTimeout(entry.timer);
+      if (message.error) {
+        entry.reject(new Error(message.error.message || JSON.stringify(message.error)));
+      } else {
+        entry.resolve(message.result);
+      }
+    });
+
+    ws.addEventListener("error", () => {
+      clearTimeout(timeout);
+      reject(new Error("Failed to connect to Antigravity DevTools WebSocket."));
+    });
+  });
+}
+
+function jsString(value) {
+  return JSON.stringify(String(value ?? ""));
+}
+
+async function submitOffloadToCurrentChat(args = {}) {
+  const { decision } = getOffloadDecision({ ...args, hasWorkspaceWork: true, estimatedCodexInputTokens: 2000 });
+  if (decision !== "offload-to-antigravity") {
+    return `SubmitOffload: skipped\nDecision: ${decision}\nReason: task does not need Antigravity.`;
+  }
+
+  const handoff = buildHandoffTemplate(args).replace(/^Use this as a compact Antigravity offload handoff:\n\n/, "");
+  const expectedProject = String(args.expectedProject || "").trim();
+  const expectedChat = String(args.expectedChat || "").trim();
+  const submit = Boolean(args.submit);
+  const fillOnly = Boolean(args.fillOnly);
+  const { port, page } = await getAntigravityPage();
+  const client = await createCdpClient(page.webSocketDebuggerUrl);
+
+  const expression = `
+(() => {
+  const prompt = ${jsString(handoff)};
+  const expectedProject = ${jsString(expectedProject)};
+  const expectedChat = ${jsString(expectedChat)};
+  const shouldSubmit = ${submit ? "true" : "false"};
+  const shouldFillOnly = ${fillOnly ? "true" : "false"};
+  const visibleText = document.body ? document.body.innerText || "" : "";
+  const missing = [];
+  if (expectedProject && !visibleText.includes(expectedProject)) missing.push("expectedProject");
+  if (expectedChat && !visibleText.includes(expectedChat)) missing.push("expectedChat");
+  if (missing.length) {
+    return { ok: false, stage: "verify", missing, submitted: false };
+  }
+
+  if (!shouldSubmit && !shouldFillOnly) {
+    return { ok: true, stage: "verified", submitted: false, promptLength: prompt.length };
+  }
+
+  const isVisible = (el) => {
+    if (!el) return false;
+    const rect = el.getBoundingClientRect();
+    const style = getComputedStyle(el);
+    return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+  };
+
+  const candidates = Array.from(document.querySelectorAll('textarea,input,[contenteditable="true"],[role="textbox"],[role="combobox"]'))
+    .filter((el) => isVisible(el) && !el.disabled && !el.readOnly)
+    .sort((a, b) => b.getBoundingClientRect().bottom - a.getBoundingClientRect().bottom);
+  const composer = candidates[0];
+  if (!composer) {
+    return { ok: false, stage: "composer", submitted: false, message: "No visible composer found." };
+  }
+
+  composer.focus();
+  if (composer.matches('textarea,input')) {
+    const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(composer), "value")?.set;
+    if (setter) setter.call(composer, prompt);
+    else composer.value = prompt;
+    composer.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: prompt }));
+    composer.dispatchEvent(new Event("change", { bubbles: true }));
+  } else {
+    document.execCommand("selectAll", false, null);
+    const inserted = document.execCommand("insertText", false, prompt);
+    if (!inserted) composer.textContent = prompt;
+    composer.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: prompt }));
+  }
+
+  if (!shouldSubmit) {
+    return { ok: true, stage: "filled", submitted: false, promptLength: prompt.length };
+  }
+
+  const composerRect = composer.getBoundingClientRect();
+  const buttons = Array.from(document.querySelectorAll('button,[role="button"]'))
+    .filter((el) => isVisible(el) && !el.disabled && el.getAttribute("aria-disabled") !== "true");
+  const labeled = buttons.find((el) => /send|submit/i.test([el.ariaLabel, el.title, el.textContent].filter(Boolean).join(" ")));
+  const nearby = buttons
+    .filter((el) => {
+      const rect = el.getBoundingClientRect();
+      return rect.top >= composerRect.top - 80 && rect.bottom <= composerRect.bottom + 120 && rect.left > composerRect.left;
+    })
+    .sort((a, b) => b.getBoundingClientRect().right - a.getBoundingClientRect().right)[0];
+  const sendButton = labeled || nearby;
+  return {
+    ok: true,
+    stage: "filled-ready-for-enter",
+    submitted: false,
+    promptLength: prompt.length,
+    hasSendButton: Boolean(sendButton)
+  };
+})()
+`;
+
+  try {
+    const result = await client.send("Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    let value = result?.result?.value || {};
+    if (submit && value.ok === true && value.stage === "filled-ready-for-enter") {
+      await client.send("Input.dispatchKeyEvent", {
+        type: "rawKeyDown",
+        key: "Enter",
+        code: "Enter",
+        windowsVirtualKeyCode: 13,
+        nativeVirtualKeyCode: 13,
+        unmodifiedText: "\r",
+        text: "\r",
+      });
+      await client.send("Input.dispatchKeyEvent", {
+        type: "keyUp",
+        key: "Enter",
+        code: "Enter",
+        windowsVirtualKeyCode: 13,
+        nativeVirtualKeyCode: 13,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const afterEnter = await client.send("Runtime.evaluate", {
+        expression: `
+(() => {
+  const visibleText = document.body ? document.body.innerText || "" : "";
+  const busy = /working|worked for|stop|cancel|running|thinking/i.test(visibleText);
+  const composer = Array.from(document.querySelectorAll('textarea,input,[contenteditable="true"],[role="textbox"],[role="combobox"]'))
+    .filter((el) => {
+      const rect = el.getBoundingClientRect();
+      const style = getComputedStyle(el);
+      return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+    })
+    .sort((a, b) => b.getBoundingClientRect().bottom - a.getBoundingClientRect().bottom)[0];
+  const composerText = composer ? (composer.value || composer.innerText || composer.textContent || "") : "";
+  return { busy, composerStillHasPrompt: composerText.includes(${jsString(handoff.slice(0, 80))}) };
+})()
+`,
+        awaitPromise: true,
+        returnByValue: true,
+      });
+      const afterValue = afterEnter?.result?.value || {};
+      value = {
+        ...value,
+        stage: afterValue.composerStillHasPrompt ? "enter-dispatched-unconfirmed" : "enter-submitted",
+        submitted: !afterValue.composerStillHasPrompt || afterValue.busy === true,
+        enterDispatched: true,
+        busy: afterValue.busy === true,
+      };
+    }
+    return [
+      "SubmitOffloadResult:",
+      `DevToolsPort: ${port}`,
+      `PageTitle: ${page.title || "<unknown>"}`,
+      `Ok: ${value.ok === true}`,
+      `Stage: ${value.stage || "<unknown>"}`,
+      `Submitted: ${value.submitted === true}`,
+      value.missing?.length ? `Missing: ${value.missing.join(", ")}` : null,
+      value.message ? `Message: ${value.message}` : null,
+      "Next: If Submitted is true, stop monitoring every UI step and read only the requested status artifact or targeted diff.",
+    ].filter(Boolean).join("\n");
+  } finally {
+    client.close();
+  }
+}
+
+function buildDevToolsHealthAdvice(result) {
+  const pageCount = Number(result?.PageCount || 0);
+  const running = Boolean(result?.Running);
+  const port = result?.DevToolsPort || "<unknown>";
+  const status = running && pageCount > 0 ? "ready" : "not-ready";
+  const next = status === "ready"
+    ? "If antigravity-devtools still says Transport closed, do not retry the same MCP transport. Restart Codex so the DevTools MCP server is re-created, or use handoff-template/manual paste for this turn."
+    : "Run antigravity-local.repair-live once. If it restarts Antigravity, restart Codex before calling antigravity-devtools again.";
+
+  return [
+    `DevToolsHealth: ${status}`,
+    `Running: ${running}`,
+    `DevToolsPort: ${port}`,
+    `PageCount: ${pageCount}`,
+    `Next: ${next}`,
+    "",
+    "Rule: antigravity-local can report health even when antigravity-devtools/list_pages fails with Transport closed. A closed transport means the DevTools MCP child process died; it is not fixed by repeatedly calling list_pages in the same session.",
+  ].join("\n");
+}
+
+function buildSubmissionGuide() {
+  return [
+    "AntigravitySubmissionGuide:",
+    "1. Verify the target project, conversation, model, and idle composer first.",
+    "2. Fill or type the prompt into the composer only. Do not include submitKey in the fill/type call.",
+    "3. Prefer clicking the visible Send/arrow button after the composer contains the prompt.",
+    "4. If a keyboard submit is required, use a separate key tool call with a simple accepted key such as Enter. Do not use Control+Enter, Ctrl+Enter, or chord strings unless the active tool schema explicitly lists that exact value.",
+    "5. After submitting, verify Antigravity accepted the message by checking for a working/streaming state or a new visible user message.",
+    "6. If the key or click fails once, stop retrying the same submit method. Report the blocker or use handoff-template for manual paste.",
+    "",
+    "Reason: some Codex DevTools tools reject chord strings like Control+Enter with Unknown key, even after the prompt was typed correctly.",
+  ].join("\n");
+}
+
+async function handleRequest(message) {
+  const { id, method, params } = message;
+
+  if (method === "initialize") {
+    sendResult(id, {
+      protocolVersion: params?.protocolVersion || "2024-11-05",
+      capabilities: { tools: {} },
+      serverInfo: { name: "antigravity-local", version: "0.1.0" },
+    });
+    return;
+  }
+
+  if (method === "notifications/initialized") {
+    return;
+  }
+
+  if (method === "tools/list") {
+    sendResult(id, { tools });
+    return;
+  }
+
+  if (method === "tools/call") {
+    const name = params?.name;
+    const tool = tools.find((entry) => entry.name === name);
+    if (!tool) {
+      sendError(id, -32602, `Unknown tool: ${name}`);
+      return;
+    }
+
+    try {
+      if (name === "handoff-template") {
+        const text = buildHandoffTemplate(params?.arguments || {});
+        sendResult(id, { content: [{ type: "text", text }] });
+        return;
+      }
+
+      if (name === "offload-advice") {
+        const text = buildOffloadAdvice(params?.arguments || {});
+        sendResult(id, { content: [{ type: "text", text }] });
+        return;
+      }
+
+      if (name === "devtools-health") {
+        const result = await runHelper("live");
+        const text = `${buildDevToolsHealthAdvice(result)}\n\nRaw live report:\n${JSON.stringify(result, null, 2)}`;
+        sendResult(id, { content: [{ type: "text", text }] });
+        return;
+      }
+
+      if (name === "submission-guide") {
+        sendResult(id, { content: [{ type: "text", text: buildSubmissionGuide() }] });
+        return;
+      }
+
+      if (name === "prepare-offload") {
+        const quick = await runHelper("quick");
+        const text = buildPrepareOffload(params?.arguments || {}, quick);
+        sendResult(id, { content: [{ type: "text", text }] });
+        return;
+      }
+
+      if (name === "submit-offload") {
+        const text = await submitOffloadToCurrentChat(params?.arguments || {});
+        sendResult(id, { content: [{ type: "text", text }] });
+        return;
+      }
+
+      const command = name === "models" ? "limits" : name;
+      const result = await runHelper(command);
+      sendResult(id, {
+        content: [
+          {
+            type: "text",
+            text: typeof result === "string" ? result : JSON.stringify(result, null, 2),
+          },
+        ],
+      });
+    } catch (error) {
+      sendError(id, -32000, error?.message || String(error));
+    }
+    return;
+  }
+
+  if (id !== undefined) {
+    sendError(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+if (process.argv[2] === "submit-offload-cli") {
+  let args = {};
+  try {
+    if (process.argv[3] === "--json-file") {
+      args = JSON.parse(fs.readFileSync(process.argv[4], "utf8"));
+    } else {
+      args = process.argv[3] ? JSON.parse(process.argv[3]) : {};
+    }
+  } catch (error) {
+    console.error(`Invalid submit-offload JSON: ${error?.message || String(error)}`);
+    process.exit(2);
+  }
+
+  submitOffloadToCurrentChat(args)
+    .then((text) => {
+      console.log(text);
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error(error?.message || String(error));
+      process.exit(1);
+    });
+  return;
+}
+
+let buffer = Buffer.alloc(0);
+
+process.stdin.on("data", (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+
+  while (true) {
+    const headerEnd = buffer.indexOf("\r\n\r\n");
+    if (headerEnd === -1) {
+      return;
+    }
+
+    const headers = buffer.slice(0, headerEnd).toString("utf8");
+    const match = headers.match(/Content-Length:\s*(\d+)/i);
+    if (!match) {
+      buffer = buffer.slice(headerEnd + 4);
+      continue;
+    }
+
+    const contentLength = Number.parseInt(match[1], 10);
+    const messageStart = headerEnd + 4;
+    const messageEnd = messageStart + contentLength;
+    if (buffer.length < messageEnd) {
+      return;
+    }
+
+    const payload = buffer.slice(messageStart, messageEnd).toString("utf8");
+    buffer = buffer.slice(messageEnd);
+
+    try {
+      const message = JSON.parse(payload);
+      handleRequest(message).catch((error) => {
+        if (message.id !== undefined) {
+          sendError(message.id, -32000, error?.message || String(error));
+        }
+      });
+    } catch (error) {
+      sendError(null, -32700, error?.message || "Parse error");
+    }
+  }
+});

--- a/plugins/comprono/antigravity-2-codex-plugin/scripts/antigravity.ps1
+++ b/plugins/comprono/antigravity-2-codex-plugin/scripts/antigravity.ps1
@@ -1,0 +1,1025 @@
+param(
+  [Parameter(Position = 0)]
+  [ValidateSet("status", "open", "repair-live", "inspect", "path", "models", "limits", "limits-summary", "quick", "live", "setup", "doctor", "privacy", "devtools-health", "submission-guide", "offload-advice", "handoff-template", "prepare-offload", "submit-offload")]
+  [string] $Command = "status",
+
+  [string] $Goal = "",
+  [string] $Workspace = "",
+  [string] $StatusFile = "notes/antigravity-status.md",
+  [string] $NextStep = "Inspect the relevant files and write a compact status checkpoint.",
+  [string] $ExpectedProject = "",
+  [string] $ExpectedChat = "",
+  [object] $Submit = $false,
+  [object] $FillOnly = $false,
+  [object] $HasWorkspaceWork = $true,
+  [int] $EstimatedCodexInputTokens = 2000
+)
+
+$ErrorActionPreference = "Stop"
+
+$installRoot = Join-Path $env:LOCALAPPDATA "Programs\Antigravity"
+$exePath = Join-Path $installRoot "Antigravity.exe"
+$userDataPath = Join-Path $env:APPDATA "Antigravity"
+$devToolsPortFile = Join-Path $userDataPath "DevToolsActivePort"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Get-AntigravityProcess {
+  Get-Process -Name "Antigravity" -ErrorAction SilentlyContinue
+}
+
+function ConvertTo-BooleanValue {
+  param(
+    [object] $Value,
+    [bool] $Default = $true
+  )
+
+  if ($null -eq $Value) {
+    return $Default
+  }
+  if ($Value -is [bool]) {
+    return [bool]$Value
+  }
+  if ($Value -is [int]) {
+    return ([int]$Value) -ne 0
+  }
+
+  $text = ([string]$Value).Trim()
+  if ([string]::IsNullOrWhiteSpace($text)) {
+    return $Default
+  }
+  if ($text -match "^(true|1|yes|y)$") {
+    return $true
+  }
+  if ($text -match "^(false|0|no|n)$") {
+    return $false
+  }
+
+  return $Default
+}
+
+function Get-DevToolsPort {
+  if (Test-Path -LiteralPath $devToolsPortFile) {
+    $lines = @(Get-Content -LiteralPath $devToolsPortFile -ErrorAction SilentlyContinue)
+    if ($lines.Count -gt 0) {
+      return [string]$lines[0]
+    }
+  }
+  return $null
+}
+
+function Get-DevToolsPages {
+  $port = Get-DevToolsPort
+  if (-not $port) {
+    return @()
+  }
+
+  try {
+    $response = Invoke-RestMethod -Uri "http://127.0.0.1:$port/json/list" -TimeoutSec 5 -ErrorAction Stop
+    foreach ($page in $response) {
+      $page
+    }
+  } catch {
+    @()
+  }
+}
+
+function Wait-DevToolsPages {
+  param(
+    [int] $TimeoutSeconds = 20
+  )
+
+  $deadline = [datetime]::UtcNow.AddSeconds($TimeoutSeconds)
+  do {
+    $pages = @(Get-DevToolsPages)
+    if ($pages.Count -gt 0) {
+      return $pages
+    }
+    Start-Sleep -Milliseconds 500
+  } while ([datetime]::UtcNow -lt $deadline)
+
+  return @()
+}
+
+function Stop-AntigravityForRepair {
+  $processes = @(Get-AntigravityProcess)
+  foreach ($process in $processes) {
+    try {
+      if ($process.MainWindowHandle -ne 0) {
+        [void]$process.CloseMainWindow()
+      }
+    } catch {
+      # Fall through to the bounded hard stop below.
+    }
+  }
+
+  if ($processes.Count -gt 0) {
+    Start-Sleep -Seconds 3
+  }
+
+  $remaining = @(Get-AntigravityProcess)
+  foreach ($process in $remaining) {
+    try {
+      Stop-Process -Id $process.Id -Force -ErrorAction Stop
+    } catch {
+      # Ignore processes that exited between enumeration and stop.
+    }
+  }
+}
+
+function Stop-DevToolsMcpProcesses {
+  $stopped = @()
+  $processes = @(Get-CimInstance Win32_Process -Filter "Name = 'node.exe'" -ErrorAction SilentlyContinue |
+    Where-Object { $_.CommandLine -like "*chrome-devtools-mcp*" })
+
+  foreach ($process in $processes) {
+    try {
+      Stop-Process -Id $process.ProcessId -Force -ErrorAction Stop
+      $stopped += [int]$process.ProcessId
+    } catch {
+      # Ignore processes that exited between enumeration and stop.
+    }
+  }
+
+  $stopped
+}
+
+function Start-AntigravityAndWait {
+  param(
+    [int] $TimeoutSeconds = 20
+  )
+
+  if (-not (Test-Path -LiteralPath $exePath)) {
+    throw "Antigravity.exe was not found at $exePath"
+  }
+
+  if (Test-Path -LiteralPath $devToolsPortFile) {
+    Remove-Item -LiteralPath $devToolsPortFile -Force -ErrorAction SilentlyContinue
+  }
+
+  Start-Process -FilePath $exePath -WorkingDirectory $installRoot
+  [void](Wait-DevToolsPages -TimeoutSeconds $TimeoutSeconds)
+}
+
+function Repair-LiveDevTools {
+  $before = Get-LiveReportObject
+  if ($before.Running -and $before.PageCount -gt 0) {
+    return [PSCustomObject]@{
+      Source = "Antigravity live DevTools repair"
+      GeneratedAtUtc = [datetime]::UtcNow.ToString("o")
+      Action = "none"
+      Reason = "Live DevTools already has pages."
+      Before = $before
+      After = $before
+      ReadyForLiveUiInspection = $true
+    }
+  }
+
+  $stoppedMcpBefore = @(Stop-DevToolsMcpProcesses)
+  Stop-AntigravityForRepair
+  Start-AntigravityAndWait -TimeoutSeconds 25
+  $stoppedMcpAfter = @(Stop-DevToolsMcpProcesses)
+  $after = Get-LiveReportObject
+
+  [PSCustomObject]@{
+    Source = "Antigravity live DevTools repair"
+    GeneratedAtUtc = [datetime]::UtcNow.ToString("o")
+    Action = "restart-antigravity"
+    Reason = "Live DevTools had no inspectable pages."
+    Before = $before
+    After = $after
+    StoppedDevToolsMcpProcessIds = @($stoppedMcpBefore + $stoppedMcpAfter)
+    StaleMcpNote = "If repair-live restarted Antigravity, any already-started antigravity-devtools MCP process must reconnect to the new DevTools port before UI actions."
+    ReadyForLiveUiInspection = [bool]($after.Running -and $after.PageCount -gt 0)
+  }
+}
+
+function Get-LanguageServerProcess {
+  $proc = Get-CimInstance Win32_Process -Filter "Name = 'language_server.exe'" -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+  if (-not $proc) {
+    $proc = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+      Where-Object { $_.CommandLine -like "*language_server.exe*" } |
+      Select-Object -First 1
+  }
+  $proc
+}
+
+function Get-LanguageServerInfo {
+  $process = Get-LanguageServerProcess
+  if (-not $process) {
+    throw "Antigravity language_server.exe is not running. Open Antigravity first."
+  }
+
+  $csrfToken = $null
+  if ($process.CommandLine -match "--csrf_token\s+([^\s]+)") {
+    $csrfToken = $Matches[1]
+  }
+
+  $ports = @(Get-NetTCPConnection -OwningProcess $process.ProcessId -State Listen -ErrorAction SilentlyContinue |
+    Where-Object { $_.LocalAddress -eq "127.0.0.1" } |
+    Select-Object -ExpandProperty LocalPort |
+    Sort-Object)
+
+  $httpPort = $null
+  $httpsPort = $null
+  foreach ($port in $ports) {
+    try {
+      $headers = @{}
+      if ($csrfToken) {
+        $headers["X-Csrf-Token"] = $csrfToken
+      }
+      $health = Invoke-WebRequest -UseBasicParsing -Uri "http://127.0.0.1:$port/healthz" -Headers $headers -TimeoutSec 2 -ErrorAction Stop
+      if ($health.StatusCode -eq 200) {
+        $httpPort = $port
+        break
+      }
+    } catch {
+      # The HTTPS gRPC-web port rejects plain HTTP; continue probing.
+    }
+  }
+
+  if ($ports.Count -gt 0) {
+    $httpsPort = @($ports | Where-Object { $_ -ne $httpPort } | Select-Object -First 1)[0]
+  }
+
+  [PSCustomObject]@{
+    ProcessId = $process.ProcessId
+    HttpPort = $httpPort
+    HttpsPort = $httpsPort
+    CsrfToken = $csrfToken
+  }
+}
+
+function Invoke-AntigravityGrpcJson {
+  param(
+    [Parameter(Mandatory = $true)]
+    [int] $Port,
+    [Parameter(Mandatory = $true)]
+    [string] $CsrfToken,
+    [Parameter(Mandatory = $true)]
+    [string] $Method,
+    [Parameter(Mandatory = $true)]
+    [object] $Message
+  )
+
+  $previousCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+  [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+
+  try {
+    $json = $Message | ConvertTo-Json -Depth 20 -Compress
+    $messageBytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+    $body = New-Object byte[] (5 + $messageBytes.Length)
+    $body[0] = 0
+    $body[1] = [byte](($messageBytes.Length -shr 24) -band 0xff)
+    $body[2] = [byte](($messageBytes.Length -shr 16) -band 0xff)
+    $body[3] = [byte](($messageBytes.Length -shr 8) -band 0xff)
+    $body[4] = [byte]($messageBytes.Length -band 0xff)
+    [Array]::Copy($messageBytes, 0, $body, 5, $messageBytes.Length)
+
+    $request = [System.Net.HttpWebRequest]::Create("https://127.0.0.1:$Port/exa.language_server_pb.LanguageServerService/$Method")
+    $request.Method = "POST"
+    $request.ContentType = "application/grpc-web+json"
+    $request.Headers.Add("X-Grpc-Web", "1")
+    $request.Headers.Add("X-User-Agent", "CONNECT_ES_USER_AGENT")
+    $request.Headers.Add("x-codeium-csrf-token", $CsrfToken)
+    $request.ContentLength = $body.Length
+
+    $requestStream = $request.GetRequestStream()
+    try {
+      $requestStream.Write($body, 0, $body.Length)
+    } finally {
+      $requestStream.Dispose()
+    }
+
+    try {
+      $response = $request.GetResponse()
+    } catch [System.Net.WebException] {
+      if ($_.Exception.Response) {
+        $_.Exception.Response.Dispose()
+      }
+      throw $_
+    }
+    try {
+      $memory = New-Object System.IO.MemoryStream
+      $response.GetResponseStream().CopyTo($memory)
+      $bytes = $memory.ToArray()
+    } finally {
+      $response.Dispose()
+    }
+
+    $offset = 0
+    $messages = @()
+    $trailers = ""
+    while ($offset + 5 -le $bytes.Length) {
+      $flag = [int]$bytes[$offset]
+      $length = ([int]$bytes[$offset + 1] -shl 24) -bor ([int]$bytes[$offset + 2] -shl 16) -bor ([int]$bytes[$offset + 3] -shl 8) -bor [int]$bytes[$offset + 4]
+      $offset += 5
+      if ($length -lt 0 -or $offset + $length -gt $bytes.Length) {
+        throw "Invalid gRPC-web frame length from Antigravity language server."
+      }
+
+      $frameBytes = New-Object byte[] $length
+      [Array]::Copy($bytes, $offset, $frameBytes, 0, $length)
+      $offset += $length
+
+      if (($flag -band 0x80) -ne 0) {
+        $trailers = [System.Text.Encoding]::UTF8.GetString($frameBytes)
+      } else {
+        $messages += [System.Text.Encoding]::UTF8.GetString($frameBytes) | ConvertFrom-Json
+      }
+    }
+
+    if ($trailers -and $trailers -notmatch "grpc-status:\s*0") {
+      throw "Antigravity gRPC-web call failed: $trailers"
+    }
+    if ($messages.Count -eq 0) {
+      return $null
+    }
+    return $messages[0]
+  } finally {
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $previousCallback
+  }
+}
+
+function Get-NodeInfo {
+  $nodeCommand = Get-Command node -ErrorAction SilentlyContinue
+  if (-not $nodeCommand) {
+    return [PSCustomObject]@{
+      Found = $false
+      Path = $null
+      Version = $null
+    }
+  }
+
+  $version = $null
+  try {
+    $version = (& $nodeCommand.Source --version 2>$null)
+  } catch {
+    $version = $null
+  }
+
+  [PSCustomObject]@{
+    Found = $true
+    Path = $nodeCommand.Source
+    Version = $version
+  }
+}
+
+function Get-SetupReportObject {
+  $status = Write-Status | ConvertFrom-Json
+  $inspect = $null
+  try {
+    $inspect = & $PSCommandPath inspect | ConvertFrom-Json
+  } catch {
+    $inspect = $null
+  }
+
+  $languageServer = $null
+  if ($status.Running) {
+    try {
+      $ls = Get-LanguageServerInfo
+      $languageServer = [PSCustomObject]@{
+        Running = $true
+        ProcessId = $ls.ProcessId
+        HttpPort = $ls.HttpPort
+        HttpsPort = $ls.HttpsPort
+        HasCsrfToken = [bool]$ls.CsrfToken
+      }
+    } catch {
+      $languageServer = [PSCustomObject]@{
+        Running = $false
+        Error = $_.Exception.Message
+      }
+    }
+  } else {
+    $languageServer = [PSCustomObject]@{
+      Running = $false
+    }
+  }
+
+  $node = Get-NodeInfo
+  $devToolsPages = Get-DevToolsPages
+
+  [PSCustomObject]@{
+    PluginRoot = $repoRoot
+    Installed = $status.Installed
+    AntigravityExe = $status.ExePath
+    AntigravityUserData = $status.UserDataPath
+    AntigravityRunning = $status.Running
+    DevToolsPort = $status.DevToolsPort
+    DevToolsReachable = $devToolsPages.Count -gt 0
+    Node = $node
+    ChromeDevToolsMcpFound = [bool]($inspect -and $inspect.BundledPackageFiles -and $inspect.BundledPackageFiles.Count -gt 0)
+    LanguageServer = $languageServer
+    ReadyForModelLimits = [bool]($languageServer.Running -and $languageServer.HttpsPort -and $languageServer.HasCsrfToken)
+    ReadyForLiveUiInspection = [bool]($status.Running -and $status.DevToolsPort -and $devToolsPages.Count -gt 0)
+  }
+}
+
+function Get-SetupReport {
+  Get-SetupReportObject | ConvertTo-Json -Depth 8
+}
+
+function Get-LiveReportObject {
+  $status = Write-Status | ConvertFrom-Json
+  $pages = Get-DevToolsPages | ForEach-Object {
+    [PSCustomObject]@{
+      Type = $_.type
+      Title = $_.title
+      Url = $_.url
+      WebSocketDebuggerUrl = $_.webSocketDebuggerUrl
+    }
+  }
+
+  [PSCustomObject]@{
+    Source = "Antigravity Chromium DevTools endpoint"
+    GeneratedAtUtc = [datetime]::UtcNow.ToString("o")
+    Running = $status.Running
+    DevToolsPort = $status.DevToolsPort
+    PageCount = @($pages).Count
+    Pages = @($pages)
+    Note = "Use the DevTools page WebSocket or the antigravity-devtools MCP server for verified live UI inspection and interaction."
+  }
+}
+
+function Get-LiveReport {
+  Get-LiveReportObject | ConvertTo-Json -Depth 8
+}
+
+function Get-PrivacyReport {
+  $patterns = @(
+    "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}",
+    "C:\\Users\\[^\\]+",
+    ("pass" + "word"),
+    ("sec" + "ret"),
+    ("tok" + "en\s*[:=]"),
+    "api[_-]?key",
+    "BEGIN (RSA|OPENSSH|PRIVATE)",
+    "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+  )
+
+  $findings = @()
+  $scanFiles = @(Get-ChildItem -LiteralPath $repoRoot -Recurse -File -Force -ErrorAction SilentlyContinue |
+    Where-Object {
+      $_.FullName -notmatch "\\.git\\" -and
+      $_.FullName -notmatch "\\node_modules\\" -and
+      $_.FullName -notmatch "\\.pytest_cache\\" -and
+      $_.FullName -notmatch "\\__pycache__\\"
+    })
+  foreach ($pattern in $patterns) {
+    $matches = @($scanFiles |
+      Select-String -Pattern $pattern -ErrorAction SilentlyContinue |
+      Where-Object { $_.Line -notmatch "csrfToken|csrf_token|x-codeium-csrf-token" } |
+      Select-Object Path, LineNumber, Pattern)
+    foreach ($match in $matches) {
+      $findings += [PSCustomObject]@{
+        Path = $match.Path
+        LineNumber = $match.LineNumber
+        Pattern = $pattern
+      }
+    }
+  }
+
+  [PSCustomObject]@{
+    Source = "Local repository pattern scan"
+    GeneratedAtUtc = [datetime]::UtcNow.ToString("o")
+    FindingCount = $findings.Count
+    Findings = $findings
+    Note = "Review findings manually before publishing. Runtime CSRF handling in code is expected; actual runtime token values must never be committed."
+  } | ConvertTo-Json -Depth 6
+}
+
+function Convert-QuotaInfo {
+  param(
+    [object] $QuotaInfo
+  )
+
+  if (-not $QuotaInfo) {
+    return [PSCustomObject]@{
+      Status = "unknown"
+      RemainingFraction = $null
+      RemainingPercent = $null
+      ResetTimeUtc = $null
+    }
+  }
+
+  $remainingFraction = $null
+  if ($QuotaInfo.PSObject.Properties.Name -contains "remainingFraction") {
+    $remainingFraction = [double]$QuotaInfo.remainingFraction
+  }
+
+  $resetTimeUtc = $null
+  if ($QuotaInfo.PSObject.Properties.Name -contains "resetTime") {
+    $resetTimeUtc = $QuotaInfo.resetTime
+  }
+
+  $status = "available"
+  if ($remainingFraction -ne $null) {
+    if ($remainingFraction -le 0) {
+      $status = "exhausted"
+    } elseif ($remainingFraction -lt 0.2) {
+      $status = "low"
+    }
+  } elseif ($resetTimeUtc) {
+    try {
+      if ([System.DateTimeOffset]::Parse($resetTimeUtc).UtcDateTime -gt [datetime]::UtcNow) {
+        $status = "exhausted"
+      }
+    } catch {
+      $status = "unknown"
+    }
+  } else {
+    $status = "unknown"
+  }
+
+  $remainingPercent = $null
+  if ($remainingFraction -ne $null) {
+    $remainingPercent = [math]::Round($remainingFraction * 100, 1)
+  }
+
+  [PSCustomObject]@{
+    Status = $status
+    RemainingFraction = $remainingFraction
+    RemainingPercent = $remainingPercent
+    ResetTimeUtc = $resetTimeUtc
+  }
+}
+
+function Get-AntigravityModelsObject {
+  $server = Get-LanguageServerInfo
+  if (-not $server.CsrfToken) {
+    throw "Could not find the Antigravity language server CSRF token in the running process command line."
+  }
+  if (-not $server.HttpsPort) {
+    throw "Could not find the Antigravity language server HTTPS gRPC-web port."
+  }
+
+  $modelsResponse = Invoke-AntigravityGrpcJson -Port $server.HttpsPort -CsrfToken $server.CsrfToken -Method "GetAvailableModels" -Message @{ forceRefresh = $false }
+  $creditsResponse = Invoke-AntigravityGrpcJson -Port $server.HttpsPort -CsrfToken $server.CsrfToken -Method "GetLoadCodeAssist" -Message @{ forceRefresh = $false }
+
+  $models = @()
+  $rawModels = $null
+  if ($modelsResponse -and $modelsResponse.response) {
+    $rawModels = $modelsResponse.response.models
+  }
+  if ($rawModels) {
+    foreach ($modelId in @($rawModels.PSObject.Properties.Name | Sort-Object)) {
+      $model = $rawModels.$modelId
+      $quota = Convert-QuotaInfo -QuotaInfo $model.quotaInfo
+      $models += [PSCustomObject]@{
+        Id = $modelId
+        DisplayName = $model.displayName
+        ApiProvider = $model.apiProvider
+        Disabled = [bool]$model.disabled
+        Quota = $quota
+      }
+    }
+  }
+
+  $creditInfo = $null
+  $tier = $null
+  if ($creditsResponse -and $creditsResponse.response) {
+    $tier = $creditsResponse.response.currentTier
+  }
+  $availableCredits = @()
+  if ($tier -and $tier.PSObject.Properties.Name -contains "availableCredits") {
+    $availableCredits = @($tier.availableCredits)
+  }
+  $creditInfo = [PSCustomObject]@{
+    CurrentTierId = $tier.id
+    CurrentTierName = $tier.name
+    AvailableCredits = $availableCredits
+    UpgradeSubscriptionType = $tier.upgradeSubscriptionType
+  }
+
+  [PSCustomObject]@{
+    Source = "Antigravity local language server gRPC-web"
+    GeneratedAtUtc = [datetime]::UtcNow.ToString("o")
+    LanguageServer = [PSCustomObject]@{
+      ProcessId = $server.ProcessId
+      HttpPort = $server.HttpPort
+      HttpsPort = $server.HttpsPort
+    }
+    Note = "Antigravity exposes per-model quota fraction/reset metadata, not a raw token ledger."
+    CreditStatus = $creditInfo
+    Models = $models
+  }
+}
+
+function Get-AntigravityModels {
+  Get-AntigravityModelsObject | ConvertTo-Json -Depth 12
+}
+
+function Get-LimitsSummaryObject {
+  $report = Get-AntigravityModelsObject
+  $namedModels = @($report.Models | Where-Object { $_.DisplayName })
+  $available = @($namedModels | Where-Object { $_.Quota.Status -eq "available" })
+  $low = @($namedModels | Where-Object { $_.Quota.Status -eq "low" })
+  $exhausted = @($namedModels | Where-Object { $_.Quota.Status -eq "exhausted" })
+  $unknown = @($namedModels | Where-Object { $_.Quota.Status -eq "unknown" })
+
+  $recommended = @($available |
+    Sort-Object `
+      @{ Expression = { if ($_.DisplayName -match "Sonnet") { 0 } elseif ($_.DisplayName -match "Gemini") { 1 } else { 2 } } },
+      @{ Expression = { if ($_.Quota.RemainingPercent -ne $null) { -1 * $_.Quota.RemainingPercent } else { 0 } } },
+      DisplayName |
+    Select-Object -First 4 |
+    ForEach-Object {
+      [PSCustomObject]@{
+        Id = $_.Id
+        DisplayName = $_.DisplayName
+        RemainingPercent = $_.Quota.RemainingPercent
+        ResetTimeUtc = $_.Quota.ResetTimeUtc
+      }
+    })
+
+  $blocked = @($exhausted |
+    Sort-Object @{ Expression = { $_.Quota.ResetTimeUtc } }, DisplayName |
+    Select-Object -First 8 |
+    ForEach-Object {
+      [PSCustomObject]@{
+        Id = $_.Id
+        DisplayName = $_.DisplayName
+        ResetTimeUtc = $_.Quota.ResetTimeUtc
+      }
+    })
+
+  [PSCustomObject]@{
+    Source = $report.Source
+    GeneratedAtUtc = $report.GeneratedAtUtc
+    Note = $report.Note
+    Counts = [PSCustomObject]@{
+      NamedModels = $namedModels.Count
+      Available = $available.Count
+      Low = $low.Count
+      Exhausted = $exhausted.Count
+      Unknown = $unknown.Count
+    }
+    CreditStatus = $report.CreditStatus
+    RecommendedAvailable = $recommended
+    BlockedOrResetting = $blocked
+  }
+}
+
+function Get-LimitsSummary {
+  Get-LimitsSummaryObject | ConvertTo-Json -Depth 8
+}
+
+function Get-QuickReport {
+  $setup = Get-SetupReportObject
+  $live = Get-LiveReportObject
+  $limitsSummary = $null
+  $limitsError = $null
+
+  if ($setup.ReadyForModelLimits) {
+    try {
+      $limitsSummary = Get-LimitsSummaryObject
+    } catch {
+      $limitsError = $_.Exception.Message
+    }
+  }
+
+  [PSCustomObject]@{
+    Source = "Antigravity local bridge quick report"
+    GeneratedAtUtc = [datetime]::UtcNow.ToString("o")
+    Setup = [PSCustomObject]@{
+      Installed = $setup.Installed
+      Running = $setup.AntigravityRunning
+      ReadyForModelLimits = $setup.ReadyForModelLimits
+      ReadyForLiveUiInspection = $setup.ReadyForLiveUiInspection
+      DevToolsReachable = $setup.DevToolsReachable
+      NodeFound = $setup.Node.Found
+    }
+    Live = [PSCustomObject]@{
+      PageCount = $live.PageCount
+      ActivePageTitle = if (@($live.Pages).Count -gt 0) { @($live.Pages)[0].Title } else { $null }
+      DevToolsPort = $live.DevToolsPort
+    }
+    Limits = if ($limitsSummary) {
+      [PSCustomObject]@{
+        GeneratedAtUtc = $limitsSummary.GeneratedAtUtc
+        Counts = $limitsSummary.Counts
+        RecommendedAvailable = $limitsSummary.RecommendedAvailable
+        BlockedOrResetting = $limitsSummary.BlockedOrResetting
+      }
+    } else {
+      $null
+    }
+    LimitsError = $limitsError
+    NextToolHint = "Use antigravity-local quick first. If ReadyForLiveUiInspection is false, call repair-live once. If repair restarts Antigravity, reconnect DevTools before UI calls. Use limits-summary for compact quota checks, full limits only when needed. If UI handoff is blocked, use handoff-template."
+  } | ConvertTo-Json -Depth 10
+}
+
+function Get-OffloadDecisionObject {
+  param(
+    [string] $TaskGoal,
+    [bool] $NeedsWorkspace,
+    [int] $EstimatedTokens
+  )
+
+  $lowerGoal = $TaskGoal.ToLowerInvariant()
+  $trivial = $lowerGoal -match "\b(2\s*\+\s*2|add\s+2\s*\+\s*2|what\s+is|time|date|summari[sz]e\s+this\s+short|one\s+line|yes\s+or\s+no)\b"
+  if ((-not $NeedsWorkspace) -and $EstimatedTokens -gt 0 -and $EstimatedTokens -lt 400) {
+    $trivial = $true
+  }
+
+  $workspaceLikely = $NeedsWorkspace -or
+    ($lowerGoal -match "\b(repo|workspace|project|files?|diff|logs?|tests?|build|lint|implement|refactor|debug|apply|continue\s+chat|job\s+search|browser|ui|analy[sz]e|review|plan|research|inspect|investigate|fix|patch|error|failure|trace|search|compare)\b") -or
+    ($EstimatedTokens -ge 800)
+
+  $shouldOffload = $workspaceLikely -and (-not $trivial)
+  if ($shouldOffload) {
+    [PSCustomObject]@{
+      Decision = "offload-to-antigravity"
+      Reason = "The task appears to benefit from Antigravity inspecting the local workspace or running longer reasoning while Codex reads back a compact artifact."
+      ShouldOffload = $true
+    }
+  } else {
+    [PSCustomObject]@{
+      Decision = "codex-direct"
+      Reason = "The task is small enough that DevTools navigation, project context scanning, and Antigravity startup/agent overhead will likely cost more time and tokens than Codex answering directly."
+      ShouldOffload = $false
+    }
+  }
+}
+
+function Get-HandoffTemplateText {
+  param(
+    [string] $TaskGoal,
+    [string] $TaskWorkspace,
+    [string] $TaskStatusFile,
+    [string] $TaskNextStep
+  )
+
+  if ([string]::IsNullOrWhiteSpace($TaskGoal)) {
+    $TaskGoal = "<goal>"
+  }
+  if ([string]::IsNullOrWhiteSpace($TaskWorkspace)) {
+    $TaskWorkspace = "<workspace/path>"
+  }
+
+  @(
+    "Use this as a compact Antigravity offload handoff:",
+    "",
+    '```text',
+    "Goal: $TaskGoal",
+    "Workspace: $TaskWorkspace",
+    "Constraints: inspect files locally; do not paste full files, full logs, or full source; use search before reading whole files.",
+    "Token rule: work token-efficiently; write progress to $TaskStatusFile; output max 10 bullets plus changed file list.",
+    "Next step: $TaskNextStep",
+    "If blocked: ask one concise question; otherwise continue autonomously.",
+    '```',
+    "",
+    "Codex follow-up rule: do not read the full Antigravity chat. Read only the status artifact, targeted diffs, or a compact visible UI status."
+  ) -join [Environment]::NewLine
+}
+
+function Get-SubmissionGuideText {
+  @(
+    "AntigravitySubmissionGuide:",
+    "1. Verify the target project, conversation, model, and idle composer first.",
+    "2. Fill or type the prompt into the composer only. Do not include submitKey in the fill/type call.",
+    "3. Prefer clicking the visible Send/arrow button after the composer contains the prompt.",
+    "4. If a keyboard submit is required, use a separate key tool call with a simple accepted key such as Enter. Do not use Control+Enter, Ctrl+Enter, or chord strings unless the active tool schema explicitly lists that exact value.",
+    "5. After submitting, verify Antigravity accepted the message by checking for a working/streaming state or a new visible user message.",
+    "6. If the key or click fails once, stop retrying the same submit method. Report the blocker or use handoff-template for manual paste.",
+    "",
+    "Reason: some Codex DevTools tools reject chord strings like Control+Enter with Unknown key, even after the prompt was typed correctly."
+  ) -join [Environment]::NewLine
+}
+
+function Get-DevToolsHealthText {
+  $live = Get-LiveReportObject
+  $pageCount = [int]$live.PageCount
+  $ready = $live.Running -and $pageCount -gt 0
+  $status = if ($ready) { "ready" } else { "not-ready" }
+  $next = if ($ready) {
+    "If antigravity-devtools still says Transport closed, do not retry the same MCP transport. Restart Codex so the DevTools MCP server is re-created, or use handoff-template/manual paste for this turn."
+  } else {
+    "Run repair-live once. If it restarts Antigravity, restart Codex before calling antigravity-devtools again."
+  }
+
+  @(
+    "DevToolsHealth: $status",
+    "Running: $($live.Running)",
+    "DevToolsPort: $($live.DevToolsPort)",
+    "PageCount: $pageCount",
+    "Next: $next",
+    "",
+    "Rule: local helper commands can report health even when antigravity-devtools/list_pages fails with Transport closed."
+  ) -join [Environment]::NewLine
+}
+
+function Get-OffloadAdviceText {
+  $needsWorkspace = ConvertTo-BooleanValue -Value $HasWorkspaceWork -Default $true
+  $decision = Get-OffloadDecisionObject -TaskGoal $Goal -NeedsWorkspace $needsWorkspace -EstimatedTokens $EstimatedCodexInputTokens
+  @(
+    "Decision: $($decision.Decision)",
+    "Reason: $($decision.Reason)",
+    "",
+    "Rules:",
+    "- Use Codex direct only for arithmetic, short factual answers, tiny commands, and small summaries.",
+    "- Use Antigravity by default for nontrivial workspace tasks, UI/project continuation, job-search/application work, debugging, implementation, reviews, research, planning, and analysis that would make Codex read files or long output.",
+    "- In existing project chats, assume Antigravity may scan attached folders. For small tests, use a blank/no-workspace chat when available or do not offload.",
+    "- If Antigravity unexpectedly starts broad folder exploration for a small task, cancel and report that offload is not token-efficient.",
+    "- When offloading, send a compact handoff and ask Antigravity to write a small status artifact; Codex should read only that artifact or a targeted diff."
+  ) -join [Environment]::NewLine
+}
+
+function Get-PrepareOffloadText {
+  $quick = Get-QuickReport | ConvertFrom-Json
+  $needsWorkspace = ConvertTo-BooleanValue -Value $HasWorkspaceWork -Default $true
+  $decision = Get-OffloadDecisionObject -TaskGoal $Goal -NeedsWorkspace $needsWorkspace -EstimatedTokens $EstimatedCodexInputTokens
+  $recommended = $null
+  if ($quick.Limits -and $quick.Limits.RecommendedAvailable -and @($quick.Limits.RecommendedAvailable).Count -gt 0) {
+    $recommended = @($quick.Limits.RecommendedAvailable)[0]
+  }
+
+  $bestModel = if ($recommended) {
+    "{0} ({1}% remaining)" -f $recommended.DisplayName, $recommended.RemainingPercent
+  } else {
+    "<unknown>"
+  }
+
+  $nextAction = if ($decision.ShouldOffload) {
+    "Use antigravity-devtools only to select the project/chat/model, fill the handoff, and click the Send/arrow button. Then stop monitoring and read only the status artifact or targeted diff."
+  } else {
+    "Do not open or drive Antigravity for this task. Answer or act directly in Codex."
+  }
+
+  $handoff = Get-HandoffTemplateText -TaskGoal $Goal -TaskWorkspace $Workspace -TaskStatusFile $StatusFile -TaskNextStep $NextStep
+  $handoff = $handoff -replace "^Use this as a compact Antigravity offload handoff:\r?\n\r?\n", ""
+
+  @(
+    "FastAntigravityOffloadPlan:",
+    "Decision: $($decision.Decision)",
+    "Reason: $($decision.Reason)",
+    "",
+    "Readiness:",
+    "Installed: $($quick.Setup.Installed)",
+    "Running: $($quick.Setup.Running)",
+    "LiveReady: $($quick.Setup.ReadyForLiveUiInspection)",
+    "PageCount: $($quick.Live.PageCount)",
+    "BestModel: $bestModel",
+    "",
+    "NextAction:",
+    $nextAction,
+    "",
+    "SubmitRule:",
+    "Fill/type the prompt without submitKey. Prefer clicking the visible Send/arrow button. If keyboard submit is required, use a separate simple Enter key call. Never use Control+Enter unless the active tool schema explicitly accepts it.",
+    "",
+    "CompactHandoff:",
+    $handoff
+  ) -join [Environment]::NewLine
+}
+
+function Invoke-SubmitOffload {
+  $submitValue = ConvertTo-BooleanValue -Value $Submit -Default $false
+  $fillOnlyValue = ConvertTo-BooleanValue -Value $FillOnly -Default $false
+  $localMcpScript = Join-Path $PSScriptRoot "antigravity-local-mcp.js"
+  if (-not (Test-Path -LiteralPath $localMcpScript)) {
+    throw "antigravity-local-mcp.js was not found at $localMcpScript"
+  }
+
+  $payload = [PSCustomObject]@{
+    goal = $Goal
+    workspace = $Workspace
+    statusFile = $StatusFile
+    nextStep = $NextStep
+    expectedProject = $ExpectedProject
+    expectedChat = $ExpectedChat
+    submit = $submitValue
+    fillOnly = $fillOnlyValue
+  } | ConvertTo-Json -Compress
+
+  $payloadFile = Join-Path ([System.IO.Path]::GetTempPath()) ("antigravity-submit-offload-{0}.json" -f ([guid]::NewGuid().ToString("N")))
+  try {
+    [System.IO.File]::WriteAllText($payloadFile, $payload, [System.Text.UTF8Encoding]::new($false))
+    & node $localMcpScript submit-offload-cli --json-file $payloadFile
+    if ($LASTEXITCODE -ne 0) {
+      throw "submit-offload failed with exit code $LASTEXITCODE"
+    }
+  } finally {
+    Remove-Item -LiteralPath $payloadFile -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Write-Status {
+  $processes = @(Get-AntigravityProcess)
+  $devToolsPort = Get-DevToolsPort
+
+  [PSCustomObject]@{
+    Installed = Test-Path -LiteralPath $exePath
+    ExePath = $exePath
+    UserDataPath = $userDataPath
+    Running = $processes.Count -gt 0
+    ProcessIds = @($processes | Select-Object -ExpandProperty Id)
+    DevToolsPort = $devToolsPort
+  } | ConvertTo-Json -Depth 4
+}
+
+switch ($Command) {
+  "path" {
+    Write-Output $exePath
+  }
+
+  "status" {
+    Write-Status
+  }
+
+  "open" {
+    if (-not (Test-Path -LiteralPath $exePath)) {
+      throw "Antigravity.exe was not found at $exePath"
+    }
+
+    $existing = @(Get-AntigravityProcess)
+    if ($existing.Count -eq 0) {
+      Start-Process -FilePath $exePath -WorkingDirectory $installRoot
+      Start-Sleep -Seconds 2
+    }
+
+    Write-Status
+  }
+
+  "repair-live" {
+    Repair-LiveDevTools | ConvertTo-Json -Depth 10
+  }
+
+  "inspect" {
+    $packageFiles = @(
+      Join-Path $installRoot "resources\app.asar.unpacked\node_modules\chrome-devtools-mcp\package.json"
+    )
+
+    $existingPackageFiles = @($packageFiles | Where-Object { Test-Path -LiteralPath $_ })
+    $binPath = Join-Path $installRoot "resources\bin"
+    $binFiles = @()
+    if (Test-Path -LiteralPath $binPath) {
+      $binFiles = @(Get-ChildItem -LiteralPath $binPath -File | Select-Object -ExpandProperty Name)
+    }
+
+    [PSCustomObject]@{
+      InstallRoot = $installRoot
+      ExePath = $exePath
+      UserDataPath = $userDataPath
+      DevToolsPort = Get-DevToolsPort
+      BundledPackageFiles = $existingPackageFiles
+      BinFiles = $binFiles
+    } | ConvertTo-Json -Depth 5
+  }
+
+  "models" {
+    Get-AntigravityModels
+  }
+
+  "limits" {
+    Get-AntigravityModels
+  }
+
+  "limits-summary" {
+    Get-LimitsSummary
+  }
+
+  "quick" {
+    Get-QuickReport
+  }
+
+  "live" {
+    Get-LiveReport
+  }
+
+  "devtools-health" {
+    Get-DevToolsHealthText
+  }
+
+  "submission-guide" {
+    Get-SubmissionGuideText
+  }
+
+  "offload-advice" {
+    Get-OffloadAdviceText
+  }
+
+  "handoff-template" {
+    Get-HandoffTemplateText -TaskGoal $Goal -TaskWorkspace $Workspace -TaskStatusFile $StatusFile -TaskNextStep $NextStep
+  }
+
+  "prepare-offload" {
+    Get-PrepareOffloadText
+  }
+
+  "submit-offload" {
+    Invoke-SubmitOffload
+  }
+
+  "setup" {
+    Get-SetupReport
+  }
+
+  "doctor" {
+    Get-SetupReport
+  }
+
+  "privacy" {
+    Get-PrivacyReport
+  }
+}

--- a/plugins/comprono/antigravity-2-codex-plugin/skills/antigravity-2/SKILL.md
+++ b/plugins/comprono/antigravity-2-codex-plugin/skills/antigravity-2/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: antigravity-2
+description: Connect Codex to a local Antigravity 2.0 desktop app for setup checks, model limits, live project/chat inspection, project creation, chat creation, and safe conversation handoff.
+license: MIT
+---
+
+# Antigravity 2.0
+
+Use this skill when the user asks Codex to connect to, set up, inspect, compare, or automate the local Antigravity 2.0 desktop app.
+
+Core jobs:
+
+- Set up or verify the plugin on another Windows machine.
+- Open Antigravity and report install/runtime status.
+- Read model quota and AI credit state from Antigravity's local language server.
+- Inspect what is happening live in Antigravity.
+- See projects and chats through the live UI.
+- Continue an existing chat after verifying the selected project, conversation, and model.
+- Start a new chat in an existing project.
+- Start a new project and then start a chat there.
+- Report quota, model, UI, or submission errors without repeatedly retrying.
+
+Primary operating model:
+
+- Codex delegates nontrivial work to Antigravity first.
+- Codex waits instead of doing the same exploration itself.
+- Codex reads only compact status artifacts, targeted diffs, or concise visible status.
+- Codex reviews Antigravity's result, identifies gaps, and gives Antigravity the next compact improvement task.
+- Codex performs final user-facing synthesis, safety checks, and narrow code patches only when that is cheaper or higher quality than another Antigravity pass.
+- Codex should not duplicate Antigravity's file reading, broad search, browser operation, or long reasoning unless Antigravity is blocked, unavailable, or the task is tiny.
+
+## MCP Tool Surfaces
+
+This plugin exposes two MCP servers:
+
+- `antigravity-local`: direct tools for `quick`, `setup`, `doctor`, `status`, `open`, `repair-live`, `inspect`, `live`, `devtools-health`, `submission-guide`, `prepare-offload`, `submit-offload`, `limits-summary`, `limits`, `models`, `offload-advice`, `handoff-template`, and `privacy`.
+- `antigravity-devtools`: Chromium DevTools controls for inspecting and driving the Antigravity UI.
+
+Prefer `antigravity-local.submit-offload` when the correct Antigravity project/chat is already selected and the user wants Codex to hand work to Antigravity with minimum friction. It prepares the compact handoff, fills the active composer, and submits with a direct CDP Enter keypress without repeated `list_pages`, snapshots, fill, key, and evaluate calls. If the MCP tool list is stale and does not show `submit-offload`, use the PowerShell helper `antigravity.ps1 submit-offload` before falling back to DevTools choreography. Use `antigravity-local.prepare-offload` when Codex should first show the plan or when the selected chat is uncertain. For any nontrivial workspace, repo, browser, UI, research, planning, debugging, review, implementation, or job-application task, default to Antigravity for exploration and long reasoning, while Codex stays the planner, safety gate, patch reviewer, and final summarizer. Use `antigravity-local.quick` for general setup checks. If `ReadyForLiveUiInspection` is false or `PageCount` is zero, call `antigravity-local.repair-live` once before using DevTools. If `repair-live` restarts Antigravity, do not keep using an already-started stale DevTools MCP connection; let it reconnect to the new port before UI calls. If `antigravity-devtools` fails with `Transport closed`, do not repeatedly call `list_pages` in that session. Call `antigravity-local.devtools-health`; if it reports pages are ready, restart Codex to recreate the DevTools MCP transport or use `handoff-template` for a manual paste this turn. Use `limits-summary` for normal quota checks and full `limits` only when complete per-model JSON is needed. Use `antigravity-devtools` for project/chat selection only when the selected chat is not already correct. If this skill file cannot be read in a Codex session, run the PowerShell helper fast path.
+
+## Requirements
+
+- Windows desktop environment.
+- Antigravity installed at the standard per-user location: `%LOCALAPPDATA%\Programs\Antigravity\Antigravity.exe`.
+- Antigravity user data at: `%APPDATA%\Antigravity`.
+- Plugin installed at: `%USERPROFILE%\plugins\antigravity-2`.
+- Node.js available on `PATH` when using the bundled `chrome-devtools-mcp` bridge.
+
+The helper scripts compute `%LOCALAPPDATA%`, `%APPDATA%`, and `%USERPROFILE%` at runtime. Do not hardcode another user's home directory, ports, project names, chats, email addresses, or runtime tokens.
+
+## First-Run Setup
+
+After a user clones the GitHub repo into `%USERPROFILE%\plugins\antigravity-2`, run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" setup
+```
+
+Use the setup report to decide the next step:
+
+- If `Installed` is false, ask the user to install Antigravity or provide its install path.
+- If `Node.Found` is false, install or expose Node.js on `PATH` before using the DevTools bridge.
+- If `AntigravityRunning` is false, run the `open` command.
+- If `ReadyForModelLimits` is false after opening Antigravity, wait a few seconds and rerun `setup`.
+- If `ReadyForLiveUiInspection` is false, run `repair-live` once. It restarts Antigravity, clears a stale `DevToolsActivePort`, and waits for inspectable pages. Use Browser/Computer Use fallback only if repair still cannot connect.
+
+## Helper Commands
+
+Check status:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" status
+```
+
+Fast combined readiness and quota summary:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" quick
+```
+
+Open Antigravity:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" open
+```
+
+Repair live DevTools inspection if Antigravity is running but exposes zero pages:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" repair-live
+```
+
+Generate a compact handoff prompt without touching the UI:
+
+```text
+Call antigravity-local.handoff-template with goal, workspace, statusFile, and nextStep.
+```
+
+Check whether a task should be offloaded before using UI tokens:
+
+```text
+Call antigravity-local.offload-advice with goal, hasWorkspaceWork, and estimatedCodexInputTokens.
+```
+
+Prepare the whole token-saving handoff in one call:
+
+```text
+Call antigravity-local.prepare-offload with goal, workspace, statusFile, nextStep, hasWorkspaceWork, and estimatedCodexInputTokens.
+```
+
+Submit the handoff in one call when the correct Antigravity chat is already selected:
+
+```text
+Call antigravity-local.submit-offload with goal, workspace, statusFile, nextStep, expectedProject, expectedChat, and submit=true.
+```
+
+Use `expectedProject` and `expectedChat` when known. If either expected string is not visible, `submit-offload` stops before filling or submitting.
+Use `submit=false` for verify-only; it must not fill the composer. Use `fillOnly=true` only when the user wants to manually review the handoff before sending.
+
+If MCP `submit-offload` is not visible in the current Codex session, use the raw helper:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" submit-offload -Goal "<goal>" -Workspace "<path>" -StatusFile "notes/antigravity-status.md" -NextStep "<next step>" -ExpectedProject "<project text>" -ExpectedChat "<chat text>" -Submit true
+```
+
+If MCP tools are unavailable and Codex can only run shell commands, use the PowerShell helper equivalent:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" prepare-offload -Goal "<goal>" -Workspace "<path>" -StatusFile "notes/antigravity-status.md" -NextStep "<next step>"
+```
+
+Inspect integration details:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" inspect
+```
+
+Inspect the live DevTools connection:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" live
+```
+
+Check DevTools transport health after `Transport closed`:
+
+```text
+Call antigravity-local.devtools-health.
+```
+
+Check how to submit a chat prompt without invalid key names:
+
+```text
+Call antigravity-local.submission-guide.
+```
+
+Report model limits:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" limits-summary
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" models
+```
+
+`limits` is an alias for `models`.
+Use `limits-summary` unless full per-model JSON is required.
+
+Run the public-repo privacy scanner:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" privacy
+```
+
+## Model Limits
+
+Use `models` or `limits` for model quota checks. The helper discovers the running Antigravity `language_server.exe`, reads its CSRF token from the local process command line, finds its local HTTPS gRPC-web port, and calls:
+
+- `exa.language_server_pb.LanguageServerService/GetAvailableModels`
+- `exa.language_server_pb.LanguageServerService/GetLoadCodeAssist`
+
+This is the same local language-server surface the Antigravity Models tab uses. It returns per-model quota fraction/reset metadata and AI credit tier data when Antigravity exposes it. It is not a raw all-model token ledger unless Antigravity exposes one through these responses.
+
+Do not parse old chats, task transcripts, or logs for model limits except as supporting evidence after the language-server path fails.
+
+## Live UI Inspection
+
+For project and chat work, the live UI is the source of truth.
+
+Preferred path:
+
+1. Run `setup` or `live` to confirm DevTools readiness.
+2. Use the plugin MCP server `antigravity-devtools` when available. It starts Antigravity's bundled `chrome-devtools-mcp` and connects through `DevToolsActivePort`.
+3. Inspect the visible UI text and interactive elements through DevTools.
+4. Confirm the project, conversation, composer state, and selected model before sending a message.
+
+If `antigravity-devtools/list_pages` or another DevTools tool fails with `Transport closed`, the child MCP process has died. This is a transport failure, not proof that Antigravity is unavailable. Call `antigravity-local.devtools-health` to confirm the live pages. If pages are ready, restart Codex before trying DevTools again; if the user wants to continue immediately, use `antigravity-local.handoff-template` and ask for manual paste into Antigravity.
+
+Manual DevTools endpoint check:
+
+```powershell
+$port = (Get-Content "$env:APPDATA\Antigravity\DevToolsActivePort")[0]
+Invoke-RestMethod "http://127.0.0.1:$port/json/list"
+```
+
+If DevTools cannot interact with a native dialog or OS-level control, use the Computer Use plugin as a fallback.
+
+## Project And Chat Workflows
+
+### See Chats In Projects
+
+Use DevTools to inspect the live Antigravity project list, selected project, conversation list, and conversation titles. If the UI has a project or conversation search control, use it rather than reading private storage first.
+
+Storage under `%APPDATA%\Antigravity\User` can support investigation, but live UI remains authoritative.
+
+### Continue An Existing Chat
+
+Before submitting:
+
+- Verify the intended project is selected.
+- Verify the intended conversation title or visible context.
+- Verify the intended model in the composer.
+- Verify the composer is idle and not already streaming.
+- Check `models` if the user asks about limits or if a quota warning is visible.
+
+Then paste the user's instruction into the composer and submit it. Report whether Antigravity accepted the message, started working, requested confirmation, or showed a quota/error state.
+
+Submission reliability:
+
+- Fill or type the prompt first without a `submitKey`.
+- Prefer clicking the visible Send/arrow button after the prompt is in the composer.
+- If a keyboard submit is needed, use a separate key call with a simple accepted key such as `Enter`.
+- Do not use `Control+Enter`, `Ctrl+Enter`, or chord strings unless the active tool schema explicitly lists that exact value. Some DevTools tools reject those strings with `Unknown key`.
+- After submission, verify a new user message or working state. If one submit method fails once, stop retrying the same method and use `handoff-template` or report the blocker.
+
+### Start A New Chat In An Existing Project
+
+Before submitting:
+
+- Select or search for the existing project.
+- Use the UI control for a new chat/conversation.
+- Verify the new composer belongs to that project.
+- Verify the selected model.
+
+Then submit the user's initial prompt. Report the new conversation title or visible identifier if Antigravity shows one.
+
+### Start A New Project
+
+Before creating:
+
+- Ask for a project name only if the user's intended name cannot be inferred.
+- Use the visible Antigravity project creation flow.
+- Select local folders/workspaces only when the user explicitly requests those paths or they are already visible and clearly intended.
+- Avoid broad filesystem access without explicit user instruction.
+
+After creation, verify the project is selected, then start a chat if requested.
+
+### Tell What Is Happening Live
+
+Inspect the active page text and state through DevTools. Summarize:
+
+- selected project,
+- selected conversation,
+- selected model,
+- whether the agent is idle, working, waiting for approval, or blocked,
+- visible quota/errors,
+- last visible meaningful action.
+
+Do not expose unrelated private chat content unless the user asked for that specific context.
+
+## Token-Saving Offload Workflow
+
+Use Antigravity as an offload worker when the user wants to save Codex tokens or asks Codex to "ride on" Antigravity.
+
+### Offload Decision Gate
+
+Run `antigravity-local.prepare-offload` before opening or driving the Antigravity UI unless the user explicitly asks to inspect the live UI. This is the cheapest token-saving step because it replaces several separate checks.
+
+Do not offload:
+
+- arithmetic, short factual answers, tiny transformations, or simple status questions,
+- small shell checks where Codex can run one command and summarize compactly,
+- prompts that can be answered without reading project files, logs, browser state, or long chat history,
+- tests inside an existing project chat when the task does not need that project's workspace.
+
+Do offload:
+
+- most nontrivial workspace tasks that would make Codex read files, large logs, browser state, or transcripts,
+- ongoing Antigravity project/chat work where the Antigravity context is already useful,
+- debugging, implementation, job-search/application workflows, UI operation, reviews, planning, research, and analysis that can write a compact artifact,
+- tasks where Antigravity can keep working while Codex waits and then reads only a small result.
+
+Cost split:
+
+- Antigravity explores, searches, reads files, inspects UI, drafts plans, and writes status artifacts.
+- Codex gives Antigravity tasks, waits, reviews the compact output, tells Antigravity how to improve, verifies final diffs/tests, and explains the result to the user.
+- If Antigravity output is incomplete, Codex should usually send a short follow-up task back to Antigravity rather than expanding its own context with broad file reads.
+
+Important lesson from project chats: Antigravity may automatically inspect attached folders before answering, even for a tiny prompt. That is useful for real project work but wasteful for tests like `2+2`. If Antigravity starts broad folder exploration for a small task, cancel it and report that offload is not token-efficient.
+
+Core rule:
+
+- Codex is the router, verifier, and final summarizer.
+- Antigravity is the long-running worker.
+- Files are the compact memory between them.
+
+Do not copy large files, long logs, full source, or full Antigravity chat transcripts into Codex. Savings happen only when Codex sends compact instructions, lets Antigravity inspect the workspace locally, and reads back a small artifact or status checkpoint.
+
+Fast preferred flow:
+
+1. If the correct project/chat is already selected, call `antigravity-local.submit-offload` with `submit=true` and expected visible project/chat text.
+2. If MCP `submit-offload` is not visible, run `antigravity.ps1 submit-offload` with the same fields.
+3. If the selected chat is uncertain, call `antigravity-local.prepare-offload`, then use DevTools only to select the project/chat/model.
+4. If the decision is `codex-direct`, do not open or drive Antigravity.
+5. After a successful `submit-offload`, stop watching every step. Read only the requested status artifact, targeted diff, or compact visible status.
+6. If the artifact is weak, issue another compact Antigravity follow-up with the exact missing point. Do not pull broad context back into Codex unless needed for final verification.
+
+Detailed fallback flow:
+
+1. Run `antigravity-local.quick`.
+2. If `ReadyForLiveUiInspection` is false, run `antigravity-local.repair-live` once.
+3. Run `antigravity-local.offload-advice` with the goal. Continue only if the decision is `offload-to-antigravity`.
+4. Run `antigravity-local.limits-summary`; avoid full `limits` unless model-level JSON is actually needed.
+5. Use `antigravity-devtools` to verify the target project, chat, model, idle composer, and whether workspace context is appropriate.
+6. Use `antigravity-local.submission-guide`, then send Antigravity a compact handoff prompt with only the goal, workspace/path, constraints, next step, and required output format.
+7. Ask Antigravity to inspect files locally, write progress/results to a small status artifact, and avoid pasting full files or logs.
+8. Stop monitoring every step. Wait until Antigravity visibly stops or writes the status artifact.
+9. Read only the small artifact or changed-file list, then summarize to the user in a few bullets.
+
+If DevTools UI submission fails because a stale port is still attached, do not spend more tokens probing CDP from Codex. Use `antigravity-local.handoff-template` to prepare the compact prompt, report that UI submission was blocked by stale DevTools, and ask the user to restart Codex or paste the handoff manually. The next Codex session should load the new DevTools port.
+
+Recommended handoff prompt:
+
+```text
+Goal: <goal>
+Workspace: <path>
+Constraints: inspect files locally; do not paste full files, full logs, or full source; use search before reading whole files.
+Token rule: work token-efficiently; write progress to <small-status-file>; output max 10 bullets plus changed file list.
+Next step: <specific next action>
+If blocked: ask one concise question; otherwise continue autonomously.
+```
+
+Recommended artifacts:
+
+- `notes/antigravity-status.md`
+- `plans/antigravity-next.md`
+- `reports/antigravity-result.json`
+- a Git diff, branch, or commit with a short summary
+
+When checking back, Codex should read only the artifact, targeted diffs, or a compact visible UI status. Do not ask Antigravity to restate the whole conversation. Use delta prompts such as:
+
+```text
+Continue from reports/antigravity-result.json. Only fix the failing item. Return max 5 bullets and changed file paths.
+```
+
+Report back to the user with:
+
+- project/chat used,
+- model selected,
+- whether Antigravity accepted the task,
+- current status,
+- next action needed.
+
+## Public Plugin Hygiene
+
+Before committing or publishing:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\plugins\antigravity-2\scripts\antigravity.ps1" privacy
+git diff --check
+```
+
+Also run a local targeted scan for any private terms the current user mentions. Do not commit names, emails, project names, runtime ports, CSRF tokens, OAuth tokens, cookies, logs, screenshots, or Antigravity user data.
+
+## Boundaries
+
+- This plugin is a local bridge, not a cloud service.
+- It does not patch Antigravity internals.
+- It does not commit runtime language-server tokens.
+- It does not bypass Antigravity quota, billing, authentication, or safety controls.
+- It should not read sensitive files, credentials, browser cookies, or private chat contents unless the user asks for that specific context.
+- If Antigravity reports quota limits, do not keep resubmitting. Report the reset time and prepare the next action plan.


### PR DESCRIPTION
## Summary
- Add Antigravity 2.0 to the README Tools & Integrations section.
- Mirror the plugin bundle under `plugins/comprono/antigravity-2-codex-plugin`.
- Plugin source repository: https://github.com/comprono/antigravity-2-codex-plugin

## Preflight
- `python scripts\check-alphabetical.py README.md`: PASS
- `python scripts\validate-plugin-pr.py --base-ref upstream/main`: PASS for `plugins\comprono\antigravity-2-codex-plugin`
- `python -m pipx run plugin-scanner lint .`: PASS, policy_pass=true, effective_score=97; only info-level `PLUGIN_JSON_INTERFACE_ASSET_SCREENSHOTS`
- `python -m pipx run plugin-scanner verify . --format json`: structural checks pass for manifest, interface metadata, assets, `.mcp.json`, and skill references; verify_pass=false only because the scanner safety-skips stdio execution for the two MCP servers (`antigravity-devtools`, `antigravity-local`) and requests manual review before trusting executable MCP commands.

## Privacy
- Mirrored bundle excludes local Git metadata, runtime folders, logs, temp files, and screenshots.
- Focused scan found no private local names, project names, runtime ports, API keys, committed CSRF values, cookies, or Antigravity user data. Generic documentation references to tokens/CSRF handling remain because they describe runtime safety boundaries.