### PR TITLE
Add Superpipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Standup Generator](./plugins/mturac/standup-gen) - Daily standup notes from git activity across repos.
 - [Stark](https://github.com/f0d010c/stark) - UI/UX design plugin for AI coding agents with product-flow routing, platform-native interface guidance, asset planning, and shipped-reference analysis before code.
 - [Superloopy](https://github.com/beefiker/superloopy) - Evidence-gated Codex loop harness with specialist skills, including near-pixel authorized website cloning backed by screenshots, assets, build output, and visual QA.
+- [Superpipelines](https://github.com/gustavo-meilus/superpipelines) - Design and run write/review-isolated multi-agent AI pipelines across Codex, Claude Code, OpenCode, Cursor, Windsurf, and Cline.
 - [tailtest](https://github.com/avansaber/tailtest-codex) - Hook-powered test generation -- detects files changed during an agent turn and instructs Codex to write and run tests automatically. Zero config, 8 languages.
 - [Tandem Workflow Architect](https://github.com/frumu-ai/tandem-codex-plugin) - Plan Tandem workflows in Codex, then validate, preview, and run them through the governed Tandem engine.
 - [Tartiner Labs](https://github.com/tartinerlabs/skills) - Agent skills for git workflows, GitHub automation, security audits, code refactoring, and project tooling.


### PR DESCRIPTION
## Plugin
https://github.com/gustavo-meilus/superpipelines

## Scanner Evidence
- Source repo HOL scanner on `main`: https://github.com/gustavo-meilus/superpipelines/actions/runs/28668843058
- Local scanner for the installable Codex bundle passed, final score 90/100, high/critical 0

## Validation
- Catalog validator passed for Superpipelines
- PR hygiene: branch diff against upstream `main` contains only `README.md` with the Superpipelines line

Note: `scripts/check-alphabetical.py` currently fails on pre-existing upstream ordering issues unrelated to this plugin entry (`BABOK Analyst`/`BGS Modding Superpowers`, `Waggle`/`Wingman`, `CONTAM Tools`/`Context Pack`, `prompt-to-asset`/`Pronounce`). This PR intentionally does not include unrelated reorder changes.