### PR TITLE
fix: add workflow_dispatch to claim-notice for manual testing

### DIFF
--- a/.github/workflows/claim-notice.yml
+++ b/.github/workflows/claim-notice.yml
@@ -7,6 +7,20 @@ on:
     paths:
       - "README.md"
       - "plugins/**"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to post claim notice on"
+        required: true
+        type: string
+      pr_title:
+        description: "PR title"
+        required: true
+        type: string
+      pr_author:
+        description: "PR author login"
+        required: true
+        type: string
 
 permissions:
   pull-requests: write
@@ -14,8 +28,7 @@ permissions:
 
 jobs:
   post-claim-notice:
-    # Only run on merged PRs
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     name: Post claim instructions
     runs-on: ubuntu-latest
     steps:
@@ -26,8 +39,8 @@ jobs:
       - name: Post claim notice
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.inputs.pr_title || github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.inputs.pr_author || github.event.pull_request.user.login }}
           REGISTRY_API: https://hol.org/registry/api/v1
         run: python3 scripts/post-claim-notice.py


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger to the claim-notice workflow so it can be manually triggered with PR parameters for testing.

## Why

PR #261 ran with the old `pull_request` event (read-only token for fork PRs) and failed with 403. The `pull_request_target` fix is on main but can't be re-triggered for already-merged PRs. `workflow_dispatch` lets us manually trigger with PR #261's parameters to verify the fix works.

## Test plan
- [ ] Merge this PR
- [ ] Trigger workflow_dispatch with `pr_number=261`, `pr_title=Add Spellbook Skills`, `pr_author=yyykf`
- [ ] Verify claim-notice comment appears on PR #261