### PR TITLE
Add DeepSeek Mini-Router (Codex plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.
 - [Context Guard](https://github.com/GreenLv/codex-context-guard) - Preserves authoritative requirements and verification evidence across long-running Codex tasks and context compaction.
 - [debt-ops](https://github.com/bcanfield/agentic-tech-debt) - Catches AI-introduced tech debt at write-time: hooks log every deferral to a registry in your repo and a review skill ranks paydown by file churn.
+- [DeepSeek Mini-Router](https://github.com/hccccc01333/codex-deepseek-mini-router) - Task-aware spec/react/flash working-contract plugin that fixes DeepSeek weak default reasoning inside Codex, with a measured BigCodeBench harness included.
 - [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.
 - [Designer Skill](https://github.com/Pythoughts-labs/designer-skill) - Plug-and-play MCP that gives your agent UI superpowers. One install: design skill + MCP server, zero config.
 - [Dev Skills](https://github.com/Jason-chen-coder/dev-skills) - Team workflow skills for specs, plans, TDD, debugging, verification, review, branch finishing, and design context.


### PR DESCRIPTION
Adds [DeepSeek Mini-Router](https://github.com/hccccc01333/codex-deepseek-mini-router) to Community Plugins > Development & Workflow.

**What it does**: Task-aware spec/react/flash working-contract plugin for DeepSeek models inside Codex. Fixes DeepSeek weak default reasoning by locking a mode per session and injecting the matching persona via trusted hooks, with a bundled skill fallback and audit log.

**Scanner**: HOL Plugin Scanner 100/100 (A), zero findings. Passing CI run: https://github.com/hccccc01333/codex-deepseek-mini-router/actions/runs/31938991010

**Plugin repo**: https://github.com/hccccc01333/codex-deepseek-mini-router (root manifest, icon, SECURITY.md, LICENSE, dependabot, package-lock.json included).