### PR TITLE
fix: refresh VidSeeds.ai trust metadata

### DIFF
--- a/plugins/CarrotGamesStudios/vidseeds-mcp/.codex-plugin/plugin.json
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vidseeds",
   "version": "1.9.2",
-  "description": "VidSeeds.ai connector — pre-upload video SEO/metadata optimization + multi-platform publishing (222 tools). Workflow skills for efficient MCP use. Paid connector with a 14-day free trial. Requires a free Personal Access Token from https://vidseeds.ai/settings/mcp-settings.",
+  "description": "VidSeeds.ai connector for pre-upload video SEO/metadata optimization + multi-platform publishing (247 tools). Workflow skills for efficient MCP use. Paid connector with a 14-day free trial. Requires a free Personal Access Token from https://vidseeds.ai/settings/mcp-settings.",
   "author": {
     "name": "VidSeeds.ai",
     "url": "https://vidseeds.ai"
@@ -27,7 +27,7 @@
     "type": "cli",
     "displayName": "VidSeeds.ai",
     "shortDescription": "Pre-upload video SEO/metadata optimization and multi-platform publishing.",
-    "longDescription": "VidSeeds.ai analyzes your existing video and generates optimized titles, descriptions, tags, thumbnails, and chapters for YouTube, TikTok, Instagram, Facebook, LinkedIn, and X — then publishes. Hosted MCP connector (222 tools) with workflow skills and a 14-day free trial; requires a free Personal Access Token from https://vidseeds.ai/settings/mcp-settings.",
+    "longDescription": "VidSeeds.ai analyzes your existing video and generates optimized titles, descriptions, tags, thumbnails, and chapters for YouTube, TikTok, Instagram, Facebook, LinkedIn, and X, then publishes. Hosted MCP connector (247 tools) with workflow skills and a 14-day free trial; requires a free Personal Access Token from https://vidseeds.ai/settings/mcp-settings.",
     "developerName": "VidSeeds.ai",
     "category": "Productivity",
     "capabilities": [
@@ -35,6 +35,12 @@
       "Write"
     ],
     "websiteURL": "https://vidseeds.ai",
-    "composerIcon": "./assets/icon.png"
+    "privacyPolicyURL": "https://vidseeds.ai/privacy-policy",
+    "termsOfServiceURL": "https://vidseeds.ai/terms-of-service",
+    "composerIcon": "./assets/icon.png",
+    "logo": "./assets/icon.png",
+    "screenshots": [
+      "./assets/icon.png"
+    ]
   }
 }

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/.codexignore
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/.codexignore
@@ -1,0 +1,18 @@
+# Local Codex scanner ignore list for the public connector package.
+
+.DS_Store
+.env
+.env.*
+!.env.example
+*.log
+*.pem
+*.key
+*.p12
+*.pfx
+node_modules/
+.next/
+dist/
+build/
+coverage/
+tmp/
+temp/

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/.github/dependabot.yml
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/README.md
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/README.md
@@ -1,7 +1,10 @@
 # VidSeeds.ai MCP marketplace and connector catalog
 
