### PR TITLE
Add Ditto plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Designer Skill](https://github.com/Pythoughts-labs/designer-skill) - Plug-and-play MCP that gives your agent UI superpowers. One install: design skill + MCP server, zero config.
 - [Dev Skills](https://github.com/Jason-chen-coder/dev-skills) - Team workflow skills for specs, plans, TDD, debugging, verification, review, branch finishing, and design context.
 - [Development Skills](https://github.com/reidemeister94/development-skills) - Three-tier triage (PASS_THROUGH / LIGHT / FULL 4-phase) development workflow for Codex and Claude Code with language auto-detection (Python, Java, TypeScript, Swift, frontend) and a staff-reviewer subagent for fresh-eyes review on every change.
+- [Ditto](https://github.com/ohad6k/ditto) - Mines selected evidence from local coding-agent sessions into private work, design, and writing profiles for Codex, Claude Code, and GitHub Copilot.
 - [Docflow](https://github.com/MedAdemBHA/docflow) - Lightweight documentation memory for AI coding agents that scaffolds a 7-category docs tree, runs readiness checks, validates docs before finishing, and keeps a monthly changelog across Claude Code and Codex.
 - [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) - MCP server exposing reasoning, code, anti-deception, and memory harness tools for Codex.
 - [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.


### PR DESCRIPTION
## Plugin

- Repository: https://github.com/ohad6k/ditto
- Passing HOL scanner CI: https://github.com/ohad6k/ditto/actions/runs/29356485650

Ditto mines selected evidence from real local coding-agent sessions into private work, design, and writing profiles. The repository includes the required `.codex-plugin/plugin.json`, icon assets, MIT license, README, and security policy.

## Verification

- HOL scanner CI passed with `min_score: 80` and `fail_on_severity: high`
- `PYTHONUTF8=1 python scripts/check-alphabetical.py README.md`
- `git diff --check -- README.md`

Only the README entry is included; the generator can mirror the plugin bundle after review.