### PR TITLE
Add CarsXE vehicle data API plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.
+- [CarsXE](https://github.com/carsxe/carsxe-codex-plugin) - Decode VINs, license plates, market value, vehicle history, recalls, liens, OBD codes, and more via the CarsXE API.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
 - [Codex Be Serious](https://github.com/lulucatdev/codex-be-serious) - Enforce formal, textbook-grade written register across all agent output.
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.


### PR DESCRIPTION
## Plugin

**[CarsXE](https://github.com/carsxe/carsxe-codex-plugin)** — Decode VINs, license plates, market value, vehicle history, recalls, liens, OBD codes, and more via the CarsXE API.

Added to **Tools & Integrations**, alphabetically between Canvas Apps and Chrome DevTools.

## Checklist

- [x] Plugin published at https://github.com/carsxe/carsxe-codex-plugin
- [x] HOL Plugin Scanner passes with `fail_on_severity: high` and `min_score: 80`
- [x] `.codex-plugin/plugin.json` present with all required fields
- [x] 13 skills with `license: MIT` in frontmatter
- [x] SessionStart hook for API key management
- [x] MIT licensed
- [x] Entry alphabetically sorted in Tools & Integrations section