### PR TITLE
Add ContextStream to Tools and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Computer Usage Summary](https://github.com/liuyewang/computer-usage-summary-skill) - Privacy-first, local ActivityWatch reports for app time, AFK time, projects, billable work, and redacted timelines across macOS, Windows, and Linux.
 - [CONTAM Tools](https://github.com/summer521521/CONTAM_plugin) - Runs and inspects CONTAM airflow projects through a local MCP server with project guards, diagnostics, simulation helpers, and bridge workflows.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
+- [ContextStream](https://contextstream.io) - Shared project context for Cursor, Claude Code, Codex, and Grok. Intelligence isn’t the bottleneck. Context is. Remote MCP: https://mcp.contextstream.io/mcp
 - [Coolify](https://github.com/Sevi-py/coolify-codex-plugin) - Control Coolify Cloud and self-hosted Coolify instances through API-aware workflow skills and local tools.
 - [Data Product Builder for dbt](https://github.com/entropy-data/dataproduct-builder-dbt) - Full data-product lifecycle on dbt for Entropy Data: scaffold, audit, and integrate projects with ODCS, ODPS, OpenLineage, and GitHub Actions.
 - [deja](https://github.com/vshulcz/deja-vu) - Search the coding sessions already on your disk — Codex, Claude Code, Cursor, opencode and nineteen more — including work from before it was installed, indexed locally with no model in the loop.


### PR DESCRIPTION
## Summary
Add ContextStream, a shared project context MCP for Cursor, Claude Code, Codex, and Grok.

- Website: https://contextstream.io
- MCP: https://mcp.contextstream.io/mcp
- Benchmarks: https://contextstream.io/benchmarks
- Pitch: Intelligence isn’t the bottleneck. Context is.

I work on ContextStream. This is a free listing suggestion. $0.

## Test plan
- [ ] Confirm ContextStream was not already listed
- [ ] Confirm the row is in the intended section
- [ ] Confirm links resolve