### PR TITLE
Add Rekall to Development & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [RAG Reviewer](https://github.com/mimfort/rag_for_git) - Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex.
 - [Red-Green Proof](https://github.com/RooAGI/red-green-proof) - Prove suspected bugs with a red-green-red test loop: verify the cause, watch the test fail, apply the fix, and confirm the test fails again when the fix is reverted.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
+- [Rekall](https://github.com/DitriXNew/rekall) - Deliberate context compaction within a single Codex thread on the VS Code extension, with a verified task handoff and one-time automatic continuation.
 - [Reviewable HTML Workbench](https://github.com/u-ichi/reviewable-html-workbench) - Generate reviewable HTML documents, serve previews, collect inline review comments, and feed review outcomes back into agent workflows.
 - [River Review](https://github.com/s977043/river-review) - Versioned Skill Registry of code-review skills driven by a perspective-based review agent (code, security, performance, architecture, testing, adversarial) that verifies findings against the diff.
 - [RoadmapSmith](https://github.com/PapiScholz/roadmapsmith) - Evidence-backed ROADMAP.md workflows for AI coding agents with validation, sync, and roadmap generation across any tech stack.


### PR DESCRIPTION
**Plugin:** [Rekall 0.3.1](https://github.com/DitriXNew/rekall)  
**Category:** Development & Workflow

**Scanner:** `plugin-scanner 3.0.103` reports **98/100 (A)**, with no critical, high, medium, or low findings. Passing scanner CI on `master`: https://github.com/DitriXNew/rekall/actions/runs/34011845175 (source commit `7995618d279230659277e8d983a611e5997eb485`). SARIF was uploaded successfully to GitHub Code Scanning.

The submission guide still describes a 130-point scale; the pinned scanner prints its final score on a 100-point scale. The four informational findings concern optional interface metadata: privacy policy URL, terms URL, logo, and screenshots. Cisco skill analysis now completes with zero findings and is required by CI. The separate Skill Trust score is 85.71/100 and the Trust aggregate is 88.45/100; these are distinct from the admission score. CI publishes its JSON report and evidence tying the skill's SHA-256 to the current commit, and verifies that its instruction body matches the immutable source revision in its metadata. No self-declared `verified` flag is used. The optional Cisco MCP analyzer remains unavailable; this is a static scanner result, not a runtime security guarantee.

Rekall lets a Codex agent compact context within a single thread at a task boundary instead of waiting for the automatic threshold, keeping a SHA-256-verified handoff and optionally resuming the authorized work once. Its scope is the Codex VS Code extension on Windows, macOS, and Linux. Standalone Codex CLI sessions, the desktop app, and Claude Code are unsupported: the current adapter requires the VS Code extension's IPC owner and conversation lifecycle. Windows and macOS ARM have recorded live verification; Linux testing is maintainer-reported without recorded platform/version details or measurements.

The source repository includes `.codex-plugin/plugin.json`, a 512x512 SVG composer icon, `SECURITY.md`, an MIT `LICENSE`, `package-lock.json`, SHA-pinned Actions (`checkout` 7.0.1 and `setup-node` 7.0.0), Dependabot configuration, and `.codexignore`. Sanitized live verification records are included. CI passes on Windows, macOS, and Linux with Node.js 20 and 22: https://github.com/DitriXNew/rekall/actions/runs/34011844957. The suite contains 62 tests; Windows skips two Unix-socket integration tests.

This change adds one README line under **Development & Workflow**, between Registry Broker and Reviewable HTML Workbench. It includes no plugin bundles or generated catalog files.


Version-tag release automation was also verified with a build-only workflow run: https://github.com/DitriXNew/rekall/actions/runs/34011845271. Publication is enabled only for pushed version tags; existing published assets are never overwritten.
