### PR TITLE
Add handoff — cross-agent task dispatcher for Claude Code / Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [VidSeeds.ai](https://github.com/CarrotGamesStudios/vidseeds-mcp) - Hosted MCP connector for pre-upload video SEO, metadata optimization, AI thumbnails, and multi-platform publishing with workflow skills for Codex agents.
 - [X Twitter Scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data, monitored workflows, HMAC webhooks, and MCP access through the Xquik REST API with confirmation-gated write guidance.
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
+- [handoff](https://github.com/dazuiba/handoff) - Cross-agent task dispatcher: delegate work to DeepSeek V4, Claude Opus, or Codex right inside your Claude Code / Codex session. Runs in background; result returns automatically.
 
 ## Plugin Development
 


### PR DESCRIPTION
## What is handoff?

[handoff](https://github.com/dazuiba/handoff) is a skill/subagent (backed by handoff-cli) that lets you delegate tasks to DeepSeek V4, Codex, or Claude Opus right inside your Claude Code / Codex session — without switching tools or losing context.

- Runs the delegated task in the background; your session never blocks
- Result comes back automatically when the task finishes
- Supports parallel tasks and resuming past sessions

## Why it belongs here

handoff is a Codex-compatible plugin/skill that lets users dispatch tasks to other agents without leaving their session.

## Links

- GitHub: https://github.com/dazuiba/handoff
- Install: `uv tool install handoff-cli && handoff init`
