### PR TITLE
fix: route sponsorships to hashgraph-online

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-github: [internet-dot]
+github: [hashgraph-online]


### PR DESCRIPTION
## Summary

- Route the repository’s GitHub Sponsors button to the `hashgraph-online` organization profile.
- Replace the stale `internet-dot` entry in `.github/FUNDING.yml`.

## Testing

- `yq '.' .github/FUNDING.yml`
- Verified the branch file through GitHub.

## Notes

- Sponsor profile: https://github.com/sponsors/hashgraph-online
