### PR TITLE
fix(ci): export contribution sweep outputs

### DIFF
--- a/.github/workflows/sweep-open-prs.yml
+++ b/.github/workflows/sweep-open-prs.yml
@@ -65,9 +65,12 @@ jobs:
           MATRIX_FILE: ${{ runner.temp }}/open-pr-matrix.json
           STATUS_FILE: ${{ runner.temp }}/open-pr-status.json
         run: |
-          echo "matrix=$(cat \"$MATRIX_FILE\")" >> "$GITHUB_OUTPUT"
-          echo "has_failures=$(jq -r '.has_failures' \"$STATUS_FILE\")" >> "$GITHUB_OUTPUT"
-          echo "results=$(jq -c '.results' \"$STATUS_FILE\")" >> "$GITHUB_OUTPUT"
+          matrix="$(cat "$MATRIX_FILE")"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          has_failures="$(jq -r '.has_failures' "$STATUS_FILE")"
+          echo "has_failures=$has_failures" >> "$GITHUB_OUTPUT"
+          results="$(jq -c '.results' "$STATUS_FILE")"
+          echo "results=$results" >> "$GITHUB_OUTPUT"
 
   scan:
     name: Scan PR #${{ matrix.contribution.pr_number }} source

--- a/.github/workflows/validate-contribution.yml
+++ b/.github/workflows/validate-contribution.yml
@@ -44,7 +44,9 @@ jobs:
         id: entries
         env:
           MATRIX_FILE: ${{ runner.temp }}/contributions.json
-        run: echo "matrix=$(cat \"$MATRIX_FILE\")" >> "$GITHUB_OUTPUT"
+        run: |
+          matrix="$(cat "$MATRIX_FILE")"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   scan:
     name: Scan ${{ matrix.contribution.owner }}/${{ matrix.contribution.repo }}


### PR DESCRIPTION
## Summary

- fix GitHub Actions output export for contribution matrices and per-PR results
- preserve JSON values as single-line job outputs so scanner and publisher jobs receive the discovered data

## Testing

- `actionlint .github/workflows/validate-contribution.yml .github/workflows/sweep-open-prs.yml`
- YAML parsing and a shell output-export smoke test
