### PR TITLE
Add Generative Media Skills by MuAPI

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1152,6 +1152,21 @@
       "description": "Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs."
     },
     {
+      "name": "generative-media-skills",
+      "displayName": "Generative Media Skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/SamurAIGPT/Generative-Media-Skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tools & Integrations",
+      "description": "13 skills for image, video, and audio generation using 100+ models — FLUX, Midjourney v7, Veo3, Kling 3.0, Suno, and HunyuanVideo via muapi.ai.",
+      "icon": "./plugins/SamurAIGPT/Generative-Media-Skills/assets/icon.svg"
+    },
+    {
       "name": "gh-project-plugin",
       "displayName": "GH Project",
       "source": {

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Dodo Payments](https://github.com/dodopayments/dodo-agent-plugin) - Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth.
 - [Education Agent Skills](https://github.com/GarethManning/education-agent-skills) - 131 evidence-based education skills for curriculum design, lesson planning, and assessment, with transparent evidence ratings and MCP server.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
+- [Generative Media Skills](https://github.com/SamurAIGPT/Generative-Media-Skills) - 13 skills for image, video, and audio generation using 100+ models — FLUX, Midjourney v7, Veo3, Kling 3.0, Suno, and HunyuanVideo via muapi.ai.
 - [GH Project](https://github.com/zfifteen/gh-project-plugin) - Create GitHub repositories from Codex with inferred defaults, native menus, explicit confirmation, and deterministic local cloning.
 - [Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet) - Hermes Agent X/Twitter plugin for read-first social research, monitoring, and approval-gated actions through Xquik.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
   "last_updated": "2026-06-15",
-  "total": 108,
+  "total": 109,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -788,6 +788,16 @@
       "category": "Tools & Integrations",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/ninihen1/power-automate-mcp-skills/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Generative Media Skills",
+      "url": "https://github.com/SamurAIGPT/Generative-Media-Skills",
+      "owner": "SamurAIGPT",
+      "repo": "Generative-Media-Skills",
+      "description": "13 skills for image, video, and audio generation using 100+ models — FLUX, Midjourney v7, Veo3, Kling 3.0, Suno, and HunyuanVideo via muapi.ai.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/SamurAIGPT/Generative-Media-Skills/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "GH Project",

--- a/plugins/SamurAIGPT/Generative-Media-Skills/.codex-plugin/plugin.json
+++ b/plugins/SamurAIGPT/Generative-Media-Skills/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "generative-media-skills",
+  "version": "1.0.0",
+  "description": "13 skills for image, video, and audio generation using 100+ models — FLUX, Midjourney v7, Veo3, Kling 3.0, Suno, and HunyuanVideo via muapi.ai.",
+  "author": {
+    "name": "MuAPI",
+    "url": "https://github.com/SamurAIGPT"
+  },
+  "homepage": "https://muapi.ai",
+  "repository": "https://github.com/SamurAIGPT/Generative-Media-Skills",
+  "license": "MIT",
+  "interface": {
+    "displayName": "Generative Media Skills",
+    "shortDescription": "Image, video & audio generation with 100+ AI models.",
+    "longDescription": "Expert skills for AI agents to generate professional-grade images, videos, and audio. Includes Cinema Director, Nano-Banana, UI Designer, Logo Creator, UGC Video Factory, AI Clipping, and 7 more. Powered by FLUX, Midjourney v7, Veo3, Kling 3.0, Suno, and HunyuanVideo.",
+    "developerName": "MuAPI",
+    "category": "Content Creation",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://muapi.ai",
+    "privacyPolicyURL": "https://github.com/SamurAIGPT/Generative-Media-Skills/blob/main/SECURITY.md",
+    "termsOfServiceURL": "https://github.com/SamurAIGPT/Generative-Media-Skills/blob/main/LICENSE",
+    "brandColor": "#6366f1",
+    "composerIcon": "./assets/icon.svg"
+  }
+}

--- a/plugins/SamurAIGPT/Generative-Media-Skills/assets/icon.svg
+++ b/plugins/SamurAIGPT/Generative-Media-Skills/assets/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#6366f1"/>
+  <text x="256" y="340" font-family="Arial,sans-serif" font-size="280" font-weight="bold" fill="white" text-anchor="middle">M</text>
+</svg>


### PR DESCRIPTION
## Plugin

**[Generative Media Skills](https://github.com/SamurAIGPT/Generative-Media-Skills)**

13 skills for image, video, and audio generation using 100+ AI models — FLUX, Midjourney v7, Veo3, Kling 3.0, Suno, and HunyuanVideo via muapi.ai.

## Scanner

CI passing on main: https://github.com/SamurAIGPT/Generative-Media-Skills/actions/runs/27420229356

Score passes ≥80 threshold, 0 critical findings, 0 high findings.

## Checklist

**In plugin repo (SamurAIGPT/Generative-Media-Skills):**
- [x] `.github/workflows/hol-plugin-scanner.yml` exists and CI passes on main
- [x] `SECURITY.md` exists
- [x] `LICENSE` (MIT) exists
- [x] `.codex-plugin/plugin.json` valid with `composerIcon`
- [x] `assets/icon.svg` present
- [x] `.codexignore` present
- [x] Scanner score ≥ 80

**In this PR:**
- [x] README entry alphabetically sorted (after Flow Studio Power Automate, before GH Project)
- [x] Plugin bundle at `plugins/SamurAIGPT/Generative-Media-Skills/`
- [x] `composerIcon` set pointing to `./assets/icon.svg`
- [x] Icon file present at referenced path
- [x] `plugins.json` updated (total: 108 → 109)
- [x] `.agents/plugins/marketplace.json` updated
- [x] No promotional language in description