### PR TITLE
Add Markdown Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [LVTD Skills](https://github.com/LVTD-LLC/skills) - Reusable Agent Skills for Codex, Claude Code, and compatible clients, covering Django, Rust, Cookiecutter, SEO, traction, product marketing, and nonfiction publishing workflows.
 - [Maestro](https://github.com/mbanderas/maestro) - Opt-in local multi-CLI fusion engine and orchestration doctrine that fans a prompt across model CLIs, then judges and synthesizes one grounded answer.
 - [MailAgent](https://github.com/Alex0nder/MailAgent) - Temporary inboxes for Codex — OTP, magic links, signup QA, simulate-first autotests (23 MCP tools).
+- [Markdown Reader](https://github.com/JoseEstevez520/mcp-md-reader) - Navigate Markdown structure and retrieve only the relevant section through a portable Codex MCP plugin.
 - [memi](https://github.com/sarveshsea/memi) - Interface understanding and design-system memory for Codex, Claude Code, Cursor, and MCP agents with UI audits, Tailwind token extraction, shadcn registry workflows, and a bundled Codex plugin.
 - [Nightshift](https://github.com/orwa-mahmoud/nightshift) - Accountable, time-bounded Codex shifts with a persistent punch list, parked decisions, and reviewable run history.
 - [Oh My Cassette](https://github.com/Cassette-Editor/oh-my-cassette) - Turn raw local clips into a finished cut by chatting: beat-synced edits, auto-matched music, subtitles, and transitions through a local stdio MCP server, with a timeline delta and contact-sheet preview every turn before anything renders.


### PR DESCRIPTION
Adds Markdown Reader to Development & Workflow.

Plugin repository: https://github.com/JoseEstevez520/mcp-md-reader
Source commit: c9da61474448b513b513231739aae0124546d5c5
Scanner: 97/100, with 0 critical, 0 high, 0 medium, and 0 low findings
Scanner run: https://github.com/JoseEstevez520/mcp-md-reader/actions/runs/31975778178
CI run: https://github.com/JoseEstevez520/mcp-md-reader/actions/runs/31975778187

The plugin is portable and has been verified with an MCP handshake, tool listing, and a real md_section call.