### PR TITLE
Add GCF Proxy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Espresso](https://github.com/mirkobozzetto/espresso) - Full token-saving stack in one plugin - output compression, global rules, RTK hook, Caveman ultra, GitNexus config. Detects existing setup, installs only what's missing. Works on Claude Code and Codex.
 - [Flaky Detector](./plugins/mturac/flaky-detector) - Run a test command N times, report per-test flakiness %.
 - [Frappe Agent](https://github.com/Dkm0315/frappe-agent) - Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.
+- [GCF Proxy](https://github.com/blackwell-systems/gcf-codex-plugin) - Save 71% on MCP tool call tokens by wrapping any server with GCF encoding, with session stats hook and setup skill.
 - [GrayMatter](https://github.com/ValkyrLabs/GrayMatter) - Durable memory and shared graph state for Codex and OpenClaw agents, with live ValkyrAI schema awareness.
 - [HOL Guard Plugin](https://github.com/hashgraph-online/hol-guard-plugin) - AI antivirus workflow for Codex, Claude Code, Cursor, Gemini, OpenCode, MCP servers, skills, and plugin release checks with local approvals and receipts.
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin for Codex, Claude Code, and Cline with structured planning, review, and verification guardrails.

--- a/plugins/blackwell-systems/gcf-codex-plugin/.codex-plugin/plugin.json
+++ b/plugins/blackwell-systems/gcf-codex-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "gcf-proxy",
+  "version": "1.0.0",
+  "description": "Save 71% on MCP tool call tokens. Wraps any MCP server with GCF encoding, zero code changes. Session stats hook shows savings per turn.",
+  "repository": "https://github.com/blackwell-systems/gcf-codex-plugin",
+  "license": "MIT",
+  "author": {
+    "name": "Blackwell Systems",
+    "url": "https://blackwell-systems.com"
+  },
+  "homepage": "https://gcformat.com",
+  "keywords": ["mcp", "proxy", "token-optimization", "gcf", "cost-reduction"],
+  "interface": {
+    "displayName": "GCF Proxy",
+    "shortDescription": "Save 71% on MCP tool call tokens with GCF encoding.",
+    "composerIcon": "./assets/icon.svg",
+    "links": {
+      "documentation": "https://gcformat.com/guide/claude-code.html",
+      "repository": "https://github.com/blackwell-systems/gcf-codex-plugin",
+      "homepage": "https://gcformat.com"
+    }
+  }
+}

--- a/plugins/blackwell-systems/gcf-codex-plugin/assets/icon.svg
+++ b/plugins/blackwell-systems/gcf-codex-plugin/assets/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#09090b"/>
+  <g transform="translate(256,210) scale(0.75)">
+    <path d="M-160,20 C-160,-60 -100,-100 -40,-100 L0,-100 C30,-100 50,-80 50,-50 C50,-20 30,0 0,0 L-20,0 C-40,0 -50,10 -50,30 C-50,50 -40,60 -20,60 L0,60 C30,60 50,40 50,10" stroke="#00d4ff" stroke-width="28" fill="none" stroke-linecap="round"/>
+    <path d="M60,20 C60,-60 120,-100 180,-100 L220,-100 C250,-100 270,-80 270,-50 C270,-20 250,0 220,0 L200,0 C180,0 170,10 170,30 C170,50 180,60 200,60 L220,60 C250,60 270,40 270,10" stroke="#00d4ff" stroke-width="28" fill="none" stroke-linecap="round"/>
+    <path d="M280,-100 L340,-100 L340,60 M280,-20 L320,-20" stroke="#00d4ff" stroke-width="28" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="256" y="380" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-weight="bold" font-size="36" fill="#ffffff">71% fewer tokens</text>
+  <text x="256" y="420" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="22" fill="#a1a1aa">1,700+ LLM evaluations</text>
+</svg>

--- a/plugins/blackwell-systems/gcf-codex-plugin/hooks/hooks.json
+++ b/plugins/blackwell-systems/gcf-codex-plugin/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rm -f /tmp/gcf-proxy-stats.json",
+            "timeout": 2
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const fs=require('fs'); try{const d=JSON.parse(fs.readFileSync('/tmp/gcf-proxy-stats.json','utf8')); if(d.calls>0){const s=d.pct_saved.toFixed(0); const tb=d.est_tokens_saved; const saved=tb>=1000?(tb/1000).toFixed(1)+'K':tb; console.log(JSON.stringify({notification:'gcf-proxy: '+d.calls+' tool calls rewritten, '+s+'% fewer tokens (~'+saved+' tokens saved)'}))}}catch(e){}\"",
+            "timeout": 2,
+            "statusMessage": "Checking GCF proxy savings"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/blackwell-systems/gcf-codex-plugin/skills/setup/SKILL.md
+++ b/plugins/blackwell-systems/gcf-codex-plugin/skills/setup/SKILL.md
@@ -1,0 +1,53 @@
+---
+description: Wrap an existing MCP server with gcf-proxy to reduce token costs by 71%. Provide the server name from your MCP config.
+---
+
+# GCF Proxy Setup
+
+The user wants to wrap an MCP server with gcf-proxy to reduce token costs.
+
+## What to do
+
+1. Read the user's MCP configuration (`.mcp.json` in the project or global config) to find the target server.
+2. If `$ARGUMENTS` is provided, find the server matching that name.
+3. Create a new entry that wraps the original server with gcf-proxy:
+   - Keep the original server entry (renamed with a `-raw` suffix, disabled) so the user can revert.
+   - The new entry prepends gcf-proxy before the original command: `npx -y @blackwell-systems/gcf-proxy@latest --stats-file /tmp/gcf-proxy-stats.json <original-command> <original-args>`
+4. Show the user what changed and explain the expected savings (71% fewer tokens on tool responses).
+
+## Example
+
+If the user has:
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}
+```
+
+Transform it to:
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@blackwell-systems/gcf-proxy@latest", "--stats-file", "/tmp/gcf-proxy-stats.json", "npx", "-y", "@modelcontextprotocol/server-github"]
+    },
+    "github-raw": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "disabled": true
+    }
+  }
+}
+```
+
+## Important
+- Do NOT use `--` between gcf-proxy and the server command. gcf-proxy takes the server command directly as positional arguments.
+- Always preserve the original server config so the user can revert.
+- If the server already uses gcf-proxy, tell the user it's already wrapped.
+- Environment variables from the original config must be preserved.

--- a/plugins/blackwell-systems/gcf-codex-plugin/skills/stats/SKILL.md
+++ b/plugins/blackwell-systems/gcf-codex-plugin/skills/stats/SKILL.md
@@ -1,0 +1,17 @@
+---
+description: Show GCF proxy token savings statistics for the current session or overall usage.
+---
+
+# GCF Stats
+
+Show the user their gcf-proxy token savings.
+
+Check if `/tmp/gcf-proxy-stats.json` exists and read it. The file contains:
+- `calls`: number of tool calls rewritten
+- `json_bytes`: total JSON bytes received
+- `gcf_bytes`: total GCF bytes sent
+- `bytes_saved`: total bytes saved
+- `pct_saved`: percentage reduction
+- `est_tokens_saved`: estimated tokens saved
+
+Present the stats in a clear format. If the file doesn't exist, explain that gcf-proxy writes stats when running with `--stats-file` and suggest wrapping a server with `/gcf-proxy:setup`.


### PR DESCRIPTION
## Summary
- Adds GCF Proxy plugin: wraps any MCP server with GCF encoding, saving 71% on tool call tokens
- Two skills (`/gcf-proxy:setup`, `/gcf-proxy:stats`) and session stats hooks
- 100% comprehension accuracy across 1,700+ LLM evaluations, 10+ models, 3 providers

## Component Details
- **Name**: gcf-proxy
- **Type**: Plugin (skills + hooks)
- **Category**: Tools & Integrations

## Scanner Score
**93/100 (A - Excellent)** on local scan. CI passing on main:
https://github.com/blackwell-systems/gcf-codex-plugin/actions

## Testing
- [x] HOL Plugin Scanner CI running and passing on main (93/100)
- [x] SECURITY.md exists
- [x] LICENSE exists
- [x] `.codex-plugin/plugin.json` valid
- [x] Tested skills loading in Codex CLI (`codex exec`)
- [x] Plugin bundle under `plugins/blackwell-systems/gcf-codex-plugin/`
- [x] Icon at `assets/icon.svg`
- [x] Dependabot configured
- [x] GitHub Actions SHA-pinned

## Examples

```
/gcf-proxy:setup github       # Wrap the github MCP server
/gcf-proxy:stats              # Show session token savings
```

After each turn, the Stop hook shows:
```
gcf-proxy: 12 tool calls rewritten, 68% fewer tokens (~4.2K tokens saved)
```

**Links:**
- [Plugin repo](https://github.com/blackwell-systems/gcf-codex-plugin)
- [GCF Proxy](https://github.com/blackwell-systems/gcf-proxy)
- [Benchmarks](https://gcformat.com/guide/benchmarks.html)