### PR TITLE
Add Lacuna Music plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Kreuzberg](https://github.com/kreuzberg-dev/plugins) - Local document extraction for 91+ formats with skills for CLI usage, OCR, table extraction, output formats, and a local MCP server.
 - [Kreuzberg Cloud](https://github.com/kreuzberg-dev/plugins) - Managed document extraction for Codex with API-key setup, presigned uploads, job tracking, webhook workflows, and usage guidance.
 - [Kreuzcrawl](https://github.com/kreuzberg-dev/plugins) - Web crawling and scraping for Codex with skills for single-page scraping, site crawls, URL mapping, and headless browser fallback.
+- [Lacuna Music](https://github.com/JOYLINK-LTD/lacuna-plugin) - Generate original instrumental music and vocal songs from Codex through the Lacuna MCP server.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.
 - [LinkedIn Skills](https://github.com/sergebulaev/linkedin-skills) - Codex-ready LinkedIn marketing bundle with a native .codex-plugin manifest and 10 skills: post writing with 16 tested hook formulas, AI-tell humanizer, pre-publish audit, comment and reply drafting, hook extraction, content planning, profile optimization, engager analytics, and thread monitoring; also works in Claude Code.


### PR DESCRIPTION
## Plugin submission

- Plugin repository: https://github.com/JOYLINK-LTD/lacuna-plugin
- HOL Plugin Scanner: **97/130 (Grade A)** locally with `plugin-scanner==2.0.1015`
- Scanner CI: https://github.com/JOYLINK-LTD/lacuna-plugin/actions/runs/31288674737
- Critical findings: 0
- High findings: 0

The repository includes a valid root `.codex-plugin/plugin.json`, pinned MCP package version, SHA-pinned scanner workflow, `SECURITY.md`, MIT license, lockfile, and plugin assets. The plugin was installed successfully through its repo marketplace and the production Lacuna generation path completed a real instrumental task.
