### PR TITLE
feat: add Quality Engineering Skills plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PR Storyteller](./plugins/mturac/pr-storyteller) - PR title + body + test plan from commits and diff vs base branch.
 - [Praxis](https://github.com/ouonet/praxis) - Intent-driven workflow skills for coding agents: describe what done looks like, not the steps. Triage-first design keeps token costs low across design, TDD, debug, review, and release.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
+- [Quality Engineering Skills](https://github.com/RBraga01/Quality-Engineering-Skills) - 22 structured quality engineering skills for automotive and manufacturing: ISO 9001, IATF 16949, AIAG-VDA FMEA, VDA 6.3, PPAP, APQP, SPC, MSA.
 - [RAG Reviewer](https://github.com/mimfort/rag_for_git) - Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
 - [Reviewable HTML Workbench](https://github.com/u-ichi/reviewable-html-workbench) - Generate reviewable HTML documents, serve previews, collect inline review comments, and feed review outcomes back into agent workflows.


### PR DESCRIPTION
## Plugin submission — Quality Engineering Skills

Adds the README entry for **Quality Engineering Skills**: 22 structured quality-engineering skills for automotive and manufacturing.

| Field | Value |
| --- | --- |
| Repository | https://github.com/RBraga01/Quality-Engineering-Skills |
| License | MIT |
| Category | Development & Workflow |
| Version | 2.0.0 |

## Scanner verification

The required HOL Plugin Scanner workflow passed on the source repository's default branch: [HOL Plugin Scanner run #29194751254](https://github.com/RBraga01/Quality-Engineering-Skills/actions/runs/29194751254).

This PR intentionally changes only `README.md`; the repository generator will fetch the plugin bundle and regenerate catalog artifacts.