-Drive **VidSeeds.ai** — pre-upload video **SEO & metadata optimization** and
-multi-platform publishing — directly from your AI coding client.
+[![VidSeeds.ai trust badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Dvidseeds-ai%252Fvidseeds%26metric%3Dtrust%26style%3Dflat)](https://hol.org/registry/plugins/vidseeds-ai%2Fvidseeds)
+[![VidSeeds.ai security badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Dvidseeds-ai%252Fvidseeds%26metric%3Dsecurity%26style%3Dflat)](https://hol.org/registry/plugins/vidseeds-ai%2Fvidseeds)
+
+Drive **VidSeeds.ai** - pre-upload video **SEO & metadata optimization** and
+multi-platform publishing - directly from your AI coding client.
 
 > **VidSeeds.ai** analyzes a creator's existing video and produces optimized titles,
 > descriptions, tags, thumbnails, and chapters for YouTube, TikTok, Instagram, Facebook,
@@ -9,7 +12,7 @@ multi-platform publishing — directly from your AI coding client.
 
 This repo is the public marketplace/catalog source for the hosted
 [MCP](https://modelcontextprotocol.io) connector that exposes the VidSeeds.ai workflow
-(**222 tools**, all prefixed `vidseeds_`). It ships the machine-readable metadata that
+(**247 tools**, all prefixed `vidseeds_`). It ships the machine-readable metadata that
 different clients expect:
 
 | Client / catalog                              | What this repo provides                                                                                      |
@@ -20,25 +23,33 @@ different clients expect:
 | ChatGPT                                       | source metadata/assets plus docs for the separate Apps SDK endpoint at `https://vidseeds.ai/api/mcp/chatgpt` |
 | Cursor and other MCP clients                  | copy-paste Streamable HTTP config for `https://vidseeds.ai/api/mcp`                                          |
 
-The connector ships no credentials — it tells your client how to call the hosted endpoint
+The connector ships no credentials - it tells your client how to call the hosted endpoint
 with a token you supply.
 
 - **Endpoint:** `https://vidseeds.ai/api/mcp` (MCP Streamable HTTP)
 - **Auth (this plugin):** Personal Access Token (`Authorization: Bearer vs_pat_…`)
-- **Auth (Claude.ai / Desktop):** the same endpoint also supports **OAuth 2.0** (PKCE + Dynamic Client Registration) — add it as a custom connector, no token needed. See the in-app guide below.
-- **ChatGPT App:** a dedicated endpoint `https://vidseeds.ai/api/mcp/chatgpt` powers the **OpenAI ChatGPT App** (Apps SDK) with rendered result widgets. Local-only tools (ffmpeg/ffprobe recipes, precision-trim, local-audio transcription) are hidden there since ChatGPT has no local shell — use this Claude Code / Codex plugin for those. ChatGPT distribution is through the ChatGPT Apps submission/directory flow, not by adding this Git repo as a custom marketplace.
+- **Auth (Claude.ai / Desktop):** the same endpoint also supports **OAuth 2.0** (PKCE + Dynamic Client Registration) - add it as a custom connector, no token needed. See the in-app guide below.
+- **ChatGPT App:** a dedicated endpoint `https://vidseeds.ai/api/mcp/chatgpt` powers the **OpenAI ChatGPT App** (Apps SDK) with rendered result widgets. Local-only tools (ffmpeg/ffprobe recipes, precision-trim, local-audio transcription) are hidden there since ChatGPT has no local shell - use this Claude Code / Codex plugin for those. ChatGPT distribution is through the ChatGPT Apps submission/directory flow, not by adding this Git repo as a custom marketplace.
 - **Server:** `vidseeds` v1.9.2 (agent orientation: routing-first server instructions sized for client truncation limits, vidseeds_guide tool, workflow prompts)
 
 > **More clients & a copy-paste walkthrough:** the in-app setup guide at
 > <https://vidseeds.ai/settings/mcp-settings> covers **Claude.ai & Desktop (OAuth)**,
-> **Claude Code**, **Cursor**, **Codex**, and any other MCP client — with ready-to-copy
+> **Claude Code**, **Cursor**, **Codex**, and any other MCP client - with ready-to-copy
 > snippets for each.
 
-> **💳 Paid connector — 14-day free trial.** The MCP server is available to paid
+> **💳 Paid connector - 14-day free trial.** The MCP server is available to paid
 > VidSeeds.ai subscribers. Every account gets a **14-day free trial that starts on the
-> first MCP connection** — including older accounts that have never connected before;
+> first MCP connection** - including older accounts that have never connected before;
 > once it ends, an active subscription is required to keep using the connector. Manage
 > plans at <https://vidseeds.ai/pricing>.
+
+> **If you are editing the VidSeeds.ai source code:**
+> Do not keep the `vidseeds` MCP server connected in the same coding agent session you use
+> to work on this repository. The catalog (even with `?toolset=core`) is the _product surface_
+> for operating on user videos/channels. It will consume context you need for the actual code
+> changes. Use your agent's normal file system / grep / edit tools. Only connect the MCP
+> (with `?toolset=core` recommended) when you are specifically testing the MCP layer, a new
+> tool, the route handler, etc. See the root `AGENTS.md` "Context Hygiene" section.
 
 ---
 
@@ -46,24 +57,24 @@ with a token you supply.
 
 1. Sign in at <https://vidseeds.ai> (free account).
 2. Open **Settings → MCP Settings**: <https://vidseeds.ai/settings/mcp-settings>.
-3. Create a token and copy the secret (`vs_pat_…`) — it is shown **only once**
+3. Create a token and copy the secret (`vs_pat_…`) - it is shown **only once**
    (90-day default expiry).
 4. Expose it to your client as the `VIDSEEDS_PAT` environment variable (below).
 
 > 🔒 The token value never belongs in any file. This package references it **by name**
 > (`VIDSEEDS_PAT`); your client injects the value from the environment at connect time.
-> A leaked PAT grants full non-admin access to your account — treat it like a password.
+> A leaked PAT grants full non-admin access to your account - treat it like a password.
 
 > ℹ️ Creating a token is free, but **connecting requires a paid subscription or an active
 > 14-day trial** (see above). Beyond access, individual tools spend **seeds** from your
-> balance (read-only tools are free) — connection access and per-tool seed cost are
+> balance (read-only tools are free) - connection access and per-tool seed cost are
 > separate, both enforced server-side per call.
 
 ---
 
 ## 2. Install in Claude Code
 
-### Option A — install the plugin (recommended)
+### Option A - install the plugin (recommended)
 
 ```text
 /plugin marketplace add CarrotGamesStudios/vidseeds-mcp
@@ -78,15 +89,15 @@ claude
 ```
 
 Run `/mcp` to confirm the `vidseeds` server is connected and listing tools. If you see an
-auth error, `VIDSEEDS_PAT` was not set in the launching shell — export it and restart.
+auth error, `VIDSEEDS_PAT` was not set in the launching shell - export it and restart.
 
-> The plugin's `.mcp.json` injects your token via `Bearer ${VIDSEEDS_PAT}` — the same
+> The plugin's `.mcp.json` injects your token via `Bearer ${VIDSEEDS_PAT}` - the same
 > shape Anthropic's official GitHub connector uses. Set `VIDSEEDS_PAT` before launching;
 > if it is unset, Claude Code flags the `vidseeds` server as needing configuration.
 
-### Option B — add the server directly (no plugin)
+### Option B - add the server directly (no plugin)
 
-For a quick test without installing the plugin. Prefer Option A for daily use — it
+For a quick test without installing the plugin. Prefer Option A for daily use - it
 keeps the token in the environment (`VIDSEEDS_PAT`) and reads it at runtime, instead
 of writing the resolved token into `~/.claude.json`.
 
@@ -95,8 +106,8 @@ your shell history or terminal scrollback:
 
 ```bash
 export VIDSEEDS_PAT="vs_pat_your_token_here"
-claude mcp add --transport http vidseeds https://vidseeds.ai/api/mcp \
-  --header "Authorization: Bearer $VIDSEEDS_PAT"
+claude mcp add --transport http vidseeds https://vidseeds.ai/api/mcp?toolset=core \
+ --header "Authorization: Bearer $VIDSEEDS_PAT"
 ```
 
 ---
@@ -106,7 +117,7 @@ claude mcp add --transport http vidseeds https://vidseeds.ai/api/mcp \
 Codex does not yet offer self-serve central plugin publishing, so the most reliable
 path is to add the server to your Codex config.
 
-### Option A — `~/.codex/config.toml` (recommended)
+### Option A - `~/.codex/config.toml` (recommended)
 
 ```toml
 [mcp_servers.vidseeds]
@@ -120,13 +131,13 @@ Then export the token in the environment Codex runs in:
 export VIDSEEDS_PAT="vs_pat_your_token_here"
 ```
 
-### Option B — CLI
+### Option B - CLI
 
 ```bash
-codex mcp add vidseeds --url https://vidseeds.ai/api/mcp --bearer-token-env-var VIDSEEDS_PAT
+codex mcp add vidseeds --url https://vidseeds.ai/api/mcp?toolset=core --bearer-token-env-var VIDSEEDS_PAT
 ```
 
-### Option C — repo/team marketplace
+### Option C - repo/team marketplace
 
 ```bash
 codex plugin marketplace add CarrotGamesStudios/vidseeds-mcp
@@ -161,7 +172,7 @@ than pasting the secret:
 ```
 
 Set `VIDSEEDS_PAT` in your environment, then enable the `vidseeds` server in
-**Cursor Settings → MCP**. Tool names use the `vidseeds_` prefix (underscore, not dot) —
+**Cursor Settings → MCP**. Tool names use the `vidseeds_` prefix (underscore, not dot) .
 Cursor rejects dotted names like `vidseeds.generate_thumbnail`.
 
 ---
@@ -214,7 +225,7 @@ Per-tool parameters and seed costs come from the hosted server's `tools/list` de
 
 ## 8. What the connector can do
 
-222 tools spanning the full VidSeeds.ai creator workflow:
+247 tools spanning the full VidSeeds.ai creator workflow:
 
 | Area                     | Examples                                                                                                                    |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
@@ -237,22 +248,31 @@ Per-tool parameters and seed costs come from the hosted server's `tools/list` de
 
 ## 9. Tool catalog size management
 
-**222 tools is a lot.** When VidSeeds connects to your MCP client, the full tool
-catalog (~42K tokens) loads into the agent's context. If your agent feels slow or
+**247 tools is a lot.** When VidSeeds.ai connects to your MCP client, the full tool
+catalog (~46K tokens) loads into the agent's context. If your agent feels slow or
 overwhelmed, you can switch to a **leaner toolset**:
 
 ### 9a. Use `?toolset=core` on the MCP URL
 
-Add `?toolset=core` to reduce the registered tools from ~222 to ~65, cutting
-context cost to ~10K tokens — without losing any essential workflow:
+Add `?toolset=guide` for the absolute minimum (only the orientation `vidseeds_guide` tool + instructions, ~1 tool).
+Add `?toolset=core` to reduce from ~247 to ~74 essential tools (~16K tokens) - the recommended default for most usage:
 
-**Claude Code**:
+**Claude Code** (recommended for most):
+
 ```bash
 claude mcp add --transport http vidseeds https://vidseeds.ai/api/mcp?toolset=core \
-  --header "Authorization: Bearer $VIDSEEDS_PAT"
+ --header "Authorization: Bearer $VIDSEEDS_PAT"
 ```
 
-**Cursor** (`~/.cursor/mcp.json` or `.cursor/mcp.json`):
+For ultra-light (guide only):
+
+```bash
+claude mcp add --transport http vidseeds https://vidseeds.ai/api/mcp?toolset=guide \
+ --header "Authorization: Bearer $VIDSEEDS_PAT"
+```
+
+**Cursor** (recommended default):
+
 ```json
 {
   "mcpServers": {
@@ -266,14 +286,18 @@ claude mcp add --transport http vidseeds https://vidseeds.ai/api/mcp?toolset=cor
 }
 ```
 
-**Codex** (`~/.codex/config.toml` or `.codex/config.toml`):
+(Use `?toolset=guide` for lightest.)
+
+**Codex** (recommended):
+
 ```toml
 [mcp_servers.vidseeds]
 url = "https://vidseeds.ai/api/mcp?toolset=core"
 bearer_token_env_var = "VIDSEEDS_PAT"
 ```
 
-**Claude Desktop** — add when defining the custom MCP connector:
+**Claude Desktop** - add when defining the custom MCP connector:
+
 ```
 URL: https://vidseeds.ai/api/mcp?toolset=core
 ```
@@ -287,38 +311,36 @@ thumbnails, basic analytics, channel management, translation, connections, billi
 and referrals. Everything else (deep intelligence, competitive research, local video
 tools, admin, autoclips, bulk edit, comments, assistant workflows) is excluded.
 
-### 9b. Make your AI default to VidSeeds tools
+### 9b. Make your AI default to VidSeeds.ai tools
 
-Modern Claude clients (Claude.ai, Claude Desktop, Claude Code) **defer large tool
-catalogs behind tool search**: at session start the model sees only tool names plus a
-truncated slice of the server's instructions, and it may reach for web search or
-browser automation instead of the connected VidSeeds tools. The server ships
+Sometimes generalist agents fall back to writing raw python, ffmpeg command templates, or
+browser automation instead of the connected VidSeeds.ai tools. The server ships
 routing-first instructions sized for those truncation limits (v1.9.2), but you can make
 the routing deterministic by telling your client directly:
 
-**Claude.ai / Claude Desktop** — paste into _Settings → Profile → Preferences_ (applies
+**Claude.ai / Claude Desktop** - paste into _Settings → Profile → Preferences_ (applies
 everywhere) or your Project's custom instructions:
 
 ```text
 When my request involves my videos, channels, titles, descriptions, tags,
 thumbnails, video SEO, keywords, analytics, comments, clips, captions,
-translations, scheduling, or publishing, ALWAYS use the connected VidSeeds
-tools (vidseeds_*) first — search the available tools for "vidseeds" if none
+translations, scheduling, or publishing, ALWAYS use the connected VidSeeds.ai
+tools (vidseeds_*) first - search the available tools for "vidseeds" if none
 are loaded. Do not use web search, browser automation, or general knowledge
-for these tasks: VidSeeds has authenticated access to my actual channel data,
+for these tasks: VidSeeds.ai has authenticated access to my actual channel data,
 transcripts, and analytics.
 ```
 
-**Claude Code** — add the same block to your project's `CLAUDE.md` (or
+**Claude Code** - add the same block to your project's `CLAUDE.md` (or
 `~/.claude/CLAUDE.md` for all projects).
 
-**Codex / Cursor** — add it to `AGENTS.md` / project rules respectively.
+**Codex / Cursor** - add it to `AGENTS.md` / project rules respectively.
 
 ---
 
 ## Platform usage quotas (MCP daily call quotas)
 
-Beyond per-tool seed costs, **every** MCP tool call — read or write — counts toward a
+Beyond per-tool seed costs, **every** MCP tool call - read or write - counts toward a
 generous **daily platform-usage quota** that refills continuously throughout the day.
 This keeps real production workloads (daily shorts, adjustments, polling, agent-driven
 investigations) comfortable on every plan, while pricing sustained high-volume scraping
@@ -338,13 +360,13 @@ or abuse in real money.
 - **Overage:** once the bucket is empty, each additional tool call costs **1 seed**
   (`MCP_OVERAGE_SEED_COST`), on top of any per-tool seed cost. The bucket keeps refilling,
   so you stop paying overage as soon as it tops up again.
-- **Balance and cost reads are free and exempt** — `vidseeds_get_seed_balance` and
+- **Balance and cost reads are free and exempt** - `vidseeds_get_seed_balance` and
   `vidseeds_get_seed_balance_and_subscription` never consume a call or charge overage.
 - **Check your remaining included calls** any time with `vidseeds_get_seed_balance` (it
   returns your daily refill, bucket cap, available included calls, and the overage rate).
 
 > If a call is over quota and your balance can't cover the 1-seed overage, the tool
-> returns a clear `MCP_QUOTA_EXCEEDED` error with a top-up link — no surprise charges.
+> returns a clear `MCP_QUOTA_EXCEEDED` error with a top-up link - no surprise charges.
 
 ### YouTube thumbnail upload limits
 
@@ -363,12 +385,12 @@ later.
   call `https://vidseeds.ai/api/mcp` with a user-supplied PAT read from `VIDSEEDS_PAT`.
 - Never commit, paste, or share a `vs_pat_…` token. Rotate or revoke tokens at
   <https://vidseeds.ai/settings/mcp-settings>.
-- Cookie/session auth is rejected by the server by design — a PAT is the only accepted
+- Cookie/session auth is rejected by the server by design - a PAT is the only accepted
   credential, so a misconfigured client can't piggyback on a dashboard login.
 
 ## Versioning
 
-The plugin version tracks the VidSeeds.ai MCP connector package (currently **1.9.2** — routing-first server `instructions` sized for client truncation limits so tool-search clients default to VidSeeds tools, plus the `vidseeds_guide` tool, the `vidseeds://guide` resource, and workflow prompts).
+The plugin version tracks the VidSeeds.ai MCP connector package (currently **1.9.2** - routing-first server `instructions` sized for client truncation limits so tool-search clients default to VidSeeds tools, plus the `vidseeds_guide` tool, the `vidseeds://guide` resource, and workflow prompts).
 The wildcard PAT scope reaches new tools automatically as the server grows, so existing
 tokens keep working without being recreated.
 
@@ -380,4 +402,4 @@ tokens keep working without being recreated.
 
 ## License
 
-MIT — see [`LICENSE`](./LICENSE).
+MIT - see [`LICENSE`](./LICENSE).

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/SECURITY.md
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+The public VidSeeds.ai MCP connector package tracks the hosted connector version in `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `server.json`, and `README.md`. Only the latest published package is supported.
+
+## Reporting a Vulnerability
+
+Report security issues privately:
+
+- Email: security@vidseeds.ai
+- Security contact file: https://vidseeds.ai/.well-known/security.txt
+- Contact form: https://vidseeds.ai/contact/
+
+Do not open a public GitHub issue for vulnerabilities, leaked credentials, auth bypasses, or account-data exposure.
+
+## Connector Security Notes
+
+This package contains no VidSeeds.ai credentials. It references the user-provided `VIDSEEDS_PAT` environment variable so MCP clients can send `Authorization: Bearer ...` to `https://vidseeds.ai/api/mcp`.
+
+If a Personal Access Token is exposed, revoke it at https://vidseeds.ai/settings/mcp-settings and create a new token.
+
+The hosted MCP server rejects cookie/session auth for this connector path. Access is enforced server-side on every call.

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/SKILL.md
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: vidseeds
+description: Registry fallback entry point for the VidSeeds.ai MCP connector. Use the bundled domain skills for setup, efficiency, thumbnails, projects, analytics, local video, and publishing workflows.
+license: MIT
+---
+
+# VidSeeds.ai MCP Connector
+
+VidSeeds.ai is a pre-upload video SEO, metadata optimization, AI thumbnail, and multi-platform publishing connector for existing videos.
+
+Use the focused skills in `skills/` for real workflows:
+
+- `vidseeds-setup`
+- `vidseeds-efficiency`
+- `vidseeds-projects`
+- `vidseeds-thumbnails`
+- `vidseeds-analytics`
+- `vidseeds-local-video`
+- `vidseeds-publishing`
+
+The hosted endpoint is `https://vidseeds.ai/api/mcp`. The connector uses a user-provided `VIDSEEDS_PAT` token and does not ship credentials.

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/codex.mcp.json
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/codex.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcp_servers": {
     "vidseeds": {
-      "url": "https://vidseeds.ai/api/mcp",
+      "url": "https://vidseeds.ai/api/mcp?toolset=core",
       "bearer_token_env_var": "VIDSEEDS_PAT"
     }
   }

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/package-lock.json
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "vidseeds-mcp",
+  "version": "1.9.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vidseeds-mcp",
+      "version": "1.9.2",
+      "license": "MIT"
+    }
+  }
+}

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/package.json
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vidseeds-mcp",
+  "version": "1.9.2",
+  "private": true,
+  "description": "Public VidSeeds.ai MCP connector package for Codex, Claude Code, and registry-compatible MCP catalogs.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CarrotGamesStudios/vidseeds-mcp.git"
+  },
+  "scripts": {
+    "scan": "plugin-scanner scan . --profile public-marketplace",
+    "verify": "plugin-scanner verify ."
+  }
+}

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-analytics/SKILL.md
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-analytics/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: vidseeds-analytics
-description: Use for VidSeeds MCP analytics and research — YouTube analytics, channel intelligence, video autopsy, outliers, competitors, trending/breakout discovery, keyword research, comment sentiment, and best-practices tools. Outcomes only; not internal scoring details.
+description: Use for VidSeeds MCP analytics and research - YouTube analytics, channel intelligence, video autopsy, outliers, competitors, trending/breakout discovery, keyword research, comment sentiment, and best-practices tools. Outcomes only; not internal scoring details.
+license: MIT
 ---
 
 # Analytics & intelligence (MCP)
 
