### PR TITLE
Add Aeon to Community Plugins (Development & Workflow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 
 - [A Team](https://github.com/RBraga01/a-team) - Universal multi-agent infrastructure with 25 specialist agents, 16 enforced workflow skills, and a lead orchestrator for Claude Code, Codex CLI, Cursor, and OpenCode.
 - [Aegis](https://github.com/GanyuanRan/Aegis) - An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.
+- [Aeon](https://github.com/aeonfun/aeon) - Operator console for an autonomous Aeon agent instance from Codex or Claude Code: enable, schedule, edit, and debug skills, wire secrets and channels, and mine past coding-agent chats into new scheduled skills.
 - [Agency Continuity Audit](https://github.com/revertcreations/agency-continuity-audit) - Read-only audit that distinguishes durable agent goals, state, corrections, restart evidence, authority boundaries, scheduler claims, and commercial proof from self-reported health.
 - [Agent Deck](https://github.com/not-so-fat/agent-deck) - One MCP for context management: bind self-improving playbooks, MCP tools, and API keys to the session.
 - [Agent Guard](https://github.com/JeongJaeSoon/agent-guard) - Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.


### PR DESCRIPTION
Adds **Aeon** to Community Plugins → Development & Workflow (alphabetical, after Aegis).

- **Plugin repo:** https://github.com/aeonfun/aeon
- **What it is:** the operator-console plugin for Aeon, an autonomous agent framework that runs your own skills on a schedule in GitHub Actions. Ships a Codex manifest (`.codex-plugin/plugin.json`) + repo marketplace (`.agents/plugins/marketplace.json`); installable with `codex plugin marketplace add aeonfun/aeon` then `codex plugin add aeon@aeon`.

### Scanner evidence
HOL AI Plugin Scanner runs in the plugin repo's CI and passes on `main`:

- **Score: 90/100 (Grade A)**
- **Critical: 0, High: 0**
- Passing run on main: https://github.com/aeonfun/aeon/actions/runs/32437083762
- Workflow: [`.github/workflows/plugin-scan.yml`](https://github.com/aeonfun/aeon/blob/main/.github/workflows/plugin-scan.yml)

Two reviewed false positives are scoped narrowly and documented in [`plugin/.plugin-scanner.toml`](https://github.com/aeonfun/aeon/blob/main/plugin/.plugin-scanner.toml): the `references/*` Markdown docs are excluded from secret-scanning (the `HARDCODED_SECRET` hits are `${VAR}` placeholder examples, not real secrets), and `DATA_EXFIL_JS_FS_ACCESS` is downgraded for one local, read-only history-mining helper.

No plugin files copied into this repo — the generator fetches the bundle from source per CONTRIBUTING.md.