### PR TITLE
Update OpenProject Codex plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [MorningAI](https://github.com/octo-patch/MorningAI) - AI news tracking skill that monitors 80+ entities across 6 sources (Reddit, HN, GitHub, Hugging Face, arXiv, X) and generates scored daily reports with infographics and message digests.
 - [Nullcost](https://github.com/johnvouros/nullcost-plugin) - Catalog-backed free-tier, free-trial, and cheap developer-tool recommendations for Codex through bundled skills and MCP tools.
 - [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.
-- [OpenProject](https://github.com/varaprasadreddy9676/team-codex-plugins) - Team collaboration via OpenProject integration.
+- [OpenProject Codex](https://github.com/varaprasadreddy9676/openproject-codex-plugin) - OpenProject integration for Codex with project, team, work package, bulk workflow, boards, wiki, meeting, attachment, and reporting support.
 - [Ophis](https://github.com/ophis-fi/skills) - Onchain token swaps for Codex via the hosted Ophis MCP server, MEV-protected and gasless, built on CoW Protocol.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.


### PR DESCRIPTION
This updates the existing OpenProject entry to point at the current public repo:\n\n- https://github.com/varaprasadreddy9676/openproject-codex-plugin\n\nThe old entry still points to . The new repo is the maintained open-source plugin with current support for project/work-package workflows, bulk actions, boards, wiki, meetings, attachments, and reporting.\n\nI also added the HOL scanner workflow to the plugin repo so it aligns better with the marketplace requirements.