### PR TITLE
maintenance: refresh Unified AI System snapshot to v0.4.9

### DIFF
--- a/plugins/happy520ai/unified-ai-system/README.md
+++ b/plugins/happy520ai/unified-ai-system/README.md
@@ -32,7 +32,7 @@
   <a href="https://github.com/happy520ai/unified-ai-system/releases/latest">
     <img alt="Release" src="https://img.shields.io/github/v/release/happy520ai/unified-ai-system?style=flat-square" />
   </a>
-  <a href="https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.6">
+  <a href="https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.8">
     <img alt="Official MCP Registry: active" src="https://img.shields.io/badge/Official_MCP_Registry-active-1f883d?style=flat-square" />
   </a>
   <a href="LICENSE">
@@ -50,7 +50,7 @@ This is not a chat UI wrapper. It is a control plane for AI workflow execution.
 **Fastest proof, no account required:**
 
 ```bash
-docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.6 pnpm gateway demo "Build a small API for my team" --enhance --profile coding
+docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.8 pnpm gateway demo "Build a small API for my team" --enhance --profile coding
 ```
 
 It preserves the original request, prints a structured coding prompt, reports
@@ -117,7 +117,7 @@ language, and proves `providerCalled=false`, `credentialRequired=false`, and
     />
   </a>
   <br />
-  <sub>v0.4.6: deterministic enhancement, no API key, no provider call.</sub>
+  <sub>v0.4.8: deterministic enhancement, no API key, no provider call.</sub>
 </p>
 
 ## Try It in 60 Seconds
@@ -125,7 +125,7 @@ language, and proves `providerCalled=false`, `credentialRequired=false`, and
 Verify the project without signing in:
 
 ```bash
-docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.6 pnpm gateway demo
+docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.8 pnpm gateway demo
 ```
 
 Expected behavior:
@@ -139,7 +139,7 @@ Expected behavior:
 One-command natural-language enhancement preview:
 
 ```bash
-docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.6 \
+docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.8 \
   pnpm gateway demo "Build a small API for my team" --enhance --profile coding
 ```
 
@@ -186,7 +186,7 @@ docker run --rm --publish 3100:3100 \
   --env AI_GATEWAY_SERVICE_HOST=0.0.0.0 \
   --env AI_GATEWAY_PROVIDER_MODE=fake \
   --env AI_GATEWAY_REAL_PROVIDER_ENABLED=false \
-  ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.6
+  ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.8
 ```
 
 Keep that process running while you send the curl request. The response
@@ -212,7 +212,7 @@ pnpm gateway chat "Hello from Unified AI System"
 Published MCP command:
 
 ```bash
-codex mcp add unified-ai-system -- docker run --rm -i ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.6
+codex mcp add unified-ai-system -- docker run --rm -i ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.8
 ```
 
 Restart Codex, run `/mcp verbose` to verify the nine tools, then follow the
@@ -325,8 +325,8 @@ CI on `master` runs Linux checks, container startup smoke tests, MCP discovery, 
 
 ## Project Links
 
-- [Official MCP Registry entry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.6)
-- [Release v0.4.6](https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.6)
+- [Official MCP Registry entry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.8)
+- [Release v0.4.8](https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.8)
 - [Codex MCP server README](packages/mcp-server/README.md)
 - [Roadmap](ROADMAP.md)
 - [Vision](VISION.md)

--- a/plugins/happy520ai/unified-ai-system/README.md
+++ b/plugins/happy520ai/unified-ai-system/README.md
@@ -32,7 +32,7 @@
   <a href="https://github.com/happy520ai/unified-ai-system/releases/latest">
     <img alt="Release" src="https://img.shields.io/github/v/release/happy520ai/unified-ai-system?style=flat-square" />
   </a>
-  <a href="https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.5">
+  <a href="https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.6">
     <img alt="Official MCP Registry: active" src="https://img.shields.io/badge/Official_MCP_Registry-active-1f883d?style=flat-square" />
   </a>
   <a href="LICENSE">
@@ -50,7 +50,7 @@ This is not a chat UI wrapper. It is a control plane for AI workflow execution.
 **Fastest proof, no account required:**
 
 ```bash
-docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.5 pnpm gateway demo "Build a small API for my team" --enhance --profile coding
+docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.6 pnpm gateway demo "Build a small API for my team" --enhance --profile coding
 ```
 
 It preserves the original request, prints a structured coding prompt, reports
@@ -117,7 +117,7 @@ language, and proves `providerCalled=false`, `credentialRequired=false`, and
     />
   </a>
   <br />
-  <sub>v0.4.5: deterministic enhancement, no API key, no provider call.</sub>
+  <sub>v0.4.6: deterministic enhancement, no API key, no provider call.</sub>
 </p>
 
 ## Try It in 60 Seconds
@@ -125,7 +125,7 @@ language, and proves `providerCalled=false`, `credentialRequired=false`, and
 Verify the project without signing in:
 
 ```bash
-docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.5 pnpm gateway demo
+docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.6 pnpm gateway demo
 ```
 
 Expected behavior:
@@ -139,7 +139,7 @@ Expected behavior:
 One-command natural-language enhancement preview:
 
 ```bash
-docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.5 \
+docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.6 \
   pnpm gateway demo "Build a small API for my team" --enhance --profile coding
 ```
 
@@ -186,7 +186,7 @@ docker run --rm --publish 3100:3100 \
   --env AI_GATEWAY_SERVICE_HOST=0.0.0.0 \
   --env AI_GATEWAY_PROVIDER_MODE=fake \
   --env AI_GATEWAY_REAL_PROVIDER_ENABLED=false \
-  ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.5
+  ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.6
 ```
 
 Keep that process running while you send the curl request. The response
@@ -212,7 +212,7 @@ pnpm gateway chat "Hello from Unified AI System"
 Published MCP command:
 
 ```bash
-codex mcp add unified-ai-system -- docker run --rm -i ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.5
+codex mcp add unified-ai-system -- docker run --rm -i ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.6
 ```
 
 Restart Codex, run `/mcp verbose` to verify the nine tools, then follow the
@@ -325,8 +325,8 @@ CI on `master` runs Linux checks, container startup smoke tests, MCP discovery, 
 
 ## Project Links
 
-- [Official MCP Registry entry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.5)
-- [Release v0.4.5](https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.5)
+- [Official MCP Registry entry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.6)
+- [Release v0.4.6](https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.6)
 - [Codex MCP server README](packages/mcp-server/README.md)
 - [Roadmap](ROADMAP.md)
 - [Vision](VISION.md)

--- a/plugins/happy520ai/unified-ai-system/README.md
+++ b/plugins/happy520ai/unified-ai-system/README.md
@@ -32,7 +32,7 @@
   <a href="https://github.com/happy520ai/unified-ai-system/releases/latest">
     <img alt="Release" src="https://img.shields.io/github/v/release/happy520ai/unified-ai-system?style=flat-square" />
   </a>
-  <a href="https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.8">
+  <a href="https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.9">
     <img alt="Official MCP Registry: active" src="https://img.shields.io/badge/Official_MCP_Registry-active-1f883d?style=flat-square" />
   </a>
   <a href="LICENSE">
@@ -50,7 +50,7 @@ This is not a chat UI wrapper. It is a control plane for AI workflow execution.
 **Fastest proof, no account required:**
 
 ```bash
-docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.8 pnpm gateway demo "Build a small API for my team" --enhance --profile coding
+docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.9 pnpm gateway demo "Build a small API for my team" --enhance --profile coding
 ```
 
 It preserves the original request, prints a structured coding prompt, reports
@@ -117,7 +117,7 @@ language, and proves `providerCalled=false`, `credentialRequired=false`, and
     />
   </a>
   <br />
-  <sub>v0.4.8: deterministic enhancement, no API key, no provider call.</sub>
+  <sub>v0.4.9: deterministic enhancement, no API key, no provider call.</sub>
 </p>
 
 ## Try It in 60 Seconds
@@ -125,7 +125,7 @@ language, and proves `providerCalled=false`, `credentialRequired=false`, and
 Verify the project without signing in:
 
 ```bash
-docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.8 pnpm gateway demo
+docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.9 pnpm gateway demo
 ```
 
 Expected behavior:
@@ -139,7 +139,7 @@ Expected behavior:
 One-command natural-language enhancement preview:
 
 ```bash
-docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.8 \
+docker run --rm ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.9 \
   pnpm gateway demo "Build a small API for my team" --enhance --profile coding
 ```
 
@@ -186,7 +186,7 @@ docker run --rm --publish 3100:3100 \
   --env AI_GATEWAY_SERVICE_HOST=0.0.0.0 \
   --env AI_GATEWAY_PROVIDER_MODE=fake \
   --env AI_GATEWAY_REAL_PROVIDER_ENABLED=false \
-  ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.8
+  ghcr.io/happy520ai/unified-ai-system/ai-gateway-service:0.4.9
 ```
 
 Keep that process running while you send the curl request. The response
@@ -212,7 +212,7 @@ pnpm gateway chat "Hello from Unified AI System"
 Published MCP command:
 
 ```bash
-codex mcp add unified-ai-system -- docker run --rm -i ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.8
+codex mcp add unified-ai-system -- docker run --rm -i ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.9
 ```
 
 Restart Codex, run `/mcp verbose` to verify the nine tools, then follow the
@@ -325,8 +325,8 @@ CI on `master` runs Linux checks, container startup smoke tests, MCP discovery, 
 
 ## Project Links
 
-- [Official MCP Registry entry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.8)
-- [Release v0.4.8](https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.8)
+- [Official MCP Registry entry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.9)
+- [Release v0.4.9](https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.9)
 - [Codex MCP server README](packages/mcp-server/README.md)
 - [Roadmap](ROADMAP.md)
 - [Vision](VISION.md)


### PR DESCRIPTION
## Maintenance update

The existing Unified AI System plugin snapshot still referenced `v0.4.8` in its MCP Registry URL, Docker commands, release link, and version notes.

This PR updates the already-listed snapshot to the published `v0.4.9` release:

- `ai-gateway-service:0.4.9`
- `mcp-server:0.4.9`
- Official MCP Registry `0.4.9` URL
- Release and visible version references

The update changes only the existing plugin snapshot. It does not change the marketplace schema or add production, L5, or AGI claims. The provider-free demo remains the default documented proof path.

Validation:

- release `v0.4.9` is published, non-draft, and non-prerelease
- Official MCP Registry `0.4.9` endpoint returns HTTP 200
- all stale `0.4.8` references are absent from the updated snapshot
- `git diff --check` passes

Source evidence:

- Release: https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.9
- Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.9
- Current source: https://github.com/happy520ai/unified-ai-system