### PR TITLE
Add OrcaReplay under Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.
 - [OpenProject Codex](https://github.com/varaprasadreddy9676/openproject-codex-plugin) - OpenProject integration for Codex with project, team, work package, bulk workflow, boards, wiki, meeting, attachment, and reporting support.
 - [Ophis](https://github.com/ophis-fi/skills) - Onchain token swaps for Codex via the hosted Ophis MCP server, MEV-protected and gasless, built on CoW Protocol.
+- [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) - Records a Codex CLI run below the harness — Responses API traffic, tool calls and per-turn file changes — then replays it with the recorded responses served back, or forks it from a checkpoint onto another model.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.


### PR DESCRIPTION
Adds [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) — one line, in the section this fits.

**Disclosure: I work on it.** Apache-2.0, free, no paid tier, no account.

## What it is

A record/replay debugger for coding agents. It captures a run **below the harness** — a base-URL variable moved for that process, or TLS terminated for one named host — so the agent itself is unmodified and needs no SDK, exporter or plugin. The trace keeps the verbatim request and response bytes, which is what makes the next part possible: the run re-executes with the network off (`egress=blocked`), served the recorded exchanges back.

```bash
npm i -g orcareplay
orca record claude            # or codex, goose, hermes, opencode, qwen, cursor, grok, openclaw
orca replay last              # reproduce it, network off
orca compare last --models a,b,c --verify "npm test"
```

## Why it is not the same thing as the tracing tools already listed

The OpenTelemetry path — which is what Langfuse, Phoenix and the rest consume — does not capture message content by default, and even with `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` what lands is span attributes: a normalised *view* of the call, not the bytes on the wire. You cannot serve a span back to an SDK as an HTTP response. It also assumes the agent can be instrumented, and the agents most people actually run — Claude Code, Codex CLI, goose — are binaries you invoke, not libraries you import.

So this sits beside those tools rather than replacing them: they are the system of record for a fleet, this is a debugger you point at one run.

## Verified, not asserted

Two harnesses have been driven end to end against the real thing, and each broke something that got fixed:

- **Claude Code** — [walked through against a real bug fix](https://github.com/Continuum-AI-Corp/OrcaReplay/blob/main/docs/validation.md).
- **goose** 1.49.0 — `1 failed` → agent fixes it → `1 passed`, then strict offline replay `reused=8/8 exact=8 divergences=0`, three runs in a row.
- **Hermes** v0.21.0 — recorded and replayed offline, `reused=1/1 egress=blocked`.

Every adapter has a fixture recording the exact environment variables it sets, so a harness that renames one turns a check red instead of producing an empty trace.

## Details

- Apache-2.0 · TypeScript · Linux/macOS/Windows · `npm i -g orcareplay`
- Ships an MCP server (`orca mcp`, protocol `2025-06-18`) and an Agent Skill
- Listed in the official MCP Registry
- ~1,700 tests and a trace-format conformance suite

Happy to reword, shorten, or move it to a different section — say which and I will push the change.
