### PR TITLE
Add Claude Code Codex Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Brooks Lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).
 - [Casefile](https://github.com/x4cc3/casefile) - Persistent security case tracking for bug bounties, CTFs, and security audits.
 - [Changelog Forge](./plugins/mturac/changelog-forge) - Conventional commits → CHANGELOG section + semver bump.
+- [Claude Code Codex Plugin](https://github.com/davidq888/claude-code-codex-plugin) - Security-focused Codex plugin that connects to the local Claude Code CLI through MCP with login, status checks, safe-mode prompts, and no credential storage.
 - [Claude Code for Codex](https://github.com/sendbird/cc-plugin-codex) - Reverse of OpenAI's official Claude-hosted plugin: use Claude Code from Codex for reviews, rescue tasks, tracked background jobs, and hook-powered review gates.
 - [Claude Code Harness](https://github.com/dadwadw233/claude-code-harness) - Harness blueprint skill for turning vague agent ideas into concrete designs for request assembly, control loops, memory, permissions, recovery, and extension planes.
 - [Claude Code Skills](https://github.com/alirezarezvani/claude-skills) - 223 production-ready skills, 23 agents, and 298 Python tools across 9 domains — engineering, marketing, product, compliance, and more.


### PR DESCRIPTION
## Summary
Adds Claude Code Codex Plugin to the Development & Workflow section.

Plugin repo: https://github.com/davidq888/claude-code-codex-plugin

## Scanner evidence
- HOL Plugin Scanner GitHub Action: https://github.com/davidq888/claude-code-codex-plugin/actions/runs/29210476917
- Local `plugin-scanner scan plugins/claude-code --format text`: 100/100, zero findings.

## Checklist
- [x] README.md entry only
- [x] Alphabetical placement within category
- [x] Public GitHub repository URL
- [x] Scanner CI configured and passing
