### PR TITLE
Add Fantasy Football Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Droplinked](https://github.com/droplinked/droplinked-codex-plugin) - Verified-inventory agentic commerce over a hosted MCP server, with merchant and product discovery, agent-initiated checkout, and onchain brand, credit-risk, and repayment attestations.
 - [Education Agent Skills](https://github.com/GarethManning/education-agent-skills) - 131 evidence-based education skills for curriculum design, lesson planning, and assessment, with transparent evidence ratings and MCP server.
 - [Exa Web Search](https://github.com/zlsbksdxl/codex-exa) - Search and fetch current web sources in Codex through the official Exa MCP server with browser OAuth.
+- [Fantasy Football Manager](https://github.com/krmisystems/fantasy-football-manager) - Manage ESPN fantasy drafts and season transactions with configurable approval limits and a multi-team portfolio dashboard.
 - [Feishu to Codex](https://github.com/zlsbksdxl/codex-lark) - Connect Codex to Feishu/Lark workflows for Docs, Messenger, Drive, Sheets, Base, Calendar, Tasks, Meetings, Mail, approvals, and more through the official Lark CLI.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
 - [GH Project](https://github.com/zfifteen/gh-project-plugin) - Create GitHub repositories from Codex with inferred defaults, native menus, explicit confirmation, and deterministic local cloning.


### PR DESCRIPTION
# Hashgraph follow-up

Add Fantasy Football Manager under Community Plugins / Tools & Integrations.

Source: https://github.com/krmisystems/fantasy-football-manager

Version 0.4.0 is published on GitHub, PyPI, and the MCP Registry. The plugin exposes three local MCP commands and four skills. The team dashboard includes exact proposal approval and submission controls. Football is the only implemented sport. Live validation limits remain explicit in the source documentation.

## Maintainer review addressed

- Rebased the one-line README submission onto the current catalog main branch.
- Reproduced the earlier catalog score with scanner 2.0.1116 and Cisco skill scanner 2.0.14: 97/100, 14 informational findings, and no higher-severity findings.
- Added `license: MIT` to all four canonical skills and their generated root copies. This removes all eight `MANIFEST_MISSING_LICENSE` findings.
- Documented the six remaining optional-field notices in the [rule-level review](https://github.com/krmisystems/fantasy-football-manager/blob/main/docs/HOL_SCANNER_REVIEW.md). Both manifests omit optional `termsOfServiceURL`, `logo`, and `screenshots` fields. They declare valid composer icons. The license, privacy policy, and screenshots are already present in project documentation. No placeholder URL or scanner suppression was added.
- Kept the existing source CI action SHA and thresholds unchanged. The current-guide supplemental scan does not replace source CI.

## Validation

Scanner 3.0.153 with Cisco skill scanner 2.0.14 returns **97/100, grade A, six informational findings, and zero critical/high/medium/low findings**. Cisco skill scanning used the balanced policy with static, bytecode, and pipeline analyzers and returned zero findings. Cisco MCP scanning was unavailable.

The scanner 3.0.153 wheel matched the exact SHA256 in the current catalog contribution guide. The pinned native scanner 3.0.151 also returns score 97 and six informational findings. Its local environment lacked optional Cisco integrations.

Contribution validation, alphabetical validation, the alphabetical validator tests, and the README-entry bundle validator passed. The current catalog generator produced a valid installable plugin from the corrected source. The generated bundle, repository root, and canonical plugin passed the Codex plugin validator. No generated catalog files or plugin bundle copies are included in this PR.

The published v0.4.0 artifacts retain their original bytes. Current source includes the skill license and publication-wording corrections. No runtime Python code or live team state changed.

I maintain the linked project. Prepared with AI assistance.


Passing source scanner CI on main: https://github.com/krmisystems/fantasy-football-manager/actions/runs/34562631095

Source commit: `399557ac33799faad7c3193a384ed6ee88ed10f8`. Source correction: https://github.com/krmisystems/fantasy-football-manager/pull/10 (22 checks passed before merge).

Catalog base verified: `37a8426158700f3e6dcf1f093a5c52c0cbf666a6`. Rebased submission head: `92db3d0481ec9782c6cc081231845dbbbb502e33`.


Verified catalog rerun: https://github.com/hashgraph-online/awesome-codex-plugins/actions/runs/34562655392/job/103148422695. The hosted job used scanner 2.0.1116 with Cisco skill scanning and returned 97/100 with six informational findings and no higher-severity findings. All five contribution checks passed on the rebased head.
