### PR TITLE
Add plori to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
 - [PDF Monster](https://github.com/jbaehova/pdf-monster) - Analyzes PDFs as extracted text, OCR text, rendered page images, and embedded figures for coding agents.
+- [plori](https://github.com/plori-ai/codex-plugin) - Create and drive plori cloud agents (each an AI agent on its own cloud computer) over plori's remote MCP server, with OAuth auto-discovery.
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - Route image-generation prompts to 30+ models (DALL-E, Stable Diffusion, Flux, Midjourney, and more) through a single MCP interface. Install: `npm install -g prompt-to-asset`.
 - [Pronounce](https://github.com/anzy-renlab-ai/pronounce) - Pronounce developer jargon out loud: an MCP server (lookup/search) and skill backed by a 1,721-entry sourced dictionary with IPA, audio, and cited pronunciations for kubectl, nginx, YAML, JWT, and more.
 - [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex with the official Remotion docs MCP, composition scaffolding, and a data-driven launch-video workflow.


### PR DESCRIPTION
Adds **plori** — cloud computers for AI agents, over one remote MCP URL.

- **Plugin repo:** https://github.com/plori-ai/codex-plugin
- **What it does:** bundles the plori remote MCP server (`https://api.plori.ai/mcp`, Streamable HTTP, OAuth 2.1 auto-discovered) plus a skill, so Codex can create and drive plori cloud agents (`create_agent`, `invoke_agent`, `schedule_run`, and more).
- **Runs no local code** — the plugin only points Codex at the hosted server and adds skill text.

### Scanner
HOL Plugin Scanner CI is set up and **passing on main** (`min_score: 80`, `fail_on_severity: high`), SHA-pinned:
https://github.com/plori-ai/codex-plugin/actions/runs/28752361179

Code scanning: **0 high/critical** findings (5 note-level). Repo has `.codex-plugin/plugin.json`, `SECURITY.md`, `LICENSE` (MIT), `README.md`, a self-marketplace at `.agents/plugins/marketplace.json`, SHA-pinned Actions, and Dependabot.

Entry added alphabetically under Tools & Integrations (between PDF Monster and prompt-to-asset).