### PR TITLE
Add Codex Usage and Resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex rg Guard](https://github.com/Rycen7822/codex-rg-guard) - Budgeted `rg`/`grep` replacement for Codex that narrows broad searches before they waste model context.
 - [Codex Skin Pack Installer](https://github.com/ChannelerH/codex-skin-packs) - Codex plugin and Skill that stages verified desktop skin packs from GitHub releases, validates files, and keeps restore guidance visible.
 - [Codex TUI Proof](https://github.com/bnc4vk/codex-tui-proof) - Visually validate real local terminal UIs in Codex's in-app browser with screenshots and session evidence.
+- [Codex Usage and Resets](https://github.com/joelfarthing/codex-usage-and-resets) - Turns Codex usage into planning facts with linear pace, projected exhaustion, banked-reset expirations, and conservative unexpected-reset detection.
 - [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.
 - [debt-ops](https://github.com/bcanfield/agentic-tech-debt) - Catches AI-introduced tech debt at write-time: hooks log every deferral to a registry in your repo and a review skill ranks paydown by file churn.
 - [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.


### PR DESCRIPTION
## Summary

- Add Codex Usage and Resets (CUAR) to the Development & Workflow catalog.
- Link the canonical public source repository for generator ingestion.

## Why

CUAR turns Codex usage into planning facts: pace relative to linear usage, projected exhaustion, Banked Reset inventory and expirations, and conservative Unscheduled Reset detection.

## Scanner evidence

- Public repository: https://github.com/joelfarthing/codex-usage-and-resets
- Passing HOL scanner CI on `main`: https://github.com/joelfarthing/codex-usage-and-resets/actions/runs/30421047940
- Local public-marketplace scan: 97/100 (A, Excellent)
- Findings: 0 critical, 0 high, 0 medium, 0 low
- Cisco balanced skill scan: no elevated findings

## Validation

- README-only submission
- Alphabetized under Development & Workflow
- Repository root and required manifest files are public
