### PR TITLE
docs: add GitHub Sponsors badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   <a href="#contributing"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
   <a href="https://hol.org/registry/plugins"><img src="https://img.shields.io/badge/Browse-Registry-green" alt="Browse Registry"></a>
+  <a href="https://github.com/sponsors/hashgraph-online"><img src="https://img.shields.io/badge/Sponsor%20HOL-GitHub%20Sponsors-ea4aaa" alt="Sponsor HOL on GitHub"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Add a visible GitHub Sponsors badge to the README badge row.
- Link the badge to the `hashgraph-online` Sponsors profile.

## Testing

- `git diff --check`
- Confirmed the README contains the sponsor link and badge text.
