### PR TITLE
Add Codex Tasklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
 - [Codex rg Guard](https://github.com/Rycen7822/codex-rg-guard) - Budgeted `rg`/`grep` replacement for Codex that narrows broad searches before they waste model context.
 - [Codex Skin Pack Installer](https://github.com/ChannelerH/codex-skin-packs) - Codex plugin and Skill that stages verified desktop skin packs from GitHub releases, validates files, and keeps restore guidance visible.
+- [Codex Tasklist](https://github.com/martinille/codex-tasklist) - A persistent per-session task list for Codex CLI with a live, scrollable panel in WezTerm.
 - [Codex TUI Proof](https://github.com/bnc4vk/codex-tui-proof) - Visually validate real local terminal UIs in Codex's in-app browser with screenshots and session evidence.
 - [Codex Usage and Resets](https://github.com/joelfarthing/codex-usage-and-resets) - Turns Codex usage into planning facts with linear pace, projected exhaustion, banked-reset expirations, and conservative unexpected-reset detection.
 - [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.


### PR DESCRIPTION
Adds Codex Tasklist to Development & Workflow. It maintains a per-session user-request queue with a live, scrollable WezTerm panel for Codex CLI. Python 3.10+, standard library only, MIT licensed.

- Source: https://github.com/martinille/codex-tasklist
- Passing HOL scanner CI: https://github.com/martinille/codex-tasklist/actions/runs/33999207779
- Local HOL scanner 3.0.102: 88/100, no critical, high, or medium findings. Optional Cisco deep skill scan was unavailable locally.
- 20 tests pass.
- Manifest and icon are in `plugins/codex-tasklist/`; the catalog generator and source validator discover the nested plugin root.
- This PR changes only the alphabetically sorted README entry.
