### PR TITLE
fix: auto-sync plugin-scanner version in contributing.md

### DIFF
--- a/.github/workflows/sync-scanner-version.yml
+++ b/.github/workflows/sync-scanner-version.yml
@@ -1,0 +1,46 @@
+name: Sync Scanner Version
+
+on:
+  schedule:
+    # Every 6 hours — hol-guard releases 5-10×/day
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync plugin-scanner version in contributing.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync scanner version
+        id: sync
+        run: |
+          python3 scripts/sync_scanner_version.py
+          if git diff --quiet -- contributing.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "contributing.md is already up to date"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat -- contributing.md
+          fi
+
+      - name: Commit and push
+        if: steps.sync.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add contributing.md
+          git commit -m "chore: sync plugin-scanner version in contributing.md
+
+          Auto-synced from the latest PyPI release.
+          
+          [skip release publish]"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,17 +59,17 @@ Wait for the CI to pass on your repo's main branch, then copy the workflow run U
 The release metadata below is synced automatically from the latest published HOL scanner release.
 
 ```bash
-pipx install --force "plugin-scanner==2.0.972"
+pipx install --force "plugin-scanner==2.0.1015"
 plugin-scanner scan . --format text
 ```
 
-Expected reviewed wheel SHA256: `2b78408526cd7382f2d289f389c359bfb4b68d6bbf003141d449667e9b1a5ded`
+Expected reviewed wheel SHA256: `c1302897304e9b7fd74cb92d6057a1785e6430fb64bd70e8f90b14267deb0e0b`
 
 If you want to verify the exact wheel before install:
 
 ```bash
 rm -rf .hol-plugin-scanner-dist
-python3 -m pip download --only-binary=:all: --no-deps --dest .hol-plugin-scanner-dist "plugin-scanner==2.0.972"
+python3 -m pip download --only-binary=:all: --no-deps --dest .hol-plugin-scanner-dist "plugin-scanner==2.0.1015"
 python3 -m pip hash .hol-plugin-scanner-dist/*.whl
 ```
 
@@ -127,7 +127,7 @@ The commands below stay pinned to the same reviewed scanner release used in the 
 
 ```bash
 # Install the current reviewed release
-pipx install --force "plugin-scanner==2.0.972"
+pipx install --force "plugin-scanner==2.0.1015"
 
 # Scan your plugin
 plugin-scanner scan . --format text
@@ -139,7 +139,7 @@ plugin-scanner lint . --format text
 plugin-scanner verify . --format text
 ```
 
-Expected reviewed wheel SHA256: `2b78408526cd7382f2d289f389c359bfb4b68d6bbf003141d449667e9b1a5ded`
+Expected reviewed wheel SHA256: `c1302897304e9b7fd74cb92d6057a1785e6430fb64bd70e8f90b14267deb0e0b`
 
 ### Required in Your Plugin Repo
 