-Map the user's question to a tool — then read the tool `description` for inputs and seed cost.
+Map the user's question to a tool - then read the tool `description` for inputs and seed cost.
 
 ## YouTube account data
 
@@ -65,12 +66,12 @@ Pass `channelId` when multiple YouTube connections exist.
 
 ## SEO experiments
 
-- `vidseeds_generate_seo_title_experiments` — title variants for testing.
+- `vidseeds_generate_seo_title_experiments` - title variants for testing.
 
 ## Copilot / assistant (Q&A)
 
-- `vidseeds_get_copilot_response` — channel-aware answers.
-- Assistant threads: `vidseeds_list_assistant_conversations`, `vidseeds_get_assistant_conversation`, `vidseeds_send_assistant_message`, `vidseeds_confirm_assistant_suggestion` — see tool descriptions for collab flows.
+- `vidseeds_get_copilot_response` - channel-aware answers.
+- Assistant threads: `vidseeds_list_assistant_conversations`, `vidseeds_get_assistant_conversation`, `vidseeds_send_assistant_message`, `vidseeds_confirm_assistant_suggestion` - see tool descriptions for collab flows.
 
 ## After research → action
 

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-efficiency/SKILL.md
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-efficiency/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vidseeds-efficiency
-description: Use before expensive VidSeeds MCP workflows — seeds, daily MCP call quotas, async jobId polling, when to call vidseeds_get_seed_balance, and avoiding retry loops on MCP_QUOTA_EXCEEDED or insufficient seeds.
+description: Use before expensive VidSeeds MCP workflows - seeds, daily MCP call quotas, async jobId polling, when to call vidseeds_get_seed_balance, and avoiding retry loops on MCP_QUOTA_EXCEEDED or insufficient seeds.
+license: MIT
 ---
 
 # VidSeeds MCP efficiency
