### PR TITLE
fix: claim-notice permissions, README fallback, stale mirror files

### DIFF
--- a/.github/workflows/claim-notice.yml
+++ b/.github/workflows/claim-notice.yml
@@ -1,7 +1,7 @@
 name: Plugin Claim Notice
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     paths:

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -45,6 +45,10 @@ OPTIONAL_PLUGIN_FILES = (
     "yarn.lock",
     ".codexignore",
     ".agents/plugins/marketplace.json",
+    "SKILL.md",
+    ".github/dependabot.yml",
+    "codex.mcp.json",
+    ".mcp.json",
   )
 METADATA_ONLY_MIRROR_REPOS = {
     # EOC's repo-root Codex plugin references a large skills/commands catalog.

--- a/scripts/post-claim-notice.py
+++ b/scripts/post-claim-notice.py
@@ -267,8 +267,22 @@ def main():
     # 5. Check which PR repos are in the registry
     matched = pr_repos & registry_repos
     if not matched:
-        print("  Skipping: none of the PR repos are in the registry")
-        return 0
+        # Fallback: check local README.md — the plugin may have just been merged
+        # and the registry sync hasn't completed yet
+        print("  Not in registry yet, checking local README.md...")
+        readme_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "README.md")
+        if os.path.exists(readme_path):
+            readme_content = open(readme_path, encoding="utf-8").read().lower()
+            readme_matched = {r for r in pr_repos if r.lower() in readme_content}
+            if readme_matched:
+                print(f"  Found in README (pending registry sync): {', '.join(readme_matched)}")
+                matched = readme_matched
+            else:
+                print("  Skipping: none of the PR repos are in the registry or README")
+                return 0
+        else:
+            print("  Skipping: README.md not found and repos not in registry")
+            return 0
 
     print(f"  Matched in registry: {', '.join(matched)}")
 


### PR DESCRIPTION
## Summary

Three bugs identified from merged PRs that didn't get claim-notice comments and stale trust metadata:

### Bug 1: claim-notice.yml — `pull_request` → `pull_request_target`
PR #261 was merged but the claim-notice workflow failed with `HTTP 403: Resource not accessible by integration`. Fork PRs get a read-only `GITHUB_TOKEN` on `pull_request` events, even with `permissions: pull-requests: write`. Switching to `pull_request_target` runs with the base branch's token, granting write access. Safe because the workflow only runs `scripts/post-claim-notice.py` from the base branch (no PR code execution).

### Bug 2: post-claim-notice.py — README fallback when plugin not in registry
PR #43 in awesome-ai-plugins was merged, the workflow ran with `completed/success`, but it printed `Skipping: none of the PR repos are in the registry`. Root cause: when a PR is merged, the claim-notice workflow fires immediately but the registry sync pipeline hasn't completed yet. Fix: fall back to checking the local `README.md` for the plugin repo URL.

### Bug 3: generate_plugins_json.py — stale trust metadata files
PR #266 reported VidSeeds.ai stuck at security 66 because the mirrored bundle was stale. Root cause: `OPTIONAL_PLUGIN_FILES` was missing `SKILL.md`, `.github/dependabot.yml`, `codex.mcp.json`, and `.mcp.json`. These trust-relevant files exist upstream but were never mirrored, causing the scanner to see stale trust scores.

## Test plan
- [x] Smoke test: `build_comment_body('testuser')` produces `@testuser` tag
- [x] Smoke test: `normalize_repo_url` handles `.git` suffix, trailing slashes, extra paths
- [x] Smoke test: `OPTIONAL_PLUGIN_FILES` has 17 entries including new files
- [x] Smoke test: existing files still present (`SECURITY.md`, `README.md`, `.codexignore`)
- [ ] Merge and verify next merged PR gets claim-notice comment