### PR TITLE
Add claude-math

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.
 - [CarsXE](https://github.com/carsxe/carsxe-codex-plugin) - Decode VINs, license plates, market value, vehicle history, recalls, liens, OBD codes, and more via the CarsXE API.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
+- [claude-math](https://github.com/vladimirrott/claude-math) - Emit mathematics as inline Unicode (∑, ≤, ℝ, x², matrices, set-builder) instead of LaTeX so equations stay legible in the Codex TUI and any terminal; copy- and search-safe. Also works in Claude Code.
 - [Codex Be Serious](https://github.com/lulucatdev/codex-be-serious) - Enforce formal, textbook-grade written register across all agent output.
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.
 - [Codex Obsidian](https://github.com/greg-asher/codex-obsidian) - Local Obsidian note and vault workflows through the official desktop `obsidian` CLI.

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.
 - [CarsXE](https://github.com/carsxe/carsxe-codex-plugin) - Decode VINs, license plates, market value, vehicle history, recalls, liens, OBD codes, and more via the CarsXE API.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
-- [claude-math](https://github.com/vladimirrott/claude-math) - Emit mathematics as inline Unicode (∑, ≤, ℝ, x², matrices, set-builder) instead of LaTeX so equations stay legible in the Codex TUI and any terminal; copy- and search-safe. Also works in Claude Code.
+- [claude-math](https://github.com/vladimirrott/claude-math) - Emit mathematics as copy- and search-safe inline Unicode (∑, ≤, ℝ, x², matrices, set-builder) instead of LaTeX so equations stay legible in the Codex TUI, terminals, and Claude Code.
 - [Codex Be Serious](https://github.com/lulucatdev/codex-be-serious) - Enforce formal, textbook-grade written register across all agent output.
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.
 - [Codex Obsidian](https://github.com/greg-asher/codex-obsidian) - Local Obsidian note and vault workflows through the official desktop `obsidian` CLI.


### PR DESCRIPTION
Adds **claude-math** to Community → Tools & Integrations (alphabetical, between Chrome DevTools and Codex Be Serious).

**Plugin:** https://github.com/vladimirrott/claude-math
**What it does:** A skills-based Codex plugin that makes the model emit mathematics as inline Unicode (∑, ≤, ℝ, x², matrices, set-builder) instead of LaTeX, so equations stay legible in the Codex TUI and any terminal. Copy- and search-safe. Also works in Claude Code (same `SKILL.md`).

### Scanner
- **Score: 93/100 (A)** with `plugin-scanner==2.0.1015`, **0 critical / 0 high** (2 low, informational only).
- **Passing scanner CI on `main`:** https://github.com/vladimirrott/claude-math/actions/runs/29624846184

### Step 3 checklist
- [x] `.codex-plugin/plugin.json` (valid manifest, skills-only)
- [x] `SECURITY.md` (vulnerability disclosure policy)
- [x] `LICENSE` (MIT)
- [x] `README.md` (clear description)
- [x] No hardcoded secrets; no MCP (no `.mcp.json`)
- [x] SHA-pinned GitHub Actions in all workflows
- [x] Dependency lockfile (`package-lock.json`; no runtime deps)
- [x] HOL scanner running in CI and passing on `main`

Single-line README addition; alphabetical order verified with `scripts/check-alphabetical.py` (all sections sorted).