### PR TITLE
Add CentricMem

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.
 - [CarsXE](https://github.com/carsxe/carsxe-codex-plugin) - Decode VINs, license plates, market value, vehicle history, recalls, liens, OBD codes, and more via the CarsXE API.
+- [CentricMem](https://github.com/zeyu-j/centricmem-skill) - Hosted librarian for agent Markdown memory via host MCP.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
 - [claude-math](https://github.com/vladimirrott/claude-math) - Emit mathematics as copy- and search-safe inline Unicode (∑, ≤, ℝ, x², matrices, set-builder) instead of LaTeX so equations stay legible in the Codex TUI, terminals, and Claude Code.
 - [Codex Be Serious](https://github.com/lulucatdev/codex-be-serious) - Enforce formal, textbook-grade written register across all agent output.


### PR DESCRIPTION
## Summary
- Add [CentricMem](https://github.com/zeyu-j/centricmem-skill) under Tools & Integrations (alphabetical, after CarsXE).
- Hosted librarian for agent Markdown memory via host MCP (`https://mem.centricmem.com/mcp`). Public Skill + Agent Plugins 1.0 package (`plugin.json`, `mcp.json`, `.codex-plugin/plugin.json`).

## Plugin repo
https://github.com/zeyu-j/centricmem-skill

## Scanner
- HOL Plugin Scanner CI on `main`: https://github.com/zeyu-j/centricmem-skill/actions/runs/34118246446
- Workflow: `.github/workflows/hol-plugin-scanner.yml` (`min_score: 80`, `fail_on_severity: high`)
- Latest run conclusion: success

## Checklist
- [x] `.github/workflows/hol-plugin-scanner.yml` exists and CI passes on main
- [x] `SECURITY.md` exists
- [x] `LICENSE` exists (PolyForm-Noncommercial-1.0.0)
- [x] `.codex-plugin/plugin.json` exists
- [x] README.md entry is alphabetically sorted
- [x] No manually-committed plugin bundles

## Test plan
- [ ] CI gate fetches zeyu-j/centricmem-skill and validates the Codex plugin manifest + scanner
- [ ] README link resolves