### PR TITLE
Rename Ditto to Emulo

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Designer Skill](https://github.com/Pythoughts-labs/designer-skill) - Plug-and-play MCP that gives your agent UI superpowers. One install: design skill + MCP server, zero config.
 - [Dev Skills](https://github.com/Jason-chen-coder/dev-skills) - Team workflow skills for specs, plans, TDD, debugging, verification, review, branch finishing, and design context.
 - [Development Skills](https://github.com/reidemeister94/development-skills) - Three-tier triage (PASS_THROUGH / LIGHT / FULL 4-phase) development workflow for Codex and Claude Code with language auto-detection (Python, Java, TypeScript, Swift, frontend) and a staff-reviewer subagent for fresh-eyes review on every change.
-- [Ditto](https://github.com/ohad6k/ditto) - Mines selected evidence from local coding-agent sessions into private work, design, and writing profiles for Codex, Claude Code, and GitHub Copilot.
+- [Emulo](https://github.com/ohad6k/emulo) - Mines selected evidence from local coding-agent sessions into private work, design, and writing profiles for Codex, Claude Code, and GitHub Copilot.
 - [Docflow](https://github.com/MedAdemBHA/docflow) - Lightweight documentation memory for AI coding agents that scaffolds a 7-category docs tree, runs readiness checks, validates docs before finishing, and keeps a monthly changelog across Claude Code and Codex.
 - [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) - MCP server exposing reasoning, code, anti-deception, and memory harness tools for Codex.
 - [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.


### PR DESCRIPTION
`ditto` was renamed to **emulo** in v0.5.0. The old name collided with several existing products (heyditto.ai, ditto.live, and an unrelated `ditto` skill on ClawHub), so the project renamed rather than fight three namespaces.

Per CONTRIBUTING this is a one-line README change; the generator re-mirrors the bundle from the source repo, so I have not touched `plugins/ohad6k/` or the catalog files. The currently mirrored bundle is `ditto` 0.3.8, and the source repo is now `emulo` 0.5.0.

**Scanner CI:** HOL Plugin Scanner is green on the source repo's main — https://github.com/ohad6k/emulo/actions/runs/29491741166 (success)

The old GitHub link redirects, so nothing is broken today, but the entry advertises a name the project no longer uses. Same plugin, same description.

Repo: https://github.com/ohad6k/emulo