### PR TITLE
Add Tree Ring Memory Codex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Test Gap](./plugins/mturac/test-gap) - Find lines in your diff lacking test coverage (Cobertura, lcov, coverage.json).
 - [TODO Harvest](./plugins/mturac/todo-harvest) - TODO/FIXME/HACK scan with `git blame` author + age.
 - [Tool Advisor](https://github.com/dragon1086/claude-skills) - Read-only meta-skill that scans your MCP servers, skills, plugins, and CLI tools, then suggests up to three ranked approaches (Methodical / Fast / Deep) with a copy-paste Quick Action table.
+- [Tree Ring Memory](https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin) - Local-first memory lifecycle guidance for Codex agents with recall, evidence-backed lessons, privacy-safe memory capture, audit, consolidation, and explicit forgetting.
 - [Unity Agent Workflows](https://github.com/AUN-PN/unity-agent-workflows) - Codex plugin and skill for Unity 2D agents that enforces "No proof, no edit" workflows with runtime-owner proof, Teach structure maps, and validation gates.
 - [Universal Design Principles](https://github.com/HDeibler/universal-design-principles) - Cross-agent UX and product-design marketplace with a root Codex collection plugin, five focused plugin bundles, and 137 Agent Skills for design review, accessibility, layout, interaction, cognition, and product polish.
 - [Velith](https://github.com/epicsagas/Velith) - AI-native publishing system with a 6-phase pipeline from ideation to EPUB/PDF across 8 genres.
@@ -267,8 +268,8 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
-- [Kreuzberg Cloud](https://github.com/kreuzberg-dev/plugins) - Managed document extraction for Codex with API-key setup, presigned uploads, job tracking, webhook workflows, and usage guidance.
 - [Kreuzberg](https://github.com/kreuzberg-dev/plugins) - Local document extraction for 91+ formats with skills for CLI usage, OCR, table extraction, output formats, and a local MCP server.
+- [Kreuzberg Cloud](https://github.com/kreuzberg-dev/plugins) - Managed document extraction for Codex with API-key setup, presigned uploads, job tracking, webhook workflows, and usage guidance.
 - [Kreuzcrawl](https://github.com/kreuzberg-dev/plugins) - Web crawling and scraping for Codex with skills for single-page scraping, site crawls, URL mapping, and headless browser fallback.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.


### PR DESCRIPTION
## Summary
- Add Tree Ring Memory to Development & Workflow as a Codex plugin wrapper for local-first agent memory lifecycle guidance.
- Fix a pre-existing two-line Kreuzberg alphabetical ordering issue so the repository alphabetizer passes.

## Scanner Evidence
- Source repo: https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin
- Public HOL scanner run on source repo main: https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin/actions/runs/28917677294
- Scanner job: https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin/actions/runs/28917677294/job/85787954750
- Local HOL scanner result: 97/100, no critical/high/medium/low findings.

## Validation
- [x] I have read the contribution guidelines.
- [x] Added one README entry in the appropriate category.
- [x] Source repo contains .codex-plugin/plugin.json, README.md, SECURITY.md, LICENSE, .codexignore, an icon, and a skill.
- [x] Source repo has HOL Plugin Scanner CI on main and it passes.
- [x] Ran python3 scripts/check-alphabetical.py README.md.
- [x] Ran python3 scripts/validate-plugin-pr.py --base-ref upstream/main.
- [x] Ran git diff --check.
- [x] Checked existing PRs/issues for Tree Ring Memory duplicates.