--- a/scripts/sync_scanner_version.py
+++ b/scripts/sync_scanner_version.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Sync the HOL plugin scanner version and wheel SHA256 in contributing.md.
+
+Fetches the latest published ``plugin-scanner`` release from PyPI and updates
+``contributing.md`` so that the pip install commands and the expected wheel
+SHA256 always reflect the current release.
+
+Usage:
+    python3 scripts/sync_scanner_version.py [--check]
+
+Exit codes:
+    0 — file was already up to date (or updated in-place with --check off)
+    0 — --check mode and file would change (prints "DRIFT" to stdout)
+    1 — network or parse error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTRIBUTING_MD = REPO_ROOT / "CONTRIBUTING.md"
+PYPI_JSON_URL = "https://pypi.org/pypi/plugin-scanner/json"
+USER_AGENT = "awesome-codex-plugins-scanner-sync"
+REQUEST_TIMEOUT_SECONDS = 30
+
+# Matches: plugin-scanner==2.0.972  (inside quotes or bare)
+VERSION_PATTERN = re.compile(r'(plugin-scanner==)(\d+\.\d+\.\d+)')
+
+# Matches: Expected reviewed wheel SHA256: `<hash>`
+SHA256_PATTERN = re.compile(
+    r'(Expected reviewed wheel SHA256:\s*`)([0-9a-f]{64})(`)'
+)
+
+
+def fetch_latest_release() -> tuple[str, str]:
+    """Return ``(version, sha256)`` for the latest plugin-scanner wheel on PyPI."""
+    req = urllib.request.Request(PYPI_JSON_URL)
+    req.add_header("User-Agent", USER_AGENT)
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as resp:
+        data = json.loads(resp.read())
+
+    version = data["info"]["version"]
+    release_files = data["releases"].get(version, [])
+
+    wheel = next(
+        (f for f in release_files if f["filename"].endswith(".whl")),
+        None,
+    )
+    if wheel is None:
+        raise RuntimeError(f"No wheel found for plugin-scanner=={version}")
+
+    sha256 = wheel["digests"]["sha256"]
+    if not sha256 or len(sha256) != 64:
+        raise RuntimeError(f"Invalid SHA256 for plugin-scanner=={version}")
+
+    return version, sha256
+
+
+def update_contributing(version: str, sha256: str) -> bool:
+    """Update contributing.md in-place. Returns True if content changed."""
+    content = CONTRIBUTING_MD.read_text(encoding="utf-8")
+
+    new_version = f"plugin-scanner=={version}"
+    updated = VERSION_PATTERN.sub(
+        lambda m: f"{m.group(1)}{version}", content
+    )
+
+    updated = SHA256_PATTERN.sub(
+        lambda m: f"{m.group(1)}{sha256}{m.group(3)}", updated
+    )
+
+    if updated == content:
+        return False
+
+    CONTRIBUTING_MD.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Sync plugin-scanner version in contributing.md"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only report drift; do not write changes.",
+    )
+    args = parser.parse_args()
+
+    try:
+        version, sha256 = fetch_latest_release()
+    except Exception as exc:
+        print(f"ERROR: failed to fetch latest release: {exc}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        # Read-only drift check
+        content = CONTRIBUTING_MD.read_text(encoding="utf-8")
+        current_version_match = VERSION_PATTERN.search(content)
+        current_sha_match = SHA256_PATTERN.search(content)
+        if current_version_match and current_sha_match:
+            current_version = current_version_match.group(2)
+            current_sha = current_sha_match.group(2)
+            if current_version != version or current_sha != sha256:
+                print("DRIFT")
+                print(f"  current: {current_version} / {current_sha[:16]}…")
+                print(f"  latest:  {version} / {sha256[:16]}…")
+            else:
+                print("OK")
+        else:
+            print("DRIFT")
+            print("  could not find version or SHA256 in contributing.md")
+        return 0
+
+    changed = update_contributing(version, sha256)
+    if changed:
+        print(f"Updated contributing.md → plugin-scanner=={version}")
+        print(f"  SHA256: {sha256}")
+    else:
+        print(f"Already up to date: plugin-scanner=={version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`contributing.md` claims "release metadata below is synced automatically from the latest published HOL scanner release" (line 59) and "commands below stay pinned to the same reviewed scanner release" (line 126), but **no automation ever existed**. The version was manually updated commit-by-commit on the `clean-work` branch and stopped at `2.0.972` when that branch was merged to `main`.

hol-guard now releases **5-10× per day** (currently at `v2.0.1015`), making manual updates infeasible. The version is **42 releases behind**.

## Changes

- **`scripts/sync_scanner_version.py`** — Fetches the latest `plugin-scanner` version + wheel SHA256 from the [PyPI JSON API](https://pypi.org/pypi/plugin-scanner/json), replaces all `plugin-scanner==X.Y.Z` and SHA256 references in `CONTRIBUTING.md`. Idempotent — exits cleanly if already up to date. Supports `--check` for drift detection.

- **`.github/workflows/sync-scanner-version.yml`** — Scheduled workflow (every 6 hours) + manual dispatch. Runs the sync script, auto-commits if `CONTRIBUTING.md` changed.

- **`CONTRIBUTING.md`** — Bump `2.0.972` → `2.0.1015`, update wheel SHA256 (5 changes across 2 sections).

## Testing

```bash
# Drift check (before)
$ python3 scripts/sync_scanner_version.py --check
DRIFT
  current: 2.0.972 / 2b78408526cd7382…
  latest:  2.0.1015 / c1302897304e9b7f…

# Apply update
$ python3 scripts/sync_scanner_version.py
Updated contributing.md → plugin-scanner==2.0.1015
  SHA256: c1302897304e9b7fd74cb92d6057a1785e6430fb64bd70e8f90b14267deb0e0b

# Idempotency check
$ python3 scripts/sync_scanner_version.py
Already up to date: plugin-scanner==2.0.1015

# Verify diff
$ git diff --stat
CONTRIBUTING.md | 10 +++++-----
1 file changed, 5 insertions(+), 5 deletions(-)
```

## Notes

- Workflow uses `permissions: contents: write` + default `GITHUB_TOKEN` — no additional secrets required.
- Commit message includes `[skip release publish]` to avoid triggering hol-guard's publish workflow.
- Schedule is every 6 hours; can also be triggered manually via `workflow_dispatch`.