### PR TITLE
Add Ophis to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Nullcost](https://github.com/johnvouros/nullcost-plugin) - Catalog-backed free-tier, free-trial, and cheap developer-tool recommendations for Codex through bundled skills and MCP tools.
 - [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.
 - [OpenProject](https://github.com/varaprasadreddy9676/team-codex-plugins) - Team collaboration via OpenProject integration.
+- [Ophis](https://github.com/ophis-fi/skills) - Onchain token swaps for Codex via the hosted Ophis MCP server, MEV-protected and gasless, built on CoW Protocol.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.


### PR DESCRIPTION
Adds Ophis to Community Plugins > Tools & Integrations (alphabetical, README-only).

Ophis is an intent-based DEX (a CoW Protocol deployment) that gives a Codex agent gasless, MEV-protected, keyless, non-custodial onchain token swaps across 11 EVM chains, via a hosted Streamable HTTP MCP server (12 tools) plus the ophis-swap skill.

- Source repo: https://github.com/ophis-fi/skills (Codex manifest at plugins/ophis/.codex-plugin/plugin.json, icon at plugins/ophis/assets/icon.svg, SECURITY.md present)
- HOL plugin scanner: Final Score 96/100 (A), 0 critical / 0 high / 0 medium / 0 low (plugin-scanner 2.0.930, plugin_dir plugins/ophis)
- Single line, alphabetical between OpenProject and OrgX; no plugins/ or plugins.json edits

Disambiguation: this is Ophis the DEX (ophis.fi), not njayp/ophis, an unrelated Go MCP library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)