### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [AutoCAD Tianzheng Tools](https://github.com/summer521521/AutoCAD_Tianzheng_plugin) - Connects Codex to AutoCAD and Tianzheng HVAC through a local MCP server for DWG-aware HVAC drawing inspection and workflow automation.
 - [AxonFlow](https://github.com/getaxonflow/axonflow-codex-plugin) - Runtime governance for Codex with policy enforcement on terminal commands, advisory checks for non-terminal tools via skills, PII/secret detection, and compliance-grade audit trails. Self-hosted via Docker.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
+- [Build Remote Agent](https://github.com/LinespottingOrg/GrokBuildRemote-Agents) - Pair a phone as spectator to a local Codex session via gbr-agent (QR / 8-char) and attach at 127.0.0.1:8788 or gbr-mcp.
 - [BurpSuite MCP Bridge](https://github.com/6jeffr3y/burpsuite-mcp-bridge) - Bridge Burp Suite traffic, replay, rewrite rules, and evidence export into Codex through MCP for WSL, Windows, and macOS workflows.
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.


### PR DESCRIPTION
Add **Build Remote Agent** under Community Plugins → Tools & Integrations (alphabetical after Bitbucket CLI).

Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.

## What this is
One README line only. Protocol `gbr/1`. Phone is spectator + veto. Pairing is `gbr-agent pair` (QR + 8-char) then `gbr-agent run`. Attach only `http://127.0.0.1:8788` or stdio `gbr-mcp`. No plugin files copied into this repo (generator should mirror from the source).

Source plugin repo: https://github.com/LinespottingOrg/GrokBuildRemote-Agents

## How to use
```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version   # need v0.6.0+
gbr-agent pair && gbr-agent run
curl -sS http://127.0.0.1:8788/health
```

HOL scanner CI on the source plugin repo can follow if this listing is accepted; this PR is the README entry only as CONTRIBUTING.md specifies.

Website: https://grokbuildremote.com/
