### PR TITLE
Add Agency Continuity Audit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Agentizer](https://github.com/Humiris/wwa-transform) - Turn any website into an AI-powered agentfront with split-pane
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
 - [AgentPack](https://github.com/vishal2612200/agentpack) - Ranks repo context for Codex with likely files, skill recommendations, agent rules, commands, warnings, and compact task-focused packs before editing.
+- [Agency Continuity Audit](https://github.com/revertcreations/agency-continuity-audit) - Read-only audit that distinguishes durable agent goals, state, corrections, restart evidence, authority boundaries, scheduler claims, and commercial proof from self-reported health.
 - [Agentry Observability](https://github.com/fr33dr4g0n/agentry-public) - Agent-native product analytics, error logging, and deploy attribution for coding agents through one HTTP API.
 - [AgiFlow](https://github.com/AgiFlow/ai-plugin) - Project management workflows for AI coding agents with planning, grooming, task execution, review, and AgiFlow MCP integration.
 - [AIBoarding](https://github.com/gustavo-meilus/aiboarding) - Generate, maintain, compress, and audit standard AI-agent onboarding files with AGENTS.md, CLAUDE.md, drift tracking, and lifecycle hooks.


### PR DESCRIPTION
Adds one Development & Workflow catalog entry for Agency Continuity Audit.

Plugin repository: https://github.com/revertcreations/agency-continuity-audit

HOL Plugin Scanner: 97/100 (A), with no critical, high, medium, or low findings.
Passing scanner CI for current main: https://github.com/revertcreations/agency-continuity-audit/actions/runs/30971818334

The plugin is local, read-only, dependency-free, and network-free. It audits durable objectives, structured state, correction paths, restart evidence, authority exceptions, scheduler claims, and commercial proof boundaries.