### PR TITLE
Add icon for Tartiner Labs plugin

### DIFF
--- a/plugins/tartinerlabs/skills/.codex-plugin/plugin.json
+++ b/plugins/tartinerlabs/skills/.codex-plugin/plugin.json
@@ -29,6 +29,7 @@
     "shortDescription": "Git, GitHub, security, refactor, and project tooling skills.",
     "developerName": "Tartiner Labs",
     "category": "Coding",
-    "websiteURL": "https://github.com/tartinerlabs/skills"
+    "websiteURL": "https://github.com/tartinerlabs/skills",
+    "composerIcon": "./assets/icon.svg"
   }
 }

--- a/plugins/tartinerlabs/skills/assets/icon.svg
+++ b/plugins/tartinerlabs/skills/assets/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Tartiner Labs">
+  <title>Tartiner Labs</title>
+  <path
+    d="M486 256 L371 56.8 L141 56.8 L26 256 L141 455.2 L371 455.2 Z"
+    fill="#ECAE45"
+    stroke="#D9982F"
+    stroke-width="26"
+    stroke-linejoin="round"
+  />
+  <g fill="none" stroke="#2A1E14" stroke-width="44" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M240 182 V340 H362" />
+    <path d="M150 182 H362" />
+  </g>
+</svg>

--- a/plugins/tartinerlabs/skills/assets/icon.svg
+++ b/plugins/tartinerlabs/skills/assets/icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Tartiner Labs">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="Tartiner Labs">
   <title>Tartiner Labs</title>
   <path
     d="M486 256 L371 56.8 L141 56.8 L26 256 L141 455.2 L371 455.2 Z"


### PR DESCRIPTION
Adds a marketplace icon for the **Tartiner Labs** plugin (`tartinerlabs/skills`), listed under Community Plugins → Development & Workflow via #60.

## Changes
- Adds `plugins/tartinerlabs/skills/assets/icon.svg` — a 512×512 vector mark (gold hexagon + monogram), 485 bytes, no embedded raster.
- Adds `interface.composerIcon` pointing at it in the bundle's `.codex-plugin/plugin.json`.

The same icon and `composerIcon` field are already on the source repo's default branch (tartinerlabs/skills@main).

## Validation
`scripts/validate-plugin-pr.py` passes for the changed bundle (only the non-blocking `.codexignore` recommendation, unchanged from before). `plugins.json` / `marketplace.json` are intentionally left for the repo's regenerate-on-merge workflow to update.