@@ -9,12 +10,12 @@ Read this before multi-step or charge-bearing workflows.
 
 ## Orient first (free)
 
-New to this server, or unsure which tool does the job? Call **`vidseeds_guide`** — it returns the capability map, the recommended tool chain for a stated `goal`, and what VidSeeds does not do. It is free and quota-exempt, so it never costs seeds or a call-bucket token. The server's `initialize` instructions and the `vidseeds://guide` resource carry the same orientation; workflow **prompts** (e.g. `optimize-youtube-video`, `make-thumbnail`) hand you the ready-made tool chain. Reach for these before concluding a capability is missing. **Parameter-level field docs are intentionally omitted from `tools/list` JSON schemas to save context** — use `vidseeds_guide` (with a `goal`) or read `vidseeds://guide` when you need argument semantics beyond types/enums.
+New to this server, or unsure which tool does the job? Call **`vidseeds_guide`** - it returns the capability map, the recommended tool chain for a stated `goal`, and what VidSeeds does not do. It is free and quota-exempt, so it never costs seeds or a call-bucket token. The server's `initialize` instructions and the `vidseeds://guide` resource carry the same orientation; workflow **prompts** (e.g. `optimize-youtube-video`, `make-thumbnail`) hand you the ready-made tool chain. Reach for these before concluding a capability is missing. **Parameter-level field docs are intentionally omitted from `tools/list` JSON schemas to save context** - use `vidseeds_guide` (with a `goal`) or read `vidseeds://guide` when you need argument semantics beyond types/enums.
 
 ## Two cost layers
 
