### PR TITLE
[issue-335] Add falsegreen-skill to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.
 - [Epic Harness](https://github.com/epicsagas/epic-harness) - Auto-trigger quality skills + self-evolving agent harness — orbit (spec-to-ship), evolve (skill mutation), team (multi-agent), TDD, check, ship, simplify, debug, perf, secure.
 - [Espresso](https://github.com/mirkobozzetto/espresso) - Full token-saving stack in one plugin - output compression, global rules, RTK hook, Caveman ultra, GitNexus config. Detects existing setup, installs only what's missing. Works on Claude Code and Codex.
+- [falsegreen-skill](https://github.com/vinicq/falsegreen-skill) - Finds tests that stay green when the code they cover is broken, applying six ordered judgments over Python, TypeScript, JavaScript, and Robot Framework suites in Codex CLI and Claude Code.
 - [Flaky Detector](./plugins/mturac/flaky-detector) - Run a test command N times, report per-test flakiness %.
 - [Frappe Agent](https://github.com/Dkm0315/frappe-agent) - Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.
 - [GCF Proxy](https://github.com/blackwell-systems/gcf-codex-plugin) - Save 71% on MCP tool call tokens by wrapping any server with GCF encoding, with session stats hook and setup skill.


### PR DESCRIPTION
## Summary

- Adds falsegreen-skill to Community Plugins > Development & Workflow, one line, between Espresso and Flaky Detector.
- README.md only, +1 line, 0 deletions. No bundle, no `plugins.json`, no `marketplace.json`, so the generator mirrors the source repo as designed.

## Why

falsegreen-skill finds tests that stay green when the implementation is wrong. It applies six ordered judgments to each test (does the assertion run, is the expected value from an independent oracle, is the real unit under test, does the assertion verify enough, is the test coupled to implementation internals, does the test pass in isolation) and reports HIGH/LOW confidence findings with evidence and a fix hint. Precision-first: a wrong HIGH finding is treated as worse than a missed LOW one. Covers Python, TypeScript, JavaScript, and Robot Framework, plus semantic patterns a static linter cannot reach.

## Scanner evidence

- Public repository: https://github.com/vinicq/falsegreen-skill
- Passing HOL scanner CI on `master`: https://github.com/vinicq/falsegreen-skill/actions/runs/30455893034
- Workflow: `.github/workflows/hol-plugin-scanner.yml` with `mode: scan`, `min_score: 80`, `fail_on_severity: high`, SARIF upload, scanner action SHA-pinned
- Present in the plugin repo: `.codex-plugin/plugin.json` with `interface.composerIcon`, `assets/icon.svg` (413 B, plain vector, no raster payload), `SECURITY.md`, `LICENSE`, `README.md`, `package-lock.json`, `.codexignore`

Before opening this PR I ran your own validators against this branch: `scripts/check-alphabetical.py` reports all sections sorted, and `scripts/validate-plugin-pr.py` reports `PASS: falsegreen-skill (vinicq/falsegreen-skill)` on the README-entry path.

## Notes

- The same entry was reviewed and merged in hashgraph-online/awesome-ai-plugins#50. That repo mirrors this README, so the entry belongs here at the source.
- Multi-host by design and stated as such in the description, matching the existing convention in this list. The Codex surface is native rather than adapted: `AGENTS.md` is generated from `fragments/*` so it cannot drift from the protocol, and `contexts/codex.md` is Codex-specific engineering (host context budget accounting, the o-series no-`system`-role caveat, a strict-mode JSON schema for structured output).
- One thing worth stating plainly: `codex plugin marketplace add vinicq/falsegreen-skill` does not work against the source repo today, because the Codex resolver expects the plugin nested under a subdirectory of the marketplace root. The listing fixes that, since your generator mirrors the bundle to `plugins/<owner>/<repo>/`, which is exactly the layout the resolver wants. Until then the documented paths are clone or copy `AGENTS.md`.
- Published on npm as `falsegreen-skill`. MIT licensed.

Submission issue: #335