### PR TITLE
Add Diffmode Growth Tactics (Community Plugins)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.
 - [Dev Skills](https://github.com/Jason-chen-coder/dev-skills) - Team workflow skills for specs, plans, TDD, debugging, verification, review, branch finishing, and design context.
 - [Development Skills](https://github.com/reidemeister94/development-skills) - Three-tier triage (PASS_THROUGH / LIGHT / FULL 4-phase) development workflow for Codex and Claude Code with language auto-detection (Python, Java, TypeScript, Swift, frontend) and a staff-reviewer subagent for fresh-eyes review on every change.
+- [Diffmode Growth Tactics](https://github.com/acogood/diffmode_free) - Growth-strategy research pipeline for Codex and Claude Code: a competitor read, a buyer jobs-to-be-done map, and 7-9 unconventional acquisition tactics written to synthesis.md. Mines growth mechanisms from fresh case studies and fuses 2-3 per tactic; every stage is reviewer-gated. Apache-2.0, Perplexity-optional.
 - [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) - MCP server exposing reasoning, code, anti-deception, and memory harness tools for Codex.
 - [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.
 - [Epic Harness](https://github.com/epicsagas/epic-harness) - Auto-trigger quality skills + self-evolving agent harness — orbit (spec-to-ship), evolve (skill mutation), team (multi-agent), TDD, check, ship, simplify, debug, perf, secure.


### PR DESCRIPTION
Adds **Diffmode Growth Tactics** under *Community Plugins → Development & Workflow* (alphabetized) — a free growth-strategy research pipeline that runs on Codex and Claude Code off the same skill files.

Point it at a product URL and it writes a `synthesis.md`:
- a **competitor read** (who you're up against + the channels each rival leans on),
- a **buyer jobs-to-be-done map**, and
- **7–9 unconventional acquisition tactics** for the founder's constraints — each fuses 2–3 growth mechanisms mined fresh from public case studies.

Every generating stage is reviewer-gated. Runs via a stdlib-only Python orchestrator (`python3 codex/orchestrate.py --url <site>`); Perplexity-optional with native web-search fallback. Apache-2.0, no account/API key.

- Repo: https://github.com/acogood/diffmode_free

Added as an external-link entry matching the existing Community Plugins format. Happy to run the local preflight (`plugin-scanner lint/verify`) or adjust if the PR gate needs anything.