-1. **Per-tool seeds** — Some tools spend seeds (thumbnails, intelligence, translation, etc.). Read-only tools are free. Charge-bearing tools state their seed cost in the first sentence of their compressed `tools/list` description; when it is not there, call `vidseeds_guide` with the tool name for the confirmed cost. Confirm with the user before charge-bearing calls. (2026-06: use `fields: ["description","tags"]` on regenerate for light/correct-price partials; thumbnail edits cost more than generation when using input reference image.)
-2. **Daily MCP call quota** — Almost every tool call counts toward a plan bucket (continuous refill, not midnight reset). When the bucket is empty, each extra call costs **1 seed** on top of any per-tool cost.
+1. **Per-tool seeds** - Some tools spend seeds (thumbnails, intelligence, translation, etc.). Read-only tools are free. Charge-bearing tools state their seed cost in the first sentence of their compressed `tools/list` description; when it is not there, call `vidseeds_guide` with the tool name for the confirmed cost. Confirm with the user before charge-bearing calls. (2026-06: use `fields: ["description","tags"]` on regenerate for light/correct-price partials; thumbnail edits cost more than generation when using input reference image.)
+2. **Daily MCP call quota** - Almost every tool call counts toward a plan bucket (continuous refill, not midnight reset). When the bucket is empty, each extra call costs **1 seed** on top of any per-tool cost.
 
 | Plan    | Refill / day | Bucket cap |
 | ------- | ------------ | ---------- |
@@ -28,9 +29,11 @@ New to this server, or unsure which tool does the job? Call **`vidseeds_guide`**
 
 ## Before expensive work
 
