### PR TITLE
Add Goal Progress plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Frappe Agent](https://github.com/Dkm0315/frappe-agent) - Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.
 - [GCF Proxy](https://github.com/blackwell-systems/gcf-codex-plugin) - Save 71% on MCP tool call tokens by wrapping any server with GCF encoding, with session stats hook and setup skill.
 - [Generative Media Skills](https://github.com/SamurAIGPT/Generative-Media-Skills) - 13 skills for image, video, and audio generation using 100+ models - FLUX, Midjourney v7, Veo3, Kling 3.0, Suno, and HunyuanVideo via muapi.ai.
+- [Goal Progress](https://github.com/ezra-y/codex-goal-progress) - A native progress bar for Codex Goals with checklist-based progress and token usage on Apple Silicon Macs.
 - [GrayMatter](https://github.com/ValkyrLabs/GrayMatter) - Durable memory and shared graph state for Codex and OpenClaw agents, with live ValkyrAI schema awareness.
 - [Hera Agent Godot](https://github.com/NotNull92/hera-agent-godot) - Drives a live Godot 4.x editor through the low-token Hera CLI — scene, node, and signal edits, play control, and runtime QA with verifiable compact JSON output, with the companion addon published on the official Godot Asset Store.
 - [Hera Agent Unity](https://github.com/NotNull92/hera-agent-unity) - Controls and verifies a live Unity Editor through a low-token CLI, with scene, asset, Inspector, Play Mode, test, screenshot, and runtime C# workflows for Codex and other coding agents.


### PR DESCRIPTION
Hi, I'm the maintainer of [Goal Progress](https://github.com/ezra-y/codex-goal-progress). I'd like to add it to **Development & Workflow**.

It adds a progress bar next to Codex's native Goal, showing the overall progress percentage and token usage in one place. During longer tasks, you can see what's finished and what's still in progress without scrolling back through the conversation. It calculates completion from a checklist and keeps confirmed progress when you resume work or adjust the scope.

![Goal Progress demo](https://raw.githubusercontent.com/ezra-y/codex-goal-progress/87f3ffe04b8d4f74ed72ed3d44d0aa7ebd8eb558/docs/assets/codex-goal-progress-demo.gif)

[README and installation](https://github.com/ezra-y/codex-goal-progress#readme) · [v0.3.7](https://github.com/ezra-y/codex-goal-progress/releases/tag/v0.3.7)

**Platform:** Apple Silicon Mac and Codex Desktop. Source installation requires Node.js 22.12+ and pnpm 11.

The [HOL Plugin Scanner workflow on main](https://github.com/ezra-y/codex-goal-progress/actions/runs/34316438355) passed. A local scan with `plugin-scanner 3.0.144` scored **97 points**, with **no high or critical findings**.

This PR adds one README entry in alphabetical order. The catalog's generator will handle mirroring the plugin bundle.