### PR TITLE
Add Project Delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PR Storyteller](./plugins/mturac/pr-storyteller) - PR title + body + test plan from commits and diff vs base branch.
 - [Praxis](https://github.com/ouonet/praxis) - Intent-driven workflow skills for coding agents: describe what done looks like, not the steps. Triage-first design keeps token costs low across design, TDD, debug, review, and release.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
+- [Project Delivery](https://github.com/sealad886/project-delivery) - Repository-grounded, risk-scaled lifecycle for taking software changes from an incomplete idea through requirements, design, planning, implementation, evidence-backed verification, review, release, and continuous improvement.
 - [Quality Engineering Skills](https://github.com/RBraga01/Quality-Engineering-Skills) - 22 structured quality engineering skills for automotive and manufacturing: ISO 9001, IATF 16949, AIAG-VDA FMEA, VDA 6.3, PPAP, APQP, SPC, MSA.
 - [RAG Reviewer](https://github.com/mimfort/rag_for_git) - Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.


### PR DESCRIPTION
## Plugin

- Source: https://github.com/sealad886/project-delivery
- Release: https://github.com/sealad886/project-delivery/releases/tag/v1.3.1
- Release commit: `fe3919407339ca973454bd7ff0e2afde3cd0a812`
- Category: Development & Workflow

Project Delivery is a repository-grounded, risk-scaled lifecycle for taking software changes from an incomplete idea through requirements, design, planning, implementation, evidence-backed verification, review, release, and continuous improvement.

## Scanner evidence

- Local reviewed scanner: `plugin-scanner==2.0.1015`
- Local public-marketplace score: 97/100 (A)
- Local findings: 0 critical, 0 high, 0 medium, 0 low; 3 informational optional-metadata findings
- Pinned hosted scanner action: `8f0a503ca2a70c1968a9a883e11fdff5737b7909`
- Hosted scanner package: `plugin-scanner==2.0.1116` on Python 3.12
- Passing release-commit scan: https://github.com/sealad886/project-delivery/actions/runs/29683164794
- Passing release-commit validation: https://github.com/sealad886/project-delivery/actions/runs/29683164790
- Hosted SARIF: all 13 prior missing-skill-license alerts fixed; remaining open alerts are informational notices for 26 required PNG icons and 3 intentionally absent optional metadata fields

## Source-repository readiness

- [x] Valid root `.codex-plugin/plugin.json`
- [x] Public repository and tagged GitHub Release
- [x] `SECURITY.md`, canonical MIT `LICENSE`, and complete `README.md`
- [x] Composer icon below 50 KB plus plugin logo and per-skill icon metadata
- [x] GitHub Actions pinned to immutable commit SHAs
- [x] No MCP server, app, executable hook, telemetry, package dependency, or external runtime
- [x] No dependency manifest requiring a lockfile
- [x] Exact marketplace-mirror simulation passed with 13 skills and all shared runtime files
- [x] Plugin Creator, 13/13 Skill Creator, 7/7 validator regressions, and 17 static route contracts passed
- [x] Personal-marketplace reinstall passed cache-layout, payload-parity, and 28/28 icon-reference checks

## Contribution verification

- [x] One alphabetized README entry
- [x] `python3 scripts/check-alphabetical.py README.md`
- [x] `python3 scripts/validate-plugin-pr.py --base-ref upstream/main`
- [x] `git diff --check upstream/main...HEAD`
- [x] `git diff --name-only upstream/main...HEAD` returns only `README.md`
- [x] No plugin bundle, `plugins.json`, or marketplace manifest changes