-1. `vidseeds_get_seed_balance` — seeds, remaining included MCP calls, overage rate (free).
+1. `vidseeds_get_seed_balance` - seeds, remaining included MCP calls, overage rate (free).
 2. Tell the user expected per-tool seed cost (from the tool's compressed description, or `vidseeds_guide` when the description omits it).
 3. Prefer **async + poll** for long jobs instead of hammering sync tools that may time out at the edge.
+
+Promo campaign note: `vidseeds_generate_promo_campaign_pack` is seed-charged on successful AI generation; conversion to drafts with `vidseeds_create_social_posts_from_campaign_pack` is not the billable AI step.
 
 ## Async job pattern
 
@@ -49,14 +52,14 @@ Examples:
 | `vidseeds_create_project_metadata_async`     | `vidseeds_get_create_project_metadata_job`     |
 | `vidseeds_optimize_marketing_metadata_async` | `vidseeds_get_optimize_marketing_metadata_job` |
 
-Thumbnail generation is typically **70–100s**. Project metadata regeneration can be **60–130s** — prefer async variants for production.
+Thumbnail generation is typically **70–100s**. Project metadata regeneration can be **60–130s** - prefer async variants for production.
 
-## Errors — do not spin
+## Errors - do not spin
 
 | Code / message                | Action                                                                          |
 | ----------------------------- | ------------------------------------------------------------------------------- |
-| `AUTH_REQUIRED` / 401         | PAT missing — see `vidseeds-setup`                                              |
-| `SUBSCRIPTION_REQUIRED` / 402 | Trial ended — user must subscribe                                               |
+| `AUTH_REQUIRED` / 401         | PAT missing - see `vidseeds-setup`                                              |
+| `SUBSCRIPTION_REQUIRED` / 402 | Trial ended - user must subscribe                                               |
 | `MCP_QUOTA_EXCEEDED`          | Stop retrying; show top-up link from error; wait for bucket refill or add seeds |
 | Insufficient seeds            | `vidseeds_get_seed_balance`; user tops up at <https://vidseeds.ai/seeds>        |
 
@@ -65,7 +68,7 @@ Thumbnail generation is typically **70–100s**. Project metadata regeneration c
 - Use `vidseeds_get_project_snapshot` when you need project + platform rows in one call instead of many `get_project` loops.
 - For connections, `vidseeds_list_platform_connections` before per-id fetches unless you already have `connectionId`.
 - Batch discovery: `vidseeds_get_bulk_video_metadata` when comparing many videos.
-- Reuse the same `requestId` / idempotency keys on retries the tool docs allow — avoids double billing.
+- Reuse the same `requestId` / idempotency keys on retries the tool docs allow - avoids double billing.
 
 ## When `tools/list` is enough
 

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-local-video/SKILL.md
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-local-video/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vidseeds-local-video
-description: Use when the user's video is on disk — VidSeeds MCP probe, frame/clip extraction, ffmpeg recipes, precision trim, and midroll analysis. Hosted tools return commands/recipes to run locally; media stays on the user's machine.
+description: Use when the user's video is on disk - VidSeeds MCP probe, frame/clip extraction, ffmpeg recipes, precision trim, and midroll analysis. Hosted tools return commands/recipes to run locally; media stays on the user's machine.
+license: MIT
 ---
 
 # Local video media (MCP)
@@ -9,7 +10,7 @@ VidSeeds.ai follows **client-first** media: the hosted MCP server does not read 
 
 ## Probe a file
 
-- `vidseeds_probe_local_video` — duration, resolution, codecs; use before trim or thumbnail frame picks.
+- `vidseeds_probe_local_video` - duration, resolution, codecs; use before trim or thumbnail frame picks.
 
 ## Frames and clips
 
@@ -24,13 +25,30 @@ Run returned shell commands on the **user's machine** (requires ffmpeg/ffprobe i
 
 ## Precision trim
 
-1. `vidseeds_analyze_precision_trim` — suggested cut points.
-2. `vidseeds_plan_precision_trim` — plan from analysis.
-3. `vidseeds_execute_precision_trim` — export recipe/commands for local ffmpeg.
+1. `vidseeds_analyze_precision_trim` - suggested cut points, segment catalog, seed cost preview.
+2. `vidseeds_plan_precision_trim` - AI edit plan (CritiquePlan) with genre-aware processing.
+3. `vidseeds_execute_precision_trim` - export recipe/commands for local ffmpeg.
+
+### V3 Genre-Aware Processing (2026-06-27)
+
+Precision Trim V3 adds **genre classification** + **soundscape analysis** + **motion profile** + **hook detection** + **semantic boundaries** as parallel client-side signals. These are passed as optional metadata in `vidseeds_analyze_precision_trim` / `vidseeds_plan_precision_trim` inputs:
+
+- `detectedGenre` - overrides automatic genre detection (speech_driven, action_dynamic, ambient_relax, visual_primary, mixed_narrative, tutorial)
+- `soundscape` - spectral classification from PCM (silence/speech/music/ambient/noise)
+- `motionProfile` - frame-by-frame pixel diff analysis (static/slow/action/scene_change)
+
+**How it affects plans:**
+
+- **ambient_relax**: high silence tolerance (15s+), preserves zero-word scenes, < 20% cut ratio
+- **action_dynamic**: aggressive pause trimming (500ms+), up to 40% cut ratio
+- **speech_driven**: cut at semantic boundaries, moderate trimming
+- **visual_primary**: preserves scenes without speech, cut only on true silence
+- **mixed_narrative**: uses all signals - only cuts when multiple agree
+- **tutorial**: precision trimming, no speed around instructions
 
 ## Midroll placement
 
-- `vidseeds_analyze_midroll_opportunities` — suggested mid-roll times from transcript/context (analysis only; user edits in their editor).
+- `vidseeds_analyze_midroll_opportunities` - suggested mid-roll times from transcript/context (analysis only; user edits in their editor).
 
 ## Thumbnails from local file
 
@@ -38,9 +56,9 @@ Prefer the **vidseeds-local** stdio MCP tool `vidseeds_generate_thumbnail_from_v
 
 ## YouTube-hosted source (not local path)
 
-- `vidseeds_get_youtube_video_transcript`, `vidseeds_get_youtube_video_captions` — text from YouTube without downloading video to the server.
+- `vidseeds_get_youtube_video_transcript`, `vidseeds_get_youtube_video_captions` - text from YouTube without downloading video to the server.
 
 ## Do not
 
 - Expect hosted tools to accept arbitrary filesystem paths for upload/processing.
-- Re-run probe/extract in a loop — cache probe results for the session.
+- Re-run probe/extract in a loop - cache probe results for the session.

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-projects/SKILL.md
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-projects/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vidseeds-projects
-description: Use for VidSeeds MCP project workflows — create a project from YouTube, list/get/snapshot, regenerate metadata (sync or async), translate metadata, apply thumbnails, and update per-platform config before publish.
+description: Use for VidSeeds MCP project workflows - create a project from YouTube, list/get/snapshot, regenerate metadata (sync or async), translate metadata, apply thumbnails, and update per-platform config before publish.
+license: MIT
 ---
 
 # Projects (MCP)
@@ -9,9 +10,9 @@ A **project** is the workspace for one video across YouTube, TikTok, Instagram, 
 
 ## Discover projects
 
-- `vidseeds_list_projects` — browse with limits/filters per tool schema.
-- `vidseeds_get_project` — single project record.
-- `vidseeds_get_project_snapshot` — project + platform config in one call (prefer over many gets).
+- `vidseeds_list_projects` - browse with limits/filters per tool schema.
+- `vidseeds_get_project` - single project record.
+- `vidseeds_get_project_snapshot` - project + platform config in one call (prefer over many gets).
 
 ## Create from YouTube
 
@@ -35,21 +36,23 @@ Pass `focus: "titles"` (with regenerate) to use the lightweight titles-only gene
 
 Reuse the same `requestId` on transport retries to avoid double seed charges when the tool allows it.
 
+Keep create, regenerate, and targeted field-refresh calls for the same video close together when possible. VidSeeds.ai reuses recent per-video analysis context for about an hour during a metadata workflow, so follow-up quality checks and regenerations are usually cheaper and faster when they stay in the same project flow.
+
 **Targeted / cheap regen (2026-06):** Use `fields: ["description", "tags"]` (or include "title") on regenerate/optimize for light per-field generators (correct lower AI cost for the work, while the action still uses the reoptimize 1-seed price). For thumbnails or edits, use the dedicated thumbnail tools (pricing is per-image with model; edits that reference an input image cost more than pure generation).
 
 ## Optimize metadata without a full project (standalone)
 
-- `vidseeds_optimize_marketing_metadata` / `vidseeds_optimize_marketing_metadata_async` — needs transcript (e.g. from `vidseeds_transcribe_audio` or YouTube transcript tools).
+- `vidseeds_optimize_marketing_metadata` / `vidseeds_optimize_marketing_metadata_async` - needs transcript (e.g. from `vidseeds_transcribe_audio` or YouTube transcript tools).
 - Poll: `vidseeds_get_optimize_marketing_metadata_job`.
 - Pass `focus: "titles"` for title-only (light generator, 1 seed).
 
 ## Suggest titles only (light 1-seed path for "new titles" requests)
 
-- `vidseeds_suggest_titles` — dedicated tool for title suggestions only. 1 seed. Accepts `projectId` (loads transcript/meaning) or direct `transcript`. Much lower AI cost than full optimize/regenerate. Use this (or regenerate+focus=titles) instead of create_new when user asks for title options. Idempotent with key.
+- `vidseeds_suggest_titles` - dedicated tool for title suggestions only. 1 seed. Accepts `projectId` (loads transcript/meaning) or direct `transcript`. Much lower AI cost than full optimize/regenerate. Use this (or regenerate+focus=titles) instead of create_new when user asks for title options. Idempotent with key.
 
 ## Translate project metadata
 
-- `vidseeds_translate_project_metadata` — localization across supported languages (no voice dubbing on VidSeeds.ai).
+- `vidseeds_translate_project_metadata` - localization across supported languages (no voice dubbing on VidSeeds.ai).
 
 ## Thumbnail on project
 
@@ -57,7 +60,7 @@ Reuse the same `requestId` on transport retries to avoid double seed charges whe
 
 ## Per-platform publish config
 
-- `vidseeds_update_project_platform_config` — enable platform, title/description/tags, schedule, connection, thumbnail URL override.
+- `vidseeds_update_project_platform_config` - enable platform, title/description/tags, schedule, connection, thumbnail URL override.
 
 ## Publish
 
@@ -65,4 +68,4 @@ After config is ready, use `vidseeds-publishing` (`vidseeds_preflight_publish` �
 
 ## History
 
-- `vidseeds_list_optimization_history`, `vidseeds_get_optimization_history_item`, `vidseeds_reoptimize_history_item` — past runs and re-run from history.
+- `vidseeds_list_optimization_history`, `vidseeds_get_optimization_history_item`, `vidseeds_reoptimize_history_item` - past runs and re-run from history.

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-publishing/SKILL.md
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-publishing/SKILL.md
@@ -1,60 +1,72 @@
 ---
 name: vidseeds-publishing
-description: Use for VidSeeds MCP publishing — platform connections, OAuth connect URLs, activate YouTube channel, update connection settings, preflight/confirm/cancel publish, publish status, direct YouTube upload, and updating live YouTube metadata.
+description: Use for VidSeeds MCP publishing - platform connections, OAuth connect URLs, activate YouTube channel, update connection settings, preflight/confirm/cancel publish, publish status, direct YouTube upload, and updating live YouTube metadata.
+license: MIT
 ---
 
 # Publishing & connections (MCP)
 
 ## Connect platforms
 
-1. `vidseeds_list_platform_connections` — see what is connected (no OAuth secrets returned).
-2. `vidseeds_get_platform_connect_url` — OAuth URL for a platform the user must open in a browser.
+1. `vidseeds_list_platform_connections` - see what is connected (no OAuth secrets returned).
+2. `vidseeds_get_platform_connect_url` - OAuth URL for a platform the user must open in a browser.
 3. After OAuth completes, list again to get `connectionId`.
 
 **YouTube channel selection (multi-channel accounts):**
 
-- `vidseeds_set_active_youtube_channel` — which channel is active for uploads/metadata.
+- `vidseeds_set_active_youtube_channel` - which channel is active for uploads/metadata.
 
 **Settings:**
 
-- `vidseeds_update_connection_settings` — per-connection options (e.g. content language, description footer, and per-asset generation guidelines for titles/descriptions/tags/thumbnails). Read current values via `vidseeds_get_platform_connection`. Guidelines are sent to the model on every generation by default; generation tools accept `applyGuidelines: false` to ignore them for one call.
-- `vidseeds_disconnect_platform_connection` — remove a connection.
+- `vidseeds_update_connection_settings` - per-connection options (e.g. content language, description footer, and per-asset generation guidelines for titles/descriptions/tags/thumbnails). Read current values via `vidseeds_get_platform_connection`. Guidelines are sent to the model on every generation by default; generation tools accept `applyGuidelines: false` to ignore them for one call.
+- `vidseeds_disconnect_platform_connection` - remove a connection.
 
 ## Publish a project
 
 Typical sequence:
 
-1. `vidseeds_get_project_snapshot` — verify per-platform config (`vidseeds_update_project_platform_config` if needed).
-2. `vidseeds_preflight_publish` — compatibility checks before spend.
-3. `vidseeds_confirm_publish` or `vidseeds_publish_project` — start publish (see tool descriptions for `now` vs `scheduled`).
-4. `vidseeds_get_publish_status` — poll until platforms complete or fail.
+1. `vidseeds_get_project_snapshot` - verify per-platform config (`vidseeds_update_project_platform_config` if needed).
+2. `vidseeds_preflight_publish` - compatibility checks before spend.
+3. `vidseeds_confirm_publish` or `vidseeds_publish_project` - start publish (see tool descriptions for `now` vs `scheduled`).
+4. `vidseeds_get_publish_status` - poll until platforms complete or fail.
 5. On failure: `vidseeds_retry_publish_target`; to abort schedule: `vidseeds_cancel_or_unschedule_publish`.
 
 ## Direct YouTube upload (bypassing manual Studio upload)
 
 For large files the user uploads from their machine through VidSeeds:
 
-1. `vidseeds_prepare_youtube_upload` — session/upload instructions.
+1. `vidseeds_prepare_youtube_upload` - session/upload instructions.
 2. User/agent completes bytes per returned guidance.
-3. `vidseeds_complete_youtube_upload` — finalize.
+3. `vidseeds_complete_youtube_upload` - finalize.
 
 Pair with project metadata from `vidseeds-projects`.
 
+## Organic promo campaign packs
+
+For product URL or product brief workflows, keep generation, draft creation, and publishing separate:
+
+1. `vidseeds_generate_promo_campaign_pack` - generate one reviewable organic campaign pack.
+2. Select the variants the user wants to use.
+3. `vidseeds_create_social_posts_from_campaign_pack` - convert only selected variants into Social Planner drafts.
+4. `vidseeds_preflight_social_post` - check each draft against platform rules and required media/context.
+5. `vidseeds_approve_social_post` - approve only after user review.
+6. `vidseeds_schedule_social_post` or `vidseeds_publish_social_post_now` - schedule or publish after explicit approval.
+
 ## Update live YouTube video metadata
 
-- `vidseeds_update_youtube_metadata` — patch title/description/tags on an existing video (connected channel).
+- `vidseeds_update_youtube_metadata` - patch title/description/tags on an existing video (connected channel).
 
 ## Thumbnail on YouTube
 
-- `vidseeds_publish_thumbnail_to_youtube` — set thumbnail on a published video (see `vidseeds-thumbnails`).
+- `vidseeds_publish_thumbnail_to_youtube` - set thumbnail on a published video (see `vidseeds-thumbnails`).
 
 ## Channel description
 
-- `vidseeds_publish_channel_description` — update channel-level description when supported.
+- `vidseeds_publish_channel_description` - update channel-level description when supported.
 
 ## History republish
 
-- `vidseeds_republish_history_item` — re-send from optimization history (check tool inputs).
+- `vidseeds_republish_history_item` - re-send from optimization history (check tool inputs).
 
 ## Before publishing
 

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-setup/SKILL.md
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-setup/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: vidseeds-setup
-description: Use when connecting to VidSeeds.ai, getting AUTH_REQUIRED or SUBSCRIPTION_REQUIRED from the vidseeds MCP server, or setting up VIDSEEDS_PAT / OAuth for the connector. Not for workflow recipes — use vidseeds-efficiency and domain skills after connect.
+description: Use when connecting to VidSeeds.ai, getting AUTH_REQUIRED or SUBSCRIPTION_REQUIRED from the vidseeds MCP server, or setting up VIDSEEDS_PAT / OAuth for the connector. Not for workflow recipes - use vidseeds-efficiency and domain skills after connect.
+license: MIT
 ---
 
 # Connect to VidSeeds.ai
 
-VidSeeds.ai is **pre-upload video SEO, metadata optimization, and multi-platform publishing** for existing videos. It is **not** a video generator or editor. All hosted tools are prefixed `vidseeds_` (underscore — Cursor rejects dotted names like `vidseeds.generate_thumbnail`).
+VidSeeds.ai is **pre-upload video SEO, metadata optimization, and multi-platform publishing** for existing videos. It is **not** a video generator or editor. All hosted tools are prefixed `vidseeds_` (underscore - Cursor rejects dotted names like `vidseeds.generate_thumbnail`).
 
 ## Authentication (this plugin)
 
 The hosted server at `https://vidseeds.ai/api/mcp` requires:
 
 - **Claude Code / Codex / Cursor (this package):** `Authorization: Bearer vs_pat_…` via **`VIDSEEDS_PAT`** in the environment. Cookie sessions are rejected.
-- **Claude.ai / Claude Desktop:** same endpoint supports **OAuth 2.0** (PKCE) as a custom connector — no PAT. See <https://vidseeds.ai/settings/mcp-settings>.
+- **Claude.ai / Claude Desktop:** same endpoint supports **OAuth 2.0** (PKCE) as a custom connector - no PAT. See <https://vidseeds.ai/settings/mcp-settings>.
 
 ### PAT setup
 
@@ -25,12 +26,12 @@ The hosted server at `https://vidseeds.ai/api/mcp` requires:
 export VIDSEEDS_PAT="vs_pat_your_token_here"
 ```
 
-> **Tool catalog size.** VidSeeds ships ~222 tools. If your agent feels overwhelmed,
-> add `?toolset=core` to the MCP URL to reduce to ~65 essential tools (~10K tokens
-> instead of ~42K). Example: `https://vidseeds.ai/api/mcp?toolset=core`.
+> **Tool catalog size.** VidSeeds.ai ships ~240 tools. If your agent feels overwhelmed,
+> Use `?toolset=guide` for the absolute lightest (only the guide tool) or `?toolset=core` for ~74 essential tools.
+> Example: `https://vidseeds.ai/api/mcp?toolset=core`. See root AGENTS.md Context Hygiene for when editing source.
 > See plugin README §9 for per-client instructions.
 
-**Claude Code:** verify with `/mcp` — `vidseeds` should list tools. Auth errors usually mean `VIDSEEDS_PAT` was not set in the shell that launched Claude.
+**Claude Code:** verify with `/mcp` - `vidseeds` should list tools. Auth errors usually mean `VIDSEEDS_PAT` was not set in the shell that launched Claude.
 
 **Codex / Cursor:** same variable; Cursor uses `Authorization: Bearer ${env:VIDSEEDS_PAT}` in MCP config (see plugin README).
 
@@ -57,4 +58,4 @@ Full capability overview: plugin README and each tool's `description` from `tool
 
 ## Default routing (avoid web-search/browser fallbacks)
 
-For anything involving the user's videos, channels, titles, descriptions, tags, thumbnails, SEO, keywords, analytics, comments, clips, captions, translations, or publishing, reach for `vidseeds_*` tools FIRST — search the tool catalog for "vidseeds" when tools are deferred. Never substitute web search or browser automation for these tasks: VidSeeds has authenticated access to the user's connected channels, transcripts, and analytics that public pages cannot show. Unsure which tool? `vidseeds_guide` with a `goal` (free).
+For anything involving the user's videos, channels, titles, descriptions, tags, thumbnails, SEO, keywords, analytics, comments, clips, captions, translations, or publishing, reach for `vidseeds_*` tools FIRST - search the tool catalog for "vidseeds" when tools are deferred. Never substitute web search or browser automation for these tasks: VidSeeds.ai has authenticated access to the user's connected channels, transcripts, and analytics that public pages cannot show. Unsure which tool? `vidseeds_guide` with a `goal` (free).

--- a/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-thumbnails/SKILL.md
+++ b/plugins/CarrotGamesStudios/vidseeds-mcp/skills/vidseeds-thumbnails/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vidseeds-thumbnails
-description: Use for VidSeeds MCP thumbnail workflows — generate, poll jobs, edit, restyle, Thumbnail Studio (trends, briefs, subjects, overlay text), apply to a project, publish to YouTube, or thumbnails from a local video file via vidseeds-local.
+description: Use for VidSeeds MCP thumbnail workflows - generate, poll jobs, edit, restyle, Thumbnail Studio (trends, briefs, subjects, overlay text), apply to a project, publish to YouTube, or thumbnails from a local video file via vidseeds-local.
+license: MIT
 ---
 
 # Thumbnails (MCP)
@@ -16,8 +17,8 @@ description: Use for VidSeeds MCP thumbnail workflows — generate, poll jobs, e
 
 ## Edit or restyle an existing thumbnail
 
-- `vidseeds_edit_thumbnail` — chat-style edit (async job; poll per tool response).
-- `vidseeds_restyle_thumbnail` — style transfer on an existing asset.
+- `vidseeds_edit_thumbnail` - chat-style edit (async job; poll per tool response).
+- `vidseeds_restyle_thumbnail` - style transfer on an existing asset.
 
 ## Attach to a project
 
@@ -51,14 +52,14 @@ Then run `vidseeds_generate_thumbnail` (or from-video flow below) with prompts/r
 The **hosted** server cannot read the user's filesystem.
 
 1. Configure **vidseeds-local** stdio MCP (see plugin README; env `VIDSEEDS_API_KEY` or PAT).
-2. `vidseeds_generate_thumbnail_from_video` on the local server — probes/transcribes/extracts frames locally, then calls the hosted pipeline.
+2. `vidseeds_generate_thumbnail_from_video` on the local server - probes/transcribes/extracts frames locally, then calls the hosted pipeline.
 
 Alternatively, extract frames locally with `vidseeds_extract_video_frames` (see `vidseeds-local-video`) and pass base64 frames into `vidseeds_generate_thumbnail`.
 
 ## From an existing YouTube video (hosted)
 
-- `vidseeds_generate_thumbnail_from_video` (hosted) when the video is addressable via allowed CDN URLs / account-owned assets — check tool `description` for inputs.
+- `vidseeds_generate_thumbnail_from_video` (hosted) when the video is addressable via allowed CDN URLs / account-owned assets - check tool `description` for inputs.
 
 ## Learning / preferences
 
-- `vidseeds_record_thumbnail_preference`, `vidseeds_get_thumbnail_learning_status` — optional feedback loop for repeat creators.
+- `vidseeds_record_thumbnail_preference`, `vidseeds_get_thumbnail_learning_status` - optional feedback loop for repeat creators.

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -56,6 +56,9 @@ EXTRA_MIRROR_PATHS = {
     # debt-ops's manifest points hooks at hooks/hooks.json; the hook commands
     # invoke sibling Python scripts in the same hooks/ directory at runtime.
     "bcanfield/agentic-tech-debt": ("hooks",),
+    # VidSeeds.ai ships a root registry fallback skill plus Dependabot metadata
+    # that HOL Guard uses when scoring the mirrored marketplace bundle.
+    "CarrotGamesStudios/vidseeds-mcp": ("SKILL.md", ".github/dependabot.yml"),
     # Staff Engineer Mode exposes one router skill and loads routed specialist
     # files from a top-level specialists/ directory at runtime.
     "sirmarkz/staff-engineer-mode": ("specialists",),


### PR DESCRIPTION
## Summary
- Refresh the mirrored VidSeeds.ai plugin bundle from CarrotGamesStudios/vidseeds-mcp
- Include the scanner trust artifacts now present upstream: privacy/terms metadata, SECURITY.md, lockfile, .codexignore, root SKILL.md, and Dependabot metadata
- Add a targeted generator exception for VidSeeds.ai so root SKILL.md and .github/dependabot.yml remain mirrored on future syncs

## Verification
- python3 scripts/generate_plugins_json.py
- python3 scripts/validate-plugin-pr.py --base-ref origin/main
- python3 scripts/check-alphabetical.py README.md
- pipx run --python /opt/homebrew/bin/python3.13 --spec plugin-scanner plugin-scanner scan plugins/CarrotGamesStudios/vidseeds-mcp --format json --profile public-marketplace -> score 100, grade A, 0 findings
- git diff --check

Context: HOL registry currently shows VidSeeds.ai security 66 because its mirrored bundle is stale. The source repo is already updated at CarrotGamesStudios/vidseeds-mcp@def940941ce0da78944357c93160a82902bda563.