### PR TITLE
Add AgentGuards (Tools & Integrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
 - [Agentgram](https://github.com/jerryfane/agentgram) - Send explicit Telegram messages from Codex and local AI agents through a Telegram bot token and chat id.
+- [AgentGuards](https://github.com/alelaguard/agentguards-plugins) - LLM security guardrails for Codex with enforcing hooks and MCP tools: jailbreak and prompt-injection detection, web-content scanning, data-exfiltration blocking, and destructive-command authorization.
 - [Aient](https://github.com/aient-ai/aient-codex-plugin) - AI operations plugin for Codex that connects production telemetry, problem lifecycle context, and remediation workflows through Aient's MCP server.
 - [Antigravity 2.0](https://github.com/comprono/antigravity-2-codex-plugin) - Local Codex bridge for Antigravity desktop with setup checks, model limit summaries, DevTools UI automation, and safe project/chat handoff.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.


### PR DESCRIPTION
## Plugin

**AgentGuards** — LLM security guardrails for OpenAI Codex.

- **Repo (root):** https://github.com/alelaguard/agentguards-plugins
- **Plugin path:** `codex/` (Codex plugin; the repo also ships a sibling Claude Code plugin under `claude/`)
- **Install:** `codex plugin marketplace add alelaguard/agentguards-plugins`

Enforcing hooks (prompt screening, shell-command authorization with allow/deny/ask, web-content scanning of curl/wget output) plus the AgentGuards MCP tools (`check_input`, `authorize_action`, `validate_output`, …). Fail-closed by default.

## Scanner (required)

- **HOL Plugin Scanner score: 97/100 (A – Excellent)** — no critical/high/medium/low findings (4 info only).
- **Passing CI run on `main`:** https://github.com/alelaguard/agentguards-plugins/actions/runs/28593427079
- Scanner workflow: `.github/workflows/hol-plugin-scanner.yml` (SHA-pinned action, `plugin_dir: codex`).

## Checklist

- [x] `.codex-plugin/plugin.json` valid manifest (with `interface` metadata)
- [x] `SECURITY.md`, `LICENSE` (MIT), `README.md`
- [x] No hardcoded secrets; API key read from `AGENTGUARDS_API_KEY` at runtime
- [x] SHA-pinned GitHub Actions
- [x] Single README line, alphabetical order, links to repo root
- [x] No plugins/ or catalog files committed to this PR