### PR TITLE
Add Zotero Research Tools plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [VidSeeds.ai](https://github.com/CarrotGamesStudios/vidseeds-mcp) - Hosted MCP connector for pre-upload video SEO, metadata optimization, AI thumbnails, and multi-platform publishing with workflow skills for Codex agents.
 - [X Twitter Scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data, monitored workflows, HMAC webhooks, and MCP access through the Xquik REST API with confirmation-gated write guidance.
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
+- [Zotero Research Tools](https://github.com/summer521521/Zotero_Research_plugin) - Connects Codex to Zotero Desktop for local-library search, citation export, collection and tag inspection, and research workflow support.
 
 ## Plugin Development
 


### PR DESCRIPTION
Adds Zotero Research Tools to the Tools & Integrations section.\n\nPlugin repository: https://github.com/summer521521/Zotero_Research_plugin\nHOL Scanner CI: https://github.com/summer521521/Zotero_Research_plugin/actions/runs/28492058488\nPlugin Check CI: https://github.com/summer521521/Zotero_Research_plugin/actions/runs/28492058496\n\nThe plugin repository passes the required HOL scanner gate and includes its own scanner workflow.