### PR TITLE
Add RAG Reviewer plugin by mimfort

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PR Storyteller](./plugins/mturac/pr-storyteller) - PR title + body + test plan from commits and diff vs base branch.
 - [Praxis](https://github.com/ouonet/praxis) - Intent-driven workflow skills for coding agents: describe what done looks like, not the steps. Triage-first design keeps token costs low across design, TDD, debug, review, and release.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
+- [RAG Reviewer](https://github.com/mimfort/rag_for_git) - Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
 - [River Review](https://github.com/s977043/river-review) - Versioned Skill Registry of code-review skills driven by a perspective-based review agent (code, security, performance, architecture, testing, adversarial) that verifies findings against the diff.
 - [RoadmapSmith](https://github.com/PapiScholz/roadmapsmith) - Evidence-backed ROADMAP.md workflows for AI coding agents with validation, sync, and roadmap generation across any tech stack.


### PR DESCRIPTION
## Add rag-reviewer plugin

**Plugin:** [RAG Reviewer](https://github.com/mimfort/rag_for_git)  
**Repo:** https://github.com/mimfort/rag_for_git  
**Category:** Development & Workflow  

Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex.

### Scanner Results

```
🔗 Plugin Scanner v2.0.885
Scanning: ./rag_for_git  
Final Score: 93/100 (A - Excellent)  
Findings: critical:0, high:0, medium:1, low:0, info:25  
```

### Checklist

- [x] `.github/workflows/hol-plugin-scanner.yml` exists (added in the same PR to plugin repo)
- [x] `SECURITY.md` exists
- [x] `LICENSE` exists (MIT)
- [x] `.codex-plugin/plugin.json` valid with all required fields
- [x] Plugin Scanner score ≥ 80 (93/100)
- [x] No critical or high findings
- [x] README.md entry alphabetically sorted
- [x] Plugin bundle under `plugins/mimfort/rag_for_git/`
- [x] `composerIcon` set in plugin.json interface