### PR TITLE
docs: add SandBase Codex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [RoadmapSmith](https://github.com/PapiScholz/roadmapsmith) - Evidence-backed ROADMAP.md workflows for AI coding agents with validation, sync, and roadmap generation across any tech stack.
 - [Runtype Skills](https://github.com/runtypelabs/skills) - Supercharge your coding agent for AI product development — build, deploy, and operate agents, flows, tools, and surfaces on Runtype's managed edge runtime.
 - [Sealos](https://github.com/labring/sealos-skills) - Deploy apps to Sealos Cloud from Codex with readiness checks, Dockerfile generation, Compose conversion, image builds, and rollout updates.
+- [SandBase Codex Plugin](https://github.com/sandbaseai/sandbase-codex-plugin) - Codex plugin with a local MCP bridge and guided skill for discovering, inspecting, and running 2,000+ AI models and APIs.
 - [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.
 - [Simple Man](https://github.com/Maksim-Burtsev/simple-man) - High-compression communication mode for Codex agents that removes filler while preserving search, validation, and implementation effort.


### PR DESCRIPTION
## Summary
- add SandBase Codex Plugin to the Community Plugins section
- link the canonical plugin repository and describe its local MCP bridge + guided skill
- document the 2,000+ model/API catalog in one concise sentence

Plugin repository requirements verified:
- `.codex-plugin/plugin.json`
- `SECURITY.md`
- Apache-2.0 `LICENSE`
- lockfile and SHA-pinned HOL scanner workflow
- latest scanner CI run: https://github.com/sandbaseai/sandbase-codex-plugin/actions/runs/33065674359
