### PR TITLE
Add YouTube Skills by TranscriptAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [X (Twitter) Skills](https://github.com/sergebulaev/x-skills) - Codex-ready X (Twitter) marketing bundle with a native .codex-plugin manifest: tweet and thread writing with corpus-validated hook formulas (validated against ~450 top tweets), AI-tell humanizer, hook extraction, reply drafting, content planning, and audience insights; also works in Claude Code.
 - [X Twitter Scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data, monitored workflows, HMAC webhooks, and MCP access through the Xquik REST API with confirmation-gated write guidance.
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
+- [YouTube Skills by TranscriptAPI](https://github.com/ZeroPointRepo/youtube-skills) - Twelve drop-in agent skills for YouTube transcripts, timestamped captions and subtitles, video and channel search, playlists and channel browsing through the TranscriptAPI service.
 - [Zotero Research Tools](https://github.com/summer521521/Zotero_Research_plugin) - Connects Codex to Zotero Desktop for local-library search, citation export, collection and tag inspection, and research workflow support.
 
 ## Plugin Development


### PR DESCRIPTION
Adds **YouTube Skills by TranscriptAPI** to Tools & Integrations (alphabetical, between Yandex Direct and Zotero Research Tools). Single line entry only, no bundle files, per CONTRIBUTING.

**Plugin repo:** https://github.com/ZeroPointRepo/youtube-skills (MIT)

**Scanner (HOL AI Plugin Scanner):**
- Score: **100/100 (A)**, zero findings at every severity (plugin-scanner==2.0.1116, wheel sha256 verified)
- Passing CI run on main: https://github.com/ZeroPointRepo/youtube-skills/actions/runs/31492628564
- Workflow: `.github/workflows/hol-plugin-scanner.yml`, both actions SHA pinned (actions/checkout v4.2.2, hashgraph-online/ai-plugin-scanner-action v1), min_score 80, fail_on_severity high, SARIF upload

**Repo requirements:** `.codex-plugin/plugin.json` manifest, `SECURITY.md`, LICENSE (MIT), README, icon + screenshot assets, `.codexignore`, dependabot config, all on main.

I maintain the plugin repo.