### PR TITLE
Add Tura to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ The score is best used as a quick trust signal and triage summary (not the only 
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) - Voice-enabled audio layer for coding agents with ambient soundscapes, event-driven SFX, and optional cloud TTS/ASR interaction.
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS for AI coding tools with 94 reference docs, 18 agents, and cross-tool support (Claude Code, Codex, Cursor, Copilot, 30+ more).
 - [HOL Plugin Registry](https://hol.org/registry/plugins) - Browse plugins with scanner-backed security analysis and trust scores.
+- [Tura](https://github.com/Tura-AI/tura) - Open-source terminal coding-agent harness with persistent task state, runtime context compaction, and local or OpenAI-compatible model support.
 
 ## Claim Your Plugin
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ The score is best used as a quick trust signal and triage summary (not the only 
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) - Voice-enabled audio layer for coding agents with ambient soundscapes, event-driven SFX, and optional cloud TTS/ASR interaction.
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS for AI coding tools with 94 reference docs, 18 agents, and cross-tool support (Claude Code, Codex, Cursor, Copilot, 30+ more).
 - [HOL Plugin Registry](https://hol.org/registry/plugins) - Browse plugins with scanner-backed security analysis and trust scores.
-- [Tura](https://github.com/Tura-AI/tura) - Open-source terminal coding-agent harness with persistent task state, runtime context compaction, and local or OpenAI-compatible model support.
+- [Tura](https://github.com/Tura-AI/tura) - A local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.
 
 ## Claim Your Plugin
 

--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ The score is best used as a quick trust signal and triage summary (not the only 
 ## Related Projects
 
 - [awesome-ai-plugins](https://github.com/hashgraph-online/awesome-ai-plugins) - Umbrella list covering Codex, Claude Code, Gemini CLI, and MCP servers.
+- [Tura](https://github.com/Tura-AI/tura) - A local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.
 - [HOL Plugin Registry](https://hol.org/registry/plugins) - Browse plugins with scanner-backed security analysis and trust scores.
 
 ## Claim Your Plugin


### PR DESCRIPTION
## What this adds

Adds [Tura](https://github.com/Tura-AI/tura) to the alphabetized **Related Projects** section.

**Tura: 16.7% better performance, 77.5% fewer rounds.**

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.

Benchmark evidence: https://turaai.net/benchmark

Tura is being proposed as a related coding-agent project, not as a Codex plugin; therefore the plugin manifest and HOL scanner requirements do not apply to this entry type. The repository has previously accepted non-plugin coding-agent tools in this section.

## Validation

- [x] Searched the README, Issues, and pull requests for an existing Tura entry
- [x] Added one project line in case-insensitive alphabetical order
- [x] Confirmed the GitHub repository link returns HTTP 200
- [x] `git diff --check` passes
- [x] Commit changes only `README.md`
- [x] The pull request has no base conflict and no requested review change

## Disclosure

I am affiliated with the Tura project. AI assistance was used to inspect the repository rules and accepted precedents, update the listing from Tura's root README, and validate the link and diff; I reviewed the final submission.