### PR TITLE
Re-add ru-text to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PDF Monster](https://github.com/jbaehova/pdf-monster) - Analyzes PDFs as extracted text, OCR text, rendered page images, and embedded figures for coding agents.
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - Route image-generation prompts to 30+ models (DALL-E, Stable Diffusion, Flux, Midjourney, and more) through a single MCP interface. Install: `npm install -g prompt-to-asset`.
 - [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex with the official Remotion docs MCP, composition scaffolding, and a data-driven launch-video workflow.
+- [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,044 rules for typography, info-style, editorial, UX writing, and business correspondence.
 - [Rust Reverse Engineering](https://github.com/jingjing2222/rust-reverse-engineering-skill) - Reverse engineer Rust binaries and libraries: triage targets, demangle symbols, recover crate namespaces, and map panic, unwind, async, and FFI paths.
 - [ScrapeGraph AI](https://github.com/ScrapeGraphAI/just-scrape) - AI-powered web scraping CLI to search, scrape, extract structured JSON, crawl, and monitor web pages via the ScrapeGraph AI API.
 - [SEO Dungeon](https://github.com/avalonreset/seo-dungeon) - Gamified local SEO audits that turn website issues into 16-bit dungeon battles for Codex, Claude, and Gemini CLI workflows.


### PR DESCRIPTION
### What

Restores the `ru-text` entry under **Community Plugins → Tools & Integrations** (alphabetically between *Remotion Plugin* and *Rust Reverse Engineering*).

### Why

The entry was inadvertently dropped from `README.md` in commit `9ada6c95` ("feat: add community plugins (ScrapeGraph AI, AgentBox, …)") — it was removed in the same commit that added six other plugins, so it looks like collateral of a rebase/regeneration rather than an intentional delisting. As a result, ru-text disappeared from the generated `marketplace.json` and `plugins.json` on subsequent syncs, even though its bundle and icon are still mirrored in the repo (the icon was added earlier in #162).

### Scope

- Single line added to `README.md`. No bundle or generated artifacts touched — the next generator sync re-mirrors the current upstream `HEAD` (now **v1.10.0**) and regenerates the marketplace entry with the existing `composerIcon`.

### Validation (run locally)

- `python3 scripts/check-alphabetical.py` → all sections sorted ✓
- `python3 scripts/validate-plugin-pr.py --base-ref main` → all checks passed (ru-text README entry recognised; local bundle present) ✓