### PR TITLE
Fix install_url for Agent Workflow System plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Aegis](https://github.com/GanyuanRan/Aegis) - An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.
 - [Agentizer](https://github.com/Humiris/wwa-transform) - Turn any website into an AI-powered agentfront with split-pane
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
+- [Agent Workflow](https://github.com/1139030773-cmd/agent-workflow-system) - 中文 AI 工作流系统。6 个 Agent 角色自动引导、规划、执行、审计、收尾。严格职能隔离+五级纠错+Artifact 交接层。新手友好，Codex & Claude Code 双平台可用。
 - [AgiFlow](https://github.com/AgiFlow/ai-plugin) - Project management workflows for AI coding agents with planning, grooming, task execution, review, and AgiFlow MCP integration.
 - [Alcove](https://github.com/epicsagas/alcove) - Local-first MCP server for private project docs with hybrid BM25+vector search, tree-sitter code indexing, and automated linting for team-wide documentation standards.
 - [Anchor](https://github.com/biefan/anchor) - Engineering discipline pack for Claude Code & Codex CLI with task-scope locking, anti-drift braking, condition-based codex review, project-CLAUDE.md pitfall writeback, and PreToolUse hooks that block irreversible bash patterns.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Aegis](https://github.com/GanyuanRan/Aegis) - An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.
 - [Agentizer](https://github.com/Humiris/wwa-transform) - Turn any website into an AI-powered agentfront with split-pane
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
-- [Agent Workflow](https://github.com/1139030773-cmd/agent-workflow-system) - Chinese AI workflow system with 6 role agents. Strict permission isolation, 5-level escalation, Artifact handoff layer. Beginner-friendly. Codex & Claude Code dual-platform. [中文AI工作流系统，6角色智能体，新手友好]
+- [Agent Workflow System](https://github.com/1139030773-cmd/agent-workflow-system) - 一套中文AI工作流系统：7个协作技能 + 行为规范宪法 + 会话恢复机制，模糊目标→可执行任务，全生命周期引导。Codex & Claude Code 双平台，新手友好。
 - [AgiFlow](https://github.com/AgiFlow/ai-plugin) - Project management workflows for AI coding agents with planning, grooming, task execution, review, and AgiFlow MCP integration.
 - [Alcove](https://github.com/epicsagas/alcove) - Local-first MCP server for private project docs with hybrid BM25+vector search, tree-sitter code indexing, and automated linting for team-wide documentation standards.
 - [Anchor](https://github.com/biefan/anchor) - Engineering discipline pack for Claude Code & Codex CLI with task-scope locking, anti-drift braking, condition-based codex review, project-CLAUDE.md pitfall writeback, and PreToolUse hooks that block irreversible bash patterns.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Aegis](https://github.com/GanyuanRan/Aegis) - An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.
 - [Agentizer](https://github.com/Humiris/wwa-transform) - Turn any website into an AI-powered agentfront with split-pane
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
-- [Agent Workflow](https://github.com/1139030773-cmd/agent-workflow-system) - 中文 AI 工作流系统。6 个 Agent 角色自动引导、规划、执行、审计、收尾。严格职能隔离+五级纠错+Artifact 交接层。新手友好，Codex & Claude Code 双平台可用。
+- [Agent Workflow](https://github.com/1139030773-cmd/agent-workflow-system) - Chinese AI workflow system with 6 role agents. Strict permission isolation, 5-level escalation, Artifact handoff layer. Beginner-friendly. Codex & Claude Code dual-platform. [中文AI工作流系统，6角色智能体，新手友好]
 - [AgiFlow](https://github.com/AgiFlow/ai-plugin) - Project management workflows for AI coding agents with planning, grooming, task execution, review, and AgiFlow MCP integration.
 - [Alcove](https://github.com/epicsagas/alcove) - Local-first MCP server for private project docs with hybrid BM25+vector search, tree-sitter code indexing, and automated linting for team-wide documentation standards.
 - [Anchor](https://github.com/biefan/anchor) - Engineering discipline pack for Claude Code & Codex CLI with task-scope locking, anti-drift braking, condition-based codex review, project-CLAUDE.md pitfall writeback, and PreToolUse hooks that block irreversible bash patterns.

--- a/plugins.json
+++ b/plugins.json
@@ -49,7 +49,7 @@
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/1139030773-cmd/agent-workflow-system/HEAD/.codex-plugin/plugin.json"
     },
-
+    {
       "name": "AgentOps",
       "url": "https://github.com/boshu2/agentops",
       "owner": "boshu2",

--- a/plugins.json
+++ b/plugins.json
@@ -47,7 +47,7 @@
       "description": "一套中文AI工作流系统：7个协作技能 + 行为规范宪法 + 会话恢复机制。模糊目标→可执行任务，全生命周期引导。Codex & Claude Code 双平台，新手友好。",
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
-      "install_url": "https://raw.githubusercontent.com/1139030773-cmd/agent-workflow-system/HEAD/.codex-plugin/plugin.json"
+      "install_url": "https://raw.githubusercontent.com/1139030773-cmd/agent-workflow-system/HEAD/plugins/agent-workflow-system/.codex-plugin/plugin.json"
     },
     {
       "name": "AgentOps",

--- a/plugins.json
+++ b/plugins.json
@@ -40,12 +40,11 @@
       "install_url": "https://raw.githubusercontent.com/Humiris/wwa-transform/HEAD/.codex-plugin/plugin.json"
     },
     {
-    {
-      "name": "Agent Workflow",
+      "name": "Agent Workflow System",
       "url": "https://github.com/1139030773-cmd/agent-workflow-system",
       "owner": "1139030773-cmd",
       "repo": "agent-workflow-system",
-      "description": "Chinese AI workflow system with 6 role agents (routing, planning, execution, auditing, closeout). Strict permission isolation, 5-level escalation, Artifact handoff layer. Beginner-friendly. Codex & Claude Code.",
+      "description": "一套中文AI工作流系统：7个协作技能 + 行为规范宪法 + 会话恢复机制。模糊目标→可执行任务，全生命周期引导。Codex & Claude Code 双平台，新手友好。",
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/1139030773-cmd/agent-workflow-system/HEAD/.codex-plugin/plugin.json"

--- a/plugins.json
+++ b/plugins.json
@@ -40,6 +40,17 @@
       "install_url": "https://raw.githubusercontent.com/Humiris/wwa-transform/HEAD/.codex-plugin/plugin.json"
     },
     {
+    {
+      "name": "Agent Workflow",
+      "url": "https://github.com/1139030773-cmd/agent-workflow-system",
+      "owner": "1139030773-cmd",
+      "repo": "agent-workflow-system",
+      "description": "Chinese AI workflow system with 6 role agents (routing, planning, execution, auditing, closeout). Strict permission isolation, 5-level escalation, Artifact handoff layer. Beginner-friendly. Codex & Claude Code.",
+      "category": "Development & Workflow",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/1139030773-cmd/agent-workflow-system/HEAD/.codex-plugin/plugin.json"
+    },
+
       "name": "AgentOps",
       "url": "https://github.com/boshu2/agentops",
       "owner": "boshu2",


### PR DESCRIPTION
The plugin.json was moved from .codex-plugin/plugin.json to plugins/agent-workflow-system/.codex-plugin/plugin.json in the upstream repo. This fixes the install_url to point to the correct location.