### PR TITLE
docs: add Core Learning plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Usage and Resets](https://github.com/joelfarthing/codex-usage-and-resets) - Turns Codex usage into planning facts with linear pace, projected exhaustion, banked-reset expirations, and conservative unexpected-reset detection.
 - [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.
 - [Context Guard](https://github.com/GreenLv/codex-context-guard) - Preserves authoritative requirements and verification evidence across long-running Codex tasks and context compaction.
+- [Core Learning](https://github.com/everclear077/codex-learning-plugin) - Guided learning with Socratic practice, Feynman teach-back, spaced recall, evidence-based project assessment, and optional local Anki export.
 - [debt-ops](https://github.com/bcanfield/agentic-tech-debt) - Catches AI-introduced tech debt at write-time: hooks log every deferral to a registry in your repo and a review skill ranks paydown by file churn.
 - [DeepSeek Mini-Router](https://github.com/hccccc01333/codex-deepseek-mini-router) - Task-aware spec/react/flash working-contract plugin that fixes DeepSeek weak default reasoning inside Codex, with a measured BigCodeBench harness included.
 - [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.


### PR DESCRIPTION
Adds Core Learning to Development & Workflow in alphabetical order. It provides guided learning through Socratic practice, Feynman teach-back, spaced recall, project assessment, and optional local Anki export.

Source repository: https://github.com/everclear077/codex-learning-plugin
Passing HOL scanner CI on main: https://github.com/everclear077/codex-learning-plugin/actions/runs/34749694258
Verified source commit: 1b299fb0d4530286d5659ec618966073e06a1dee

The self-contained plugin lives at plugins/core-learning/ with its .codex-plugin/plugin.json, assets/icon.svg, LICENSE, SECURITY.md, README.md, and skills/learn-core/. The source repository also has root LICENSE and SECURITY.md files. The repository marketplace points to that plugin directory; the catalog generator supports discovering nested plugin roots.

Validation:
- HOL Plugin Scanner 3.0.166: local plugin score 88/100; policy_pass and verify_pass true; no critical, high, medium, or low findings. Optional Cisco deep scanning was unavailable locally; the linked GitHub Actions run is the CI evidence.
- Scanner runs on push to main and pull requests with min_score 80 and fail_on_severity high; the action is pinned to a commit SHA.
- Source repository validation, 55 local links, all 11 unit tests, public-content scan, and deterministic packaging passed.
- This PR changes only one README line; alphabetical validation passed. No generated catalogs or plugin bundles are committed.

Disclosure: I maintain the linked project.