### PR TITLE
Add Reviewable HTML Workbench

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -715,6 +715,21 @@
       "icon": "./plugins/hashgraph-online/registry-broker-codex-plugin/assets/icon.png"
     },
     {
+      "name": "reviewable-html-workbench",
+      "displayName": "Reviewable HTML Workbench",
+      "source": {
+        "source": "local",
+        "path": "./plugins/u-ichi/reviewable-html-workbench"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development & Workflow",
+      "description": "Generate reviewable HTML documents, serve previews, collect inline review comments, and feed review outcomes back into agent workflows.",
+      "icon": "./plugins/u-ichi/reviewable-html-workbench/assets/icon.svg"
+    },
+    {
       "name": "river-review",
       "displayName": "River Review",
       "source": {

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Praxis](https://github.com/ouonet/praxis) - Intent-driven workflow skills for coding agents: describe what done looks like, not the steps. Triage-first design keeps token costs low across design, TDD, debug, review, and release.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
+- [Reviewable HTML Workbench](https://github.com/u-ichi/reviewable-html-workbench) - Generate reviewable HTML documents, serve previews, collect inline review comments, and feed review outcomes back into agent workflows.
 - [River Review](https://github.com/s977043/river-review) - Versioned Skill Registry of code-review skills driven by a perspective-based review agent (code, security, performance, architecture, testing, adversarial) that verifies findings against the diff.
 - [RoadmapSmith](https://github.com/PapiScholz/roadmapsmith) - Evidence-backed ROADMAP.md workflows for AI coding agents with validation, sync, and roadmap generation across any tech stack.
 - [Runtype Skills](https://github.com/runtypelabs/skills) - Supercharge your coding agent for AI product development — build, deploy, and operate agents, flows, tools, and surfaces on Runtype's managed edge runtime.

--- a/plugins.json
+++ b/plugins.json
@@ -490,6 +490,16 @@
       "install_url": "https://raw.githubusercontent.com/hashgraph-online/registry-broker-codex-plugin/HEAD/.codex-plugin/plugin.json"
     },
     {
+      "name": "Reviewable HTML Workbench",
+      "url": "https://github.com/u-ichi/reviewable-html-workbench",
+      "owner": "u-ichi",
+      "repo": "reviewable-html-workbench",
+      "description": "Generate reviewable HTML documents, serve previews, collect inline review comments, and feed review outcomes back into agent workflows.",
+      "category": "Development & Workflow",
+      "source": "awesome-codex-plugins",
+      "install_url": "https://raw.githubusercontent.com/u-ichi/reviewable-html-workbench/HEAD/.codex-plugin/plugin.json"
+    },
+    {
       "name": "River Review",
       "url": "https://github.com/s977043/river-review",
       "owner": "s977043",

--- a/plugins/u-ichi/reviewable-html-workbench/.codex-plugin/plugin.json
+++ b/plugins/u-ichi/reviewable-html-workbench/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "reviewable-html-workbench",
+  "version": "1.11.7",
+  "description": "Generate reviewable HTML documents, serve previews, collect inline review comments, and feed review outcomes back into agent workflows.",
+  "repository": "https://github.com/u-ichi/reviewable-html-workbench",
+  "license": "MIT",
+  "author": {
+    "name": "u1"
+  },
+  "keywords": [
+    "html",
+    "review",
+    "design-doc",
+    "agent-skill",
+    "preview"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Reviewable HTML Workbench",
+    "shortDescription": "Create reviewable HTML docs and process comments.",
+    "composerIcon": "./assets/icon.svg",
+    "category": "Productivity",
+    "brandColor": "#2563EB"
+  }
+}

--- a/plugins/u-ichi/reviewable-html-workbench/LICENSE
+++ b/plugins/u-ichi/reviewable-html-workbench/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yuichi Uemura
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/u-ichi/reviewable-html-workbench/SECURITY.md
+++ b/plugins/u-ichi/reviewable-html-workbench/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x     | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Email:** Send a report to u1@u-kt.com
+2. **Do not** open a public GitHub issue for security vulnerabilities
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### Response timeline
+
+- **Acknowledgment:** Within 48 hours
+- **Initial assessment:** Within 1 week
+- **Fix release:** Depends on severity, typically within 2 weeks for critical issues

--- a/plugins/u-ichi/reviewable-html-workbench/assets/icon.svg
+++ b/plugins/u-ichi/reviewable-html-workbench/assets/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <rect width="128" height="128" rx="24" fill="#2563EB"/>
+  <rect x="24" y="28" width="80" height="10" rx="3" fill="#fff" opacity="0.9"/>
+  <rect x="24" y="46" width="60" height="6" rx="2" fill="#fff" opacity="0.5"/>
+  <rect x="24" y="58" width="72" height="6" rx="2" fill="#fff" opacity="0.5"/>
+  <rect x="24" y="70" width="50" height="6" rx="2" fill="#fff" opacity="0.5"/>
+  <circle cx="96" cy="92" r="18" fill="#fff" opacity="0.2"/>
+  <path d="M90 92 l4 4 l8-8" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/plugins/u-ichi/reviewable-html-workbench/skills/plan-preview/SKILL.md
+++ b/plugins/u-ichi/reviewable-html-workbench/skills/plan-preview/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: plan-preview
+description: |
+  Plan Mode の `<proposed_plan>` を出す直前に、計画の段階・依存関係・検証観点を一時HTMLで視覚確認したい時に使う agent-internal skill。Use this agent-internal skill to create a temporary HTML preview for a plan just before presenting `<proposed_plan>`. plugin配布だけで発火し、ユーザーにCLI実行を求めず、agentが `plan-preview` CLIでセッション限定URLを作り、本文に自然に差し込む。Triggers: planをグラフィカルに見たい, planを図で確認したい, この計画をHTMLでプレビューして, 計画をHTMLで確認したい, graphical plan review, proposed_planをプレビューして, 計画URLを入れて, preview this plan as HTML, show this plan visually, graphical plan preview, add a plan preview URL, preview the proposed plan。使用しない場面: 通常の最終HTML生成、レビュー可能な設計資料作成、コメント取り込み、恒久成果物の公開、外部アップロードが必要な図式化。Do not use for: final HTML artifacts, reviewable design docs, comment ingestion, permanent publication, or external-upload diagrams.
+argument-hint: "[plan-preview-payload.json]"
+strict_procedure: true
+---
+
+# plan-preview
+
+## 役割
+
+Plan Mode で正式な `<proposed_plan>` を提示する直前に、同じ計画内容を一時HTML previewとして出す。
+
+このskillは利用者が手でコマンドを打つためのものではない。agentが計画本文を組み立てた段階で `plan-preview` CLIを呼び、返却JSONの `url` を `<proposed_plan>` 内へ自然に入れる。
+
+Plan Mode 中の計画確認プレビューは、このskillが優先入口になる。通常の最終HTML成果物を作る `visual-html-renderer` の `document-model.json` → `render` → `validate` → `preview` フローへ流さない。
+
+## Role
+
+Create a temporary visual preview for a Plan Mode proposal. The user should not run the CLI manually. The agent calls `plan-preview`, receives a session-scoped URL, and places that URL naturally inside the `<proposed_plan>` text. During Plan Mode, plan preview requests should route here instead of the final-artifact `visual-html-renderer` document-model flow.
+
+## Strict procedure profile
+
+- Strictness: strict-procedure。Plan Mode の正式な実装基準は `<proposed_plan>` 本文であり、previewは判断補助として扱う。
+- Hard gates: 外部サービス送信、shared state変更、永続ファイル出力、skill実行時にhookを動的に追加しない（plugin同梱の静的hook定義は対象外）。
+- Forcing function: `plan-preview` CLI、TTL付き一時ディレクトリ、`Plan preview: <url>` 行、失敗時の明示。
+- Completion receipt: `<proposed_plan>` 内に preview URL または `Plan preview: unavailable (<reason>)` を含める。
+
+## 言語方針 / Language behavior
+
+Follow the language of the latest user request for progress updates, preview labels, and the surrounding plan text. 日本語の計画依頼には日本語で、英語の計画依頼には英語で返す。`Plan preview: <url>` の固定ラベルは互換性のため英語のまま使ってよい。
+
+## 発火条件
+
+次のいずれかに当たる場合、このskillを使う。
+
+- ユーザーが plan のグラフィカル表示、図示、preview URL、graphical plan review を求めている。
+- ユーザーが Plan Mode 中に「この計画をHTMLでプレビューして」「計画をHTMLで確認したい」のように求めている。
+- ユーザーが `preview this plan as HTML`, `show this plan visually`, `graphical plan preview`, `add a plan preview URL`, `preview the proposed plan` のように求めている。
+- 計画に phase、依存関係、並列worker、検証層、リスク・前提の分岐があり、文字だけでは確認しづらい。
+- plugin利用者の体験として、Plan Mode の本文に自然にURLが入っていることが求められている。
+
+## Trigger Conditions
+
+Use this skill when the user asks for a graphical plan view, diagrammed plan, preview URL, `preview this plan as HTML`, `show this plan visually`, `graphical plan preview`, `add a plan preview URL`, or `preview the proposed plan`. During Plan Mode, use this skill for plan preview requests instead of `visual-html-renderer`. Also use it when the plan has phases, dependencies, parallel workers, verification layers, or risk branches that are hard to inspect as plain text.
+
+## 使用しない場面
+
+- 最終成果物としてHTMLを生成する場合。これは `visual-html-renderer` を使う。
+- レビュー可能な設計資料を作り、HTML上のコメントを取り込む場合。これは `reviewable-design-doc` を使う。
+- planとは無関係な説明資料、恒久公開資料、Notion投稿、外部アップロードが必要な図式化。
+
+## Do Not Use For
+
+Do not use this skill for final HTML artifacts, reviewable design documents, comment ingestion, unrelated explainers, permanent publications, Notion posts, or diagrams that require external uploads.
+
+## 入力payload
+
+agentは `<proposed_plan>` に入れる直前の計画全文を `source_text` にそのまま入れる。
+`summary` / `phases` / `key_changes` / `flow` / `test_plan` / `assumptions` / `sections` / `visual_notes`
+は、全文の代替ではなくHTML上の補助ビューとして使う。preview用に情報を削らない。
+CLI本文では読み取りにくい依存関係、判断材料、検証観点、未決事項は `sections` や `visual_notes`
+で追加表示してよい。
+
+```json
+{
+  "title": "Plan Preview",
+  "summary": "この計画で何を達成するか",
+  "source_text": "<proposed_plan> に出す計画本文全文",
+  "phases": [
+    {"title": "Phase 1", "detail": "調査と境界確認"}
+  ],
+  "key_changes": [
+    "CLIを追加する",
+    "skill metadataを追加する"
+  ],
+  "flow": [
+    {"from": "計画作成", "to": "preview生成", "label": "agent内部"}
+  ],
+  "sections": [
+    {
+      "title": "判断材料",
+      "content": "CLI本文では長くなりやすい背景・比較・依存関係を補足する",
+      "items": ["元本文にない実装範囲は追加しない"]
+    }
+  ],
+  "test_plan": [
+    "unit test",
+    "CLI疎通確認"
+  ],
+  "assumptions": [
+    "hookは初期版では追加しない"
+  ],
+  "visual_notes": [
+    "図とリストで依存関係を補助表示する"
+  ]
+}
+```
+
+外部画像URL、外部asset、機密情報、未確定のsecret値はpayloadに入れない。
+
+## Input Payload
+
+Put the full plan text that will appear in `<proposed_plan>` into `source_text`. Use summary, phases, key changes, flow, test plan, assumptions, sections, and visual notes only as supplemental HTML views, not as replacements for the original text. Do not drop information for preview generation; add dependencies, review context, verification details, and unresolved points that are hard to inspect in CLI text. Do not include external image URLs, external assets, secrets, or unconfirmed secret values.
+
+## CLI手順
+
+1. renderer repo root を作業ディレクトリにする。現在のチャットやworkspaceのcwdをrepo rootとして扱わない。
+2. payloadを標準入力で渡して、次を実行する。preview は `auto` mode を既定にし、Tailscale IPv4 を検出できる場合は Tailscale URL を優先する。
+
+```bash
+python3 -m scripts.html_review_workbench.cli plan-preview --payload - --ttl 1800 --mode auto
+```
+
+3. 成功したら返却JSONの `url` を `<proposed_plan>` 本文に入れる。推奨表記:
+
+```text
+Plan preview: http://<tailscale-ip-or-127.0.0.1>:<port>/index.html
+```
+
+Codex sandbox内で Tailscale 検出に失敗する場合は、IPだけを先に取得して `HTML_REVIEW_WORKBENCH_TAILSCALE_IP=<tailscale-ip>` を渡してから `plan-preview --mode auto` を起動する。
+
+4. 失敗しても計画提示を止めない。代わりに短い理由を入れる。
+
+```text
+Plan preview: unavailable (<short reason>)
+```
+
+5. `stop_command` はagent用の後片付け手段であり、通常はユーザーに実行させない。TTLで自動終了する。
+
+## CLI Workflow
+
+Run the CLI from the renderer repo root. Pass the plan payload through standard input with `python3 -m scripts.html_review_workbench.cli plan-preview --payload - --ttl 1800 --mode auto`. On success, insert `Plan preview: <url>` into `<proposed_plan>`. On failure, do not block the plan; insert `Plan preview: unavailable (<short reason>)`. The returned `stop_command` is for agent cleanup and normally should not be handed to the user.
+
+## 計画本文との関係
+
+- 正式な実装基準は `<proposed_plan>` のテキスト。previewだけに存在する項目を作らない。
+- preview URLは本文の冒頭または末尾ではなく、計画の確認に自然な位置へ置く。
+- preview作成のために計画を短縮しない。HTML上では元の計画本文を全文表示し、構造化ビューは補助表示として追加する。
+- CLI本文では表現しにくい図示、依存関係、比較、検証の広がりはHTML側で情報量を増やす。ただし実装範囲や約束をpreviewだけに追加しない。
+- previewの生成に失敗した場合でも、`<proposed_plan>` 自体は成立させる。
+
+## Relationship to the Plan Text
+
+The authoritative implementation plan is the `<proposed_plan>` text, not the preview alone. Do not add implementation scope that exists only in the preview. Place the URL where it helps review the plan. Do not shorten the plan to make preview generation easier. The HTML preview must show the original plan text in full, then add structured supplemental views for relationships, comparisons, verification context, and unresolved points that are hard to inspect in CLI text. If preview generation fails, still produce the plan with the unavailable reason.
+
+## 禁止事項
+
+- ユーザーに CLI を実行させない。
+- Plan Mode の前にhookを自動追加しない。
+- `output/` やplugin cacheにpreview成果物を残さない。
+- 外部アップロードを使わない。
+- Preview Runtime は `auto` mode で Tailscale IPv4 を優先し、検出できない場合だけ `127.0.0.1` にfallbackする。
+- preview URLを正式な実装基準として扱わない。
+
+## Guards
+
+Do not ask the user to run the CLI. Do not auto-add hooks before Plan Mode. Do not leave preview artifacts in `output/` or plugin cache. Do not use external uploads. Prefer Tailscale IPv4 in `auto` mode and fall back to `127.0.0.1` only when needed. Do not treat the preview URL as the authoritative implementation plan.

--- a/plugins/u-ichi/reviewable-html-workbench/skills/plan-preview/agents/openai.yaml
+++ b/plugins/u-ichi/reviewable-html-workbench/skills/plan-preview/agents/openai.yaml
@@ -1,0 +1,20 @@
+display_name: Plan Preview
+short_description: Plan Mode の計画全文を保持し、一時HTML previewで補助情報を増やして確認する / Create temporary visual previews that preserve full plan text.
+default_prompt: Preview this plan as HTML / planをグラフィカルに確認したい
+trigger_examples:
+  - planをグラフィカルに見たい
+  - planを図で確認したい
+  - この計画をHTMLでプレビューして
+  - 計画をHTMLで確認したい
+  - proposed_planをプレビューして
+  - 計画URLを入れて
+  - graphical plan review
+  - preview this plan as HTML
+  - show this plan visually
+  - graphical plan preview
+  - add a plan preview URL
+  - preview the proposed plan
+entrypoint: python3 -m scripts.html_review_workbench.cli
+working_directory: plugin_root
+workflow:
+  - plan-preview

--- a/plugins/u-ichi/reviewable-html-workbench/skills/reviewable-design-doc/SKILL.md
+++ b/plugins/u-ichi/reviewable-html-workbench/skills/reviewable-design-doc/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: reviewable-design-doc
+description: |
+  要求・設計・アーキテクチャ・未決事項を整理し、レビュー可能な設計資料HTMLを作りたい時に使う。Use this skill to structure requirements, design, architecture, alternatives, decisions, and unresolved issues into a review-ready HTML design document. レビュー完了後はHTMLコメントを読み込み、設計へ反映し、確認が必要な場合はHTMLコメントスレッドへagent返信を書き戻す。Triggers: レビュー可能な設計資料, 設計資料をHTMLで, design doc, reviewable design doc, レビュー終わったので確認して, コメントを反映して, create a reviewable design doc, make a design doc in HTML, build a review-ready design document, ingest review comments, process review comments, reply to review comments, apply resolved comments。使用しない場面: 汎用HTMLレンダリングだけ、Notion投稿だけ、既存HTMLの見た目修正だけ。Do not use for: generic HTML rendering, Notion-only publishing, or small visual tweaks to existing HTML.
+argument-hint: "[設計対象またはdocument-model.json] [--review-mode standalone|review-server] [--preview auto|tailscale|local|off]"
+---
+
+# reviewable-design-doc
+
+## 役割
+
+設計資料としてレビューできる構造を作り、最終HTML生成は `visual-html-renderer` に渡す。
+
+レビュー完了後は `annotations/comments.json` を読み、明確な指摘は設計へ反映し、確認・回答が必要な指摘は `add-reply` CLI でHTMLの同じコメントスレッドへ書き戻す（チャットへの回答ではなくHTML上の返信として）。
+
+## Role
+
+Create a design document that can be reviewed in the browser. This skill owns design structure, review intent, comment ingestion, and comment-thread replies. Final HTML rendering is delegated to `visual-html-renderer`. After review, read `annotations/comments.json`, apply clear resolved feedback, and write clarification replies back into the same HTML comment thread with `add-reply`.
+
+## 言語方針 / Language behavior
+
+Follow the language of the latest user request for progress updates, final responses, and review handoff text. レビューコメントへの返信は、原則としてそのコメント本文の言語に合わせる。日本語コメントには日本語で、英語コメントには英語で返信する。設計本文や引用内容は、ユーザーが翻訳を求めない限り勝手に翻訳しない。
+
+## 基本手順
+
+1. 設計対象、読者、レビュー目的、完了条件を整理する。
+2. 要求、制約、アーキテクチャ、代替案、意思決定、未決事項へ分解する。
+3. レビュー観点とコメントしてほしい範囲を明示する。
+4. 最初から `document-model.json` を作る。設計本文の下書きや中間成果物として `.md` を作らない。
+5. 文書モデルには、要求、制約、アーキテクチャ、代替案、意思決定、未決事項、レビュー観点を、それぞれ現行rendererで有効なHTML表現を選んだblockとして入れる。
+6. `image.generation_status=requested` のブロックがある場合は、`imagegen` skillで画像を生成し、`attach-image` CLIで文書モデルへ添付する。
+7. `check-model` CLIで最終render前の文書モデル品質を検査する。
+8. `render` CLIでHTML bundleを生成する。
+9. `validate` CLIでHTML bundleを検証する。
+10. ユーザー向け最終HTMLでは既定で `preview` CLIを `--mode auto` で起動し、返却JSONの `url` と `stop_command` を最終応答に必ず書く。
+11. preview 起動直後に、Monitor ツールで `watch-comments` を開始する。これによりブラウザからのコメントを自動検知できるようになる。Monitor 起動コマンド: `python3 -m scripts.html_review_workbench.cli watch-comments --root <output-dir>`。イベント受信後の処理は「コメント自動回答と解決待ちゲート」セクションに従う。
+12. ユーザーがコメントを入れたら「レビューコメントへの対応」セクションに従う。
+
+## Basic Workflow
+
+1. Clarify the design target, audience, review purpose, and completion criteria.
+2. Split the material into requirements, constraints, architecture, alternatives, decisions, unresolved issues, and review points.
+3. Create `document-model.json` from the start; do not create a `.md` draft as the design body.
+4. Choose renderer-supported HTML blocks for each design unit.
+5. Generate requested images with `imagegen` and attach them before rendering.
+6. Run `check-model`, `render`, `validate`, and `preview`.
+7. Start `watch-comments` after preview startup.
+8. When the user adds comments, ingest them, classify them, reply in the HTML thread, and apply resolved feedback only after gates allow it.
+
+## 設計資料モデル作成の規約
+
+設計資料作成は、`.md` 原稿をHTMLへ変換する作業ではない。`reviewable-design-doc` は、設計内容を最初からレビュー可能なHTML bundleの情報設計として作る。
+
+- 新規に設計資料を作る場合、最初の保存対象は `output/tmp/<purpose>/document-model.json` または `output/<YYYY-MM-DD>_<name>/document-model.json` にする。
+- `.md` ファイルを設計本文の下書き、中間成果物、HTML化対象として作らない。
+- 一時的に自然文入力を保存する必要がある場合だけ、`source.txt`, `input.txt`, `source-content.txt` のようなプレーンテキスト名を使う。
+- 設計資料の本文は、見出し記号を含む原稿ではなく、`blocks[].title`, `blocks[].type`, `blocks[].heading_level`, `blocks[].content`, `review_required` を持つ文書モデルとして表現する。
+- 大区分のブロック（背景・要求、アーキテクチャ、代替案比較、意思決定、未決事項など）には `heading_level: 2` を設定し、その配下の詳細ブロックには `heading_level: 3` を使う。各章の冒頭にはその章で扱う内容を示す導入段落を置く。
+- 比較・代替案・評価軸は `html` block内の `<table>`、手順は `<ol>`、並列項目は `<ul>`、操作例・ログ・コマンドは `<pre><code>`、処理・依存・構成はdiagramブロック、決定・前提・注意はplain textのcallout、レビューしてほしい論点は専用のレビュー観点blockにする。
+- `section`, `text`, `table` block typeは現行rendererに専用描画がないため、最終モデルでは使わない。
+- diagramブロックはMermaid sourceを構造保存用に残し、生成画像を主表示にする。sourceに無い関係や判断を画像側で追加しない。
+- 既存資料を取り込む場合も、既存ファイルをそのまま表示へ流し込まず、`visual-html-renderer` のHTML情報設計規約に従って文書モデルへ再構成する。
+- `build-model` は最終HTMLモデルを作るplannerではなく、入力退避用のsource-capture draftに限る。既存本文やユーザー指定内容を取り込む場合も、そのdraftをそのままrenderせず、agentが設計構造を判断して文書モデルを直接作る。
+
+## Design Document Model Rules
+
+This skill does not convert a `.md` draft into HTML. It designs a reviewable HTML bundle from the beginning. Store new models under `output/tmp/<purpose>/document-model.json` or `output/<YYYY-MM-DD>_<name>/document-model.json`. If temporary natural-language input must be saved, use plain text filenames such as `source.txt`, `input.txt`, or `source-content.txt`. Use `heading_level: 2` for major sections and `heading_level: 3` for detailed subsections. Represent comparisons with tables, steps with ordered lists, parallel items with lists, commands and logs with code blocks, flows and dependencies with diagrams, and decisions or cautions with callouts.
+
+## レビューコメントへの対応
+
+ユーザーが「コメント入れた」「レビューした」「ingest review comments」「process review comments」「reply to review comments」「apply resolved comments」等でコメントの存在を知らせた時に開始する。文書作成（手順 1-10）とは独立したインタラクションであり、以下を毎回実行する。
+
+IMPORTANT: レビューコメントへの回答は、必ず `add-reply` CLI で HTML コメントスレッドに書き戻す。チャットだけで回答を返して終わりにしてはならない。チャットでは補足や次のアクション提案のみ行い、コメントへの実質的な回答は HTML 側に書く。
+
+### 手順
+
+1. `ingest-review` CLI でコメントを分類し、`annotations/review-cycle-state.json` に状態を保存する。`ingest-review` はコメントスレッドへ返信を書かない。
+2. 分類結果に関係なく、各コメントの `comment` と `selected_text` を読み、設計資料の該当箇所の文脈を踏まえてコメントの意図を理解する。
+3. 回答・受領・確認依頼が必要なコメントには、実質的な回答を `add-reply` CLI で HTML コメントスレッドに書き戻す。
+4. `actionable` なコメントは、解決待ちゲートが開いてから設計へ反映し、必要に応じて再 render する。
+5. ユーザーにブラウザでの確認を依頼する。
+
+### なぜチャット回答ではなく add-reply か
+
+- ユーザーはブラウザ上でコメントと回答をセットで読む。チャットに書いた回答は、コメントの文脈から切り離される。
+- 複数コメントがある場合、チャットでは各コメントへの回答の対応関係が崩れる。
+- HTML 上の回答はコメントスレッドに紐づいて永続化される。チャットの回答はセッション終了で消える。
+
+## Handling Review Comments
+
+Start this workflow when the user says comments were added or asks to `ingest review comments`, `process review comments`, `reply to review comments`, or `apply resolved comments`. Always run `ingest-review` to classify comments and write review-cycle state only, inspect each comment's `comment` and `selected_text`, write substantive answers with `add-reply` when a thread needs a response, and apply actionable feedback only when the review gates allow it. Do not answer only in chat; the durable answer belongs in the HTML comment thread.
+
+## コメント自動回答と解決待ちゲート
+
+preview server 起動後に必ず実行する。手順 11 で Monitor ツールによる `watch-comments` を起動し、以下のフローでコメントの自動検知・回答・解決待ちを行う。
+
+### watch-comments の起動
+
+preview server 起動後、以下で SSE イベント監視を開始する。
+
+```bash
+python3 -m scripts.html_review_workbench.cli watch-comments \
+  --root <output-dir>
+```
+
+agent は Monitor ツールでこのプロセスの stdout を監視する。各行は 1 行 JSON のイベント。
+
+### 自動回答フロー
+
+`watch-comments` から `comment_updated` イベントを受信したら:
+
+1. `ingest-review --root <dir>` でコメントを分類し、状態だけを保存する。`ingest-review` の実行だけで返信が追加されることはない。
+2. `comment` と `selected_text` を読み、設計資料の文脈を踏まえて実質的な回答を作成する。
+3. 回答・受領・確認依頼が必要なコメントにだけ `add-reply --root <dir> --thread-id <id> --body "<reply>"` で HTML コメントスレッドに書き戻す。
+4. 回答本文をコンソール（会話）にも出力する。ユーザーはブラウザとコンソールの両方で回答を確認できる。
+5. `actionable` コメントにはまだ設計変更を適用しない。回答で受領を伝え、スレッド解決後に反映する旨を書く。
+6. 自動回答が完了したら、設計変更には進まず停止する。`ingest-review` と `watch-comments` の出力に含まれる `gate` フィールドが `blocked` の場合、`document-model.json` を含むいかなる設計ファイルも変更してはならない。ゲートが `open` になるまで待機する。
+
+### 解決待ちゲート
+
+IMPORTANT: 未解決の `needs_clarification` スレッドがある間は、設計反映（ドキュメント修正）に進まない。
+
+修正判断の前に以下でゲートを確認する:
+
+```bash
+python3 -m scripts.html_review_workbench.cli check-gates \
+  --root <output-dir>
+```
+
+- `{"gate": "blocked", ...}` → 設計修正を行わない。コメントへの回答に専念する。
+- `{"gate": "open", "resolved_actionable": [...]}` → 解決済みの actionable スレッド内容を document model に反映してよい。
+
+### スレッド解決時の反映フロー
+
+ユーザーがスレッドを「解決」した `comment_updated` イベントを受信したら:
+
+1. `check-gates` でゲートが `open` であることを確認する。
+2. `resolved_actionable` の各スレッドについて、スレッド全体の議論を読み、修正が必要か判断する。
+3. 必要な修正を document model に適用する。
+4. `render` CLI で再生成する。
+5. `notify-update --root <dir> --message "コメント反映済み"` でブラウザに更新通知を送る。
+
+### 修正完了のブラウザ通知
+
+`notify-update` を実行すると、preview server 経由でブラウザに SSE イベントが送られ、画面上部にバナーが表示される。ユーザーは自分のタイミングでリロードして確認できる。自動リロードはしない。
+
+```bash
+python3 -m scripts.html_review_workbench.cli notify-update \
+  --root <output-dir> \
+  --message "コメント反映済み。リロードして確認してください"
+```
+
+## Automatic Comment Reply and Resolution Gate
+
+After preview startup, monitor browser comment events with `watch-comments`. On each `comment_updated` event, run `ingest-review`, identify clarification threads, write same-thread replies with `add-reply`, and avoid design edits while unresolved clarification threads remain. Before applying any document changes, run `check-gates`. Apply resolved actionable feedback to the document model, re-render, and use `notify-update` so the browser shows an update notice without forcing an automatic reload.
+
+## CodexでのCLI呼び出し
+
+HTML生成時は、`visual-html-renderer` と同じ共通CLI入口を使う。
+CLI実行前に、この `SKILL.md` の配置から renderer repo root を決める。
+`skills/reviewable-design-doc/SKILL.md` の2階層上が renderer repo root であり、
+そこに `scripts/html_review_workbench/cli.py` が存在することを確認する。
+すべての `python3 -m scripts.html_review_workbench.cli ...` は renderer repo root を
+作業ディレクトリにして実行する。現在のチャットやworkspaceのcwdをrepo rootとして扱わない。
+cwdに `scripts/html_review_workbench/cli.py` が無い場合は、代替HTMLを作らず、
+renderer repo rootへ移動してCLIを実行する。
+
+```bash
+python3 -m scripts.html_review_workbench.cli build-model \
+  --text "<existing content when converting an existing source>" \
+  --output <document-model.json>
+
+python3 -m scripts.html_review_workbench.cli attach-image \
+  --model <document-model.json> \
+  --block-id <generated-image-block-id> \
+  --image <generated-image-path>
+
+python3 -m scripts.html_review_workbench.cli check-model \
+  --model <document-model.json>
+
+python3 -m scripts.html_review_workbench.cli render \
+  --model <document-model.json> \
+  --output <output-dir>
+
+python3 -m scripts.html_review_workbench.cli validate \
+  --root <output-dir>
+
+python3 -m scripts.html_review_workbench.cli preview \
+  --root <output-dir> \
+  --mode auto
+```
+
+Codex / Claude では preview コマンドを一回限りの shell から起動することがあるため、標準手順では `--owner-pid` を渡さない。preview server は 24時間アクセスが無い場合に idle timeout で自動停止する。長寿命の所有プロセスが明確に分かる場合だけ `--owner-pid <pid>` を使ってよい。一回限りの shell の `$$` や `$PPID` は短命プロセスを指すため使わない。
+
+Codex sandbox内で `tailscale ip -4` が設定ファイル読み取りに失敗する場合は、`visual-html-renderer` と同じく `python3 -m scripts.html_review_workbench.preview_host_resolve` で取得したIPv4を `HTML_REVIEW_WORKBENCH_TAILSCALE_IP` に渡してから `preview --mode auto` を起動する。
+
+`preview` が `status: running` を返した場合、レビュー依頼の最終応答に `url` を必ず含める。ファイルパスだけで完了しない。標準では `--owner-pid` を渡さず、24時間アクセスが無い場合に idle timeout で自動停止させる。長寿命の所有プロセスが明確な場合だけ `--owner-pid <pid>` を使う。
+
+レビュー取り込み時は、最新のpreview sessionまたはユーザー指定の成果物rootから `annotations/comments.json` を読み込む。
+
+```bash
+python3 -m scripts.html_review_workbench.cli ingest-review \
+  --root <output-dir>
+```
+
+回答・受領・確認依頼が必要なコメントへagent replyを書き戻す場合は、`ingest-review` の分類結果から対象thread idを確認し、同じ成果物rootへ `add-reply` を実行する。
+
+```bash
+python3 -m scripts.html_review_workbench.cli add-reply \
+  --root <output-dir> \
+  --thread-id <thread-id> \
+  --body "<agent reply body>"
+```
+
+document modelへ反映する場合は、完全一致置換に限定して明示的に実行する。
+
+```bash
+python3 -m scripts.html_review_workbench.cli ingest-review \
+  --root <output-dir> \
+  --model <document-model.json> \
+  --apply-model
+```
+
+解決待ちゲートの確認:
+
+```bash
+python3 -m scripts.html_review_workbench.cli check-gates \
+  --root <output-dir>
+```
+
+コメント変更の SSE 監視（Monitor ツールで stdout を監視する）:
+
+```bash
+python3 -m scripts.html_review_workbench.cli watch-comments \
+  --root <output-dir>
+```
+
+ドキュメント更新通知をブラウザへ送信:
+
+```bash
+python3 -m scripts.html_review_workbench.cli notify-update \
+  --root <output-dir> \
+  --message "コメント反映済み"
+```
+
+## CLI Usage in Codex
+
+Use the same shared CLI as `visual-html-renderer`. Resolve the renderer repo root from this `SKILL.md`: two levels above `skills/reviewable-design-doc/SKILL.md`. Run every `python3 -m scripts.html_review_workbench.cli ...` command from that repo root. If the current workspace does not contain `scripts/html_review_workbench/cli.py`, move to the renderer repo root instead of creating fallback HTML. Use `ingest-review`, `add-reply`, `check-gates`, `watch-comments`, and `notify-update` for review cycles.
+
+## 完了時の確認
+
+- `index.html` と `renderer-manifest.json` が生成され、`validate` が `status: ok` を返している。
+- `check-model` が `status: ok` 相当の成功終了を返している。
+- preview有効時は、レビュー用URLをユーザーへ提示している。
+- レビュー取り込み後、`annotations/review-cycle-state.json` が生成されている。
+- 回答・受領・確認依頼が必要なコメントには、`add-reply` によりHTMLコメントスレッド上のagent replyが追加されている。
+- コメント反映でユーザー確認が必要な場合は、チャットだけでなくHTMLコメントへ返信済みであることを確認している。
+
+## 実シナリオ検証
+
+自動テスト pass と CLI の JSON 出力確認は、実シナリオ検証ではない。「動作確認」を求められた場合、以下のエンドツーエンドフローを実行する。
+
+### レビュー取り込み・返信の検証
+
+1. ユーザーが HTML 上にコメントを入れたことを確認する（ユーザーからの報告を待つ）。
+2. `ingest-review` で `comments.json` を取り込み、分類結果を読む。
+3. 各コメントの `comment` と `selected_text` を読み、設計資料の該当箇所の文脈を踏まえて、コメントの意図を理解する。
+4. 回答・受領・確認依頼が必要なコメントに対して、コメント内容に対する実質的な返答を考え、`add-reply` で HTML コメントスレッドに書き戻す。
+5. ユーザーに返信した旨を伝え、ブラウザで表示と内容の両方を確認してもらう。
+
+検証の完了条件: ユーザーがブラウザ上で agent の返信を読み、内容と表示の両方が意図通りであることを確認した時点。CLI が正しい JSON を返したことではない。
+
+## Real Scenario Verification
+
+Passing unit tests and receiving valid CLI JSON are prerequisites, not real scenario verification. For an operational check, the user must add a browser comment, the agent must ingest it, read `comment` and `selected_text`, write the actual answer with `add-reply`, and the user must confirm in the browser that both the reply text and display are correct.
+
+## ガード
+
+- 設計として未確定の内容は確定事項と分けて書く。
+- レビューコメント機能は必須で有効化する。
+- IMPORTANT: レビューコメントに回答する時は `add-reply` で HTML コメントスレッドに書き戻す。チャットで回答内容を述べただけでは回答完了にならない。
+- HTML低レベル実装をこのskillに重複実装しない。
+- IMPORTANT: `comments.json` を Edit ツールや直接のファイル編集で変更してはならない。コメントの追加・返信は必ず `add-reply` CLI 経由で行う。CLI はスキーマ検証を通すため、不正なデータがファイルに書き込まれることを防ぐ。
+
+## Guards
+
+Separate unresolved design ideas from confirmed decisions. Keep review comments enabled. When answering comments, use `add-reply` to write back into the HTML thread; a chat-only answer is not completion. Do not duplicate low-level HTML implementation inside this skill.
+
+IMPORTANT: Never edit `comments.json` directly with the Edit tool or any file-writing tool. All comment mutations must go through the `add-reply` CLI, which enforces schema validation and prevents malformed data from being written.
+
+### 禁止事項 / Prohibited Actions
+
+以下の操作は明示的に禁止する。違反するとデータ破損やレビュープロセスの破綻を引き起こす。
+
+1. `comments.json` を Edit/Write ツールで直接変更すること。reply の追加は `add-reply` CLI のみ。
+2. `check-gates` が `blocked` を返している状態で `document-model.json` を変更すること。
+3. `ingest-review` の出力に `"gate": {"gate": "blocked", ...}` が含まれている状態で設計変更に着手すること。
+4. `render` の stderr 警告を無視して次のステップに進むこと。
+
+The following actions are explicitly prohibited. Violations cause data corruption or review process breakdown.
+
+1. Editing `comments.json` directly with Edit/Write tools. Use `add-reply` CLI only.
+2. Modifying `document-model.json` while `check-gates` returns `blocked`.
+3. Starting design changes when `ingest-review` output contains `"gate": {"gate": "blocked", ...}`.
+4. Ignoring `render` stderr warnings and proceeding to the next step.

--- a/plugins/u-ichi/reviewable-html-workbench/skills/reviewable-design-doc/agents/openai.yaml
+++ b/plugins/u-ichi/reviewable-html-workbench/skills/reviewable-design-doc/agents/openai.yaml
@@ -1,0 +1,26 @@
+display_name: Reviewable Design Doc
+short_description: レビュー可能な設計資料HTMLを作り、コメント反映まで扱う / Build review-ready HTML design docs.
+default_prompt: Create a reviewable design doc in HTML / 設計資料をレビュー可能なHTMLで作って
+trigger_examples:
+  - レビュー可能な設計資料
+  - 設計資料をHTMLで
+  - design doc
+  - reviewable design doc
+  - レビュー終わったので確認して
+  - コメントを反映して
+  - create a reviewable design doc
+  - make a design doc in HTML
+  - build a review-ready design document
+  - ingest review comments
+  - process review comments
+  - reply to review comments
+  - apply resolved comments
+entrypoint: python3 -m scripts.html_review_workbench.cli
+working_directory: plugin_root
+workflow:
+  - attach-image
+  - check-model
+  - render
+  - validate
+  - preview
+  - ingest-review

--- a/plugins/u-ichi/reviewable-html-workbench/skills/visual-html-renderer/SKILL.md
+++ b/plugins/u-ichi/reviewable-html-workbench/skills/visual-html-renderer/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: visual-html-renderer
+description: |
+  HTMLを最終成果物として生成・検証・プレビューしたい時に使う共通レンダラー。Use this shared renderer when the user wants content turned into a final, validated, previewable HTML artifact. 現行rendererの表現能力を前提にagentが文書モデルを直接設計し、表・リスト・コード・注記・図・生成画像を選んだHTML bundleとセッション限定のプレビューURLを提示する。Triggers: html出力して, HTMLにして, HTMLで出して, この内容をHTMLで出して, HTMLでプレビューして, HTMLレンダラー, HTML出力を共通化, 図示つきHTML, visual HTML renderer, render this as HTML, turn this into HTML, create an HTML preview, generate a visual HTML report, make this a reviewable HTML document, diagrammed HTML report。使用しない場面: Plan Mode 中の計画確認プレビュー、設計内容そのものの作成、Notion投稿だけ、既存HTMLの軽微な見た目修正だけ。Do not use for: Plan Mode proposal previews, creating the design content itself, Notion-only publishing, or minor visual tweaks to existing HTML.
+argument-hint: "[document-model.json] [--output output/<date>_<slug>] [--preview auto|tailscale|local|off]"
+strict_procedure: true
+---
+
+# visual-html-renderer
+
+## 役割
+
+HTML出力系skillの共通レンダラーとして、個別HTML生成ロジックを置き換える。
+
+重い処理は `scripts/html_review_workbench/` のPython実装に委譲し、このskillは入力確認、呼び出し順、ガード、検証を担当する。
+
+## Role
+
+Use this skill as the shared renderer for HTML-output workflows. It replaces one-off HTML generation logic with a fixed flow: understand the requested content, design the document model, run the shared CLI, validate the bundle, and return a preview URL. Heavy implementation stays in `scripts/html_review_workbench/`; this skill owns input handling, workflow order, gates, and verification.
+
+Plan Mode 中の計画確認プレビューには、このskillを使わない。その場合は `plan-preview` を使い、一時HTML previewとして扱う。`visual-html-renderer` は通常の最終HTML成果物、レポート、レビュー可能な文書のbundle生成だけを担当する。
+
+Do not use this skill for Plan Mode proposal previews. Route those requests to `plan-preview`; this skill is only for final HTML artifacts, reports, and reviewable document bundles.
+
+## Strict procedure profile
+
+- Strictness: strict-procedure。HTML表現設計、文書モデルread-back、render、validate、preview URL提示までがこのskillの成果。
+- Hard gates: 外部サービス送信、画像生成、外部アップロード、shared state変更は該当する承認ゲートに従う。
+- Forcing function: rendererブロック対応表、render前自己レビュー、`check-model` CLI、Completion receipt。
+- Completion receipt: HTML表現設計、生成物、検証、preview、未実施層を最終応答に必ず含める。
+
+## 言語方針 / Language behavior
+
+Follow the language of the latest user request for progress updates, final responses, preview handoff text, and user-facing summaries. 日本語の依頼には日本語で、英語の依頼には英語で返す。入力本文や引用内容は、ユーザーが翻訳を求めない限り勝手に翻訳しない。HTML内の見出しや本文は、元資料の言語、ユーザーの指定、レビュー対象読者に合わせる。
+
+## 基本手順
+
+0. Plan Mode 中の計画確認プレビュー、`<proposed_plan>` の視覚確認、計画URLの追加が目的なら、このskillではなく `plan-preview` を使う。
+1. 文書モデルとレンダリングオプションを確認する。
+2. 文書モデルが未指定の場合は、直前の成果物またはユーザー指定内容を読み、HTML表現設計フェーズで構成を決める。
+3. 現行rendererのブロック型に合わせて、agentが `document-model.json` を直接作る。
+4. 一時的な入力退避が必要な場合だけ `build-model` で source-capture draft を作ってよい。ただし draft は最終モデルではないため、そのまま `render` へ渡さない。
+5. render前に `document-model.json` を読み返し、未再構成テキストの流し込みやrenderer非対応型の使用がないことを確認する。
+6. `image.generation_status=requested` のブロックがある場合は、`imagegen` skillで画像を生成し、`attach-image` CLIで文書モデルへ添付する。
+7. `check-model` CLIで最終render前の文書モデル品質を検査する。
+8. `render` CLIでHTML bundleを生成する。
+9. `validate` CLIでHTML、asset、comment schema、図・画像の非空を検証する。
+10. ユーザー向け最終HTMLでは既定で `preview` CLIを `--mode auto` で起動し、返却JSONの `url` と `stop_command` を最終応答に必ず書く。
+11. preview 起動直後に、Monitor ツールで `watch-comments` を開始する。これによりブラウザからのコメントを自動検知できるようになる。Monitor 起動コマンド: `python3 -m scripts.html_review_workbench.cli watch-comments --root <output-dir>`。自前の polling スクリプトではなく、この CLI を使うこと。イベント受信後の処理は `reviewable-design-doc` skill の「コメント自動回答と解決待ちゲート」セクションに従う。
+
+## Basic Workflow
+
+0. If the request is a Plan Mode proposal preview, `<proposed_plan>` visual check, or plan preview URL request, use `plan-preview` instead of this skill.
+1. Check the document model and rendering options.
+2. If no `document-model.json` is provided, inspect the user's content or the latest artifact and design the HTML structure yourself.
+3. Create the final `document-model.json` directly using the renderer-supported block types.
+4. Use `build-model` only as a source-capture draft when temporary input storage is needed; never pass that draft straight to `render`.
+5. Read back the model before rendering and confirm that raw or unsupported content was not dumped into the model.
+6. If image blocks request generation, use the `imagegen` skill and attach images with `attach-image`.
+7. Run `check-model`, then `render`, then `validate`, then `preview`.
+8. For user-facing artifacts, use `preview --mode auto` by default and include the returned `url` and `stop_command` in the final response.
+9. Start `watch-comments` immediately after preview startup so browser comments can be detected.
+
+## HTML情報設計の規約
+
+HTML出力はテキスト変換ではなく、最終HTML bundleの情報設計として扱う。
+
+- 入力本文の記号や行構造をそのまま表示へ流し込まない。
+- まず内容の意味、用途、読者、比較軸、時系列、依存関係、操作手順、注意点を読み取り、HTML上の表現を選ぶ。
+- 比較は表、手順は番号付きリスト、並列項目はリスト、注意・決定・前提はcallout、処理や依存関係はdiagramブロック、画面イメージや説明画像が有効な箇所はimageブロック、コマンドやログはコードブロックにする。
+- diagramブロックはMermaid sourceを構造保存用に残し、既定では生成画像を主表示にする。生成画像が未添付の場合だけMermaid fallbackを表示する。
+- 現行rendererのブロック型で表現が足りない場合、未再構成テキストへ戻さず、必要なブロック型やレンダリング拡張を検討する。
+- 一時入力ファイルが必要な場合も `.md` は使わない。`source.txt`, `input.txt`, `source-content.txt` のようなプレーンテキスト名を使う。
+- ユーザーへの進捗・最終報告では、`.md` やMarkdownという語をHTML出力の前提として扱わない。
+
+## rendererブロック対応表
+
+現行rendererで最終HTMLに使う表現は、実装上の描画挙動に合わせて選ぶ。
+
+| block type | rendererの扱い | contentに書くもの |
+|---|---|---|
+| `html` | HTML片をそのまま挿入する | agentが設計した `<p>`, `<table>`, `<ul>`, `<ol>`, `<pre><code>` 等の構造化HTML |
+| `callout` | HTML escapeしてcallout表示する | 決定、注意、前提などの短いプレーンテキスト。HTMLタグは書かない |
+| `diagram` | Mermaid sourceを保存し、fallback previewまたは生成画像を表示する | `diagram_source` または `diagram.source` にMermaid source。sourceに無い関係を画像側で追加しない |
+| `image` | 添付済み生成画像を表示する | `image.prompt`, `image.alt`, `image.caption`, `image.source_path` |
+| `section` / `text` / `table` | 専用描画なし。通常段落へescapeされる | 最終HTMLモデルでは使わない。表は `html` block内の `<table>` で表現する |
+
+`html` blockはraw insertされるため、外部入力をそのまま混ぜない。入力由来の文字列はagentが意味単位へ再構成し、必要な箇所だけescape済みHTMLとして入れる。
+
+## 見出し階層
+
+rendererは `<h1>` を文書タイトルに使う。本文ブロックの見出しは `heading_level` フィールドで制御する。
+
+| heading_level | HTML タグ | 用途 |
+|---|---|---|
+| `2` | `<h2>` | 章見出し。文書を大きく区切る上位セクション。読者が目次で選ぶ単位 |
+| `3` | `<h3>` | 節見出し。章の中を細分化するサブセクション |
+
+- `heading_level` は必須。`2`（章）または `3`（直前の章の配下の節）を指定する。
+- content 内に `<h2>` や `<h3>` を直接書かない。小見出しが必要な場合は `<h4>` を使う（renderer が content 内の見出しを自動シフトする）。
+
+## html block 内の HTML 品質
+
+`html` block の content に書く HTML は、セマンティックな構造を意識する。
+
+- 表は `<table>` に `<thead>` と `<tbody>` を含め、ヘッダセルは `<th scope="col">` または `<th scope="row">` にする。
+- 手順は `<ol>`、並列項目は `<ul>`、用語と説明の対は `<dl>` にする。
+- 長い本文は `<p>` で段落分けし、`<div>` に流し込まない。
+- 強調は `<strong>`（重要）と `<em>`（ニュアンス）を使い分ける。
+
+## HTML表現設計フェーズ
+
+文書モデルを作る前に、agentは次を決める。
+
+- 読者と用途。
+- 章構成。文書全体を概要→各論→結論のような読み手を誘導する流れに分ける。どのブロックが章（`heading_level: 2`）でどのブロックが節（`heading_level: 3`）かを先に決める。1つの章に節が偏りすぎないようバランスを取る。
+- 主要な情報単位。
+- 比較軸、時系列、依存関係、操作手順、決定、前提、未決事項。
+- 各blockの `type`, `title`, `heading_level`, `content`, `review_required`。
+- 各 `heading_level: 2` ブロックの冒頭に、その章で扱う内容の文脈を示す導入段落を置く。
+- `html` block内で使う表、番号付きリスト、箇条書き、コードブロック、通常本文の構成。
+- 図示または画像が必要な箇所と、Mermaid sourceまたは生成画像prompt。
+
+入力がMarkdownや箇条書きで整理されていても、記号構造をそのまま変換しない。最終HTMLで読みやすい単位へ組み替えてから文書モデルにする。
+
+## HTML Information Design Rules
+
+Treat HTML output as information design for the final bundle, not as text conversion. Identify the audience, purpose, comparison axes, chronology, dependencies, steps, decisions, assumptions, and unresolved issues before writing the model. Use tables for comparisons, ordered lists for procedures, lists for parallel items, callouts for decisions or cautions, diagrams for flows and dependencies, images for useful visual explanations, and code blocks for commands or logs. Even when the input is Markdown or a list, restructure it into readable HTML blocks instead of mechanically converting the symbols.
+
+## 入力モデル未指定時の規約
+
+ユーザーが「html出力して」「HTMLにして」「HTMLで出して」「render this as HTML」「turn this into HTML」「create an HTML preview」「generate a visual HTML report」「make this a reviewable HTML document」「diagrammed HTML report」のように自然文で依頼し、`document-model.json` を指定していない場合も、このskillを発火させる。
+
+その場合は、次の順で入力を決める。
+
+1. ユーザーが明示した対象ファイル、本文、直前の成果物をHTML化対象にする。
+2. 対象が曖昧で、直前の成果物も特定できない場合だけ、短く確認する。
+3. 対象を特定できる場合は、確認で止めずにHTML表現設計フェーズへ進み、`output/tmp/<purpose>/document-model.json` または `output/<YYYY-MM-DD>_<name>/document-model.json` を直接作る。
+4. 作成する文書モデルは `schema_version`, `document_id`, `title`, `generated_at`, `blocks` を必ず持つ。
+5. `image.generation_status=requested` のブロックがある場合は画像生成と `attach-image` を完了してから、`check-model` → `render` → `validate` → `preview` まで進める。
+
+`build-model` は最終HTMLモデルを作るplannerではない。入力を安全に保持する source-capture draft を作るだけで、Markdown表・リスト・コード等の機械変換や、内容に応じた表現選択は行わない。最終HTML出力では、agentがHTML表現設計フェーズで文書モデルを直接設計する。画像生成が外部サービス送信・機密情報・ユーザー承認を要する条件に当たる場合は、該当する承認ゲートに従う。設計判断、要求整理、レビュー観点の作成が主目的の場合は `reviewable-design-doc` を使う。
+
+## When No Input Model Is Provided
+
+Natural requests such as `render this as HTML`, `turn this into HTML`, `create an HTML preview`, `generate a visual HTML report`, `make this a reviewable HTML document`, and `diagrammed HTML report` should still trigger this skill. Use the explicitly named file, pasted content, or latest artifact as the HTML source. Ask only when the target cannot be identified. If the target is clear, proceed into HTML information design and create `output/tmp/<purpose>/document-model.json` or `output/<YYYY-MM-DD>_<name>/document-model.json` directly.
+
+## render前自己レビュー
+
+`render` CLIを呼ぶ前に、文書モデルを読み返して次を確認する。
+
+- `heading_level: 2` のブロックが少なくとも1つある。`heading_level: 3` のブロックが最初の `heading_level: 2` ブロックより前に出現していない。
+- 各 `heading_level: 2` ブロックの content が導入段落で始まっている。
+- `html` block の `<table>` に `<thead>` と `<th>` がある。content 内に `<h2>` や `<h3>` を直接書いていない。
+- `html` blockが未再構成テキストを `<p>` または `<pre>` だけで抱えていない。
+- 比較対象がある場合は、`html` block内の `<table>` 等で比較軸を明示している。
+- 手順がある場合は、`html` block内の `<ol>` 等で順序を明示している。
+- 決定、前提、注意は `callout` または専用の `html` blockとして本文に埋もれないようにしている。
+- `callout` blockの `content` にHTMLタグを書いていない。
+- `section`, `text`, `table` block typeを最終モデルで使っていない。
+- `diagram` blockは有効なMermaid sourceを持ち、画像生成promptはsourceに無い事実を追加していない。
+- `image` blockは `source_path` が添付済みになるまで `render` しない。
+
+## Pre-render Self Review
+
+Before calling `render`, read the model back and confirm the heading hierarchy, introductory paragraphs, supported block types, table semantics, ordered steps, callouts, diagram sources, attached images, and absence of raw unstructured dumps. Do not render until requested images have been attached and unsupported block types have been removed.
+
+## 生成画像promptの規約
+
+- diagramブロックの生成画像は、Mermaid sourceのノード、ラベル、矢印方向、関係を保持する。sourceに無い事実、指標、関係、ブランド要素、装飾を追加しない。
+- diagramブロックではMermaid sourceを `assets/diagrams/*.mmd` に保存し、HTML上は生成画像を主表示にする。生成画像が未添付の場合だけMermaid fallbackを表示する。
+- imageブロックの生成画像は、白背景、十分な余白、資料向けの落ち着いた見た目、必要最小限の文字量を基本にする。
+- 画面イメージは実在スクリーンショットではなくmockupとして生成する。公式ロゴ、ブランド名、UIラベル、数値、根拠を入力に無い形で作らない。
+- 概念画像は直感理解の補助に限定する。事実関係、依存関係、数値、判断順を説明する場合はdiagramブロックを優先する。
+
+## CodexでのCLI呼び出し
+
+このskillは、低レベル実装へ直接importせず、共通CLIだけを呼ぶ。
+
+CLI実行前に、この `SKILL.md` の配置から renderer repo root を決める。
+`skills/visual-html-renderer/SKILL.md` の2階層上が renderer repo root であり、
+そこに `scripts/html_review_workbench/cli.py` が存在することを確認する。
+すべての `python3 -m scripts.html_review_workbench.cli ...` は renderer repo root を
+作業ディレクトリにして実行する。現在のチャットやworkspaceのcwdをrepo rootとして扱わない。
+cwdに `scripts/html_review_workbench/cli.py` が無い場合は、代替HTMLを作らず、
+renderer repo rootへ移動してCLIを実行する。
+
+```bash
+python3 -m scripts.html_review_workbench.cli build-model \
+  --text "<content>" \
+  --output <document-model.json>
+
+python3 -m scripts.html_review_workbench.cli attach-image \
+  --model <document-model.json> \
+  --block-id <generated-image-block-id> \
+  --image <generated-image-path>
+
+python3 -m scripts.html_review_workbench.cli check-model \
+  --model <document-model.json>
+
+python3 -m scripts.html_review_workbench.cli render \
+  --model <document-model.json> \
+  --output <output-dir>
+
+python3 -m scripts.html_review_workbench.cli validate \
+  --root <output-dir>
+
+python3 -m scripts.html_review_workbench.cli preview \
+  --root <output-dir> \
+  --mode auto
+```
+
+Codex / Claude では preview コマンドを一回限りの shell から起動することがあるため、標準手順では `--owner-pid` を渡さない。preview server は 24時間アクセスが無い場合に idle timeout で自動停止する。
+
+Codex sandbox内で `tailscale ip -4` が設定ファイル読み取りに失敗する場合は、preview本体をsandbox内で起動したまま、IPだけを小さいresolverで先に取得して渡す。
+
+```bash
+python3 -m scripts.html_review_workbench.preview_host_resolve
+
+HTML_REVIEW_WORKBENCH_TAILSCALE_IP=<tailscale-ip> \
+  python3 -m scripts.html_review_workbench.cli preview \
+    --root <output-dir> \
+    --mode auto
+```
+
+長寿命の所有プロセスが明確に分かる場合だけ `--owner-pid <pid>` を使ってよい。一回限りの shell の `$$` や `$PPID` は短命プロセスを指すため使わない。
+
+ユーザーが明示的にプレビュー不要と言った場合、または自動テスト・fixture検証で副作用を抑える場合だけ `--mode off` を使う。ユーザー向け成果物では `--mode off` を既定にしない。
+成果物はユーザーが直接読む最終HTMLなら `output/<YYYY-MM-DD>_<name>/`、再利用しない検証なら `output/tmp/<purpose>/` に置く。
+
+## CLI Usage in Codex
+
+Call only the shared CLI. Resolve the renderer repo root from this `SKILL.md`: two levels above `skills/visual-html-renderer/SKILL.md`. Run every `python3 -m scripts.html_review_workbench.cli ...` command from that repo root. If the current workspace does not contain `scripts/html_review_workbench/cli.py`, move to the renderer repo root instead of creating fallback HTML. Use `--mode off` only for explicit no-preview requests or tests; user-facing artifacts should default to `--mode auto`.
+
+## Preview URL提示とライフサイクル
+
+- `preview` が `status: running` を返した場合、最終応答に `url` を必ず含める。ファイルパスだけで完了しない。
+- `preview` が `status: off` または `status: failed` の場合、URLが無い理由を明示し、可能なら `--mode auto` で再実行してURL提示まで進める。
+- 標準では `--owner-pid` を渡さず、24時間アクセスが無い場合に idle timeout で自動停止させる。長寿命の所有プロセスが明確な場合だけ `--owner-pid <pid>` を使う。
+- 手動停止が必要な時だけ、返却JSONの `stop_command` を使う。PIDなしで全previewを停止しない。
+
+## Preview URL and Lifecycle
+
+When `preview` returns `status: running`, include the `url` in the final response; a file path alone is not completion. If preview is off or failed, state the reason and try `--mode auto` when appropriate. Do not pass `--owner-pid` by default; the preview server stops after 24 hours without access. Use the returned `stop_command` only when manual cleanup is needed.
+
+## 完了時の確認
+
+- `index.html` と `renderer-manifest.json` が生成されている。
+- `validate` が `status: ok` を返している。
+- preview 有効時は提示URL、bind先、PID、停止方法をユーザーへ伝える。
+- preview は `0.0.0.0` にbindしていない。
+
+## 実シナリオ検証
+
+自動テスト pass と CLI の JSON 出力確認は、実シナリオ検証ではない。「動作確認」を求められた場合、以下を実行する。
+
+1. 実際の内容について `document-model.json` を作り、`render` → `validate` → `preview` を実行する。
+2. preview URL をユーザーに提示し、ブラウザで表示を確認してもらう。
+3. 表示に問題がある場合は、文書モデルを修正して再 render する。
+
+検証の完了条件: ユーザーがブラウザ上で最終 HTML の表示を確認した時点。`validate` が `status: ok` を返したことではない。
+
+## Real Scenario Verification
+
+Passing unit tests and receiving valid CLI JSON are prerequisites, not real scenario verification. When the user asks for an operational check, create a real `document-model.json`, run `render` -> `validate` -> `preview`, provide the preview URL, and have the user confirm the rendered HTML in the browser. Verification is complete only after the browser-visible result is accepted.
+
+## Completion receipt
+
+最終応答には次を含める。
+
+- HTML表現設計: 使用した主要block型と、その表現にした理由。
+- 生成物: `index.html` と `renderer-manifest.json` の場所。
+- 検証: `validate` の結果。
+- preview: URL、bind先、PID、`stop_command`。
+- 未実施: 画像生成、manual-acceptance-testing 等の未実施層があれば理由。
+
+Final responses must include: HTML design choices, generated `index.html` and `renderer-manifest.json` paths, validation result, preview URL/bind/PID/`stop_command`, and any unperformed verification layers with reasons.
+
+## ガード
+
+- レンダラーは内容判断を作らない。
+- 図示は入力された構造を補助する目的に限定する。
+- ブラウザを自動で開かない。URL提示までを責務とする。
+- Preview Runtime は `0.0.0.0` にbindしない。
+- 外部サービスへ投稿・アップロードする場合は別途承認ゲートを通す。
+
+## Guards
+
+The renderer does not invent content decisions. Diagrams only support the provided structure. Do not open the browser automatically; return the URL. Never bind Preview Runtime to `0.0.0.0`. Any external posting, upload, or service transmission requires the appropriate approval gate.

--- a/plugins/u-ichi/reviewable-html-workbench/skills/visual-html-renderer/agents/openai.yaml
+++ b/plugins/u-ichi/reviewable-html-workbench/skills/visual-html-renderer/agents/openai.yaml
@@ -1,0 +1,27 @@
+display_name: Visual HTML Renderer
+short_description: 図示つきHTML生成とPreview Runtimeを扱う共通レンダラー / Shared renderer for visual HTML previews.
+default_prompt: Create a visual HTML preview / 図示つきHTMLレポートを生成して
+trigger_examples:
+  - html出力して
+  - HTMLにして
+  - HTMLで出して
+  - この内容をHTMLで出して
+  - HTMLでプレビューして
+  - HTMLレンダラー
+  - HTML出力を共通化
+  - 図示つきHTML
+  - visual HTML renderer
+  - render this as HTML
+  - turn this into HTML
+  - create an HTML preview
+  - generate a visual HTML report
+  - make this a reviewable HTML document
+  - diagrammed HTML report
+entrypoint: python3 -m scripts.html_review_workbench.cli
+working_directory: plugin_root
+workflow:
+  - attach-image
+  - check-model
+  - render
+  - validate
+  - preview


### PR DESCRIPTION
## Plugin

- **Name:** [Reviewable HTML Workbench](https://github.com/u-ichi/reviewable-html-workbench)
- **Category:** Development & Workflow
- **Description:** Generate reviewable HTML documents, serve previews, collect inline review comments, and feed review outcomes back into agent workflows.

## Scanner Results

- **Score:** 85/100 (B - Good)
- **Severity:** No critical or high findings
- **CI run:** https://github.com/u-ichi/reviewable-html-workbench/actions

## Checklist

- [x] Plugin bundle exists under `plugins/u-ichi/reviewable-html-workbench/`
- [x] `composerIcon` field is set in `plugin.json` interface section
- [x] Icon file exists at the path referenced by `composerIcon`
- [x] README entry is alphabetically sorted
- [x] Scanner workflow running in plugin repo's GitHub Actions
- [x] Scanner score >= 80 with no critical/high findings