### PR TITLE
Add Agent Harness Skills plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -34,6 +34,21 @@
       "icon": "./plugins/GanyuanRan/Aegis/assets/aegis-small.svg"
     },
     {
+      "name": "agent-harness-skills",
+      "displayName": "Agent Harness Skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/yfge/agent-harness-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development & Workflow",
+      "description": "Designs agent-ready repository harnesses with entrypoints, validation surfaces, runtime evidence, delivery records, and atomic commit guidance.",
+      "icon": "./plugins/yfge/agent-harness-skills/assets/icon.svg"
+    },
+    {
       "name": "codiris-agentizer",
       "displayName": "Agentizer",
       "source": {

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 
 - [A Team](https://github.com/RBraga01/a-team) - Universal multi-agent infrastructure with 25 specialist agents, 16 enforced workflow skills, and a lead orchestrator for Claude Code, Codex CLI, Cursor, and OpenCode.
 - [Aegis](https://github.com/GanyuanRan/Aegis) - An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.
+- [Agent Harness Skills](https://github.com/yfge/agent-harness-skills) - Designs agent-ready repository harnesses with entrypoints, validation surfaces, runtime evidence, delivery records, and atomic commit guidance.
 - [Agentizer](https://github.com/Humiris/wwa-transform) - Turn any website into an AI-powered agentfront with split-pane
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
 - [AgiFlow](https://github.com/AgiFlow/ai-plugin) - Project management workflows for AI coding agents with planning, grooming, task execution, review, and AgiFlow MCP integration.

--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-06-07",
-  "total": 104,
+  "last_updated": "2026-06-08",
+  "total": 105,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -28,6 +28,16 @@
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/GanyuanRan/Aegis/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Agent Harness Skills",
+      "url": "https://github.com/yfge/agent-harness-skills",
+      "owner": "yfge",
+      "repo": "agent-harness-skills",
+      "description": "Designs agent-ready repository harnesses with entrypoints, validation surfaces, runtime evidence, delivery records, and atomic commit guidance.",
+      "category": "Development & Workflow",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/yfge/agent-harness-skills/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Agentizer",

--- a/plugins/yfge/agent-harness-skills/.codex-plugin/plugin.json
+++ b/plugins/yfge/agent-harness-skills/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "id": "agent-harness-skills",
+  "name": "agent-harness-skills",
+  "version": "0.1.0",
+  "description": "Reusable skills for building agent-ready repository harnesses.",
+  "author": {
+    "name": "Agent Harness Skills contributors"
+  },
+  "homepage": "https://github.com/yfge/agent-harness-skills",
+  "repository": "https://github.com/yfge/agent-harness-skills",
+  "license": "MIT",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Agent Harness Skills",
+    "shortDescription": "Repo harness practices for agent-ready engineering work",
+    "longDescription": "Use Agent Harness Skills as a methodology plugin to assess and design repository harnesses: role mapping, agent entrypoints, architecture boundaries, validation surfaces, runtime evidence, delivery records, quality gates, and atomic commits.",
+    "developerName": "Agent Harness Skills contributors",
+    "category": "Coding",
+    "websiteURL": "https://github.com/yfge/agent-harness-skills",
+    "brandColor": "#2F6FED",
+    "composerIcon": "./assets/icon.svg",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": "Assess this repository's agent harness maturity."
+  },
+  "keywords": [
+    "agent-harness",
+    "skills",
+    "repository",
+    "validation",
+    "codex-plugin",
+    "methodology",
+    "templates",
+    "runtime-evidence",
+    "delivery"
+  ]
+}

--- a/plugins/yfge/agent-harness-skills/.codexignore
+++ b/plugins/yfge/agent-harness-skills/.codexignore
@@ -1,0 +1,11 @@
+.git/
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+node_modules/
+dist/
+build/
+.venv/
+artifacts/

--- a/plugins/yfge/agent-harness-skills/LICENSE
+++ b/plugins/yfge/agent-harness-skills/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agent Harness Skills contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/yfge/agent-harness-skills/README.md
+++ b/plugins/yfge/agent-harness-skills/README.md
@@ -1,0 +1,242 @@
+# Agent Harness Skills
+
+Reusable skills for turning real software repositories into agent-ready engineering environments.
+
+Agent Harness Skills helps teams build the repo-side control layer that coding agents need: clear entrypoints, explicit boundaries, runnable validation, runtime evidence, and reviewable delivery records.
+
+## Repository
+
+Canonical Git remote:
+
+```bash
+git@github.com:yfge/agent-harness-skills.git
+```
+
+Use this remote for git-backed installs and for publishing repository updates. A local clone path can still be used anywhere the installation examples accept `<repo-url-or-local-path>`.
+
+## What It Is
+
+Agent Harness Skills is a reusable skill library for designing repository harnesses.
+
+A repository harness is the engineering layer around a codebase that tells an agent where to start, which rules matter, what boundaries it must respect, how to prove a change is safe, and what evidence should be left behind for review. It is not a separate product runtime. It is the control layer that makes an existing repository easier for agents and humans to operate together.
+
+Use it when a project has grown beyond "read the README and run the tests" and needs a more explicit way for agents to navigate source-of-truth documents, validation commands, runtime traces, quality gates, and delivery records.
+
+The guidance is role-based. `AGENTS.md`, `tasks.md`, `agent_chats/`, and `artifacts/runs/` are default artifacts, not mandatory forms. If a repository already has an equivalent issue tracker, review template, validation command, generated report, or runtime artifact system, the skills should map those surfaces first and create defaults only for missing roles.
+
+## Why It Exists
+
+Coding agents can edit files quickly, but real repositories need more than fast edits. They need a stable operating surface.
+
+Without a harness, an agent has to infer too much: which document is authoritative, which directories are owned by which subsystem, which checks are meaningful, whether an observed failure maps to a runtime error, and what evidence belongs in a review or delivery record. That creates drift, repeated rediscovery, weak validation, and delivery summaries that cannot be audited.
+
+Agent Harness Skills turns those expectations into reusable repository practices. The goal is not to add ceremony. The goal is to make the important work discoverable, executable, and reviewable.
+
+## What It Helps Agents Do
+
+- Find the correct entrypoint and source of truth before making changes.
+- Understand architecture, ownership, and dependency boundaries.
+- Choose the validation surface that actually proves a change.
+- Connect observed runtime behavior to logs, traces, request IDs, screenshots, and artifacts.
+- Separate code regressions from environment, external dependency, data, or quota blockers.
+- Keep task state and acceptance criteria tied to the change that fulfills them.
+- Leave concise delivery records through commits, review notes, ledgers, and handoffs.
+- Improve quality incrementally without turning every task into a broad refactor.
+
+## Included Skills
+
+The skills form a capability map for building and improving an agent-ready repository:
+
+- `repo-harness-assessment`: assess a repository's current agent/harness maturity and identify the smallest useful next slice.
+- `agent-entrypoint-design`: design `AGENTS.md`, mirrored agent files, instruction precedence, and source-of-truth navigation.
+- `repo-contracts-and-boundaries`: turn architecture and directory boundaries into mechanical checks, baselines, and allowlists.
+- `validation-harness-design`: design repo validation entrypoints, test matrix, JSON/JUnit outputs, and CI gates.
+- `runtime-evidence-and-tracing`: design run IDs, request IDs, artifact bundles, runtime traces, and failure evidence.
+- `agent-ledger-and-delivery`: design collaboration ledgers, delivery evidence summaries, and links between tasks, commits, and reviews.
+- `quality-gardening`: design quality snapshots, structural metrics, debt thresholds, and generated quality reports.
+- `design-doc-and-task-board`: coordinate design documents, work-state surfaces such as `tasks.md`, exec plans, status updates, acceptance criteria, and task-to-change traceability.
+- `atomic-commit-discipline`: split work into minimal commits, include related task-state updates, verify diffs, run scoped checks, and keep related evidence together.
+
+Shared methodology support:
+
+- `references/harness-profiles.json`: machine-readable repository archetypes and role mappings for library, service, monorepo, CLI/tooling, docs-only, and regulated/high-audit repositories.
+- `templates/`: neutral starter templates for missing roles such as entrypoints, validation matrices, delivery records, work-state surfaces, runtime evidence summaries, and quality reports.
+- `Detected Mapping`: every skill output should name the repository's existing equivalent artifacts before recommending new files.
+
+## When To Use
+
+Use this repository when you want to:
+
+- Prepare a repository for agent-driven engineering work.
+- Turn scattered docs, scripts, and conventions into a navigable harness.
+- Design `AGENTS.md` and related entrypoints so agents know where to start.
+- Add validation gates that are useful locally and reusable in CI.
+- Connect observed behavior, runtime signals, external dependency results, and logs into artifact bundles.
+- Create durable delivery records for reviews, commits, handoffs, and follow-up work.
+- Use `tasks.md` or `docs/tasks.md` as a lightweight repo-local default when there is no reliable Jira, Linear, GitHub Issues, or internal board.
+
+It is especially useful when a repository already has product code, tests, and scripts, but agents still lose time rediscovering rules, guessing boundaries, or reporting work without enough evidence.
+
+## What It Is Not
+
+- It is not a product template or business scaffold.
+- It is not a private workflow bundle copied from one team or project.
+- It is not a replacement for project-specific architecture decisions.
+- It is not only a test harness; tests are one part of the validation surface.
+- It is not a platform requirement; a small script or document is often the right first layer.
+
+## Installation
+
+Installation differs by agent runtime. If you use more than one agent, install Agent Harness Skills separately for each one.
+
+Use one of two patterns:
+
+- Packaged install: use the metadata files in this repo when the agent runtime supports plugins or extensions.
+- Skills-path install: point the agent runtime directly at this repository's `skills/` directory.
+
+In the examples below, replace `<repo-url-or-local-path>` with this repository's git URL (`git@github.com:yfge/agent-harness-skills.git`) or an absolute local path to the repository root.
+
+### Generic Skills Directory
+
+Use this fallback for any agent runtime that supports an explicit skills path:
+
+```text
+<repo-url-or-local-path>/skills
+```
+
+Verify by asking the agent to list or load the `repo-harness-assessment` skill.
+
+### Codex CLI And Codex App
+
+This repository includes `.codex-plugin/plugin.json`, which exposes `./skills/` as a Codex plugin.
+
+- For a packaged or marketplace install, install `agent-harness-skills` through the Codex plugin UI or `/plugins` flow once the repository is published in that channel.
+- For local development, register this repository through a configured marketplace entry, then install `agent-harness-skills` from that marketplace.
+- Keep `.codex-plugin/plugin.json` as the Codex source of truth. It must point `skills` at `./skills/`, omit `apps` and `mcpServers` unless their companion manifests exist, and keep version metadata aligned with the other extension manifests.
+- When publishing through a marketplace, update that marketplace entry after the release commit so its source, ref, or sha points at the published revision.
+- Validate packaging changes with `python3 scripts/validate_plugin_metadata.py`.
+- Verify by asking Codex to use `repo-harness-assessment` on a repository.
+
+### Claude Code
+
+This repository includes `.claude-plugin/plugin.json` for Claude Code plugin packaging.
+
+- Install from the plugin marketplace once published, or use Claude Code's local/plugin-from-repository workflow for this repository.
+- Verify by asking Claude Code to load `repo-harness-assessment` or assess a repository's harness maturity.
+
+### Cursor
+
+This repository includes `.cursor-plugin/plugin.json`, with `skills` set to `./skills/`.
+
+- Install from the Cursor plugin marketplace once published, or add this repository through Cursor's plugin flow.
+- Verify by asking Cursor to list available skills or load `repo-harness-assessment`.
+
+### Gemini CLI
+
+This repository includes `gemini-extension.json` and `GEMINI.md`.
+
+Install the extension from a git URL or local path:
+
+```bash
+gemini extensions install git@github.com:yfge/agent-harness-skills.git
+```
+
+Gemini loads `GEMINI.md`, which points it to `INDEX.md` for skill routing. Verify by asking Gemini which Agent Harness Skills are available.
+
+### OpenCode
+
+This repository includes an OpenCode plugin entrypoint at `.opencode/plugins/agent-harness-skills.js`. On startup, the plugin injects a compact bootstrap that points the agent to `INDEX.md`, the native OpenCode skill tool, and this repository's `skills/` directory.
+
+For a local clone, add the repository root to the `plugin` array in your global or project-level `opencode.json`:
+
+```json
+{
+  "plugin": ["/absolute/path/to/agent-harness-skills"]
+}
+```
+
+For a git-backed install:
+
+```json
+{
+  "plugin": ["agent-harness-skills@git+ssh://git@github.com/yfge/agent-harness-skills.git"]
+}
+```
+
+Restart OpenCode, then verify that the startup bootstrap is present and that skills can be loaded:
+
+```text
+use skill tool to list skills
+use skill tool to load repo-harness-assessment
+```
+
+See `docs/README.opencode.md` for the longer OpenCode guide.
+
+## Usage
+
+Install through the runtime-specific path above, or point your agent runtime at this repository's `skills/` directory.
+
+Use this repository when you want an agent to answer questions like:
+
+- "What harness pieces is this repo missing?"
+- "How should this project structure `AGENTS.md` and validation commands?"
+- "How do we connect observed behavior to request traces?"
+- "Should this requirement live in a work-state surface such as `tasks.md`, a design doc, or an exec plan?"
+- "How should these changes be split into atomic commits?"
+
+## Repository Layout
+
+```text
+.codex-plugin/
+  plugin.json
+.claude-plugin/
+  plugin.json
+.cursor-plugin/
+  plugin.json
+.opencode/
+  INSTALL.md
+  plugins/agent-harness-skills.js
+GEMINI.md
+gemini-extension.json
+skills/
+  <skill-name>/SKILL.md
+docs/
+  README.opencode.md
+  scenario-tests.md
+references/
+  harness-profiles.json
+  harness-patterns.md
+scripts/
+  check_skill_closure.py
+  check_profile_consistency.py
+  check_skill_language.py
+  check_reference_neutrality.py
+  validate_plugin_metadata.py
+  validate_skill_quality.py
+templates/
+  AGENTS.md
+  delivery-record.md
+  quality-report.md
+  runtime-evidence-summary.md
+  task-state.md
+  validation-matrix.md
+```
+
+## Validation
+
+```bash
+python3 -m unittest discover -s scripts -p 'test_*.py'
+python3 scripts/validate_skill_quality.py
+python3 scripts/check_skill_language.py
+python3 scripts/check_skill_closure.py
+python3 scripts/check_reference_neutrality.py
+python3 scripts/check_profile_consistency.py
+python3 scripts/validate_plugin_metadata.py
+node --check .opencode/plugins/agent-harness-skills.js
+```
+
+For substantial skill wording changes, record at least one realistic prompt and observed output in `docs/scenario-tests.md`.
+
+## License
+
+MIT License. See `LICENSE`.

--- a/plugins/yfge/agent-harness-skills/SECURITY.md
+++ b/plugins/yfge/agent-harness-skills/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+Agent Harness Skills is a documentation and skills repository. It should not contain credentials, private URLs, account identifiers, customer data, or environment-specific secrets.
+
+## Supported Versions
+
+Security fixes are handled on the default branch. If releases are introduced later, this section should list supported release lines.
+
+## Reporting A Vulnerability
+
+Do not open a public issue containing secrets, exploit details, or sensitive repository information.
+
+Use the repository host's private vulnerability reporting feature if it is enabled. If no private route is available, open a minimal public issue asking maintainers to provide a private disclosure channel, without including sensitive details.
+
+When reporting, include:
+
+- A concise description of the issue.
+- The affected file or installation path.
+- Whether any private data or credentials are exposed.
+- Steps maintainers can use to confirm the problem safely.
+
+## Scope
+
+Relevant issues include:
+
+- Committed secrets, credentials, private URLs, or account identifiers.
+- Install instructions that could cause unsafe execution or credential exposure.
+- Plugin or extension metadata that grants broader capabilities than documented.
+- Skill text that instructs agents to collect, expose, or commit sensitive data.
+
+Out of scope:
+
+- Product vulnerabilities in repositories that use these skills.
+- General questions about agent behavior without a concrete security impact.
+- Reports that require access to private systems not controlled by this project.

--- a/plugins/yfge/agent-harness-skills/assets/icon.svg
+++ b/plugins/yfge/agent-harness-skills/assets/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Agent Harness Skills">
+  <rect width="512" height="512" rx="96" fill="#2F6FED"/>
+  <path d="M144 150c0-18 14-32 32-32h160c18 0 32 14 32 32v212c0 18-14 32-32 32H176c-18 0-32-14-32-32z" fill="#F8FAFC"/>
+  <path d="M186 180h140M186 230h82M186 280h140" stroke="#1E293B" stroke-width="24" stroke-linecap="round"/>
+  <path d="M198 342l38 38 86-98" fill="none" stroke="#2F6FED" stroke-width="28" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="364" cy="150" r="38" fill="#12B981"/>
+  <path d="M348 150l11 11 21-26" fill="none" stroke="#F8FAFC" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/plugins/yfge/agent-harness-skills/package.json
+++ b/plugins/yfge/agent-harness-skills/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "agent-harness-skills",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Reusable skills for building agent-ready repository harnesses.",
+  "homepage": "https://github.com/yfge/agent-harness-skills",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/yfge/agent-harness-skills.git"
+  },
+  "main": ".opencode/plugins/agent-harness-skills.js",
+  "scripts": {
+    "validate": "python3 -m unittest discover -s scripts -p 'test_*.py' && node --test scripts/test_opencode_plugin.mjs && python3 scripts/validate_skill_quality.py && python3 scripts/check_skill_language.py && python3 scripts/check_skill_closure.py && python3 scripts/check_reference_neutrality.py && python3 scripts/check_profile_consistency.py && python3 scripts/validate_plugin_metadata.py && node --check .opencode/plugins/agent-harness-skills.js",
+    "validate:plugin": "node --test scripts/test_opencode_plugin.mjs && python3 scripts/validate_plugin_metadata.py && python3 scripts/check_profile_consistency.py && node --check .opencode/plugins/agent-harness-skills.js"
+  },
+  "license": "MIT"
+}

--- a/plugins/yfge/agent-harness-skills/skills/agent-entrypoint-design/SKILL.md
+++ b/plugins/yfge/agent-harness-skills/skills/agent-entrypoint-design/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: agent-entrypoint-design
+description: Use when designing or refactoring AGENTS.md, CLAUDE.md, GEMINI.md, Cursor rules, GitHub instructions, source-of-truth navigation, or agent onboarding entrypoints.
+---
+
+# Agent Entrypoint Design
+
+## Overview
+
+Create a small, stable entrypoint that tells agents where truth lives, what rules apply, and which checks gate changes.
+
+The entrypoint should be navigation plus hard rules, not a long project encyclopedia. For shared harness terms, see `../../references/harness-patterns.md`; when entrypoint files are absent, use `references/build-when-missing.md`. For mirror casing and drift rules, see `references/mirror-policy.md`.
+
+## When To Use
+
+- The user wants to create or refactor `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, or GitHub instructions.
+- Multiple agent instruction files duplicate content, drift, or contradict each other.
+- A new project needs to define what an agent reads first, what it can change, and what it must run afterward.
+
+## Inputs Needed
+
+- Repository root and main app/module boundaries.
+- Existing agent instruction files and docs entrypoints.
+- Whether mirrors, symlinks, generation scripts, or CI drift checks are expected.
+
+## Execution Order
+
+- First: Read existing entrypoint files and identify which file should be the source of truth.
+- Then: Design the root entrypoint, subtree entrypoints, mirror strategy, and validation commands.
+- Finally: Output the entrypoint structure and sync/drift-prevention checks.
+
+## Step-by-Step Process
+
+1. Search for `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.cursor`, and `.github/instructions`.
+2. Identify repeated rules, oversized rules, stale paths, or chat-only facts.
+3. If no usable entrypoint exists, create the minimum source-of-truth entrypoint from `references/build-when-missing.md`.
+4. Choose one primary entrypoint; other agent-specific files should mirror, symlink, or explicitly reference it.
+5. Keep the root entrypoint to scope, source-of-truth docs, do/avoid rules, commands, tests, and relevant skills.
+6. If a subtree has special rules, put a closer `AGENTS.md` in that subtree instead of overloading the root.
+7. Define drift prevention through a generation script, check script, CI job, or explicit manual checklist.
+
+## Checks
+
+- Entrypoint: an agent can learn what to read first, where it may edit, and the minimum validation command within 60 seconds.
+- Consistency: mirrored files cannot silently drift, or they carry a generation note or symlink constraint.
+- Source of truth: rules point to versioned docs/scripts, not conversation memory.
+- Scope: root rules are not too detailed, and subtree rules are not missing.
+- Executability: every key rule maps to a command, file, or clear decision standard.
+
+## Output Format
+
+```markdown
+# Agent Entrypoint Design
+
+## Detected Mapping
+- entrypoint:
+- mirrors:
+- validation:
+
+## Source Of Truth
+- Primary entrypoint:
+- Mirrors:
+- Subtree overrides:
+
+## Root Entrypoint Sections
+-
+
+## Sync / Drift Prevention
+-
+
+## Minimum Commands
+-
+
+## Follow-up Files
+-
+```
+
+## Common Mistakes
+
+- Copying large rule blocks into every agent file, which creates drift.
+- Turning the entrypoint into a project encyclopedia that still leaves agents unsure what to do first.
+- Putting concrete product requirements into general agent rules.
+- Failing to document instruction precedence.
+
+## Example Prompts
+
+- "Design AGENTS.md and mirror rules for this repository."
+- "This repo has multiple agent instruction files. Make them source-of-truth safe."
+- "Shrink the agent entrypoint into high-signal navigation."

--- a/plugins/yfge/agent-harness-skills/skills/agent-entrypoint-design/references/build-when-missing.md
+++ b/plugins/yfge/agent-harness-skills/skills/agent-entrypoint-design/references/build-when-missing.md
@@ -1,0 +1,36 @@
+# Build When Missing
+
+Use this when a repository has no usable agent entrypoint. Pattern sources include first-read guidance, mirror policies, and subtree overrides in larger repositories.
+
+## Equivalent Artifacts
+
+- Existing agent instruction files, contributor guides, or runtime-specific rule files may already satisfy the entrypoint role.
+- Record the chosen artifact under `Detected Mapping` before creating a default file.
+- Use `templates/AGENTS.md` only when no equivalent entrypoint exists.
+
+## Minimum Files
+
+- Root `AGENTS.md` or an explicitly mapped equivalent entrypoint.
+- Optional mirrors: `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, or `.github/instructions/*`.
+- Optional subtree `AGENTS.md` only where a directory has stricter local rules.
+
+## Bootstrap Steps
+
+1. Map any existing first-read guidance to the entrypoint role.
+2. If no equivalent exists, create a root entrypoint from `templates/AGENTS.md`.
+3. Declare instruction precedence: system/developer, user, nearest agent file, linked docs.
+4. Add a mirror policy: symlink, exact copy with generation marker, or explicit "read the primary entrypoint first" pointer.
+5. Add only high-signal navigation; link deeper docs instead of embedding long procedures.
+6. Add a drift check if mirrors are generated or exact-copy files.
+
+## Validation
+
+- Confirm an agent can identify first-read docs, edit boundaries, and minimum validation in under one minute.
+- Run the mirror/drift checker if present.
+- If no checker exists, compare mirror contents or symlink targets manually.
+
+## Do Not Include
+
+- Product secrets, credentials, local machine paths, or private environment assumptions.
+- Long project encyclopedia content that belongs in architecture or runbook docs.
+- Business-specific requirements that should live in design docs or task boards.

--- a/plugins/yfge/agent-harness-skills/skills/agent-entrypoint-design/references/mirror-policy.md
+++ b/plugins/yfge/agent-harness-skills/skills/agent-entrypoint-design/references/mirror-policy.md
@@ -1,0 +1,28 @@
+# Mirror Policy
+
+Use this when a repository has more than one agent instruction surface.
+
+## Canonical File
+
+- Choose one primary entrypoint, normally `AGENTS.md`.
+- Treat name casing as part of the contract. Do not create parallel files whose names differ only by case.
+- If a runtime expects another filename, make that file a symlink, generated mirror, or short pointer to the primary entrypoint.
+
+## Drift Prevention
+
+- Generated mirrors should include a marker that names the source file and generation command.
+- Exact-copy mirrors need a check that compares content byte-for-byte.
+- Symlink mirrors need a check that verifies the target path.
+- Pointer mirrors should be short and should not duplicate rules.
+
+## Validation
+
+- List every agent-facing instruction file.
+- Confirm each file is canonical, a symlink, a generated mirror, or a pointer.
+- Run the mirror check if one exists; otherwise compare targets manually.
+
+## Do Not Include
+
+- Multiple independent sources of truth for the same rule.
+- Case-only filename variants.
+- Runtime-specific rules that should live in the primary entrypoint or a subtree entrypoint.

--- a/plugins/yfge/agent-harness-skills/skills/agent-ledger-and-delivery/SKILL.md
+++ b/plugins/yfge/agent-harness-skills/skills/agent-ledger-and-delivery/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: agent-ledger-and-delivery
+description: Use when designing agent_chats or agents_chat records, delivery evidence summaries, linked tasks or commits, validation notes, risks, review notes, or handoff records.
+---
+
+# Agent Ledger And Delivery
+
+## Overview
+
+Define how agent work is recorded so reviewers can see prompt, intent, changes, validation, risks, and linked tasks or commits.
+
+This skill focuses on delivery evidence and long-term traceability, not commit splitting or task-state ownership. A ledger may reference tasks and commits, but `tasks.md`, an issue tracker, or another work-state surface remains responsible for current task status and acceptance criteria. For shared harness terms, see `../../references/harness-patterns.md`; when ledger files are absent, use `references/build-when-missing.md`. For ledger coupling and skip policy, see `references/delivery-coupling.md`.
+
+## When To Use
+
+- The user mentions `agent_chats`, `agents_chat`, review descriptions, delivery records, linked tasks, or linked commits.
+- A project requires AI collaboration records for each delivery.
+- Validation, risk, next steps, and artifact references need a stable format.
+
+## Inputs Needed
+
+- Existing ledger directory and naming rules.
+- User goal, change summary, validation commands, artifacts, task IDs, reviews, or commits.
+- Whether the repository requires ledger updates in the same commit.
+
+## Execution Order
+
+- First: Read existing ledger rules and recent examples.
+- Then: Design the record schema, naming, required sections, and task/commit/review coupling.
+- Finally: Output a reusable ledger template and delivery checklist.
+
+## Step-by-Step Process
+
+1. Search for `agent_chats`, `agents_chat`, CI checks, AGENTS rules, and review templates.
+2. Confirm record granularity: per commit, per review, per session, or per milestone.
+3. If no ledger convention exists, bootstrap the minimum directory and template from `references/build-when-missing.md`.
+4. Define filename, frontmatter, body sections, language, and redaction rules.
+5. Define when ledger updates are required, when skip is allowed, and how skip is recorded.
+6. Define how review or delivery summaries reference tasks, commits, validation, artifacts, risks, and next steps.
+7. Keep ledger and atomic commit rules separate: this skill defines records; `atomic-commit-discipline` defines commit splitting.
+8. Keep ledger and task-state rules separate: this skill summarizes evidence; the work-state surface owns current task status.
+
+## Checks
+
+- Completeness: prompt, goals, changes, validation, risks, and linked tasks or commits are present.
+- Coupling: code changes have a corresponding ledger or explicit skip reason.
+- Boundary: ledger summaries do not replace updates to task status or acceptance criteria.
+- Readability: future agents can resume from the record; it is not just "done."
+- Privacy: records do not include tokens, secrets, private chat transcripts, or sensitive logs.
+- Duplication: avoid two ledger formats that drift from each other.
+
+## Output Format
+
+```markdown
+# Agent Ledger And Delivery
+
+## Detected Mapping
+- ledger:
+- work-state:
+- validation:
+
+## Ledger Policy
+- Directory:
+- Filename:
+- Required metadata:
+- Required sections:
+
+## Delivery Summary Template
+-
+
+## Task / Commit / Review Coupling
+-
+
+## Validation Evidence
+-
+
+## Skip Policy
+-
+```
+
+## Common Mistakes
+
+- Writing a diary instead of validation and risk evidence.
+- Letting the review summary disagree with actual validation.
+- Treating a ledger entry as a substitute for updating task state.
+- Mixing atomic commit rules into the ledger skill until responsibilities overlap.
+- Recording sensitive content.
+
+## Example Prompts
+
+- "Design an agents_chat record policy for this project."
+- "Make a review evidence template for this agent-driven repo."
+- "What validation, tasks, and linked commits should this delivery record include?"

--- a/plugins/yfge/agent-harness-skills/skills/agent-ledger-and-delivery/references/build-when-missing.md
+++ b/plugins/yfge/agent-harness-skills/skills/agent-ledger-and-delivery/references/build-when-missing.md
@@ -1,0 +1,39 @@
+# Build When Missing
+
+Use this when agent work has no durable delivery record. Pattern sources include delivery ledgers, review summaries, release notes, and handoff records with validation sections, linked tasks, and linked commits.
+
+## Equivalent Artifacts
+
+- Pull request descriptions, release notes, handoff notes, or an existing delivery log may already satisfy the ledger role.
+- Record the chosen artifact under `Detected Mapping` before creating a default ledger directory.
+- Use `templates/delivery-record.md` only when no equivalent delivery evidence format exists.
+
+## Minimum Files
+
+- `agent_chats/`, `agents_chat/`, or an explicitly mapped equivalent ledger surface.
+- `.gitkeep` if the directory would otherwise be empty.
+- `docs/agent-ledger-template.md` or a template section in `AGENTS.md`.
+- Optional CI checker only after the policy is stable.
+
+## Bootstrap Steps
+
+1. Map any existing review, release, or handoff record to the ledger role.
+2. If no equivalent exists, choose one ledger location and document that no parallel format should be created.
+3. Define filename or record identity format appropriate to the mapped surface.
+4. Define required sections: user prompt or goal, changes, validation, risks or next steps, linked tasks, and linked commits.
+5. Define coupling: per commit, per review, per session, or per milestone.
+6. Add skip policy for trivial or emergency changes, including how to record the skip reason.
+
+## Validation
+
+- Create or inspect one sample record and confirm all required sections exist.
+- Confirm validation commands and artifact paths in the record match what actually ran.
+- Confirm the ledger references task state without replacing the authoritative task surface.
+- If CI exists, confirm code changes that require ledgers are detected.
+
+## Do Not Include
+
+- Raw private chat transcripts, secrets, credentials, or sensitive logs.
+- Two competing ledger directory names unless one is explicitly deprecated.
+- Task-status ownership that belongs in `tasks.md`, an issue tracker, or another work-state surface.
+- Commit-splitting rules that belong in atomic commit discipline.

--- a/plugins/yfge/agent-harness-skills/skills/agent-ledger-and-delivery/references/delivery-coupling.md
+++ b/plugins/yfge/agent-harness-skills/skills/agent-ledger-and-delivery/references/delivery-coupling.md
@@ -1,0 +1,30 @@
+# Delivery Coupling
+
+Use this when ledger records must be tied to code review, tasks, commits, or handoff.
+
+## Coupling Levels
+
+- Advisory: records are expected but not mechanically checked.
+- Commit-coupled: relevant changes must include a ledger record in the same commit.
+- Review-coupled: review notes must link the ledger record.
+- Task-linked: ledger records reference the task or work-state entry they summarize without owning its current status.
+- Gate-coupled: a hook or CI check blocks missing records for configured paths.
+
+## Skip Policy
+
+- Skips must be explicit and searchable.
+- A skip record should state reason, affected paths, validation that still ran, and follow-up owner if any.
+- Emergency skips should create a repayment task or follow-up record.
+
+## Validation
+
+- Check whether changed paths trigger a required record.
+- Confirm the ledger record names the prompt, goal, task reference, changes, validation, risks, and linked delivery artifacts.
+- Confirm review notes and commit bodies do not claim validation that is absent from the record.
+- Confirm task status is updated in the work-state surface, not only in the ledger.
+
+## Do Not Include
+
+- Silent bypasses.
+- Raw private conversation transcripts.
+- Two active ledger formats without a deprecation note.

--- a/plugins/yfge/agent-harness-skills/skills/atomic-commit-discipline/SKILL.md
+++ b/plugins/yfge/agent-harness-skills/skills/atomic-commit-discipline/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: atomic-commit-discipline
+description: Use when splitting changes into atomic commits, checking git status and diffs, staging exact paths, including related task-state updates, writing Conventional Commits, or preventing unrelated changes.
+---
+
+# Atomic Commit Discipline
+
+## Overview
+
+Turn completed work into small, reviewable commits with scoped validation, related task-state updates, and no unrelated files.
+
+This skill is not a review template or ledger template. It focuses on minimal commits, exact staged paths, task-state coupling, validation, and commit messages. For shared harness terms, see `../../references/harness-patterns.md`; when commit rules are absent, use `references/build-when-missing.md`. For delivery artifact evidence, see `references/delivery-artifact-checklist.md`.
+
+## When To Use
+
+- The user asks to commit, split commits, stage exact paths, or avoid unrelated changes.
+- The worktree has multiple changes and you need to decide which belong in the same logical commit.
+- A tracked task is completed, changed, or invalidated and its task-state update must travel with the related commit.
+- The project requires Conventional Commits or a ledger entry paired with each commit.
+
+## Inputs Needed
+
+- Current `git status`, `git diff`, and `git diff --cached`.
+- User goal and completed validation.
+- Current task-state surface, such as `tasks.md`, `docs/tasks.md`, or the repository's issue tracker reference.
+- Repository commit rules and whether ledger entries must be committed together.
+
+## Execution Order
+
+- First: Read `git status` and relevant diffs to identify your changes and unrelated changes.
+- Then: Split staged paths by one logical behavior per commit, include related task-state updates, and run the minimum relevant validation.
+- Finally: Write a Conventional Commit message, commit, and re-check status and commit contents.
+
+## Step-by-Step Process
+
+1. Run `git status --short --branch` and list all tracked and untracked changes.
+2. Read `git diff -- <path>` for every file you intend to commit; do not commit changes you do not understand.
+3. If no commit discipline is documented, bootstrap the minimum grouping and validation checklist from `references/build-when-missing.md`.
+4. Identify whether the change completes, changes, or invalidates a tracked task; if yes, include the corresponding task-state update in the same logical commit.
+5. Group by logical boundary: docs, tests, implementation, harness, ledger, and task state should not be mixed unless they describe the same logical change or repository rules require the same commit.
+6. Run the smallest validation command that matches each group; fix failures before committing.
+7. Use `git add <exact paths>`; avoid `git add .` unless the whole worktree contains only this change.
+8. Write a Conventional Commit subject, and use the body for validation, skip reasons, task IDs, or linked artifacts when needed.
+9. After committing, run `git show --stat --oneline HEAD` and `git status --short`.
+
+## Checks
+
+- Scope: each commit has one logical purpose.
+- Ownership: no user-owned changes or temporary generated files are included by accident.
+- Task coupling: task-state updates are present when the commit fulfills, changes, or invalidates a tracked task; unrelated task churn is absent.
+- Validation: the commit has matching pre-commit validation.
+- Message: the subject describes behavior, not "update files."
+- Ledger: if the repository requires `agent_chats` in the same commit, it is staged with the change.
+
+## Output Format
+
+```markdown
+# Atomic Commit Plan
+
+## Detected Mapping
+- work-state:
+- ledger:
+- validation:
+
+## Worktree State
+-
+
+## Commit Groups
+1. Subject:
+   Paths:
+   Task-state updates:
+   Validation:
+
+## Excluded Changes
+-
+
+## Final Checks
+- First:
+- Then:
+- Finally:
+```
+
+## Common Mistakes
+
+- Using `git add .` and bringing unrelated files into the commit.
+- Mixing features, formatting, docs, refactors, and temporary fixes in one commit.
+- Splitting a completed task's status update into a later unrelated commit.
+- Committing before reading the diff.
+- Writing commit messages such as "fix" or "update."
+- Committing after validation fails.
+
+## Example Prompts
+
+- "Split these changes into atomic commits."
+- "Commit only the harness docs and leave unrelated files unstaged."
+- "Check git status and commit by logical group, including related task updates."

--- a/plugins/yfge/agent-harness-skills/skills/atomic-commit-discipline/references/build-when-missing.md
+++ b/plugins/yfge/agent-harness-skills/skills/atomic-commit-discipline/references/build-when-missing.md
@@ -1,0 +1,40 @@
+# Build When Missing
+
+Use this when a repository has no commit discipline beyond informal convention. Pattern sources include Conventional Commit policies, exact-path staging rules, task-state coupling, ledger coupling, and validation-before-commit checklists.
+
+## Equivalent Artifacts
+
+- Contributor guides, pull request templates, protected-branch rules, or existing release policies may already satisfy parts of the commit discipline role.
+- Record the chosen artifacts under `Detected Mapping` before adding new policy text.
+- Add default policy sections only where no equivalent rule exists.
+
+## Minimum Files
+
+- Commit policy section in `AGENTS.md`, `CONTRIBUTING.md`, or an explicitly mapped equivalent.
+- Task-state policy section in the mapped work-state surface or planning documentation.
+- Optional `.github/pull_request_template.md`.
+- Optional `docs/commit-checklist.md` if the policy is too long for the entrypoint.
+- Optional CI commit-message or ledger-coupling checker.
+
+## Bootstrap Steps
+
+1. Map existing commit, review, and task-state rules.
+2. State only the missing commit rules: one logical purpose per commit and exact-path staging.
+3. Require reading `git status`, `git diff`, and `git diff --cached` before staging.
+4. State the task coupling rule: when a commit completes, changes, or invalidates a tracked task, include the task-state update in the same logical commit.
+5. Define the commit subject format, preferably Conventional Commits when no repository format exists.
+6. Define minimum validation evidence for docs, tests, implementation, harness, task-state, and ledger changes.
+
+## Validation
+
+- Before commit, confirm staged files match one logical group.
+- Confirm task-state updates are included only when related to that logical group.
+- Run the minimum validation command for that group.
+- After commit, run `git show --stat --oneline HEAD` and `git status --short`.
+
+## Do Not Include
+
+- Permission to use `git add .` by default.
+- A rule that every commit must have a task entry unless the repository explicitly requires it.
+- Commit messages such as "fix" or "update" without behavioral detail.
+- Rules that allow unrelated user changes to be staged silently.

--- a/plugins/yfge/agent-harness-skills/skills/atomic-commit-discipline/references/delivery-artifact-checklist.md
+++ b/plugins/yfge/agent-harness-skills/skills/atomic-commit-discipline/references/delivery-artifact-checklist.md
@@ -1,0 +1,29 @@
+# Delivery Artifact Checklist
+
+Use this when a commit is part of a release, deploy, package, or handoff flow.
+
+## Minimum Evidence
+
+- Artifact identity: version, tag, package name, bundle name, or run ID.
+- Build command and result.
+- Validation command and result.
+- Target channel or audience, described generically.
+- Rollback, restore, or follow-up note when the delivery can affect users.
+
+## Commit Grouping
+
+- Keep release metadata separate from unrelated implementation work unless the repository explicitly requires one commit.
+- Keep generated artifacts out of source commits unless they are versioned outputs by policy.
+- Link large artifacts by path or run ID instead of committing them by default.
+
+## Validation
+
+- Re-read staged files and confirm they match one delivery purpose.
+- Confirm the artifact can be reproduced from committed sources and documented commands.
+- Confirm ledger or handoff records reference the artifact identity and validation.
+
+## Do Not Include
+
+- Unrelated formatting or cleanup.
+- Local-only build products.
+- Delivery claims without artifact identity.

--- a/plugins/yfge/agent-harness-skills/skills/design-doc-and-task-board/SKILL.md
+++ b/plugins/yfge/agent-harness-skills/skills/design-doc-and-task-board/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: design-doc-and-task-board
+description: Use when deciding how requirements should be captured in design docs, tasks.md, external task systems, exec plans, acceptance criteria, status updates, or planning source-of-truth files.
+---
+
+# Design Doc And Task Board
+
+## Overview
+
+Decide where intent, design, work state, and acceptance criteria should live so they do not drift.
+
+Design docs explain why and how; a work-state surface tracks current tasks, statuses, acceptance criteria, and task-to-change traceability; exec plans describe how to execute a complex batch of changes. `tasks.md` or `docs/tasks.md` is the lightweight repo-local default when no reliable Jira, Linear, GitHub Issues, internal board, or equivalent tracker exists. For shared harness terms, see `../../references/harness-patterns.md`; when planning files are absent, use `references/build-when-missing.md`.
+
+## When To Use
+
+- The user asks whether a requirement belongs in a design doc, `tasks.md`, an external task system, or an exec plan.
+- README, design docs, tasks, and exec plans start to duplicate or drift.
+- Requirements need to become tasks, statuses, acceptance criteria, and commit-linked change records.
+
+## Inputs Needed
+
+- Current requirement or change goal.
+- Existing task tracker or `tasks.md`, design docs, exec plans, README, and docs index.
+- Change size, cross-module scope, and whether long-term tracking is needed.
+
+## Execution Order
+
+- First: Read existing planning and work-state sources of truth and identify how this project expresses intent and status.
+- Then: Decide whether this requirement belongs in a design doc, existing task system, repo-local task board, exec plan, or combination.
+- Finally: Output the doc/task sync strategy, acceptance criteria, and update order.
+
+## Step-by-Step Process
+
+1. Search for `tasks.md`, `PLANS.md`, `docs/design*`, `docs/exec-plans`, README, issue references, and documented external task systems.
+2. Identify each file's actual responsibility; do not infer solely from names.
+3. If no reliable work-state surface exists, bootstrap the minimum design/task/exec-plan set from `references/build-when-missing.md`, using `tasks.md` or `docs/tasks.md` as the repo-local default.
+4. Classify by complexity: small fixes update tasks only; architecture or cross-module changes start with a design doc; multi-day batches use an exec plan.
+5. Write task entries with owner, status, acceptance criteria, linked paths, and the expected commit or change reference; do not put chat notes into `tasks.md`.
+6. When design changes, update the design source of truth first, then sync task state and acceptance criteria.
+7. When a tracked task is completed, changed, or invalidated by a commit, include that task-state update in the same logical commit as the related change.
+8. Output drift checks: one conclusion has one source of truth, and other files reference it.
+
+## Checks
+
+- Responsibility: design doc, work-state surface, and exec plan each have a clear role.
+- Sync: task status matches current code and design decisions.
+- Acceptance: every task has executable acceptance criteria.
+- Granularity: tasks are small enough to verify and large enough to express user value.
+- Commit coupling: task-state updates travel with the logical commit that fulfills, changes, or invalidates them.
+- Pollution: `tasks.md` does not become a chat log or unordered TODO list.
+
+## Output Format
+
+```markdown
+# Design Doc And Task Board Decision
+
+## Detected Mapping
+- design source:
+- work-state:
+- exec plan:
+
+## Where This Belongs
+- Design doc:
+- Work-state surface:
+- Exec plan:
+
+## Update Order
+- First:
+- Then:
+- Finally:
+
+## Task Entries
+-
+
+## Commit Coupling
+-
+
+## Acceptance Criteria
+-
+
+## Drift Checks
+-
+```
+
+## Common Mistakes
+
+- Putting task status into a design doc where it cannot be maintained.
+- Updating only the task surface while leaving the design source of truth stale.
+- Completing a task in code while leaving its task-state update for a later unrelated commit.
+- Opening a large exec plan for every small requirement.
+- Writing tasks with no acceptance criteria, such as "improve" or "optimize."
+
+## Example Prompts
+
+- "Should this requirement live in a design doc, an issue tracker, or tasks.md?"
+- "Turn this design into a task board and acceptance criteria."
+- "Our task board and design docs have drifted; how should we converge them?"

--- a/plugins/yfge/agent-harness-skills/skills/design-doc-and-task-board/references/build-when-missing.md
+++ b/plugins/yfge/agent-harness-skills/skills/design-doc-and-task-board/references/build-when-missing.md
@@ -1,0 +1,40 @@
+# Build When Missing
+
+Use this when product intent and execution state live only in conversation. Pattern sources include task boards, external task systems, design-doc directories, active/completed exec-plan directories, and docs indexes.
+
+## Equivalent Artifacts
+
+- External trackers, planning documents, issue templates, design indexes, or roadmap files may already satisfy the work-state, design, or exec-plan roles.
+- Record the chosen artifacts under `Detected Mapping` before creating `tasks.md` or new planning directories.
+- Use `templates/task-state.md` only when no reliable work-state surface exists.
+
+## Minimum Files
+
+- `tasks.md`, `docs/tasks.md`, or an explicitly mapped external tracker for current work state.
+- `docs/design/`, `docs/design-docs/`, or an explicitly mapped equivalent for durable decisions.
+- `docs/exec-plans/active/` and `docs/exec-plans/completed/` only for complex work that needs execution plans.
+- `docs/exec-plans/template.md` or an equivalent plan template.
+
+## Bootstrap Steps
+
+1. Map existing issue trackers, planning docs, and design docs to their roles.
+2. Create a default task-state file only when no reliable mapped work-state surface exists.
+3. Create a design-doc directory and index only if decisions need longer-lived explanation.
+4. Create exec-plan directories only when the repository has multi-step or multi-day work.
+5. Define update order: design source first, task state second, exec-plan status third.
+6. Define commit coupling: when a commit completes, changes, or invalidates a tracked task, stage the task-state update with that same logical commit.
+7. Link planning files or external trackers from README or the entrypoint.
+
+## Validation
+
+- Confirm every active task has a status and acceptance criteria.
+- Confirm design docs and task board do not duplicate the same decision as separate sources of truth.
+- Confirm completed, changed, or invalidated tracked tasks are updated with the corresponding logical commit.
+- Confirm completed exec plans are archived or clearly marked.
+
+## Do Not Include
+
+- Chat logs as task board content.
+- Vague tasks such as "improve" without acceptance criteria.
+- A rule that every commit must have a task, unless the repository explicitly wants that overhead.
+- Large exec-plan machinery for small one-file fixes.

--- a/plugins/yfge/agent-harness-skills/skills/quality-gardening/SKILL.md
+++ b/plugins/yfge/agent-harness-skills/skills/quality-gardening/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: quality-gardening
+description: Use when designing quality snapshots, generated quality reports, structural metrics, debt thresholds, regression budgets, quality gates, or gradual cleanup loops.
+---
+
+# Quality Gardening
+
+## Overview
+
+Track quality as concrete metrics and debt movement, not as a vague single score.
+
+This skill freezes new degradation first, then uses generated metrics to show current quality and convergence direction. For shared harness terms, see `../../references/harness-patterns.md`; when quality surfaces are absent, use `references/build-when-missing.md`. For generated snapshot ownership, see `references/generated-snapshot-ownership.md`.
+
+## When To Use
+
+- The user mentions `QUALITY_SCORE.md`, quality reports, quality snapshots, debt reduction, or red lines.
+- A repository needs structural metrics beyond lint and tests.
+- The team needs periodic gardening instead of a one-time large refactor.
+
+## Inputs Needed
+
+- Current quality pain points: large files, scattered events, direct API calls, duplicated entrypoints, missing tests, or similar risks.
+- Source paths to scan and paths to exclude.
+- CI or scheduled run strategy.
+
+## Execution Order
+
+- First: Find existing quality docs, generated reports, lint checks, and baselines.
+- Then: Choose a small set of trackable metrics and thresholds; do not create a fake aggregate score.
+- Finally: Output the quality report shape, gate policy, and convergence cadence.
+
+## Step-by-Step Process
+
+1. Search for `QUALITY_SCORE.md`, quality scripts, baselines, and CI gardening workflows.
+2. Choose four to eight metrics, and make each one automatically collectable.
+3. If no quality report exists, bootstrap the minimum score/report/baseline set from `references/build-when-missing.md`.
+4. Separate blocking gates from informational reports.
+5. Use thresholds or baselines for historical problems; new degradation should fail.
+6. Generate Markdown for humans and JSON for scripts and trends.
+7. Design a gardening cadence: lower one threshold or close one allowlist item at a time.
+
+## Checks
+
+- Metrics: each metric is repeatable and reflects a real structural risk.
+- Thresholds: checks freeze new degradation instead of demanding immediate full cleanup.
+- Reports: each finding includes path, metric, current value, threshold, and suggested action.
+- CI: it is clear which metrics fail builds and which only report.
+- Incentives: do not hide critical risks behind one attractive total score.
+
+## Output Format
+
+```markdown
+# Quality Gardening
+
+## Detected Mapping
+- quality:
+- validation:
+- work-state:
+
+## Metrics
+| Metric | Source | Threshold | Gate |
+| --- | --- | --- | --- |
+
+## Generated Reports
+-
+
+## Baseline Policy
+-
+
+## Garden Loop
+-
+
+## Non-Goals
+-
+```
+
+## Common Mistakes
+
+- Inventing a good-looking total score that does not guide repairs.
+- Tracking too many metrics, so nobody reads or fixes them.
+- Skipping baselines, which makes the quality gate unusable on day one.
+- Treating one large refactor as quality governance.
+
+## Example Prompts
+
+- "Design QUALITY_SCORE.md and a quality report for this repo."
+- "How should we track structural debt without inventing a fake score?"
+- "Add historical large files and scattered calls to a quality garden."

--- a/plugins/yfge/agent-harness-skills/skills/quality-gardening/references/build-when-missing.md
+++ b/plugins/yfge/agent-harness-skills/skills/quality-gardening/references/build-when-missing.md
@@ -1,0 +1,37 @@
+# Build When Missing
+
+Use this when quality is discussed but not measured. Pattern sources include `QUALITY_SCORE.md`, generated quality reports, harness baseline files, and scheduled gardening commands.
+
+## Equivalent Artifacts
+
+- Existing quality dashboards, generated reports, static-analysis summaries, or debt baselines may already satisfy the quality role.
+- Record the chosen artifacts under `Detected Mapping` before creating default score files.
+- Use `templates/quality-report.md` only when no equivalent quality report exists.
+
+## Minimum Files
+
+- `QUALITY_SCORE.md`, `docs/quality/QUALITY_SCORE.md`, or an explicitly mapped equivalent quality summary.
+- `docs/generated/quality-report.md` or a mapped generated report path.
+- Optional JSON report under `docs/generated/` or `artifacts/`.
+- Baseline or threshold file under `scripts/baselines/` or `scripts/harness-baselines/`.
+
+## Bootstrap Steps
+
+1. Map existing quality reports, dashboards, and baselines.
+2. Choose four to eight automatically collectible metrics tied to structural risk only if the mapped surface lacks them.
+3. Separate blocking gates from informational metrics.
+4. Create thresholds or baselines so historical debt is visible but new degradation fails.
+5. Generate a Markdown report for humans and JSON only if scripts need trend data.
+6. Define a gardening cadence that lowers thresholds or removes allowlist entries gradually.
+
+## Validation
+
+- Run the report generator or manual collection command.
+- Confirm every finding includes path, metric, current value, threshold, and suggested action.
+- Confirm new degradation can be detected without forcing full historical cleanup.
+
+## Do Not Include
+
+- A single aggregate score that hides critical risk.
+- Metrics that cannot be collected repeatably.
+- One-off refactor plans presented as ongoing quality governance.

--- a/plugins/yfge/agent-harness-skills/skills/quality-gardening/references/generated-snapshot-ownership.md
+++ b/plugins/yfge/agent-harness-skills/skills/quality-gardening/references/generated-snapshot-ownership.md
@@ -1,0 +1,29 @@
+# Generated Snapshot Ownership
+
+Use this when quality reports, inventories, or score files are generated from scripts.
+
+## Ownership Rules
+
+- Each generated snapshot needs a source command.
+- The snapshot should say whether it is current, informational, or gate-enforced.
+- Generated files should be refreshed by command, not hand-edited.
+- Historical debt should live in baselines or thresholds with repayment notes.
+
+## Refresh Flow
+
+1. Run the source command.
+2. Inspect generated changes for scope and unexpected drift.
+3. Run the drift or quality checker.
+4. Commit generated snapshots with the change that made them necessary, or record why refresh is deferred.
+
+## Validation
+
+- The source command exists and is documented.
+- The checker fails when generated snapshots are stale.
+- Each baseline entry has reason, owner or area, and repayment direction.
+
+## Do Not Include
+
+- A polished score that hides critical findings.
+- Generated output with no source command.
+- Manual edits to generated snapshots as the normal workflow.

--- a/plugins/yfge/agent-harness-skills/skills/repo-contracts-and-boundaries/SKILL.md
+++ b/plugins/yfge/agent-harness-skills/skills/repo-contracts-and-boundaries/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: repo-contracts-and-boundaries
+description: Use when turning architecture, layering, directory ownership, dependency direction, file-size limits, choke points, baselines, or allowlists into repository checks.
+---
+
+# Repo Contracts And Boundaries
+
+## Overview
+
+Convert architectural intent into checks that prevent new drift instead of relying on repeated prose warnings.
+
+This skill freezes new violations first and then supports gradual baseline reduction. For shared harness terms, see `../../references/harness-patterns.md`; when contract files are absent, use `references/build-when-missing.md`. For schema, fixture, and golden-payload contracts, see `references/schema-fixture-contracts.md`.
+
+## When To Use
+
+- The user mentions architecture boundaries, directory ownership, choke points, allowlists, baselines, or contracts.
+- The repository has layering rules, but agents still add bypass calls or wrong dependencies.
+- You need to distinguish diff checks from full audit checks.
+
+## Inputs Needed
+
+- Architecture docs or expected layering.
+- Current directory structure and known historical debt.
+- Rules to protect: dependency direction, file size, public entrypoints, data access, interface boundaries, or similar constraints.
+
+## Execution Order
+
+- First: Read architecture docs and current code to identify real boundaries and known debt.
+- Then: Design diff checks, audit checks, baselines, and allowlists.
+- Finally: Output executable contract rules and a gradual convergence strategy.
+
+## Step-by-Step Process
+
+1. Search for `ARCHITECTURE.md`, contract docs, lint scripts, baseline files, and allowlists.
+2. List protected rules; each rule must be checkable by script or review.
+3. If architecture or contract surfaces are missing, bootstrap the minimum files and checker shape from `references/build-when-missing.md`.
+4. Separate new drift from historical debt: new drift should fail, historical debt should enter a baseline.
+5. Design `--mode diff` for changed files and `--mode audit` for full-repository reports.
+6. For each violation, output path, rule, reason, and suggested direction.
+7. Define when allowlists may change and what repayment note is required.
+
+## Checks
+
+- Mechanical: each rule can be checked by AST, regex, import graph, path scan, or report script.
+- Baseline: historical debt is explicit and not hidden by a fake green state.
+- Diff: new changes can be blocked cheaply.
+- Exception: allowlist entries have owner, reason, and convergence plan.
+- Overbuild: do not use a complex platform when a clear script is enough.
+
+## Output Format
+
+```markdown
+# Repo Contracts And Boundaries
+
+## Detected Mapping
+- architecture:
+- contracts:
+- validation:
+
+## Protected Boundaries
+-
+
+## Diff Checks
+-
+
+## Audit Checks
+-
+
+## Baseline / Allowlist Policy
+-
+
+## Failure Message Shape
+-
+
+## Rollout Plan
+-
+```
+
+## Common Mistakes
+
+- Skipping baselines, which makes checks permanently red because of historical debt.
+- Running audit only, which still lets agents introduce new drift.
+- Treating architecture advice as a rule when it cannot be mechanically checked.
+- Writing failure messages that do not tell an agent how to fix the violation.
+
+## Example Prompts
+
+- "Turn this project's architecture boundaries into checks."
+- "Design a diff/audit contract checker for this repo."
+- "How should we freeze new dependencies on these historical choke points?"

--- a/plugins/yfge/agent-harness-skills/skills/repo-contracts-and-boundaries/references/build-when-missing.md
+++ b/plugins/yfge/agent-harness-skills/skills/repo-contracts-and-boundaries/references/build-when-missing.md
@@ -1,0 +1,37 @@
+# Build When Missing
+
+Use this when architecture intent exists only in conversations or conventions. Pattern sources include repositories with `ARCHITECTURE.md`, contract docs, diff/audit checkers, generated baselines, and allowlists.
+
+## Equivalent Artifacts
+
+- Architecture indexes, design docs, lint rules, import-boundary checks, or review policies may already satisfy the contract role.
+- Record the chosen artifacts under `Detected Mapping` before creating default architecture or checker files.
+- Add default files only for missing roles, not for surfaces already covered by an equivalent.
+
+## Minimum Files
+
+- `ARCHITECTURE.md`, `docs/architecture/index.md`, or an explicitly mapped architecture source.
+- `docs/architecture/contracts.md`, a contract section, or an explicitly mapped equivalent.
+- `scripts/check_repo_contracts.py` or a mapped checker command.
+- Baseline or allowlist file under `docs/generated/`, `scripts/baselines/`, or `scripts/harness-baselines/`.
+
+## Bootstrap Steps
+
+1. Map existing architecture and contract sources.
+2. Write or amend the architecture map only for missing source-of-truth coverage.
+3. Choose two or three rules that can be checked mechanically before adding more.
+4. Create or map a checker with diff mode for changed files and audit mode for full-repository reports.
+5. Put historical violations in a baseline or allowlist with owner, reason, and repayment note.
+6. Make new violations fail while historical debt remains visible.
+
+## Validation
+
+- Run diff mode against changed files.
+- Run audit mode and confirm historical findings are reported without blocking unexpectedly.
+- Verify failure messages include path, rule, reason, and suggested direction.
+
+## Do Not Include
+
+- Rules that cannot be checked or reviewed consistently.
+- A baseline that silently hides all debt without a report.
+- Product-specific ports, service names, or private deployment paths from pattern sources.

--- a/plugins/yfge/agent-harness-skills/skills/repo-contracts-and-boundaries/references/schema-fixture-contracts.md
+++ b/plugins/yfge/agent-harness-skills/skills/repo-contracts-and-boundaries/references/schema-fixture-contracts.md
@@ -1,0 +1,29 @@
+# Schema And Fixture Contracts
+
+Use this when repository boundaries are expressed through payloads, schemas, fixtures, or golden examples.
+
+## Contract Types
+
+- Schema contract: validates input or output shape.
+- Fixture contract: stores anonymized representative examples.
+- Golden payload: captures a stable expected transformation or report.
+- Compatibility contract: documents tolerated legacy shape and repayment plan.
+
+## Bootstrap Steps
+
+1. Identify the boundary where shape drift causes real breakage.
+2. Add the smallest schema, fixture, or golden payload that captures that boundary.
+3. Add a checker that validates current examples and changed files.
+4. Put historical exceptions in a baseline with reason and repayment direction.
+
+## Validation
+
+- Run the checker in changed-file mode and full audit mode when available.
+- Confirm fixtures contain no sensitive real data.
+- Confirm failure output names path, contract, reason, and expected direction.
+
+## Do Not Include
+
+- Fixtures copied from private data.
+- Golden payloads that require hidden services to interpret.
+- Compatibility exceptions without an owner or repayment direction.

--- a/plugins/yfge/agent-harness-skills/skills/repo-harness-assessment/SKILL.md
+++ b/plugins/yfge/agent-harness-skills/skills/repo-harness-assessment/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: repo-harness-assessment
+description: Use when evaluating an existing repository's agent-readiness, harness maturity, validation surfaces, source-of-truth docs, evidence artifacts, or next smallest harness improvement.
+---
+
+# Repo Harness Assessment
+
+## Overview
+
+Assess how well a repository lets an agent understand rules, make safe changes, verify them, and produce reviewable evidence.
+
+Use this skill to diagnose current harness maturity before proposing changes. For shared vocabulary and neutral artifact names, see `../../references/harness-patterns.md`; when expected harness files are missing, use `references/build-when-missing.md`.
+
+## When To Use
+
+- The user asks what harness pieces a repository is missing.
+- You need to compare entrypoints, validation commands, runtime evidence, delivery records, or quality gates across repositories.
+- You need to decide whether the next smallest improvement is an entrypoint, validation script, artifact bundle, ledger, contract check, or quality gate.
+
+## Inputs Needed
+
+- Repository root path.
+- User scope: whole repository, one surface, docs-only work, runtime behavior, CI, or delivery flow.
+- Any expected harness shape or maturity target the user names.
+
+## Execution Order
+
+- First: Read repository entrypoints and source-of-truth files, including `AGENTS.md`, README, architecture/reliability docs, indexes, CI, and scripts.
+- Then: Check whether validation, evidence, collaboration records, task/design docs, and commit discipline have mechanical entrypoints.
+- Finally: Report maturity, gaps, the smallest useful improvement slice, and what not to build yet.
+
+## Step-by-Step Process
+
+1. Use `rg --files` or `find` to list entrypoint files, docs, scripts, CI, and agent ledger locations.
+2. Read the nearest agent instruction file and decide whether it is a high-signal navigation entrypoint rather than a project encyclopedia.
+3. Search for `check_repo_harness`, `doctor`, `trace_run`, `quality`, `artifacts/runs`, `agent_chats`, and `tasks.md`.
+4. Check for a stable validation matrix: docs, contracts, unit/type/lint, runtime, external-dependency, and CI.
+5. Check whether failures can be traced through run IDs, request IDs, logs, screenshots, JSON/JUnit output, PRs, or commits.
+6. If a layer is absent, define the minimum bootstrap artifact from `references/build-when-missing.md` before recommending broader work.
+7. Compress gaps into no more than three next steps, ordered by value and risk.
+
+## Checks
+
+- File facts: entrypoint files exist and point to each other instead of duplicating drifting rules.
+- Structure: there is a clear source of truth, directory boundary model, and no-new-drift rule.
+- Validation: there is one local minimum command and one CI gate command.
+- Evidence: a failure can be connected to logs, traces, screenshots, or runtime artifacts.
+- Overbuild: do not recommend a full platform, broad scaffold, or cross-environment deployment system before the minimum slice is justified.
+
+## Output Format
+
+```markdown
+# Repo Harness Assessment
+
+## Detected Mapping
+- entrypoint:
+- work-state:
+- ledger:
+- validation:
+- runtime-evidence:
+- quality:
+
+## Current State
+- Agent entrypoint:
+- Source-of-truth docs:
+- Validation surface:
+- Runtime evidence:
+- Delivery/ledger:
+
+## Gaps
+1.
+2.
+3.
+
+## Recommended Minimum Slice
+- First:
+- Then:
+- Finally:
+
+## Do Not Build Yet
+-
+
+## Validation Needed
+-
+```
+
+## Common Mistakes
+
+- Reducing harness maturity to "there are tests."
+- Reading only README while ignoring scripts, CI, and real artifacts.
+- Copying environment variables, ports, accounts, or private workflow details from one implementation into another.
+- Producing a long wish list instead of a small, implementable improvement slice.
+
+## Example Prompts
+
+- "Assess what harness pieces this repository is missing."
+- "Compare this repository against a mature run-artifact pattern."
+- "Can an agent safely take over this project as it stands?"

--- a/plugins/yfge/agent-harness-skills/skills/repo-harness-assessment/references/build-when-missing.md
+++ b/plugins/yfge/agent-harness-skills/skills/repo-harness-assessment/references/build-when-missing.md
@@ -1,0 +1,37 @@
+# Build When Missing
+
+Use this when a repository has no clear harness inventory. Pattern sources include full harness repositories with root docs and checks, medium harness repositories with generated reports, and thin repositories that only have an entrypoint plus task board.
+
+## Equivalent Artifacts
+
+- Existing entrypoints, architecture docs, validation docs, trackers, ledgers, reports, or dashboards may already satisfy harness roles.
+- Record the chosen artifacts under `Detected Mapping` before recommending new files.
+- Use `references/harness-profiles.json` to choose a minimum role set for the repository archetype.
+
+## Minimum Files
+
+- `AGENTS.md` or an explicitly mapped equivalent agent entrypoint.
+- `ARCHITECTURE.md`, `docs/architecture/index.md`, or a mapped architecture source.
+- `docs/validation.md`, a validation section in README, or a mapped validation command surface.
+- `docs/harness-assessment.md` for the first inventory if no generated report exists.
+
+## Bootstrap Steps
+
+1. Identify the repository archetype from `references/harness-profiles.json`.
+2. Inventory existing entrypoints, docs, scripts, CI, artifact directories, trackers, reports, and ledgers.
+3. Classify each harness role as mapped, partial, or absent: entrypoint, work-state, contracts, validation, runtime evidence, ledger, quality, commit discipline.
+4. For absent roles required by the archetype, name the smallest artifact that would make the role discoverable.
+5. Write `docs/harness-assessment.md` with current state, detected mapping, gaps, and the next three slices.
+6. Link the assessment from the mapped entrypoint or README so future agents can find it.
+
+## Validation
+
+- Run a docs/structure check if one exists.
+- If no checker exists, verify that the assessment links to concrete files or explicitly says "absent".
+- Confirm every recommended next slice names a file, command, or directory to create.
+
+## Do Not Include
+
+- Private URLs, credentials, account names, or environment-specific hosts.
+- A full platform roadmap before the first minimum slice is justified.
+- Product-specific workflow details copied from a pattern source.

--- a/plugins/yfge/agent-harness-skills/skills/runtime-evidence-and-tracing/SKILL.md
+++ b/plugins/yfge/agent-harness-skills/skills/runtime-evidence-and-tracing/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: runtime-evidence-and-tracing
+description: Use when connecting observed behavior, logs, metrics, request IDs, run IDs, screenshots, traces, external dependency results, or artifacts into a runtime evidence loop.
+---
+
+# Runtime Evidence And Tracing
+
+## Overview
+
+Make runtime validation auditable by tying observed behavior to runtime evidence through stable IDs and artifacts.
+
+Agents should not only say they tested something; they should leave run IDs, request IDs, logs, screenshots, interaction records, or traces. For shared harness terms, see `../../references/harness-patterns.md`; when evidence surfaces are absent, use `references/build-when-missing.md`. For neutral runtime profiles and redaction policy, see `references/runtime-profile-policy.md`.
+
+## When To Use
+
+- The user mentions interactive validation, runtime validation, request IDs, traces, logs, metrics, or artifacts.
+- A production or test-environment issue must be traced from observed behavior to runtime evidence.
+- A flow with external dependencies needs classification as code failure, dependency blocker, environment issue, or data problem.
+
+## Inputs Needed
+
+- Target flow, entry action, command, or interface.
+- Existing logging, request wrapper, headers, and observability endpoints.
+- Artifact directory and run ID naming preference.
+
+## Execution Order
+
+- First: Find the request entrypoint and existing request/log/trace propagation points.
+- Then: Design run IDs, request IDs, artifact bundles, and collection commands.
+- Finally: Output the evidence contract and validation path, including fallback and blocker classification.
+
+## Step-by-Step Process
+
+1. Search request wrappers, service entrypoints, logs, metrics, and trace scripts.
+2. Confirm whether the calling surface can generate or propagate `X-Request-ID` and `X-Harness-Run-ID`.
+3. If no evidence contract exists, bootstrap the minimum run artifact contract from `references/build-when-missing.md`.
+4. Design `artifacts/runs/<run_id>/` with manifest, summary, logs, network, screenshots, and trace files.
+5. Define the collection order for the target flow: start, authenticate if needed, operate, wait, read artifacts, and attribute the result.
+6. Define blocker categories: code regression, environment unavailable, external dependency unavailable, data missing, and not evaluable.
+7. Explain how PRs or ledgers should reference artifacts without committing large temporary files.
+
+## Checks
+
+- Propagation: request ID and run ID remain searchable across caller, service, job, and external dependency evidence.
+- Artifact: the directory includes manifest, summary, and reproducible commands.
+- Evidence: screenshots, console, network, logs, and metrics cover the failure boundary.
+- Attribution: external dependency or environment blockers are not reported as product-quality failures.
+- Privacy: artifacts do not contain tokens, phone numbers, real secrets, or sensitive payloads.
+
+## Output Format
+
+```markdown
+# Runtime Evidence And Tracing
+
+## Detected Mapping
+- runtime-evidence:
+- validation:
+- ledger:
+
+## ID Contract
+- Run ID:
+- Request ID:
+- Header propagation:
+
+## Artifact Bundle
+-
+
+## Collection Flow
+1.
+2.
+3.
+
+## Failure Classification
+-
+
+## PR / Ledger Reference
+-
+```
+
+## Common Mistakes
+
+- Keeping only screenshots with no request ID or runtime evidence.
+- Creating traces only in one layer, leaving observed failures disconnected.
+- Treating external account or quota issues as product-quality failures.
+- Committing large artifacts instead of referencing paths and summaries.
+
+## Example Prompts
+
+- "Connect interactive validation to request IDs."
+- "Design artifacts/runs evidence for this runtime workflow."
+- "How should this failure be classified: code, environment, or external blocker?"

--- a/plugins/yfge/agent-harness-skills/skills/runtime-evidence-and-tracing/references/build-when-missing.md
+++ b/plugins/yfge/agent-harness-skills/skills/runtime-evidence-and-tracing/references/build-when-missing.md
@@ -1,0 +1,37 @@
+# Build When Missing
+
+Use this when runtime validation is not auditable. Use generic run artifacts, request IDs, interaction evidence, trace scripts, log queries, and external-blocker classification.
+
+## Equivalent Artifacts
+
+- Existing trace exports, test reports, monitoring links, smoke-test artifacts, or run logs may already satisfy the runtime-evidence role.
+- Record the chosen artifacts under `Detected Mapping` before creating default run directories.
+- Use `templates/runtime-evidence-summary.md` only when no equivalent runtime evidence summary exists.
+
+## Minimum Files
+
+- `artifacts/runs/<run_id>/manifest.json` or an explicitly mapped equivalent manifest.
+- `artifacts/runs/<run_id>/summary.md` or a mapped human-readable result and classification summary.
+- `scripts/harness/trace_run.py`, `scripts/harness/doctor.py`, or a mapped collection command.
+- A request/run ID policy in `RELIABILITY.md`, README, or a runbook.
+
+## Bootstrap Steps
+
+1. Map existing runtime reports, logs, trace exports, and collection commands.
+2. Define run ID and request ID names only where the mapped runtime surface can carry them.
+3. Create a run directory structure only when no equivalent artifact bundle exists.
+4. Add a minimal collection command that writes manifest and summary even when deeper logs are unavailable.
+5. Define failure classification: code regression, environment unavailable, external dependency blocker, data missing, not evaluable.
+6. Require PR or ledger summaries to reference artifact path and classification.
+
+## Validation
+
+- Run one smoke collection and confirm manifest plus summary are written.
+- Confirm the same run ID appears in available caller, service, worker, or external dependency evidence.
+- Confirm artifacts are referenced but not committed when large or sensitive.
+
+## Do Not Include
+
+- Tokens, real user identifiers, contact details, dependency keys, or sensitive payloads.
+- Claims of runtime validation without evidence of the actual path used.
+- Large binary artifacts in normal source commits unless the repository explicitly allows them.

--- a/plugins/yfge/agent-harness-skills/skills/runtime-evidence-and-tracing/references/runtime-profile-policy.md
+++ b/plugins/yfge/agent-harness-skills/skills/runtime-evidence-and-tracing/references/runtime-profile-policy.md
@@ -1,0 +1,32 @@
+# Runtime Profile Policy
+
+Use this when runtime evidence needs setup details without leaking private access or binding to one engineering form.
+
+## Runtime Profile
+
+A runtime profile is a neutral description of how to exercise a flow:
+
+- entry action or command;
+- required setup state;
+- safe test identity or anonymized fixture;
+- external dependency availability;
+- artifact directory;
+- redaction rules.
+
+## Redaction Rules
+
+- Store handles, run IDs, and request IDs.
+- Redact contact details, tokens, keys, private payloads, account names, and hostnames.
+- Record unavailable dependencies as blockers instead of inventing successful evidence.
+
+## Validation
+
+- Confirm the profile lets another agent repeat the run without private knowledge.
+- Confirm the artifact manifest records profile name, command, started time, result, and classification.
+- Confirm sensitive values are absent from committed summaries.
+
+## Do Not Include
+
+- Real account names, keys, hosts, or contact details.
+- Claims that a runtime path was tested without artifact evidence.
+- Setup steps that only work on one private machine.

--- a/plugins/yfge/agent-harness-skills/skills/validation-harness-design/SKILL.md
+++ b/plugins/yfge/agent-harness-skills/skills/validation-harness-design/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: validation-harness-design
+description: Use when designing repository validation commands, doctor scripts, test matrices, JSON or JUnit outputs, CI gates, smoke checks, or harness command surfaces.
+---
+
+# Validation Harness Design
+
+## Overview
+
+Define the smallest repeatable command surface that proves repository changes are safe enough for review.
+
+This skill turns scattered checks into commands agents can run, CI can reuse, and failures can diagnose. For shared harness terms, see `../../references/harness-patterns.md`; when validation commands are absent, use `references/build-when-missing.md`. For setup probes and CI-safe fallbacks, see `references/environment-bootstrap.md`.
+
+## When To Use
+
+- The user wants `check_repo_harness.py`, `doctor.py`, a test matrix, or CI gates.
+- Existing validation commands are scattered and agents do not know what to run for docs-only, interface, service, logic, or runtime changes.
+- JSON, JUnit, or artifact output is needed.
+
+## Inputs Needed
+
+- Project shape, main surfaces, existing test commands, and CI configuration.
+- Change types and the minimum gate for each type.
+- Whether runtime, packaged-environment, external-dependency, or manual checks are needed.
+
+## Execution Order
+
+- First: Inventory existing commands and CI to confirm what already works.
+- Then: Design a layered validation matrix and unified entrypoint.
+- Finally: Output the command table, report formats, CI wiring, and fallback rules.
+
+## Step-by-Step Process
+
+1. Search `package.json`, Makefile, scripts, CI workflows, test directories, and docs.
+2. Split validation into repo/docs, contracts, unit/type/lint, runtime, and external-dependency layers.
+3. If there is no shared validation entrypoint, bootstrap the minimum command surface from `references/build-when-missing.md`.
+4. For each change type, choose the minimum command and escalation condition.
+5. Design a unified entrypoint: `check_repo_harness` or `doctor` handles environment/structure, while focused commands test behavior.
+6. Design report output: stdout for humans, JSON/JUnit for CI and artifacts.
+7. Require skip/fallback reasons; do not describe degraded validation as full validation.
+
+## Checks
+
+- Runnable: commands work in a clean checkout or documented setup.
+- Layered: docs-only work does not require heavy runtime checks, and runtime changes do not stop at static checks.
+- Output: failures identify case, path, command, and artifact.
+- CI: local commands and CI logic are consistent.
+- Cost: minimum gates are fast, and heavy gates trigger only on higher-risk changes.
+
+## Output Format
+
+```markdown
+# Validation Harness Design
+
+## Detected Mapping
+- validation:
+- runtime-evidence:
+- CI:
+
+## Change-Type Matrix
+| Change type | Minimum check | Escalation |
+| --- | --- | --- |
+
+## Command Surface
+-
+
+## Report Outputs
+-
+
+## CI Gates
+-
+
+## Fallback / Skip Policy
+-
+```
+
+## Common Mistakes
+
+- Requiring the heaviest end-to-end check for every change, which causes agents to skip validation.
+- Providing only a command list without a change-type matrix.
+- Emitting unstable JSON/JUnit output that cannot be aggregated later.
+- Omitting fallback records, then claiming a degraded path was full runtime validation.
+
+## Example Prompts
+
+- "Design a check_repo_harness.py command surface for this repo."
+- "Design validation commands for docs-only, interface, service, logic, and runtime changes."
+- "Organize these tests into a CI gate and test matrix."

--- a/plugins/yfge/agent-harness-skills/skills/validation-harness-design/references/build-when-missing.md
+++ b/plugins/yfge/agent-harness-skills/skills/validation-harness-design/references/build-when-missing.md
@@ -1,0 +1,37 @@
+# Build When Missing
+
+Use this when a repository has tests but no clear command surface. Pattern sources include repositories with `check_repo_harness.py`, `doctor.py`, validation pipelines, JSON reports, JUnit output, and CI gates.
+
+## Equivalent Artifacts
+
+- Manifest scripts, Makefile targets, CI jobs, task runner commands, or existing doctor commands may already satisfy the validation role.
+- Record the chosen artifacts under `Detected Mapping` before creating a default checker.
+- Use `templates/validation-matrix.md` to document the mapping when no validation guide exists.
+
+## Minimum Files
+
+- `scripts/check_repo_harness.py`, `scripts/doctor.py`, or an explicitly mapped equivalent validation command.
+- `docs/validation.md`, `docs/runbooks/validation.md`, README validation section, or a mapped validation matrix.
+- CI workflow step that runs the minimum checker.
+- Optional JSON/JUnit output directory under `artifacts/` for runtime or manual checks.
+
+## Bootstrap Steps
+
+1. Inventory existing commands from manifests, Makefiles, task runners, scripts, and CI.
+2. Map existing commands to change types before creating new commands.
+3. Create a change-type matrix: docs, contracts, unit/type/lint, runtime, and external-dependency checks.
+4. Implement a minimum checker only if no mapped command can validate required docs, command availability, and known generated artifacts.
+5. Add stdout output for humans and stable JSON/JUnit only when automation will consume it.
+6. Wire the minimum checker or mapped command into CI before adding heavier runtime gates.
+
+## Validation
+
+- Run the minimum checker from a clean checkout or documented setup.
+- Confirm docs-only changes do not require heavy runtime checks.
+- Confirm runtime-sensitive changes have an escalation path beyond static checks.
+
+## Do Not Include
+
+- A single heavyweight command for every change type.
+- Skip/fallback behavior that is not recorded.
+- External dependency credentials, account names, or machine-specific setup hidden in the checker.

--- a/plugins/yfge/agent-harness-skills/skills/validation-harness-design/references/environment-bootstrap.md
+++ b/plugins/yfge/agent-harness-skills/skills/validation-harness-design/references/environment-bootstrap.md
@@ -1,0 +1,29 @@
+# Environment Bootstrap
+
+Use this when validation needs setup checks before functional commands can be trusted.
+
+## Minimum Surface
+
+- Setup command or documented preparation steps.
+- Example configuration file with placeholder values.
+- Doctor or readiness command that checks required tools, generated files, and external dependency reachability.
+- CI-safe fallback for checks that cannot run in every environment.
+
+## Bootstrap Steps
+
+1. Inventory required tools, generated assets, local services, and external dependencies.
+2. Split setup checks from behavior checks.
+3. Make readiness failures explicit and non-destructive.
+4. Document fallback or skip reasons with the validation result.
+
+## Validation
+
+- Run the readiness command from a clean checkout or documented setup.
+- Confirm failures name the missing prerequisite and next action.
+- Confirm CI does not require private credentials or private machines.
+
+## Do Not Include
+
+- Hidden local setup.
+- Credentials or account names in setup docs.
+- A single heavyweight command that mixes setup, behavior, and delivery checks.


### PR DESCRIPTION
## Summary
- Add Agent Harness Skills to the Development & Workflow plugin list.
- Mirror the installable plugin bundle under `plugins/yfge/agent-harness-skills`.
- Update `plugins.json` and `.agents/plugins/marketplace.json` for the curated marketplace entry.

## Source repo readiness
- Added `interface.composerIcon`, `assets/icon.svg`, and `.codexignore` to `yfge/agent-harness-skills`.
- Added the required HOL scanner workflow to the source repo.
- `yfge/agent-harness-skills@347e721`: `Validate Skills` passed.
- `yfge/agent-harness-skills@347e721`: `HOL Plugin Scanner` passed.

## Validation
- `python3 scripts/check-alphabetical.py README.md`
- `python3 scripts/validate-plugin-pr.py --base-ref upstream/main`
- `git diff upstream/main --check`