### PR TITLE
Add CodeTruss

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Claude Octopus](https://github.com/nyldn/claude-octopus) - Multi-LLM orchestration dispatching to 8 providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) with Double Diamond workflows, adversarial review, and safety gates.
 - [Clean Room](https://github.com/whit3rabbit/clean-room-skill) - Spec-first clean-room workflow for authorized source analysis, behavioral specs, role separation, and verification without replacement code.
 - [Codebase Recon](https://github.com/yujiachen-y/codebase-recon-skill) - Analyze git history to understand a codebase before reading any code — auto-scales by repo size and cross-references hotspots with bug magnets to surface high-risk files, bus factor, and team momentum.
+- [CodeTruss](https://github.com/DeliriumPulse/codetruss-plugins) - Local-first acceptance gate that checks coding-agent scope, sensitive surfaces, deterministic analyzers, and repository verification from immutable Git snapshots, then writes signed receipts before the PR.
 - [Codex Agenteam](https://github.com/yimwoo/codex-agenteam) - Specialist AI agents (researcher, PM, architect, developer, QA, reviewer) orchestrated as a configurable team pipeline.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.


### PR DESCRIPTION
## Plugin

- Source: https://github.com/DeliriumPulse/codetruss-plugins
- Scanner CI on source `main`: https://github.com/DeliriumPulse/codetruss-plugins/actions/runs/29439520035
- HOL scanner 2.0.1015: 94/100 combined, 97/100 root plugin
- Severity gate: 0 critical, 0 high

CodeTruss is a local-first acceptance gate for coding-agent scope, sensitive surfaces, deterministic analysis, repository verification, and signed pre-PR receipts. The PR adds only the required alphabetized README entry; the catalog generator can mirror the root plugin bundle from the source repository.