### PR TITLE
docs: update Codex Tasklist terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
 - [Codex rg Guard](https://github.com/Rycen7822/codex-rg-guard) - Budgeted `rg`/`grep` replacement for Codex that narrows broad searches before they waste model context.
 - [Codex Skin Pack Installer](https://github.com/ChannelerH/codex-skin-packs) - Codex plugin and Skill that stages verified desktop skin packs from GitHub releases, validates files, and keeps restore guidance visible.
-- [Codex Tasklist](https://github.com/martinille/codex-tasklist) - A persistent per-session task list for Codex CLI with a live, scrollable panel in WezTerm.
+- [Codex Tasklist](https://github.com/martinille/codex-tasklist) - A persistent per-session task list for Codex CLI with a live, scrollable panel across terminals through native integrations or a launcher with tmux fallback.
 - [Codex TUI Proof](https://github.com/bnc4vk/codex-tui-proof) - Visually validate real local terminal UIs in Codex's in-app browser with screenshots and session evidence.
 - [Codex Usage and Resets](https://github.com/joelfarthing/codex-usage-and-resets) - Turns Codex usage into planning facts with linear pace, projected exhaustion, banked-reset expirations, and conservative unexpected-reset detection.
 - [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.


### PR DESCRIPTION
The Codex Tasklist entry still describes the panel as WezTerm-only. Update the single README sentence to reflect v2's native terminal integrations and launcher with tmux fallback.

Source: https://github.com/martinille/codex-tasklist
Terminal support and platform limits: https://github.com/martinille/codex-tasklist#readme
Passing HOL Plugin Scanner: https://github.com/martinille/codex-tasklist/actions/runs/34049588755

Validation: checked the wording against the source README and ran `git diff --check`. Only the existing README entry changes; its repository link and alphabetical position are preserved.
