### PR TITLE
docs: add red-green-proof to plugin catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Quality Engineering Skills](https://github.com/RBraga01/Quality-Engineering-Skills) - 22 structured quality engineering skills for automotive and manufacturing: ISO 9001, IATF 16949, AIAG-VDA FMEA, VDA 6.3, PPAP, APQP, SPC, MSA.
 - [RAG Reviewer](https://github.com/mimfort/rag_for_git) - Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex.
+- [Red-Green Proof](https://github.com/RooAGI/red-green-proof) - Prove suspected bugs with a red-green-red test loop: verify the cause, watch the test fail, apply the fix, and confirm the test fails again when the fix is reverted.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
 - [Reviewable HTML Workbench](https://github.com/u-ichi/reviewable-html-workbench) - Generate reviewable HTML documents, serve previews, collect inline review comments, and feed review outcomes back into agent workflows.
 - [River Review](https://github.com/s977043/river-review) - Versioned Skill Registry of code-review skills driven by a perspective-based review agent (code, security, performance, architecture, testing, adversarial) that verifies findings against the diff.


### PR DESCRIPTION
## Summary

- Add Red-Green Proof to the Development & Workflow community plugin list.
- Link to the public plugin repository.

## Plugin readiness

- Source repository: https://github.com/RooAGI/red-green-proof
- Includes `.codex-plugin/plugin.json`, `README.md`, `LICENSE`, and `SECURITY.md`.
- Added the required HOL Plugin Scanner workflow; its first run will provide the scanner result for review.
- This PR intentionally changes only `README.md`, per the contribution guide; the catalog generator mirrors the plugin bundle from the source repository.

## Validation

- `git diff --check`
- Catalog entry is alphabetized in the Development & Workflow section.