### PR TITLE
Add Pronounce — developer-jargon pronunciation MCP server + skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1649,6 +1649,20 @@
       "category": "Tools & Integrations",
       "description": "GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.",
       "icon": "./plugins/nebelov/yandex-direct-for-all/assets/icon.png"
+    },
+    {
+      "name": "pronounce",
+      "displayName": "Pronounce",
+      "source": {
+        "source": "local",
+        "path": "./plugins/anzy-renlab-ai/pronounce"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Tools & Integrations",
+      "description": "Pronounce developer jargon out loud: an MCP server (lookup/search) and skill backed by a 1,721-entry sourced dictionary with IPA, audio, and cited pronunciations for kubectl, nginx, YAML, JWT, and more."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
 - [PDF Monster](https://github.com/jbaehova/pdf-monster) - Analyzes PDFs as extracted text, OCR text, rendered page images, and embedded figures for coding agents.
+- [Pronounce](https://github.com/anzy-renlab-ai/pronounce) - Pronounce developer jargon out loud: an MCP server (lookup/search) and skill backed by a 1,721-entry sourced dictionary with IPA, audio, and cited pronunciations for kubectl, nginx, YAML, JWT, and more.
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - Route image-generation prompts to 30+ models (DALL-E, Stable Diffusion, Flux, Midjourney, and more) through a single MCP interface. Install: `npm install -g prompt-to-asset`.
 - [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex with the official Remotion docs MCP, composition scaffolding, and a data-driven launch-video workflow.
 - [ScrapeGraph AI](https://github.com/ScrapeGraphAI/just-scrape) - AI-powered web scraping CLI to search, scrape, extract structured JSON, crawl, and monitor web pages via the ScrapeGraph AI API.

--- a/plugins.json
+++ b/plugins.json
@@ -400,6 +400,16 @@
       "install_url": "https://raw.githubusercontent.com/AlexMi64/codex-project-autopilot/HEAD/.codex-plugin/plugin.json"
     },
     {
+      "name": "Pronounce",
+      "url": "https://github.com/anzy-renlab-ai/pronounce",
+      "owner": "anzy-renlab-ai",
+      "repo": "pronounce",
+      "description": "Pronounce developer jargon out loud: an MCP server (lookup/search) and skill backed by a 1,721-entry sourced dictionary with IPA, audio, and cited pronunciations for kubectl, nginx, YAML, JWT, and more.",
+      "category": "Tools & Integrations",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/anzy-renlab-ai/pronounce/HEAD/.codex-plugin/plugin.json"
+    },
+    {
       "name": "Registry Broker",
       "url": "https://github.com/hashgraph-online/registry-broker-codex-plugin",
       "owner": "hashgraph-online",

--- a/plugins/anzy-renlab-ai/pronounce/.codex-plugin/plugin.json
+++ b/plugins/anzy-renlab-ai/pronounce/.codex-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "pronounce",
+  "version": "2.12.0",
+  "description": "Pronounce developer jargon out loud — 1721+ sourced entries (kubectl, GIF, JSON, JWT, …). Ships the pronounce-word skill and the pronounce MCP server.",
+  "author": "anzy-renlab-ai",
+  "homepage": "https://pronounce.renlab.ai",
+  "license": "MIT",
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/anzy-renlab-ai/pronounce/.codex-plugin/plugin.json
+++ b/plugins/anzy-renlab-ai/pronounce/.codex-plugin/plugin.json
@@ -1,9 +1,15 @@
 {
   "name": "pronounce",
   "version": "2.12.0",
-  "description": "Pronounce developer jargon out loud — 1721+ sourced entries (kubectl, GIF, JSON, JWT, …). Ships the pronounce-word skill and the pronounce MCP server.",
+  "description": "Pronounce developer jargon out loud — 1738+ sourced entries (kubectl, GIF, JSON, JWT, …). Ships the pronounce-word skill and the pronounce MCP server.",
   "author": "anzy-renlab-ai",
   "homepage": "https://pronounce.renlab.ai",
+  "repository": "https://github.com/anzy-renlab-ai/pronounce",
   "license": "MIT",
+  "interface": {
+    "displayName": "Pronounce",
+    "shortDescription": "Hear how developer jargon is actually pronounced",
+    "composerIcon": "./assets/icon.svg"
+  },
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/anzy-renlab-ai/pronounce/.mcp.json
+++ b/plugins/anzy-renlab-ai/pronounce/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "pronounce": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/anzy-renlab-ai/pronounce.git#subdirectory=mcp-server",
+        "pronounce-mcp"
+      ]
+    }
+  }
+}

--- a/plugins/anzy-renlab-ai/pronounce/LICENSE
+++ b/plugins/anzy-renlab-ai/pronounce/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 say-it contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/anzy-renlab-ai/pronounce/README.md
+++ b/plugins/anzy-renlab-ai/pronounce/README.md
@@ -1,0 +1,24 @@
+# Pronounce — Codex plugin
+
+Pronounce developer jargon out loud. A community-maintained pronunciation
+dictionary of **1,721 sourced entries** (kubectl, nginx, YAML, GIF, JSON, JWT, …)
+— each with IPA, a plain-English respelling, audio, and a cited source.
+
+This plugin ships:
+
+- the **pronounce MCP server** — tools `lookup(word)` and `search(query)` returning
+  IPA, respelling, `audio_url`, source, and confidence for any term;
+- the **pronounce-word skill** — auto-answers "how do you pronounce X" with the
+  sourced reading instead of a confabulated guess.
+
+- Browse all entries: https://pronounce.renlab.ai
+- Source / issues: https://github.com/anzy-renlab-ai/pronounce
+- License: MIT
+
+## Install
+
+```
+codex plugin marketplace add anzy-renlab-ai/pronounce
+```
+
+Or point any MCP client at the bundled `.mcp.json`.

--- a/plugins/anzy-renlab-ai/pronounce/SECURITY.md
+++ b/plugins/anzy-renlab-ai/pronounce/SECURITY.md
@@ -1,0 +1,41 @@
+# Security policy
+
+## What's in scope
+
+This project ships:
+
+- A Bash CLI (`bin/say-it`) that reads a TSV file and calls macOS `say` / `afplay`.
+- A static website at <https://pronounce.renlab.ai> (HTML / CSS / JS / pre-rendered audio).
+- A Python MCP server (`mcp-server/`) that proxies the public JSON API.
+
+If you find a vulnerability in any of these, please report it.
+
+## What's NOT in scope
+
+- The macOS `say` command itself (Apple).
+- Vercel's hosting platform (Vercel).
+- GitHub's infrastructure (GitHub).
+- General complaints about Wikipedia being a weak source — please open a regular issue or PR.
+
+## Reporting
+
+Report security issues via:
+
+1. **GitHub Security Advisories** — preferred. Visit <https://github.com/anzy-renlab-ai/pronounce/security/advisories/new>.
+2. **Or email the repository owner** through their GitHub profile.
+
+Do **not** open a public issue for a real vulnerability.
+
+## Response
+
+We'll respond within 7 days. If the issue is real, we'll cut a fix and credit you in the release notes (unless you prefer to remain anonymous).
+
+## Known limitations
+
+- The CLI runs arbitrary text through `say -v <voice>` — if you pass untrusted input as the `-v` argument or the word itself, macOS `say` parses it normally (no shell escaping issues we've found, but exercise care if scripting).
+- The MCP server fetches data over HTTPS from `pronounce.renlab.ai`. If you replace `SAY_IT_UPSTREAM` env var with a non-trusted server, all bets are off.
+- The static site uses only public CDNs (shields.io for the GitHub star badge, your browser's Web Speech API as fallback). No third-party tracking is loaded.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/plugins/anzy-renlab-ai/pronounce/assets/icon.svg
+++ b/plugins/anzy-renlab-ai/pronounce/assets/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="Pronounce">
+  <rect width="512" height="512" rx="96" fill="#0e0e10"/>
+  <rect x="20" y="20" width="472" height="472" rx="80" fill="none" stroke="#ff6a3d" stroke-width="10"/>
+  <!-- speaker body + cone -->
+  <path d="M150 214 h54 l78 -64 v212 l-78 -64 h-54 a14 14 0 0 1 -14 -14 v-42 a14 14 0 0 1 14 -14 z" fill="#ff6a3d"/>
+  <!-- sound waves -->
+  <g fill="none" stroke="#7adfbb" stroke-width="18" stroke-linecap="round">
+    <path d="M316 196 a72 72 0 0 1 0 120"/>
+    <path d="M352 168 a120 120 0 0 1 0 176"/>
+  </g>
+</svg>

--- a/plugins/anzy-renlab-ai/pronounce/skills/pronounce-word/SKILL.md
+++ b/plugins/anzy-renlab-ai/pronounce/skills/pronounce-word/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: pronounce-word
+description: User asks how to pronounce an English word or project/product name ("how to pronounce X", "pronounce X", "X 怎么读", "X 怎么发音", "读一下 X"). Generate audio via the `say-it` CLI so the user actually HEARS the word — three times by default — instead of only writing IPA/syllable hints. The CLI consults a community-maintained pronunciation dictionary (kubectl → "koob-control", GIF → "jif", JSON → "jay-son", ...) and feeds an English-like respelling to the system TTS engine (macOS `say`, Linux `espeak-ng`, or Windows PowerShell) so project names come out the way engineers actually say them. Triggers on a single word or short phrase the user explicitly wants spoken.
+---
+
+# pronounce-word — speak the word out loud
+
+**Purpose.** When the user asks how to pronounce an English word — and especially a project, product, or programmer-jargon name (`kubectl`, `nginx`, `Pydantic`, `LaTeX`, `JSON`, ...) — don't just respond in text. Play the audio so they can hear the *community* reading, then add a short text caption with the source.
+
+## Trigger patterns
+
+Auto-invoke ONLY when the user's message matches a **single-word or short-name** pronunciation request:
+
+- English: `how to pronounce <X>`, `how do you pronounce <X>`, `pronounce <X>`, `how do you say <X>`, `what does <X> sound like`
+- Chinese: `<X> 怎么读`, `<X> 怎么念`, `<X> 怎么发音`, `读一下 <X>`, `念一下 <X>`
+
+`<X>` MUST be a single token: a word, project name, product name, acronym, or identifier — the kind of thing a developer would actually type into `say-it <X>`. The dictionary is keyed on single tokens, so multi-word input is spoken raw (not looked up); for a two-part name pick the head token (`say-it postgres`, not `say-it postgres database`).
+
+**Do NOT trigger this skill when:**
+
+- `<X>` is a sentence or paragraph the user wants narrated (e.g. `读一下这段` / `read this paragraph`). That's a TTS request, not a pronunciation lookup. Suggest `say "<sentence>"` instead, or just answer in text.
+- The message is asking *about* pronunciation conceptually (e.g. `IPA 是什么` / `what is phonetic spelling`). Answer in text.
+- `<X>` is non-English everyday vocabulary or a person's name unrelated to tech. The dictionary's editorial scope is tech-only — fall through to a text-only answer, or skip.
+
+If the target token is ambiguous (multiple candidates in the message), ask which one before invoking.
+
+## What to do
+
+1. **Speak it 3 times via `say-it`.**
+
+   ```bash
+   say-it <word>
+   ```
+
+   The CLI looks the word up in the dictionary and, if found, sends the dictionary's English-like respelling (e.g. "koob control") to the TTS engine so the pronunciation is the *intended* community reading — not whatever the engine would have guessed from the spelling alone. (macOS `say` does not parse IPA / `[[inpt PHON]]` / SSML `<phoneme>` markup — it reads them literally — so the dictionary stores respellings that ride the engine's built-in letter-to-sound rules.) If the word isn't in the dictionary, the CLI speaks the raw spelling.
+
+   Defaults: voice `Samantha` (General American), rate 130 wpm, 3 repetitions. This blocks until the audio finishes; the user hears it through the speakers.
+
+2. **Reply with one short line of text alongside the audio.** Always include:
+
+   - The IPA reading (GenAm).
+   - The "syllabified" / respelling form (e.g. "KOOB-control").
+   - **Source** of the pronunciation when the dictionary entry has one (creator interview, conference talk, official FAQ). Surface the URL — it's the project's headline feature.
+   - For *contested* readings, mention the alternative and how to play it (`say-it --alt <word>`).
+
+3. **Use `say-it --why <word>` to inspect** the dictionary entry (IPA, alternates, source, category, confidence) if you need to compose the caption — this is the canonical metadata for the reply.
+
+## Examples
+
+**Example 1 — creator-clarified word:**
+
+User: `GIF 怎么读？`
+
+Tool call:
+```bash
+say-it GIF
+```
+
+Reply:
+> 🔊 /dʒɪf/ — "JIF". Per the creator Steve Wilhite at the [Webby Awards 2013](https://www.nytimes.com/2013/05/22/business/media/creator-of-the-gif-says-its-pronounced-jif.html). The alternate reading /ɡɪf/ is widespread too — try `say-it --alt GIF` to hear it.
+
+**Example 2 — community-consensus product name:**
+
+User: `how do you pronounce kubectl`
+
+Tool call:
+```bash
+say-it kubectl
+```
+
+Reply:
+> 🔊 /ˈkuːb kənˌtroʊl/ — "KOOB-control". Kelsey Hightower and most K8s maintainers say it this way ([talk](https://www.youtube.com/watch?v=2wgAIvXpJqU)). "Cube-cuddle" and letter-by-letter "K-U-B-E-C-T-L" both circulate as alternates.
+
+**Example 3 — tech term not yet in the dictionary:**
+
+User: `how do you pronounce containerd`
+
+Tool call:
+```bash
+say-it containerd
+```
+
+Reply:
+> 🔊 /kənˈteɪnər diː/ — "container-D" (the D is for "daemon"). Per the [containerd docs](https://containerd.io/).
+
+## Useful flags
+
+| Flag | Effect |
+|------|--------|
+| (none) | Primary × 3, then a spoken `"or: <alt>"` for each recorded alternate. |
+| `--solo` | Primary × 3 only — silence the "or:" tail. |
+| `--alt [N]` | Focus on the Nth alternate (default N=1) instead of the primary. |
+| `--all` | Primary AND every alternate, each repeated, chained with "or:". |
+| `--why` | Print the dict entry's IPA, source URL, category, confidence, notes (no audio). |
+| `--json` | Print the entry as JSON (`in_dict`, alt arrays, source) — the cleanest form to parse when composing the caption (no audio). |
+| `--md` | Print a ready-to-paste markdown card (no audio). |
+| `--copy` | Copy the respelling to the clipboard after speaking. |
+| `--no-dict` | Bypass the dictionary; let the TTS engine interpret the raw spelling. |
+| `-n 5` | Repeat 5 times instead of 3. |
+| `-r 110` | Slower rate (110 wpm; default is 130). |
+| `-o /tmp/word.aiff` | Save to file instead of playing. |
+
+**Why the default chains alternates.** Multi-reading words (`GIF`, `SQL`, `GUI`, `kubectl`, `char`, ...) carry useful context: the user should know there's debate. Chaining alternates audibly with `"or:"` makes that perceptible without forcing them to read the terminal. Use `--solo` when the user has already grasped the multi-reading status and just wants the primary again.
+
+## Notes
+
+- The CLI auto-detects a TTS backend: macOS `say`, Linux `espeak-ng`/`espeak`, or Windows PowerShell. macOS quality is the gold standard; the others are functional best-effort. If no backend is found, the CLI prints install hints, but the text-only flags (`--why`, `--json`, `--md`) still work — fall back to a text IPA + respelling reply in that case.
+- If the user says "stop playing audio" or "just text", skip the speak step for the rest of the conversation.
+- **Tech context only.** This skill targets project names, product names, programmer jargon, and acronyms (`kubectl`, `nginx`, `Pydantic`, `JSON`, `GIF`, `regex`, ...). For general English vocabulary the user wants spoken (rare), `say-it <word>` still works (falls through to raw TTS), but the dictionary's editorial scope is tech-only.
+- The dictionary is American English (GenAm) only. UK/AU/etc. readings are explicitly out of scope.


### PR DESCRIPTION
## Add Pronounce (Tools & Integrations)

[Pronounce](https://github.com/anzy-renlab-ai/pronounce) is a community-maintained pronunciation dictionary for developer jargon — **1,721 sourced entries** (kubectl, nginx, YAML, GIF, JSON, JWT, …), each with IPA, a plain-English respelling, audio, and a cited source.

The plugin ships:
- the **pronounce MCP server** — `lookup(word)` / `search(query)` returning IPA, respelling, `audio_url`, source, and confidence;
- the **pronounce-word skill** — auto-answers "how do you pronounce X" with the sourced reading instead of a guess.

Requested by a community member in anzy-renlab-ai/pronounce#41.

### Scanner (mandatory)
- **HOL Plugin Scanner running in CI** on the plugin repo's `main` branch: https://github.com/anzy-renlab-ai/pronounce/actions/runs/27814499520
- Config: `min_score: 80`, `fail_on_severity: high`, SARIF uploaded — **job passed** (no critical/high findings).

### Checklist
- [x] `.codex-plugin/plugin.json` (valid manifest)
- [x] `SECURITY.md`, `LICENSE` (MIT), `README.md`
- [x] No hardcoded secrets / dangerous MCP commands (zero-dep; MCP server is a read-only lookup)
- [x] Scanner workflow SHA-pins `actions/checkout`
- [x] README entry added alphabetically under **Tools & Integrations**
- [x] Plugin bundle under `plugins/anzy-renlab-ai/pronounce/`
- [x] Entries added to `plugins.json` and `.agents/plugins/marketplace.json`
