### PR TITLE
feat: add RoadmapSmith to Development & Workflow

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -596,6 +596,21 @@
       "icon": "./plugins/hashgraph-online/registry-broker-codex-plugin/assets/icon.png"
     },
     {
+      "name": "roadmapsmith",
+      "displayName": "RoadmapSmith",
+      "source": {
+        "source": "local",
+        "path": "./plugins/PapiScholz/roadmapsmith"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development & Workflow",
+      "description": "Evidence-backed ROADMAP.md workflows for AI coding agents with validation, sync, and roadmap generation across any tech stack.",
+      "icon": "./plugins/PapiScholz/roadmapsmith/assets/roadmapsmith-logo.svg"
+    },
+    {
       "name": "runtype-skills",
       "displayName": "Runtype Skills",
       "source": {

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Praxis](https://github.com/ouonet/praxis) - Intent-driven workflow skills for coding agents: describe what done looks like, not the steps. Triage-first design keeps token costs low across design, TDD, debug, review, and release.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
+- [RoadmapSmith](https://github.com/PapiScholz/roadmapsmith) - Evidence-backed ROADMAP.md workflows for AI coding agents with validation, sync, and roadmap generation across any tech stack.
 - [Runtype Skills](https://github.com/runtypelabs/skills) - Supercharge your coding agent for AI product development — build, deploy, and operate agents, flows, tools, and surfaces on Runtype's managed edge runtime.
 - [Sealos](https://github.com/labring/sealos-skills) - Deploy apps to Sealos Cloud from Codex with readiness checks, Dockerfile generation, Compose conversion, image builds, and rollout updates.
 - [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.

--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-codex-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-06-16",
-  "total": 112,
+  "last_updated": "2026-06-21",
+  "total": 113,
   "categories": [
     "Development & Workflow",
     "Tools & Integrations"
@@ -408,6 +408,16 @@
       "category": "Development & Workflow",
       "source": "awesome-codex-plugins",
       "install_url": "https://raw.githubusercontent.com/hashgraph-online/registry-broker-codex-plugin/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "RoadmapSmith",
+      "url": "https://github.com/PapiScholz/roadmapsmith",
+      "owner": "PapiScholz",
+      "repo": "roadmapsmith",
+      "description": "Evidence-backed ROADMAP.md workflows for AI coding agents with validation, sync, and roadmap generation across any tech stack.",
+      "category": "Development & Workflow",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/PapiScholz/roadmapsmith/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Runtype Skills",

--- a/plugins/PapiScholz/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/PapiScholz/roadmapsmith/.codex-plugin/plugin.json
@@ -31,7 +31,6 @@
     "markdown",
     "agent-workflow"
   ],
-  "skills": "./skills/",
   "interface": {
     "displayName": "RoadmapSmith",
     "shortDescription": "Evidence-backed roadmap workflows for AI coding agents",

--- a/plugins/PapiScholz/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/PapiScholz/roadmapsmith/.codex-plugin/plugin.json
@@ -1,0 +1,55 @@
+{
+  "name": "roadmapsmith",
+  "version": "0.9.31",
+  "description": "Evidence-backed ROADMAP.md workflows for AI coding agents, with canonical RoadmapSmith status and maintain surfaces plus advanced sync/generate tools and legacy compatibility aliases.",
+  "author": {
+    "name": "PapiScholz"
+  },
+  "homepage": "https://github.com/PapiScholz/roadmapsmith#readme",
+  "repository": "https://github.com/PapiScholz/roadmapsmith",
+  "license": "MIT",
+  "keywords": [
+    "roadmap",
+    "planning",
+    "agent",
+    "cli",
+    "validation",
+    "sync",
+    "task-tracking",
+    "evidence-based",
+    "deterministic",
+    "monorepo",
+    "claude-code",
+    "ai-agent",
+    "project-management",
+    "coding-agents",
+    "agent-skills",
+    "roadmap-generator",
+    "roadmap-sync",
+    "task-validation",
+    "developer-tools",
+    "markdown",
+    "agent-workflow"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "RoadmapSmith",
+    "shortDescription": "Evidence-backed roadmap workflows for AI coding agents",
+    "longDescription": "Install RoadmapSmith in Codex to expose the shared skills bundle for zero-mode onboarding, existing-repo maintenance, roadmap discovery, evidence-backed validation, and compatibility-aware host readiness while keeping the CLI and Claude bundle surfaces aligned.",
+    "developerName": "PapiScholz",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/PapiScholz/roadmapsmith#readme",
+    "defaultPrompt": [
+      "Help me bootstrap or maintain this repository roadmap with RoadmapSmith."
+    ],
+    "brandColor": "#2B6CB0",
+    "composerIcon": "./assets/roadmapsmith-logo.svg",
+    "logo": "./assets/roadmapsmith-logo.svg",
+    "screenshots": []
+  }
+}

--- a/plugins/PapiScholz/roadmapsmith/assets/roadmapsmith-logo.svg
+++ b/plugins/PapiScholz/roadmapsmith/assets/roadmapsmith-logo.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#2B6CB0"/>
+  <!-- Road/path lines -->
+  <path d="M256 420 L256 92" stroke="#EBF4FF" stroke-width="28" stroke-linecap="round" stroke-dasharray="1 64"/>
+  <!-- Horizontal milestones -->
+  <line x1="120" y1="148" x2="392" y2="148" stroke="#90CDF4" stroke-width="16" stroke-linecap="round"/>
+  <line x1="156" y1="220" x2="356" y2="220" stroke="#90CDF4" stroke-width="16" stroke-linecap="round"/>
+  <line x1="120" y1="292" x2="392" y2="292" stroke="#90CDF4" stroke-width="16" stroke-linecap="round"/>
+  <line x1="156" y1="364" x2="356" y2="364" stroke="#90CDF4" stroke-width="16" stroke-linecap="round"/>
+  <!-- Checkmark circles -->
+  <circle cx="256" cy="148" r="24" fill="#48BB78"/>
+  <polyline points="245,148 253,156 269,140" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="256" cy="220" r="24" fill="#48BB78"/>
+  <polyline points="245,220 253,228 269,212" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="256" cy="292" r="24" fill="#ECC94B"/>
+  <line x1="256" y1="280" x2="256" y2="300" stroke="white" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="256" cy="364" r="24" fill="#4A5568"/>
+</svg>


### PR DESCRIPTION
## Summary

- Adds **[RoadmapSmith](https://github.com/PapiScholz/roadmapsmith)** to the \Development & Workflow\ category, inserted alphabetically between *Registry Broker* and *Runtype Skills*.
- Updates \plugins.json\ (total: 112 → 113, last_updated: 2026-06-21).
- Adds marketplace entry to \.agents/plugins/marketplace.json\.
- Adds plugin bundle at \plugins/PapiScholz/roadmapsmith/\ with \plugin.json\ and SVG icon.

## What RoadmapSmith does

RoadmapSmith is a Codex + Claude Code plugin that gives AI coding agents evidence-backed \ROADMAP.md\ workflows:

- **Zero-mode onboarding** (\`roadmapsmith zero\`) — bootstraps a roadmap in an empty or low-context repo
- **Maintenance** (\`roadmapsmith maintain\`) — syncs tasks against real code evidence, marks \[x] for passing tasks
- **Validation** (\`roadmapsmith validate\`) — multi-pass evidence scoring (file paths, symbols, imports, artifacts)
- **Generation** (\`roadmapsmith generate\`) — scans the repo, auto-generates P0/P1/P2 task candidates
- **Status** (\`roadmapsmith status --json\`) — host readiness and compatibility checks
- CLI: \`npm install -g roadmapsmith\`; skill bundle: \`npx skills add PapiScholz/roadmapsmith\`

## Plugin manifest

- Repository: https://github.com/PapiScholz/roadmapsmith
- License: MIT
- \`.codex-plugin/plugin.json\`: present and valid
- \`SECURITY.md\`: present in source repo
- Versioned releases: yes (current v0.9.33 on npm as \`roadmapsmith\`)

## HOL Plugin Scanner

The HOL AI Plugin Scanner runs in CI on the source repo. Latest run on `main` is green:

**Scanner run:** https://github.com/PapiScholz/roadmapsmith/actions/runs/27920554212

- Scan plugin bundle: ✅ pass (score ≥ 80, 0 HIGH findings)
- All test suite gates: ✅ pass (Node 18 + Node 20)
- CodeQL: ✅ pass

## Checklist

- [x] README entry added alphabetically (between Registry Broker and Runtype Skills)
- [x] Plugin bundle at \`plugins/PapiScholz/roadmapsmith/\`
- [x] \`plugins.json\` updated (total, last_updated, new entry)
- [x] \`.agents/plugins/marketplace.json\` updated
- [x] SVG icon at \`plugins/PapiScholz/roadmapsmith/assets/roadmapsmith-logo.svg\`
- [x] MIT license
- [x] \`SECURITY.md\` present in source repo
- [x] HOL plugin scanner CI — running on main, green ✅