### PR TITLE
Add Codex Process Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [CodeTruss](https://github.com/DeliriumPulse/codetruss-plugins) - Local-first acceptance gate that checks coding-agent scope, sensitive surfaces, deterministic analyzers, and repository verification from immutable Git snapshots, then writes signed receipts before the PR.
 - [Codex Agenteam](https://github.com/yimwoo/codex-agenteam) - Specialist AI agents (researcher, PM, architect, developer, QA, reviewer) orchestrated as a configurable team pipeline.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
+- [Codex Process Jobs](https://github.com/joelfarthing/codex-process-jobs) - Run long local builds, tests, benchmarks, and inference jobs as durable detached processes with tracked status, bounded results, and completion delivery across Codex surfaces.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
 - [Codex rg Guard](https://github.com/Rycen7822/codex-rg-guard) - Budgeted `rg`/`grep` replacement for Codex that narrows broad searches before they waste model context.
 - [Codex TUI Proof](https://github.com/bnc4vk/codex-tui-proof) - Visually validate real local terminal UIs in Codex's in-app browser with screenshots and session evidence.


### PR DESCRIPTION
## Plugin

https://github.com/joelfarthing/codex-process-jobs

Codex Process Jobs runs long local builds, tests, benchmarks, inference jobs, and repair commands as durable detached processes. It provides tracked status, bounded and untrusted-output-safe result inspection, cancellation, and completion delivery across Codex App, CLI, VS Code, and remote/mobile workflows.

## Scanner

The required HOL Plugin Scanner passes on the plugin's current `main` branch:

https://github.com/joelfarthing/codex-process-jobs/actions/runs/29865023983

The repository also includes a valid Codex plugin manifest with composer icon, `SECURITY.md`, Apache-2.0 `LICENSE`, `README.md`, SHA-pinned Actions, Dependabot configuration, and `package-lock.json`.

## Submission diff

- one alphabetized README entry in **Development & Workflow**
- no mirrored plugin bundle or generated catalog files committed
