### PR TITLE
Add SolidWorks GPT Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [SEO Dungeon](https://github.com/avalonreset/seo-dungeon) - Gamified local SEO audits that turn website issues into 16-bit dungeon battles for Codex, Claude, and Gemini CLI workflows.
 - [Shots](https://github.com/hitSlop/shots) - Agent-native App Store screenshot, app icon, ASO, and localization workflows through the hosted Shots MCP server.
 - [sitemd](https://github.com/sitemd-cc/sitemd) - Build websites from Markdown via MCP — 22 tools for creating pages, generating content, validating, running SEO audits, configuring settings, and deploying static sites to Cloudflare Pages.
+- [SolidWorks GPT Plugin](https://github.com/Erfouni/solidworks-GPT-plugin) - Knowledge-backed SolidWorks design and validation workflows for Codex with standards lookup, CAD evidence gates, and consent-based session learning.
 - [Synta MCP](https://github.com/Synta-ai/n8n-mcp-codex-plugin-synta) - Build, edit, validate, and self-heal n8n workflows with Synta MCP tools and Codex-ready workflow guidance.
 - [Taisly Agent Kit](https://github.com/taisly/agent) - Publish short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook from Codex with the Taisly MCP server and bundled social media posting skill.
 - [Task Scheduler](https://github.com/6Delta9/task-scheduler-codex-plugin) - OpenAI Codex plugin and local MCP server for turning task lists into realistic schedules with blocked dates, capacity overrides, overflow tracking, and markdown planning output.


### PR DESCRIPTION
## Plugin

- **Name:** SolidWorks GPT Plugin
- **Source:** https://github.com/Erfouni/solidworks-GPT-plugin
- **Category:** Tools & Integrations
- **Current release:** https://github.com/Erfouni/solidworks-GPT-plugin/releases/tag/v1.0.2

## Why it belongs

The plugin packages five coordinated Codex skills for requirements capture, engineering knowledge retrieval, SolidWorks planning, CAD validation, and consent-based session learning. It is an installable public plugin rather than a general project or prompt collection.

## Submission checks

- root and bundled `.codex-plugin/plugin.json` manifests are present
- repository and installable bundle include README, MIT license, security policy, and icon
- all external GitHub Actions are pinned to immutable commit SHAs
- Python 3.9 and 3.13 validation passes on the v1.0.2 release commit
- HOL Plugin Scanner passes on the v1.0.2 release commit: https://github.com/Erfouni/solidworks-GPT-plugin/actions/runs/29733512555
- source validation passes on the same commit: https://github.com/Erfouni/solidworks-GPT-plugin/actions/runs/29733512501
- the README marketplace-add and plugin-add commands were verified with Codex CLI 0.144.5
- the installed v1.0.2 bundle validator passes from Codex's real versioned cache with all 7 runtime tests

This PR changes one alphabetically placed README entry only. It does not commit generated bundles or catalog files.
