### PR TITLE
Add CONTAM Tools plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
 - [Codex Usage Tracker](https://github.com/douglasmonsky/codex-usage-tracker) - Track aggregate Codex token usage from local session logs with MCP tools for summaries, session detail, CSV export, and dashboard generation.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
+- [CONTAM Tools](https://github.com/summer521521/CONTAM_plugin) - Runs and inspects CONTAM airflow projects through a local MCP server with project guards, diagnostics, simulation helpers, and bridge workflows.
 - [Data Product Builder for dbt](https://github.com/entropy-data/dataproduct-builder-dbt) - Full data-product lifecycle on dbt for Entropy Data: scaffold, audit, and integrate projects with ODCS, ODPS, OpenLineage, and GitHub Actions.
 - [Dodo Payments](https://github.com/dodopayments/dodo-agent-plugin) - Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth.
 - [Education Agent Skills](https://github.com/GarethManning/education-agent-skills) - 131 evidence-based education skills for curriculum design, lesson planning, and assessment, with transparent evidence ratings and MCP server.


### PR DESCRIPTION
Adds CONTAM Tools to the Tools & Integrations section.\n\nPlugin repository: https://github.com/summer521521/CONTAM_plugin\nHOL Scanner CI: https://github.com/summer521521/CONTAM_plugin/actions/runs/28492510929\nPlugin Regression CI: https://github.com/summer521521/CONTAM_plugin/actions/runs/28492510938\n\nThe plugin repository passes the required HOL scanner gate and includes its own scanner workflow.